### PR TITLE
ignore IntelliJ IDEA artifacts by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 **/.project
 **/.settings
 .gradle
+**.ipr
+**.iml
+**.iws


### PR DESCRIPTION
ignores the files produced by IntelliJ IDEA.