### PR TITLE
Watch for circular references during HollowObjectMapper#initializeTypeState, fail fast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **.ipr
 **.iml
 **.iws
+.idea

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
@@ -25,7 +25,10 @@ import com.netflix.hollow.core.write.HollowListWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class HollowListTypeMapper extends HollowTypeMapper {
 
@@ -37,8 +40,8 @@ public class HollowListTypeMapper extends HollowTypeMapper {
 
     private final HollowTypeMapper elementMapper;
 
-    public HollowListTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, boolean ignoreListOrdering) {
-        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null);
+    public HollowListTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, boolean ignoreListOrdering, Set<Type> visited) {
+        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, visited);
         String typeName = declaredName != null ? declaredName : getDefaultTypeName(type);
         this.schema = new HollowListSchema(typeName, elementMapper.getTypeName());
         this.ignoreListOrdering = ignoreListOrdering;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -26,7 +26,9 @@ import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Set;
 
 public class HollowMapTypeMapper extends HollowTypeMapper {
 
@@ -38,9 +40,9 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
     private HollowTypeMapper keyMapper;
     private HollowTypeMapper valueMapper;
 
-    public HollowMapTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, String[] hashKeyFieldPaths, HollowWriteStateEngine stateEngine, boolean useDefaultHashKeys) {
-        this.keyMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null);
-        this.valueMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[1], null, null);
+    public HollowMapTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, String[] hashKeyFieldPaths, HollowWriteStateEngine stateEngine, boolean useDefaultHashKeys, Set<Type> visited) {
+        this.keyMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, visited);
+        this.valueMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[1], null, null, visited);
         String typeName = declaredName != null ? declaredName : getDefaultTypeName(type);
         
         if(hashKeyFieldPaths == null && useDefaultHashKeys && (keyMapper instanceof HollowObjectTypeMapper))

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
@@ -66,6 +66,9 @@ public class HollowObjectMapper {
     }
 
     HollowTypeMapper getTypeMapper(Type type, String declaredName, String[] hashKeyFieldPaths) {
+        return getTypeMapper(type, declaredName, hashKeyFieldPaths, new HashSet<Type>());
+    }
+    HollowTypeMapper getTypeMapper(Type type, String declaredName, String[] hashKeyFieldPaths, Set<Type> visited) {
         String typeName = declaredName != null ? declaredName : HollowObjectTypeMapper.getDefaultTypeName(type);
 
         HollowTypeMapper typeMapper = typeMappers.get(typeName);
@@ -77,17 +80,17 @@ public class HollowObjectMapper {
                 Class<?> clazz = (Class<?>) parameterizedType.getRawType();
 
                 if(List.class.isAssignableFrom(clazz)) {
-                    typeMapper = new HollowListTypeMapper(this, parameterizedType, declaredName, ignoreListOrdering);
+                    typeMapper = new HollowListTypeMapper(this, parameterizedType, declaredName, ignoreListOrdering, visited);
                 } else if(Set.class.isAssignableFrom(clazz)) {
-                    typeMapper = new HollowSetTypeMapper(this, parameterizedType, declaredName, hashKeyFieldPaths, stateEngine, useDefaultHashKeys);
+                    typeMapper = new HollowSetTypeMapper(this, parameterizedType, declaredName, hashKeyFieldPaths, stateEngine, useDefaultHashKeys, visited);
                 } else if(Map.class.isAssignableFrom(clazz)) {
-                    typeMapper = new HollowMapTypeMapper(this, parameterizedType, declaredName, hashKeyFieldPaths, stateEngine, useDefaultHashKeys);
+                    typeMapper = new HollowMapTypeMapper(this, parameterizedType, declaredName, hashKeyFieldPaths, stateEngine, useDefaultHashKeys, visited);
                 } else {
-                    return getTypeMapper(clazz, declaredName, hashKeyFieldPaths);
+                    return getTypeMapper(clazz, declaredName, hashKeyFieldPaths, visited);
                 }
 
             } else {
-                typeMapper = new HollowObjectTypeMapper(this, (Class<?>)type, declaredName);
+                typeMapper = new HollowObjectTypeMapper(this, (Class<?>)type, declaredName, visited);
             }
 
             HollowTypeMapper existing = typeMappers.putIfAbsent(typeName, typeMapper);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
@@ -21,6 +21,7 @@ import com.netflix.hollow.core.write.HollowWriteStateEngine;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.Map;
 import java.util.Set;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -26,6 +26,7 @@ import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Set;
 
 public class HollowSetTypeMapper extends HollowTypeMapper {
@@ -37,8 +38,8 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
 
     private final HollowTypeMapper elementMapper;
 
-    public HollowSetTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, String[] hashKeyFieldPaths, HollowWriteStateEngine stateEngine, boolean useDefaultHashKeys) {
-        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null);
+    public HollowSetTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, String[] hashKeyFieldPaths, HollowWriteStateEngine stateEngine, boolean useDefaultHashKeys, Set<Type> visited) {
+        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, visited);
         String typeName = declaredName != null ? declaredName : getDefaultTypeName(type);
         
         if(hashKeyFieldPaths == null && useDefaultHashKeys && (elementMapper instanceof HollowObjectTypeMapper))

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/DirectCircularReference.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/DirectCircularReference.java
@@ -1,0 +1,21 @@
+package com.netflix.hollow.core.write.objectmapper;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Sample type that represents a direct circular reference between 2 classes.
+ */
+public class DirectCircularReference {
+
+    private final String name;
+    private final List<DirectCircularReference> children;
+
+    public DirectCircularReference(String name) {
+        this(name, Collections.<DirectCircularReference>emptyList());
+    }
+    public DirectCircularReference(String name, List<DirectCircularReference> children) {
+        this.name = name;
+        this.children = children;
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/DirectCircularReference.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/DirectCircularReference.java
@@ -1,7 +1,5 @@
 package com.netflix.hollow.core.write.objectmapper;
 
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Sample type that represents a direct circular reference between 2 classes.
@@ -9,13 +7,10 @@ import java.util.List;
 public class DirectCircularReference {
 
     private final String name;
-    private final List<DirectCircularReference> children;
+    private final DirectCircularReference child;
 
-    public DirectCircularReference(String name) {
-        this(name, Collections.<DirectCircularReference>emptyList());
-    }
-    public DirectCircularReference(String name, List<DirectCircularReference> children) {
+    public DirectCircularReference(String name, DirectCircularReference child) {
         this.name = name;
-        this.children = children;
+        this.child = child;
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/DirectListCircularReference.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/DirectListCircularReference.java
@@ -1,0 +1,18 @@
+package com.netflix.hollow.core.write.objectmapper;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Sample type that represents a direct circular reference between 2 classes, with a List containing the child.
+ */
+public class DirectListCircularReference {
+
+    private final String name;
+    private final List<DirectListCircularReference> children;
+
+    public DirectListCircularReference(String name, List<DirectListCircularReference> children) {
+        this.name = name;
+        this.children = children;
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/DirectMapCircularReference.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/DirectMapCircularReference.java
@@ -1,0 +1,17 @@
+package com.netflix.hollow.core.write.objectmapper;
+
+import java.util.Map;
+
+/**
+ * Sample type that represents a direct circular reference between 2 classes, with a Map containing the child.
+ */
+public class DirectMapCircularReference {
+
+    private final String name;
+    private final Map<String, DirectMapCircularReference> children;
+
+    public DirectMapCircularReference(String name, Map<String, DirectMapCircularReference> children) {
+        this.name = name;
+        this.children = children;
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/DirectSetCircularReference.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/DirectSetCircularReference.java
@@ -1,0 +1,17 @@
+package com.netflix.hollow.core.write.objectmapper;
+
+import java.util.Set;
+
+/**
+ * Sample type that represents a direct circular reference between 2 classes, with a Set containing the child.
+ */
+public class DirectSetCircularReference {
+
+    private final String name;
+    private final Set<DirectSetCircularReference> children;
+
+    public DirectSetCircularReference(String name, Set<DirectSetCircularReference> children) {
+        this.name = name;
+        this.children = children;
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperTest.java
@@ -23,7 +23,6 @@ import com.netflix.hollow.tools.stringifier.HollowRecordJsonStringifier;
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
 import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
 import com.netflix.hollow.core.index.key.PrimaryKey;
-import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,6 +76,17 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
         Assert.assertEquals(3, subObj.getInt("val2"));
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void testMappingCircularReference() throws IOException {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+        mapper.initializeTypeState(DirectCircularReference.class);
+    }
+    @Test(expected = IllegalStateException.class)
+    public void testMappingDeeperCircularReference() throws IOException {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+        mapper.initializeTypeState(IndirectCircularReference.TypeE.class);
+    }
+
     private Map<String, List<Integer>> map(Object... keyValues) {
         Map<String, List<Integer>> map = new HashMap<String, List<Integer>>();
         int i = 0;
@@ -127,6 +137,7 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
             this.val2 = val2;
         }
     }
+
 
 
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperTest.java
@@ -76,17 +76,44 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
         Assert.assertEquals(3, subObj.getInt("val2"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testMappingCircularReference() throws IOException {
-        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
-        mapper.initializeTypeState(DirectCircularReference.class);
+        assertExpectedFailureMappingType(DirectCircularReference.class, "child");
     }
-    @Test(expected = IllegalStateException.class)
-    public void testMappingDeeperCircularReference() throws IOException {
-        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
-        mapper.initializeTypeState(IndirectCircularReference.TypeE.class);
+    @Test
+    public void testMappingCircularReferenceList() throws IOException {
+        assertExpectedFailureMappingType(DirectListCircularReference.class, "children");
+    }
+    @Test
+    public void testMappingCircularReferenceSet() throws IOException {
+        assertExpectedFailureMappingType(DirectSetCircularReference.class, "children");
+    }
+    @Test
+    public void testMappingCircularReferenceMap() throws IOException {
+        assertExpectedFailureMappingType(DirectMapCircularReference.class, "children");
+    }
+    @Test
+    public void testMappingIndirectircularReference() throws IOException {
+        assertExpectedFailureMappingType(IndirectCircularReference.TypeE.class, "f");
     }
 
+    /**
+     * Convenience method for experimenting with {@link HollowObjectMapper#initializeTypeState(Class)}
+     * on classes we know should fail due to circular references, confirming the exception message is correct.
+     *
+     * @param clazz class to initialize
+     * @param fieldName the name of the field that should trip the circular reference detection
+     */
+    protected void assertExpectedFailureMappingType(Class<?> clazz, String fieldName) {
+        final String expected = clazz.getSimpleName() + "." + fieldName;
+        try {
+            HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+            mapper.initializeTypeState(clazz);
+        } catch (IllegalStateException e) {
+
+            Assert.assertTrue(String.format("missing expected fieldname %s in the message, was %s", expected, e.getMessage()), e.getMessage().contains(expected));
+        }
+    }
     private Map<String, List<Integer>> map(Object... keyValues) {
         Map<String, List<Integer>> map = new HashMap<String, List<Integer>>();
         int i = 0;

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/IndirectCircularReference.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/IndirectCircularReference.java
@@ -1,0 +1,31 @@
+package com.netflix.hollow.core.write.objectmapper;
+
+/**
+ * Object model representing an indirect or nested circular reference:
+ *
+ * E depends on F, F depends on G, and G depends back on E
+ */
+public class IndirectCircularReference {
+
+    class TypeE {
+        private final TypeF f;
+
+        public TypeE(TypeF f) {
+            this.f = f;
+        }
+    }
+    class TypeF {
+        private final TypeG g;
+
+        public TypeF(TypeG g) {
+            this.g = g;
+        }
+    }
+    class TypeG {
+        private final TypeE e;
+
+        public TypeG(TypeE e) {
+            this.e = e;
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/tools/diff/HollowDiffTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/diff/HollowDiffTest.java
@@ -74,14 +74,14 @@ public class HollowDiffTest {
         typeCSchema.addField("c1", FieldType.LONG);
         typeCSchema.addField("c2", FieldType.BOOLEAN);
 
-        typeDSchema = new HollowObjectSchema("DirectCircularReference", 3, "d1", "d2");
+        typeDSchema = new HollowObjectSchema("TypeD", 3, "d1", "d2");
         typeDSchema.addField("d1", FieldType.FLOAT);
         typeDSchema.addField("d2", FieldType.DOUBLE);
         typeDSchema.addField("d3", FieldType.BYTES);
 
         listOfTypeCSchema = new HollowListSchema("ListOfTypeC", "TypeC");
-        setOfTypeDSchema = new HollowSetSchema("SetOfTypeD", "DirectCircularReference");
-        mapOfTypeCToTypeDSchema = new HollowMapSchema("MapOfTypeCToTypeD", "TypeC", "DirectCircularReference");
+        setOfTypeDSchema = new HollowSetSchema("SetOfTypeD", "TypeD");
+        mapOfTypeCToTypeDSchema = new HollowMapSchema("MapOfTypeCToTypeD", "TypeC", "TypeD");
     }
 
     @Test
@@ -215,7 +215,7 @@ public class HollowDiffTest {
 
         Assert.assertEquals(1, diff.getTypeDiffs().size());
 
-        HollowTypeDiff typeDDiff = diff.getTypeDiff("DirectCircularReference");
+        HollowTypeDiff typeDDiff = diff.getTypeDiff("TypeD");
         Assert.assertNotNull(typeDDiff);
 
         HollowDiffMatcher matcher = typeDDiff.getMatcher();
@@ -335,7 +335,7 @@ public class HollowDiffTest {
         rec.setFloat("d1", typeD.d1);
         rec.setDouble("d2", typeD.d2);
         rec.setBytes("d3", typeD.d3);
-        return stateEngine.add("DirectCircularReference", rec);
+        return stateEngine.add("TypeD", rec);
     }
 
     private TypeCRec[] cList(TypeCRec... cs) {

--- a/hollow/src/test/java/com/netflix/hollow/tools/diff/HollowDiffTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/diff/HollowDiffTest.java
@@ -74,14 +74,14 @@ public class HollowDiffTest {
         typeCSchema.addField("c1", FieldType.LONG);
         typeCSchema.addField("c2", FieldType.BOOLEAN);
 
-        typeDSchema = new HollowObjectSchema("TypeD", 3, "d1", "d2");
+        typeDSchema = new HollowObjectSchema("DirectCircularReference", 3, "d1", "d2");
         typeDSchema.addField("d1", FieldType.FLOAT);
         typeDSchema.addField("d2", FieldType.DOUBLE);
         typeDSchema.addField("d3", FieldType.BYTES);
 
         listOfTypeCSchema = new HollowListSchema("ListOfTypeC", "TypeC");
-        setOfTypeDSchema = new HollowSetSchema("SetOfTypeD", "TypeD");
-        mapOfTypeCToTypeDSchema = new HollowMapSchema("MapOfTypeCToTypeD", "TypeC", "TypeD");
+        setOfTypeDSchema = new HollowSetSchema("SetOfTypeD", "DirectCircularReference");
+        mapOfTypeCToTypeDSchema = new HollowMapSchema("MapOfTypeCToTypeD", "TypeC", "DirectCircularReference");
     }
 
     @Test
@@ -215,7 +215,7 @@ public class HollowDiffTest {
 
         Assert.assertEquals(1, diff.getTypeDiffs().size());
 
-        HollowTypeDiff typeDDiff = diff.getTypeDiff("TypeD");
+        HollowTypeDiff typeDDiff = diff.getTypeDiff("DirectCircularReference");
         Assert.assertNotNull(typeDDiff);
 
         HollowDiffMatcher matcher = typeDDiff.getMatcher();
@@ -335,7 +335,7 @@ public class HollowDiffTest {
         rec.setFloat("d1", typeD.d1);
         rec.setDouble("d2", typeD.d2);
         rec.setBytes("d3", typeD.d3);
-        return stateEngine.add("TypeD", rec);
+        return stateEngine.add("DirectCircularReference", rec);
     }
 
     private TypeCRec[] cList(TypeCRec... cs) {


### PR DESCRIPTION
While working with hollow for the first time, I was trying to generate types for a fairly complex domain model. Running `HollowObjectMapper#initializeTypeState(Class)` on some of my types would generate `StackOverflowError`s that were kind of tricky to diagnose. 

It turns out that there is a circular reference within the data model I'm working with, not immediately obvious to see (which isn't supported per http://hollow.how/data-modeling/#circular-references).

I thought it might be helpful for others in similar circumstances to have hollow fail fast and point directly to the class that couldn't be mapped.

Sample Exception message:

```
java.lang.IllegalStateException: circular reference detected on field private final java.util.List com.netflix.hollow.core.write.objectmapper.DirectCircularReference.children; this type of relationship is not supported
```