### PR TITLE
Shard large types

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/HollowBlobHeader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowBlobHeader.java
@@ -41,7 +41,6 @@ import java.util.Map;
  */
 public class HollowBlobHeader {
 
-    public static final int HOLLOW_BLOB_OLD_FORMAT_VERSION_HEADER = 1029;
     public static final int HOLLOW_BLOB_VERSION_HEADER = 1030;
 
     private Map<String, String> headerTags = new HashMap<String, String>();

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobHeaderReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobHeaderReader.java
@@ -41,7 +41,7 @@ public class HollowBlobHeaderReader {
         DataInputStream dis = new DataInputStream(is);
 
         int headerVersion = dis.readInt();
-        if(headerVersion != HollowBlobHeader.HOLLOW_BLOB_VERSION_HEADER && headerVersion != HollowBlobHeader.HOLLOW_BLOB_OLD_FORMAT_VERSION_HEADER) {
+        if(headerVersion != HollowBlobHeader.HOLLOW_BLOB_VERSION_HEADER) {
             throw new IOException("The HollowBlob you are trying to read is incompatible.  "
                     + "The expected Hollow blob version was " + HollowBlobHeader.HOLLOW_BLOB_VERSION_HEADER + " but the actual version was " + headerVersion);
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -170,9 +170,9 @@ public class HollowBlobReader {
             }
         } else if (schema instanceof HollowListSchema) {
             if(!filter.doesIncludeType(schema.getName())) {
-                HollowListTypeReadState.discardSnapshot(is);
+                HollowListTypeReadState.discardSnapshot(is, numShards);
             } else {
-                populateTypeStateSnapshot(is, new HollowListTypeReadState(stateEngine, (HollowListSchema)schema));
+                populateTypeStateSnapshot(is, new HollowListTypeReadState(stateEngine, (HollowListSchema)schema, numShards));
             }
         } else if(schema instanceof HollowSetSchema) {
             if(!filter.doesIncludeType(schema.getName())) {
@@ -237,7 +237,7 @@ public class HollowBlobReader {
         if(schema instanceof HollowObjectSchema)
             HollowObjectTypeReadState.discardDelta(dis, (HollowObjectSchema)schema, numShards);
         else if(schema instanceof HollowListSchema)
-            HollowListTypeReadState.discardDelta(dis);
+            HollowListTypeReadState.discardDelta(dis, numShards);
         else if(schema instanceof HollowSetSchema)
             HollowSetTypeReadState.discardDelta(dis);
         else if(schema instanceof HollowMapSchema)

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -176,9 +176,9 @@ public class HollowBlobReader {
             }
         } else if(schema instanceof HollowSetSchema) {
             if(!filter.doesIncludeType(schema.getName())) {
-                HollowSetTypeReadState.discardSnapshot(is);
+                HollowSetTypeReadState.discardSnapshot(is, numShards);
             } else {
-                populateTypeStateSnapshot(is, new HollowSetTypeReadState(stateEngine, (HollowSetSchema)schema));
+                populateTypeStateSnapshot(is, new HollowSetTypeReadState(stateEngine, (HollowSetSchema)schema, numShards));
             }
         } else if(schema instanceof HollowMapSchema) {
             if(!filter.doesIncludeType(schema.getName())) {
@@ -239,7 +239,7 @@ public class HollowBlobReader {
         else if(schema instanceof HollowListSchema)
             HollowListTypeReadState.discardDelta(dis, numShards);
         else if(schema instanceof HollowSetSchema)
-            HollowSetTypeReadState.discardDelta(dis);
+            HollowSetTypeReadState.discardDelta(dis, numShards);
         else if(schema instanceof HollowMapSchema)
             HollowMapTypeReadState.discardDelta(dis);
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -182,9 +182,9 @@ public class HollowBlobReader {
             }
         } else if(schema instanceof HollowMapSchema) {
             if(!filter.doesIncludeType(schema.getName())) {
-                HollowMapTypeReadState.discardSnapshot(is);
+                HollowMapTypeReadState.discardSnapshot(is, numShards);
             } else {
-                populateTypeStateSnapshot(is, new HollowMapTypeReadState(stateEngine, (HollowMapSchema)schema));
+                populateTypeStateSnapshot(is, new HollowMapTypeReadState(stateEngine, (HollowMapSchema)schema, numShards));
             }
         }
         
@@ -241,7 +241,7 @@ public class HollowBlobReader {
         else if(schema instanceof HollowSetSchema)
             HollowSetTypeReadState.discardDelta(dis, numShards);
         else if(schema instanceof HollowMapSchema)
-            HollowMapTypeReadState.discardDelta(dis);
+            HollowMapTypeReadState.discardDelta(dis, numShards);
     }
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -199,13 +199,13 @@ public class HollowBlobReader {
     private String readTypeStateDelta(DataInputStream is, HollowBlobHeader header) throws IOException {
         HollowSchema schema = HollowSchema.readFrom(is);
 
-        readNumShards(is);
+        int numShards = readNumShards(is);
 
         HollowTypeReadState typeState = stateEngine.getTypeState(schema.getName());
         if(typeState != null) {
             typeState.applyDelta(is, schema, stateEngine.getMemoryRecycler());
         } else {
-            discardDelta(is, schema);
+            discardDelta(is, schema, numShards);
         }
         
         return schema.getName();
@@ -233,9 +233,9 @@ public class HollowBlobReader {
     }
 
 
-    private void discardDelta(DataInputStream dis, HollowSchema schema) throws IOException {
+    private void discardDelta(DataInputStream dis, HollowSchema schema, int numShards) throws IOException {
         if(schema instanceof HollowObjectSchema)
-            HollowObjectTypeReadState.discardDelta(dis, (HollowObjectSchema)schema, 1);
+            HollowObjectTypeReadState.discardDelta(dis, (HollowObjectSchema)schema, numShards);
         else if(schema instanceof HollowListSchema)
             HollowListTypeReadState.discardDelta(dis);
         else if(schema instanceof HollowSetSchema)

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
@@ -147,12 +147,12 @@ public abstract class HollowTypeReadState implements HollowTypeDataAccess {
         return stateEngine;
     }
 
-    protected void notifyListenerAboutDeltaChanges(GapEncodedVariableLengthIntegerReader removals, GapEncodedVariableLengthIntegerReader additions) {
+    protected void notifyListenerAboutDeltaChanges(GapEncodedVariableLengthIntegerReader removals, GapEncodedVariableLengthIntegerReader additions, int shardNumber, int numShards) {
         for(HollowTypeStateListener stateListener : stateListeners) {
             removals.reset();
             int removedOrdinal = removals.nextElement();
             while(removedOrdinal < Integer.MAX_VALUE) {
-                stateListener.removedOrdinal(removedOrdinal);
+                stateListener.removedOrdinal((removedOrdinal * numShards) + shardNumber);
                 removals.advance();
                 removedOrdinal = removals.nextElement();
             }
@@ -160,7 +160,7 @@ public abstract class HollowTypeReadState implements HollowTypeDataAccess {
             additions.reset();
             int addedOrdinal = additions.nextElement();
             while(addedOrdinal < Integer.MAX_VALUE) {
-                stateListener.addedOrdinal(addedOrdinal);
+                stateListener.addedOrdinal((addedOrdinal * numShards) + shardNumber);
                 additions.advance();
                 addedOrdinal = additions.nextElement();
             }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
@@ -193,5 +193,10 @@ public abstract class HollowTypeReadState implements HollowTypeDataAccess {
      * @return an approximate accounting of the current cost of the "ordinal holes" in this type state.
      */
     public abstract long getApproximateHoleCostInBytes();
+    
+    /**
+     * @return The number of shards into which this type is split.  Sharding is transparent, so this has no effect on normal usage.
+     */
+    public abstract int numShards();
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeDataElements.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeDataElements.java
@@ -75,23 +75,28 @@ public class HollowListTypeDataElements {
         elementArray = FixedLengthElementArray.deserializeFrom(dis, memoryRecycler);
     }
 
-    static void discardFromStream(DataInputStream dis, boolean isDelta) throws IOException {
-        VarInt.readVInt(dis); /// max ordinal
-
-        if(isDelta) {
-            /// addition/removal ordinals
-            GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
-            GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
+    static void discardFromStream(DataInputStream dis, int numShards, boolean isDelta) throws IOException {
+        if(numShards > 1)
+            VarInt.readVInt(dis); /// max ordinal
+        
+        for(int i=0;i<numShards;i++) {
+            VarInt.readVInt(dis); /// max ordinal
+    
+            if(isDelta) {
+                /// addition/removal ordinals
+                GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
+                GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
+            }
+    
+            /// statistics
+            VarInt.readVInt(dis);
+            VarInt.readVInt(dis);
+            VarInt.readVLong(dis);
+    
+            /// fixed-length data
+            FixedLengthElementArray.discardFrom(dis);
+            FixedLengthElementArray.discardFrom(dis);
         }
-
-        /// statistics
-        VarInt.readVInt(dis);
-        VarInt.readVInt(dis);
-        VarInt.readVLong(dis);
-
-        /// fixed-length data
-        FixedLengthElementArray.discardFrom(dis);
-        FixedLengthElementArray.discardFrom(dis);
     }
 
     public void applyDelta(HollowListTypeDataElements fromData, HollowListTypeDataElements deltaData) {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -70,7 +70,7 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
         nextData.applyDelta(currentData, deltaData);
         HollowListTypeDataElements oldData = currentData;
         setCurrentData(nextData);
-        notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions);
+        notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, 0, 1);
         deltaData.destroy();
         oldData.destroy();
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -225,4 +225,9 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
         return totalApproximateHoleCostInBytes;
     }
 
+    @Override
+    public int numShards() {
+        return shards.length;
+    }
+
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -100,6 +100,7 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
             notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
             deltaData.destroy();
             oldData.destroy();
+            stateEngine.getMemoryRecycler().swap();
         }
         
         if(shards.length == 1)

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateShard.java
@@ -103,7 +103,7 @@ class HollowListTypeReadStateShard {
                 int shardOrdinal = ordinal / numShards;
                 int size = size(shardOrdinal);
     
-                checksum.applyInt(shardOrdinal);
+                checksum.applyInt(ordinal);
                 for(int i=0;i<size;i++)
                     checksum.applyInt(getElementOrdinal(shardOrdinal, i));
             }
@@ -130,6 +130,6 @@ class HollowListTypeReadStateShard {
             holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
         }
         
-        return (holeBits * (long)currentData.bitsPerListPointer) / 8;
+        return holeBits / 8;
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateShard.java
@@ -1,0 +1,135 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.read.engine.list;
+
+import com.netflix.hollow.tools.checksum.HollowChecksum;
+import java.util.BitSet;
+
+class HollowListTypeReadStateShard {
+
+    private HollowListTypeDataElements currentData;
+    private volatile HollowListTypeDataElements currentDataVolatile;
+
+    public int getElementOrdinal(int ordinal, int listIndex) {
+        HollowListTypeDataElements currentData;
+        int elementOrdinal;
+
+        do {
+            long startAndEndElement;
+
+            do {
+                currentData = this.currentData;
+
+                long fixedLengthOffset = currentData.bitsPerListPointer * ordinal;
+
+                startAndEndElement = ordinal == 0 ?
+                        currentData.listPointerArray.getElementValue(fixedLengthOffset, currentData.bitsPerListPointer) << currentData.bitsPerListPointer :
+                            currentData.listPointerArray.getElementValue(fixedLengthOffset - currentData.bitsPerListPointer, currentData.bitsPerListPointer * 2);
+
+            } while(readWasUnsafe(currentData));
+
+            long endElement = startAndEndElement >> currentData.bitsPerListPointer;
+            long startElement = startAndEndElement &  ((1 << currentData.bitsPerListPointer) - 1);
+
+            long elementIndex = startElement + listIndex;
+
+            if(elementIndex >= endElement)
+                throw new ArrayIndexOutOfBoundsException("Array index out of bounds: " + listIndex + ", list size: " + (endElement - startElement));
+
+            elementOrdinal = (int)currentData.elementArray.getElementValue(elementIndex * currentData.bitsPerElement, currentData.bitsPerElement);
+        } while(readWasUnsafe(currentData));
+
+        return elementOrdinal;
+    }
+
+    public int size(int ordinal) {
+        HollowListTypeDataElements currentData;
+        int size;
+
+        do {
+            currentData = this.currentData;
+
+            long fixedLengthOffset = currentData.bitsPerListPointer * ordinal;
+
+            long startAndEndElement = ordinal == 0 ?
+                    currentData.listPointerArray.getElementValue(fixedLengthOffset, currentData.bitsPerListPointer) << currentData.bitsPerListPointer :
+                        currentData.listPointerArray.getElementValue(fixedLengthOffset - currentData.bitsPerListPointer, currentData.bitsPerListPointer * 2);
+
+            long endElement = startAndEndElement >> currentData.bitsPerListPointer;
+            long startElement = startAndEndElement &  ((1 << currentData.bitsPerListPointer) - 1);
+
+            size = (int)(endElement - startElement);
+        } while(readWasUnsafe(currentData));
+
+        return size;
+    }
+
+    void invalidate() {
+        setCurrentData(null);
+    }
+
+    HollowListTypeDataElements currentDataElements() {
+        return currentData;
+    }
+
+    private boolean readWasUnsafe(HollowListTypeDataElements data) {
+        return data != currentDataVolatile;
+    }
+
+    void setCurrentData(HollowListTypeDataElements data) {
+        this.currentData = data;
+        this.currentDataVolatile = data;
+    }
+
+    protected void applyToChecksum(HollowChecksum checksum, BitSet populatedOrdinals, int shardNumber, int numShards) {
+        int ordinal = populatedOrdinals.nextSetBit(0);
+        while(ordinal != -1) {
+            if((ordinal & (numShards - 1)) == shardNumber) {
+                int shardOrdinal = ordinal / numShards;
+                int size = size(shardOrdinal);
+    
+                checksum.applyInt(shardOrdinal);
+                for(int i=0;i<size;i++)
+                    checksum.applyInt(getElementOrdinal(shardOrdinal, i));
+            }
+
+            ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
+        }
+    }
+
+    public long getApproximateHeapFootprintInBytes() {
+        long requiredListPointerBits = ((long)currentData.bitsPerListPointer * (currentData.maxOrdinal + 1));
+        long requiredElementBits = (currentData.totalNumberOfElements * currentData.bitsPerElement);
+        long requiredBits = requiredListPointerBits + requiredElementBits;
+        return requiredBits / 8;
+    }
+    
+    public long getApproximateHoleCostInBytes(BitSet populatedOrdinals, int shardNumber, int numShards) {
+        long holeBits = 0;
+        
+        int holeOrdinal = populatedOrdinals.nextClearBit(0);
+        while(holeOrdinal <= currentData.maxOrdinal) {
+            if((holeOrdinal & (numShards - 1)) == shardNumber)
+                holeBits += currentData.bitsPerListPointer;
+            
+            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
+        }
+        
+        return (holeBits * (long)currentData.bitsPerListPointer) / 8;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeDataElements.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeDataElements.java
@@ -88,25 +88,30 @@ public class HollowMapTypeDataElements {
         entryArray = FixedLengthElementArray.deserializeFrom(dis, memoryRecycler);
     }
 
-    static void discardFromStream(DataInputStream dis, boolean isDelta) throws IOException {
-        VarInt.readVInt(dis); /// max ordinal
+    static void discardFromStream(DataInputStream dis, int numShards, boolean isDelta) throws IOException {
+        if(numShards > 1)
+            VarInt.readVInt(dis); /// max ordinal
 
-        if(isDelta) {
-            /// addition/removal ordinals
-            GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
-            GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
+        for(int i=0;i<numShards;i++) {
+            VarInt.readVInt(dis); /// max ordinal
+
+            if(isDelta) {
+                /// addition/removal ordinals
+                GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
+                GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
+            }
+    
+            /// statistics
+            VarInt.readVInt(dis);
+            VarInt.readVInt(dis);
+            VarInt.readVInt(dis);
+            VarInt.readVInt(dis);
+            VarInt.readVLong(dis);
+    
+            /// fixed length data
+            FixedLengthElementArray.discardFrom(dis);
+            FixedLengthElementArray.discardFrom(dis);
         }
-
-        /// statistics
-        VarInt.readVInt(dis);
-        VarInt.readVInt(dis);
-        VarInt.readVInt(dis);
-        VarInt.readVInt(dis);
-        VarInt.readVLong(dis);
-
-        /// fixed length data
-        FixedLengthElementArray.discardFrom(dis);
-        FixedLengthElementArray.discardFrom(dis);
     }
 
     public void applyDelta(HollowMapTypeDataElements fromData, HollowMapTypeDataElements deltaData) {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -76,7 +76,7 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
         nextData.applyDelta(currentData, deltaData);
         HollowMapTypeDataElements oldData = currentData;
         setCurrentData(nextData);
-        notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions);
+        notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, 0, 1);
         deltaData.destroy();
         oldData.destroy();
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -105,6 +105,7 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
             notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
             deltaData.destroy();
             oldData.destroy();
+            stateEngine.getMemoryRecycler().swap();
         }
         
         if(shards.length == 1)

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -17,28 +17,26 @@
  */
 package com.netflix.hollow.core.read.engine.map;
 
-import com.netflix.hollow.core.memory.encoding.HashCodes;
-
-import com.netflix.hollow.tools.checksum.HollowChecksum;
-import com.netflix.hollow.core.schema.HollowMapSchema;
-import com.netflix.hollow.core.schema.HollowSchema;
-import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
-import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
-import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
 import com.netflix.hollow.api.sampling.DisabledSamplingDirector;
 import com.netflix.hollow.api.sampling.HollowMapSampler;
 import com.netflix.hollow.api.sampling.HollowSampler;
 import com.netflix.hollow.api.sampling.HollowSamplingDirector;
-import com.netflix.hollow.core.read.filter.HollowFilterConfig;
+import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
+import com.netflix.hollow.core.memory.encoding.VarInt;
+import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.core.read.dataaccess.HollowMapTypeDataAccess;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
-import com.netflix.hollow.core.read.engine.SetMapKeyHasher;
 import com.netflix.hollow.core.read.engine.SnapshotPopulatedOrdinalsReader;
+import com.netflix.hollow.core.read.filter.HollowFilterConfig;
 import com.netflix.hollow.core.read.iterator.EmptyMapOrdinalIterator;
 import com.netflix.hollow.core.read.iterator.HollowMapEntryOrdinalIterator;
 import com.netflix.hollow.core.read.iterator.HollowMapEntryOrdinalIteratorImpl;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.tools.checksum.HollowChecksum;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.BitSet;
@@ -48,71 +46,95 @@ import java.util.BitSet;
  */
 public class HollowMapTypeReadState extends HollowTypeReadState implements HollowMapTypeDataAccess {
 
-    private HollowMapTypeDataElements currentData;
-    private volatile HollowMapTypeDataElements currentDataVolatile;
-
     private final HollowMapSampler sampler;
     
+    private final int shardNumberMask;
+    private final int shardOrdinalShift;
+    private final HollowMapTypeReadStateShard shards[];
+    
     private HollowPrimaryKeyValueDeriver keyDeriver;
+    
+    private int maxOrdinal;
 
-    public HollowMapTypeReadState(HollowReadStateEngine stateEngine, HollowMapSchema schema) {
+    public HollowMapTypeReadState(HollowReadStateEngine stateEngine, HollowMapSchema schema, int numShards) {
         super(stateEngine, schema);
         this.sampler = new HollowMapSampler(schema.getName(), DisabledSamplingDirector.INSTANCE);
+        this.shardNumberMask = numShards - 1;
+        this.shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(numShards);
+        
+        if(numShards < 1 || 1 << shardOrdinalShift != numShards)
+            throw new IllegalArgumentException("Number of shards must be a power of 2!");
+        
+        HollowMapTypeReadStateShard shards[] = new HollowMapTypeReadStateShard[numShards];
+        for(int i=0;i<shards.length;i++)
+            shards[i] = new HollowMapTypeReadStateShard();
+        
+        this.shards = shards;
+        
     }
 
     @Override
     public void readSnapshot(DataInputStream dis, ArraySegmentRecycler memoryRecycler) throws IOException {
-        HollowMapTypeDataElements currentData = new HollowMapTypeDataElements(memoryRecycler);
-        currentData.readSnapshot(dis);
-        setCurrentData(currentData);
+        if(shards.length > 1)
+            maxOrdinal = VarInt.readVInt(dis);
+        
+        for(int i=0;i<shards.length;i++) {
+            HollowMapTypeDataElements snapshotData = new HollowMapTypeDataElements(memoryRecycler);
+            snapshotData.readSnapshot(dis);
+            shards[i].setCurrentData(snapshotData);
+        }
+        
+        if(shards.length == 1)
+            maxOrdinal = shards[0].currentDataElements().maxOrdinal;
+        
         SnapshotPopulatedOrdinalsReader.readOrdinals(dis, stateListeners);
     }
 
     @Override
     public void applyDelta(DataInputStream dis, HollowSchema schema, ArraySegmentRecycler memoryRecycler) throws IOException {
-        HollowMapTypeDataElements deltaData = new HollowMapTypeDataElements(memoryRecycler);
-        HollowMapTypeDataElements nextData = new HollowMapTypeDataElements(memoryRecycler);
-        deltaData.readDelta(dis);
-        nextData.applyDelta(currentData, deltaData);
-        HollowMapTypeDataElements oldData = currentData;
-        setCurrentData(nextData);
-        notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, 0, 1);
-        deltaData.destroy();
-        oldData.destroy();
+        if(shards.length > 1)
+            maxOrdinal = VarInt.readVInt(dis);
+
+        for(int i=0;i<shards.length;i++) {
+            HollowMapTypeDataElements deltaData = new HollowMapTypeDataElements(memoryRecycler);
+            HollowMapTypeDataElements nextData = new HollowMapTypeDataElements(memoryRecycler);
+            deltaData.readDelta(dis);
+            HollowMapTypeDataElements oldData = shards[i].currentDataElements();
+            nextData.applyDelta(oldData, deltaData);
+            shards[i].setCurrentData(nextData);
+            notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+            deltaData.destroy();
+            oldData.destroy();
+        }
+        
+        if(shards.length == 1)
+            maxOrdinal = shards[0].currentDataElements().maxOrdinal;
     }
 
-    public static void discardSnapshot(DataInputStream dis) throws IOException {
-        discardType(dis, false);
+    public static void discardSnapshot(DataInputStream dis, int numShards) throws IOException {
+        discardType(dis, numShards, false);
     }
 
-    public static void discardDelta(DataInputStream dis) throws IOException {
-        discardType(dis, true);
+    public static void discardDelta(DataInputStream dis, int numShards) throws IOException {
+        discardType(dis, numShards, true);
     }
 
-    public static void discardType(DataInputStream dis, boolean delta) throws IOException {
-        HollowMapTypeDataElements.discardFromStream(dis, delta);
+    public static void discardType(DataInputStream dis, int numShards, boolean delta) throws IOException {
+        HollowMapTypeDataElements.discardFromStream(dis, numShards, delta);
         if(!delta)
             SnapshotPopulatedOrdinalsReader.discardOrdinals(dis);
     }
 
     @Override
     public int maxOrdinal() {
-        return currentData.maxOrdinal;
+        return maxOrdinal;
     }
 
     @Override
     public int size(int ordinal) {
         sampler.recordSize();
 
-        HollowMapTypeDataElements currentData;
-        int size;
-
-        do {
-            currentData = this.currentData;
-            size = (int)currentData.mapPointerAndSizeArray.getElementValue((long)(ordinal * currentData.bitsPerFixedLengthMapPortion) + currentData.bitsPerMapPointer, currentData.bitsPerMapSizeValue);
-        } while(readWasUnsafe(currentData));
-
-        return size;
+        return shards[ordinal & shardNumberMask].size(ordinal >> shardOrdinalShift);
     }
 
     @Override
@@ -123,40 +145,8 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     @Override
     public int get(int ordinal, int keyOrdinal, int hashCode) {
         sampler.recordGet();
-
-        HollowMapTypeDataElements currentData;
-        int valueOrdinal;
-
-        threadsafe:
-        do {
-            long startBucket;
-            long endBucket;
-            do {
-                currentData = this.currentData;
-
-                startBucket = ordinal == 0 ? 0 : currentData.mapPointerAndSizeArray.getElementValue((long)(ordinal - 1) * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
-                endBucket = currentData.mapPointerAndSizeArray.getElementValue((long)ordinal * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
-            } while(readWasUnsafe(currentData));
-
-            hashCode = HashCodes.hashInt(hashCode);
-            long bucket = startBucket + (hashCode & (endBucket - startBucket - 1));
-            int bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
-
-            while(bucketKeyOrdinal != currentData.emptyBucketKeyValue) {
-                if(bucketKeyOrdinal == keyOrdinal) {
-                    valueOrdinal = getBucketValueByAbsoluteIndex(currentData, bucket);
-                    continue threadsafe;
-                }
-                bucket++;
-                if(bucket == endBucket)
-                    bucket = startBucket;
-                bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
-            }
-
-            valueOrdinal = -1;
-        } while(readWasUnsafe(currentData));
-
-        return valueOrdinal;
+        
+        return shards[ordinal & shardNumberMask].get(ordinal >> shardOrdinalShift, keyOrdinal, hashCode);
     }
     
     @Override
@@ -171,41 +161,7 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
         if(hashKey.length != fieldTypes.length)
             return -1;
 
-        int hashCode = SetMapKeyHasher.hash(hashKey, fieldTypes);
-
-        HollowMapTypeDataElements currentData;
-
-        threadsafe:
-        do {
-            long startBucket;
-            long endBucket;
-            do {
-                currentData = this.currentData;
-
-                startBucket = ordinal == 0 ? 0 : currentData.mapPointerAndSizeArray.getElementValue((long)(ordinal - 1) * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
-                endBucket = currentData.mapPointerAndSizeArray.getElementValue((long)ordinal * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
-            } while(readWasUnsafe(currentData));
-
-            long bucket = startBucket + (hashCode & (endBucket - startBucket - 1));
-            int bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
-
-            while(bucketKeyOrdinal != currentData.emptyBucketKeyValue) {
-                if(readWasUnsafe(currentData))
-                    continue threadsafe;
-                
-                if(keyDeriver.keyMatches(bucketKeyOrdinal, hashKey)) {
-                    return bucketKeyOrdinal;
-                }
-                    
-                bucket++;
-                if(bucket == endBucket)
-                    bucket = startBucket;
-                bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
-            }
-
-        } while(readWasUnsafe(currentData));
-
-        return -1;
+        return shards[ordinal & shardNumberMask].findKey(ordinal >> shardOrdinalShift, hashKey);
     }
 
     @Override
@@ -225,45 +181,7 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
         if(hashKey.length != fieldTypes.length)
             return -1L;
 
-        int hashCode = SetMapKeyHasher.hash(hashKey, fieldTypes);
-
-        HollowMapTypeDataElements currentData;
-
-        threadsafe:
-        do {
-            long startBucket;
-            long endBucket;
-            do {
-                currentData = this.currentData;
-
-                startBucket = ordinal == 0 ? 0 : currentData.mapPointerAndSizeArray.getElementValue((long)(ordinal - 1) * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
-                endBucket = currentData.mapPointerAndSizeArray.getElementValue((long)ordinal * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
-            } while(readWasUnsafe(currentData));
-
-            long bucket = startBucket + (hashCode & (endBucket - startBucket - 1));
-            int bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
-
-            while(bucketKeyOrdinal != currentData.emptyBucketKeyValue) {
-                if(readWasUnsafe(currentData))
-                    continue threadsafe;
-                
-                if(keyDeriver.keyMatches(bucketKeyOrdinal, hashKey)) {
-                    long valueOrdinal = getBucketValueByAbsoluteIndex(currentData, bucket);
-                    if(readWasUnsafe(currentData))
-                        continue threadsafe;
-                    
-                    return (long)bucketKeyOrdinal << 32 | valueOrdinal;
-                }
-                    
-                bucket++;
-                if(bucket == endBucket)
-                    bucket = startBucket;
-                bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
-            }
-
-        } while(readWasUnsafe(currentData));
-
-        return -1L;
+        return shards[ordinal & shardNumberMask].findEntry(ordinal >> shardOrdinalShift, hashKey);
     }
 
     @Override
@@ -286,32 +204,7 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
 
     @Override
     public long relativeBucket(int ordinal, int bucketIndex) {
-        HollowMapTypeDataElements currentData;
-        do {
-            long absoluteBucketIndex;
-            do {
-                currentData = this.currentData;
-                absoluteBucketIndex = getAbsoluteBucketStart(currentData, ordinal) + bucketIndex;
-            } while(readWasUnsafe(currentData));
-            long key = getBucketKeyByAbsoluteIndex(currentData, absoluteBucketIndex);
-            if(key == currentData.emptyBucketKeyValue)
-                return -1;
-
-            return key << 32 | getBucketValueByAbsoluteIndex(currentData, absoluteBucketIndex);
-        } while(readWasUnsafe(currentData));
-    }
-
-    private long getAbsoluteBucketStart(HollowMapTypeDataElements currentData, int ordinal) {
-        long startBucket = ordinal == 0 ? 0 : currentData.mapPointerAndSizeArray.getElementValue((long)(ordinal - 1) * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
-        return startBucket;
-    }
-
-    private int getBucketKeyByAbsoluteIndex(HollowMapTypeDataElements currentData, long absoluteBucketIndex) {
-        return (int)currentData.entryArray.getElementValue(absoluteBucketIndex * currentData.bitsPerMapEntry, currentData.bitsPerKeyElement);
-    }
-
-    private int getBucketValueByAbsoluteIndex(HollowMapTypeDataElements currentData, long absoluteBucketIndex) {
-        return (int)currentData.entryArray.getElementValue((absoluteBucketIndex * currentData.bitsPerMapEntry) + currentData.bitsPerKeyElement, currentData.bitsPerValueElement);
+        return shards[ordinal & shardNumberMask].relativeBucket(ordinal >> shardOrdinalShift, bucketIndex);
     }
 
     @Override
@@ -342,20 +235,23 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     @Override
     protected void invalidate() {
         stateListeners = EMPTY_LISTENERS;
-        setCurrentData(null);
+        for(int i=0;i<shards.length;i++)
+            shards[i].invalidate();
     }
 
-    HollowMapTypeDataElements currentDataElements() {
-        return currentData;
-    }
-
-    private boolean readWasUnsafe(HollowMapTypeDataElements data) {
-        return data != currentDataVolatile;
+    HollowMapTypeDataElements[] currentDataElements() {
+        HollowMapTypeDataElements currentDataElements[] = new HollowMapTypeDataElements[shards.length];
+        
+        for(int i=0;i<shards.length;i++)
+            currentDataElements[i] = shards[i].currentDataElements();
+        
+        return currentDataElements;
     }
 
     void setCurrentData(HollowMapTypeDataElements data) {
-        this.currentData = data;
-        this.currentDataVolatile = data;
+        if(shards.length > 1)
+            throw new UnsupportedOperationException("Cannot directly set data on sharded type state");
+        shards[0].setCurrentData(data);
     }
 
     @Override
@@ -365,38 +261,30 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
         
         BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
 
-        int ordinal = populatedOrdinals.nextSetBit(0);
-        while(ordinal != -1) {
-            int numBuckets = HashCodes.hashTableSize(size(ordinal));
-            long offset = getAbsoluteBucketStart(currentData, ordinal);
-
-            checksum.applyInt(ordinal);
-            for(int i=0;i<numBuckets;i++) {
-                int bucketKey = getBucketKeyByAbsoluteIndex(currentData, offset + i);
-                if(bucketKey != currentData.emptyBucketKeyValue) {
-                    checksum.applyInt(i);
-                    checksum.applyInt(bucketKey);
-                    checksum.applyInt(getBucketValueByAbsoluteIndex(currentData, offset + i));
-                }
-            }
-
-            ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
-        }
+        for(int i=0;i<shards.length;i++)
+            shards[i].applyToChecksum(checksum, populatedOrdinals, i, shards.length);
     }
 
-	@Override
-	public long getApproximateHeapFootprintInBytes() {
-		long requiredBitsForMapPointers = (long)currentData.bitsPerFixedLengthMapPortion * (currentData.maxOrdinal + 1);
-		long requiredBitsForMapBuckets = (long)currentData.bitsPerMapEntry * currentData.totalNumberOfBuckets;
-		long requiredBits = requiredBitsForMapPointers + requiredBitsForMapBuckets;
-		return requiredBits / 8;
-	}
-	
+    @Override
+    public long getApproximateHeapFootprintInBytes() {
+        long totalApproximateHeapFootprintInBytes = 0;
+        
+        for(int i=0;i<shards.length;i++)
+            totalApproximateHeapFootprintInBytes += shards[i].getApproximateHeapFootprintInBytes();
+        
+        return totalApproximateHeapFootprintInBytes;
+    }
+    
     @Override
     public long getApproximateHoleCostInBytes() {
-        BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
+        long totalApproximateHoleCostInBytes = 0;
         
-        return ((long)(populatedOrdinals.length() - populatedOrdinals.cardinality()) * (long)currentData.bitsPerFixedLengthMapPortion) / 8; 
+        BitSet populatedOrdinals = getPopulatedOrdinals();
+
+        for(int i=0;i<shards.length;i++)
+            totalApproximateHoleCostInBytes += shards[i].getApproximateHoleCostInBytes(populatedOrdinals, i, shards.length);
+        
+        return totalApproximateHoleCostInBytes;
     }
     
     public HollowPrimaryKeyValueDeriver getKeyDeriver() {
@@ -406,6 +294,9 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     public void buildKeyDeriver() {
         if(getSchema().getHashKey() != null)
             this.keyDeriver = new HollowPrimaryKeyValueDeriver(getSchema().getHashKey(), getStateEngine());
+        
+        for(int i=0;i<shards.length;i++)
+            shards[i].setKeyDeriver(keyDeriver);
     }
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -300,4 +300,9 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
             shards[i].setKeyDeriver(keyDeriver);
     }
 
+    @Override
+    public int numShards() {
+        return shards.length;
+    }
+
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadStateShard.java
@@ -1,0 +1,240 @@
+package com.netflix.hollow.core.read.engine.map;
+
+import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
+import com.netflix.hollow.core.memory.encoding.HashCodes;
+import com.netflix.hollow.core.read.engine.SetMapKeyHasher;
+import com.netflix.hollow.tools.checksum.HollowChecksum;
+import java.util.BitSet;
+
+class HollowMapTypeReadStateShard {
+    
+    private HollowMapTypeDataElements currentData;
+    private volatile HollowMapTypeDataElements currentDataVolatile;
+
+    private HollowPrimaryKeyValueDeriver keyDeriver;
+
+    public int size(int ordinal) {
+        HollowMapTypeDataElements currentData;
+        int size;
+
+        do {
+            currentData = this.currentData;
+            size = (int)currentData.mapPointerAndSizeArray.getElementValue((long)(ordinal * currentData.bitsPerFixedLengthMapPortion) + currentData.bitsPerMapPointer, currentData.bitsPerMapSizeValue);
+        } while(readWasUnsafe(currentData));
+
+        return size;
+    }
+
+    public int get(int ordinal, int keyOrdinal, int hashCode) {
+        HollowMapTypeDataElements currentData;
+        int valueOrdinal;
+
+        threadsafe:
+        do {
+            long startBucket;
+            long endBucket;
+            do {
+                currentData = this.currentData;
+
+                startBucket = ordinal == 0 ? 0 : currentData.mapPointerAndSizeArray.getElementValue((long)(ordinal - 1) * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
+                endBucket = currentData.mapPointerAndSizeArray.getElementValue((long)ordinal * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
+            } while(readWasUnsafe(currentData));
+
+            hashCode = HashCodes.hashInt(hashCode);
+            long bucket = startBucket + (hashCode & (endBucket - startBucket - 1));
+            int bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
+
+            while(bucketKeyOrdinal != currentData.emptyBucketKeyValue) {
+                if(bucketKeyOrdinal == keyOrdinal) {
+                    valueOrdinal = getBucketValueByAbsoluteIndex(currentData, bucket);
+                    continue threadsafe;
+                }
+                bucket++;
+                if(bucket == endBucket)
+                    bucket = startBucket;
+                bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
+            }
+
+            valueOrdinal = -1;
+        } while(readWasUnsafe(currentData));
+
+        return valueOrdinal;
+    }
+    
+    public int findKey(int ordinal, Object... hashKey) {
+        int hashCode = SetMapKeyHasher.hash(hashKey, keyDeriver.getFieldTypes());
+
+        HollowMapTypeDataElements currentData;
+
+        threadsafe:
+        do {
+            long startBucket;
+            long endBucket;
+            do {
+                currentData = this.currentData;
+
+                startBucket = ordinal == 0 ? 0 : currentData.mapPointerAndSizeArray.getElementValue((long)(ordinal - 1) * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
+                endBucket = currentData.mapPointerAndSizeArray.getElementValue((long)ordinal * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
+            } while(readWasUnsafe(currentData));
+
+            long bucket = startBucket + (hashCode & (endBucket - startBucket - 1));
+            int bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
+
+            while(bucketKeyOrdinal != currentData.emptyBucketKeyValue) {
+                if(readWasUnsafe(currentData))
+                    continue threadsafe;
+                
+                if(keyDeriver.keyMatches(bucketKeyOrdinal, hashKey)) {
+                    return bucketKeyOrdinal;
+                }
+                    
+                bucket++;
+                if(bucket == endBucket)
+                    bucket = startBucket;
+                bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
+            }
+
+        } while(readWasUnsafe(currentData));
+
+        return -1;
+    }
+
+    public long findEntry(int ordinal, Object... hashKey) {
+        int hashCode = SetMapKeyHasher.hash(hashKey, keyDeriver.getFieldTypes());
+
+        HollowMapTypeDataElements currentData;
+
+        threadsafe:
+        do {
+            long startBucket;
+            long endBucket;
+            do {
+                currentData = this.currentData;
+
+                startBucket = ordinal == 0 ? 0 : currentData.mapPointerAndSizeArray.getElementValue((long)(ordinal - 1) * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
+                endBucket = currentData.mapPointerAndSizeArray.getElementValue((long)ordinal * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
+            } while(readWasUnsafe(currentData));
+
+            long bucket = startBucket + (hashCode & (endBucket - startBucket - 1));
+            int bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
+
+            while(bucketKeyOrdinal != currentData.emptyBucketKeyValue) {
+                if(readWasUnsafe(currentData))
+                    continue threadsafe;
+                
+                if(keyDeriver.keyMatches(bucketKeyOrdinal, hashKey)) {
+                    long valueOrdinal = getBucketValueByAbsoluteIndex(currentData, bucket);
+                    if(readWasUnsafe(currentData))
+                        continue threadsafe;
+                    
+                    return (long)bucketKeyOrdinal << 32 | valueOrdinal;
+                }
+                    
+                bucket++;
+                if(bucket == endBucket)
+                    bucket = startBucket;
+                bucketKeyOrdinal = getBucketKeyByAbsoluteIndex(currentData, bucket);
+            }
+
+        } while(readWasUnsafe(currentData));
+
+        return -1L;
+    }
+
+    public long relativeBucket(int ordinal, int bucketIndex) {
+        HollowMapTypeDataElements currentData;
+        do {
+            long absoluteBucketIndex;
+            do {
+                currentData = this.currentData;
+                absoluteBucketIndex = getAbsoluteBucketStart(currentData, ordinal) + bucketIndex;
+            } while(readWasUnsafe(currentData));
+            long key = getBucketKeyByAbsoluteIndex(currentData, absoluteBucketIndex);
+            if(key == currentData.emptyBucketKeyValue)
+                return -1;
+
+            return key << 32 | getBucketValueByAbsoluteIndex(currentData, absoluteBucketIndex);
+        } while(readWasUnsafe(currentData));
+    }
+
+    private long getAbsoluteBucketStart(HollowMapTypeDataElements currentData, int ordinal) {
+        long startBucket = ordinal == 0 ? 0 : currentData.mapPointerAndSizeArray.getElementValue((long)(ordinal - 1) * currentData.bitsPerFixedLengthMapPortion, currentData.bitsPerMapPointer);
+        return startBucket;
+    }
+
+    private int getBucketKeyByAbsoluteIndex(HollowMapTypeDataElements currentData, long absoluteBucketIndex) {
+        return (int)currentData.entryArray.getElementValue(absoluteBucketIndex * currentData.bitsPerMapEntry, currentData.bitsPerKeyElement);
+    }
+
+    private int getBucketValueByAbsoluteIndex(HollowMapTypeDataElements currentData, long absoluteBucketIndex) {
+        return (int)currentData.entryArray.getElementValue((absoluteBucketIndex * currentData.bitsPerMapEntry) + currentData.bitsPerKeyElement, currentData.bitsPerValueElement);
+    }
+
+    void invalidate() {
+        setCurrentData(null);
+    }
+
+    HollowMapTypeDataElements currentDataElements() {
+        return currentData;
+    }
+
+    private boolean readWasUnsafe(HollowMapTypeDataElements data) {
+        return data != currentDataVolatile;
+    }
+
+    void setCurrentData(HollowMapTypeDataElements data) {
+        this.currentData = data;
+        this.currentDataVolatile = data;
+    }
+
+    protected void applyToChecksum(HollowChecksum checksum, BitSet populatedOrdinals, int shardNumber, int numShards) {
+        int ordinal = populatedOrdinals.nextSetBit(0);
+        while(ordinal != -1) {
+            if((ordinal & (numShards - 1)) == shardNumber) {
+                int shardOrdinal = ordinal / numShards;
+                int numBuckets = HashCodes.hashTableSize(size(shardOrdinal));
+                long offset = getAbsoluteBucketStart(currentData, shardOrdinal);
+    
+                checksum.applyInt(ordinal);
+                for(int i=0;i<numBuckets;i++) {
+                    int bucketKey = getBucketKeyByAbsoluteIndex(currentData, offset + i);
+                    if(bucketKey != currentData.emptyBucketKeyValue) {
+                        checksum.applyInt(i);
+                        checksum.applyInt(bucketKey);
+                        checksum.applyInt(getBucketValueByAbsoluteIndex(currentData, offset + i));
+                    }
+                }
+            }
+
+            ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
+        }
+    }
+
+    public long getApproximateHeapFootprintInBytes() {
+        long requiredBitsForMapPointers = (long)currentData.bitsPerFixedLengthMapPortion * (currentData.maxOrdinal + 1);
+        long requiredBitsForMapBuckets = (long)currentData.bitsPerMapEntry * currentData.totalNumberOfBuckets;
+        long requiredBits = requiredBitsForMapPointers + requiredBitsForMapBuckets;
+        return requiredBits / 8;
+    }
+    
+    public long getApproximateHoleCostInBytes(BitSet populatedOrdinals, int shardNumber, int numShards) {
+        long holeBits = 0;
+        
+        int holeOrdinal = populatedOrdinals.nextClearBit(0);
+        while(holeOrdinal <= currentData.maxOrdinal) {
+            if((holeOrdinal & (numShards - 1)) == shardNumber)
+                holeBits += currentData.bitsPerFixedLengthMapPortion;
+            
+            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
+        }
+        
+        return holeBits / 8;
+    }
+
+    
+    public void setKeyDeriver(HollowPrimaryKeyValueDeriver keyDeriver) {
+        this.keyDeriver = keyDeriver;
+    }
+
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectDeltaHistoricalStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectDeltaHistoricalStateCreator.java
@@ -136,15 +136,15 @@ public class HollowObjectDeltaHistoricalStateCreator {
 
     private void copyRecord(int ordinal) {
         int shard = ordinal & shardNumberMask;
-        int translatedOrdinal = ordinal >> shardOrdinalShift; 
+        int shardOrdinal = ordinal >> shardOrdinalShift; 
 
         for(int i=0;i<historicalDataElements.schema.numFields();i++) {
             if(historicalDataElements.varLengthData[i] == null) {
-                long value = stateEngineDataElements[shard].fixedLengthData.getLargeElementValue(((long)translatedOrdinal * stateEngineDataElements[shard].bitsPerRecord) + stateEngineDataElements[shard].bitOffsetPerField[i], stateEngineDataElements[shard].bitsPerField[i]);
+                long value = stateEngineDataElements[shard].fixedLengthData.getLargeElementValue(((long)shardOrdinal * stateEngineDataElements[shard].bitsPerRecord) + stateEngineDataElements[shard].bitOffsetPerField[i], stateEngineDataElements[shard].bitsPerField[i]);
                 historicalDataElements.fixedLengthData.setElementValue(((long)nextOrdinal * historicalDataElements.bitsPerRecord) + historicalDataElements.bitOffsetPerField[i], historicalDataElements.bitsPerField[i], value);
             } else {
-                long fromStartByte = varLengthStartByte(shard, translatedOrdinal, i);
-                long fromEndByte = varLengthEndByte(shard, translatedOrdinal, i);
+                long fromStartByte = varLengthStartByte(shard, shardOrdinal, i);
+                long fromEndByte = varLengthEndByte(shard, shardOrdinal, i);
                 long size = fromEndByte - fromStartByte;
 
                 historicalDataElements.fixedLengthData.setElementValue(((long)nextOrdinal * historicalDataElements.bitsPerRecord) + historicalDataElements.bitOffsetPerField[i], historicalDataElements.bitsPerField[i], currentWriteVarLengthDataPointers[i] + size);

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -278,7 +278,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 	    BitSet populatedOrdinals = getPopulatedOrdinals();
 
 	    for(int i=0;i<shards.length;i++)
-	        totalApproximateHoleCostInBytes += shards[i].getApproximateHoleCostInBytes(populatedOrdinals);
+	        totalApproximateHoleCostInBytes += shards[i].getApproximateHoleCostInBytes(populatedOrdinals, i, shards.length);
         
 	    return totalApproximateHoleCostInBytes;
 	}

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -17,52 +17,58 @@
  */
 package com.netflix.hollow.core.read.engine.object;
 
-import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.memory.encoding.VarInt;
-import com.netflix.hollow.core.memory.encoding.ZigZag;
 
-import com.netflix.hollow.tools.checksum.HollowChecksum;
-import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.schema.HollowSchema;
-import com.netflix.hollow.core.memory.ByteData;
-import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.api.sampling.DisabledSamplingDirector;
 import com.netflix.hollow.api.sampling.HollowObjectSampler;
 import com.netflix.hollow.api.sampling.HollowSampler;
 import com.netflix.hollow.api.sampling.HollowSamplingDirector;
-import com.netflix.hollow.core.read.filter.HollowFilterConfig;
-import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
-import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
 import com.netflix.hollow.core.read.engine.SnapshotPopulatedOrdinalsReader;
+import com.netflix.hollow.core.read.filter.HollowFilterConfig;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.tools.checksum.HollowChecksum;
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * A {@link HollowTypeReadState} for OBJECT type records. 
  */
 public class HollowObjectTypeReadState extends HollowTypeReadState implements HollowObjectTypeDataAccess {
 
-    private HollowObjectTypeDataElements currentData;
-    private volatile HollowObjectTypeDataElements currentDataVolatile;
-
     private final HollowObjectSchema unfilteredSchema;
     private final HollowObjectSampler sampler;
+    
+    private final int shardNumberMask;
+    private final int shardOrdinalShift;
+    private final HollowObjectTypeReadStateShard shards[];
+    
+    private int maxOrdinal;
 
     public HollowObjectTypeReadState(HollowReadStateEngine stateEngine, HollowObjectSchema schema) {
-        this(stateEngine, schema, schema);
+        this(stateEngine, schema, schema, 1);
     }
 
-    public HollowObjectTypeReadState(HollowReadStateEngine stateEngine, HollowObjectSchema schema, HollowObjectSchema unfilteredSchema) {
+    public HollowObjectTypeReadState(HollowReadStateEngine stateEngine, HollowObjectSchema schema, HollowObjectSchema unfilteredSchema, int numShards) {
         super(stateEngine, schema);
         this.sampler = new HollowObjectSampler(schema, DisabledSamplingDirector.INSTANCE);
         this.unfilteredSchema = unfilteredSchema;
+        this.shardNumberMask = numShards - 1;
+        this.shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(numShards);
+        
+        if(numShards < 1 || 1 << shardOrdinalShift != numShards)
+            throw new IllegalArgumentException("Number of shards must be a power of 2!");
+        
+        HollowObjectTypeReadStateShard shards[] = new HollowObjectTypeReadStateShard[numShards];
+        for(int i=0;i<shards.length;i++)
+            shards[i] = new HollowObjectTypeReadStateShard(schema);
+        
+        this.shards = shards;
     }
 
     @Override
@@ -72,40 +78,57 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
     @Override
     public int maxOrdinal() {
-        return currentData.maxOrdinal;
+        return maxOrdinal;
     }
 
     @Override
     public void readSnapshot(DataInputStream dis, ArraySegmentRecycler memoryRecycler) throws IOException {
-        HollowObjectTypeDataElements currentData = new HollowObjectTypeDataElements(getSchema(), memoryRecycler);
-        currentData.readSnapshot(dis, unfilteredSchema);
-        setCurrentData(currentData);
+        if(shards.length > 1)
+            maxOrdinal = VarInt.readVInt(dis);
+        
+        for(int i=0;i<shards.length;i++) {
+            HollowObjectTypeDataElements snapshotData = new HollowObjectTypeDataElements(getSchema(), memoryRecycler);
+            snapshotData.readSnapshot(dis, unfilteredSchema);
+            shards[i].setCurrentData(snapshotData);
+        }
+        
+        if(shards.length == 1)
+            maxOrdinal = shards[0].currentDataElements().maxOrdinal;
+        
         SnapshotPopulatedOrdinalsReader.readOrdinals(dis, stateListeners);
     }
-
+    
     @Override
     public void applyDelta(DataInputStream dis, HollowSchema deltaSchema, ArraySegmentRecycler memoryRecycler) throws IOException {
-        HollowObjectTypeDataElements deltaData = new HollowObjectTypeDataElements((HollowObjectSchema)deltaSchema, memoryRecycler);
-        HollowObjectTypeDataElements nextData = new HollowObjectTypeDataElements(getSchema(), memoryRecycler);
-        deltaData.readDelta(dis);
-        nextData.applyDelta(currentData, deltaData);
-        HollowObjectTypeDataElements oldData = currentData;
-        setCurrentData(nextData);
-        notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions);
-        deltaData.destroy();
-        oldData.destroy();
+        if(shards.length > 1)
+            maxOrdinal = VarInt.readVInt(dis);
+
+        for(int i=0;i<shards.length;i++) {
+            HollowObjectTypeDataElements deltaData = new HollowObjectTypeDataElements((HollowObjectSchema)deltaSchema, memoryRecycler);
+            HollowObjectTypeDataElements nextData = new HollowObjectTypeDataElements(getSchema(), memoryRecycler);
+            deltaData.readDelta(dis);
+            HollowObjectTypeDataElements oldData = shards[i].currentDataElements();
+            nextData.applyDelta(oldData, deltaData);
+            shards[i].setCurrentData(nextData);
+            notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+            deltaData.destroy();
+            oldData.destroy();
+        }
+        
+        if(shards.length == 1)
+            maxOrdinal = shards[0].currentDataElements().maxOrdinal;
     }
 
-    public static void discardSnapshot(DataInputStream dis, HollowObjectSchema schema) throws IOException {
-        discardType(dis, schema, false);
+    public static void discardSnapshot(DataInputStream dis, HollowObjectSchema schema, int numShards) throws IOException {
+        discardType(dis, schema, numShards, false);
     }
 
-    public static void discardDelta(DataInputStream dis, HollowObjectSchema schema) throws IOException {
-        discardType(dis, schema, true);
+    public static void discardDelta(DataInputStream dis, HollowObjectSchema schema, int numShards) throws IOException {
+        discardType(dis, schema, numShards, true);
     }
 
-    public static void discardType(DataInputStream dis, HollowObjectSchema schema, boolean delta) throws IOException {
-        HollowObjectTypeDataElements.discardFromStream(dis, schema, delta);
+    public static void discardType(DataInputStream dis, HollowObjectSchema schema, int numShards, boolean delta) throws IOException {
+        HollowObjectTypeDataElements.discardFromStream(dis, schema, numShards, delta);
         if(!delta)
             SnapshotPopulatedOrdinalsReader.discardOrdinals(dis);
     }
@@ -113,358 +136,84 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
     @Override
     public boolean isNull(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        long fixedLengthValue;
-
-        do {
-            currentData = this.currentData;
-
-            long bitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-            int numBitsForField = currentData.bitsPerField[fieldIndex];
-
-            fixedLengthValue = numBitsForField <= 56 ?
-                    currentData.fixedLengthData.getElementValue(bitOffset, numBitsForField)
-                    : currentData.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
-        } while(readWasUnsafe(currentData));
-
-        switch(getSchema().getFieldType(fieldIndex)) {
-        case BYTES:
-        case STRING:
-            int numBits = currentData.bitsPerField[fieldIndex];
-            return (fixedLengthValue & (1 << (numBits - 1))) != 0;
-        case FLOAT:
-            return (int)fixedLengthValue == HollowObjectWriteRecord.NULL_FLOAT_BITS;
-        case DOUBLE:
-            return fixedLengthValue == HollowObjectWriteRecord.NULL_DOUBLE_BITS;
-        default:
-            return fixedLengthValue == currentData.nullValueForField[fieldIndex];
-        }
+        return shards[ordinal & shardNumberMask].isNull(ordinal >> shardOrdinalShift, fieldIndex);
     }
 
     @Override
     public int readOrdinal(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        long refOrdinal;
-
-        do {
-            currentData = this.currentData;
-            refOrdinal = readFixedLengthFieldValue(currentData, ordinal, fieldIndex);
-        } while(readWasUnsafe(currentData));
-
-        if(refOrdinal == currentData.nullValueForField[fieldIndex])
-            return -1;
-        return (int)refOrdinal;
+        return shards[ordinal & shardNumberMask].readOrdinal(ordinal >> shardOrdinalShift, fieldIndex);
     }
 
     @Override
     public int readInt(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        long value;
-
-        do {
-            currentData = this.currentData;
-            value = readFixedLengthFieldValue(currentData, ordinal, fieldIndex);
-        } while(readWasUnsafe(currentData));
-
-        if(value == currentData.nullValueForField[fieldIndex])
-            return Integer.MIN_VALUE;
-        return ZigZag.decodeInt((int)value);
+        return shards[ordinal & shardNumberMask].readInt(ordinal >> shardOrdinalShift, fieldIndex);
     }
 
     @Override
     public float readFloat(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        int value;
-
-        do {
-            currentData = this.currentData;
-            value = (int)readFixedLengthFieldValue(currentData, ordinal, fieldIndex);
-        } while(readWasUnsafe(currentData));
-
-        if(value == HollowObjectWriteRecord.NULL_FLOAT_BITS)
-            return Float.NaN;
-        return Float.intBitsToFloat(value);
+        return shards[ordinal & shardNumberMask].readFloat(ordinal >> shardOrdinalShift, fieldIndex);
     }
 
     @Override
     public double readDouble(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        long value;
-
-        do {
-            currentData = this.currentData;
-            long bitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-            value = currentData.fixedLengthData.getLargeElementValue(bitOffset, 64, -1L);
-        } while(readWasUnsafe(currentData));
-
-        if(value == HollowObjectWriteRecord.NULL_DOUBLE_BITS)
-            return Double.NaN;
-        return Double.longBitsToDouble(value);
+        return shards[ordinal & shardNumberMask].readDouble(ordinal >> shardOrdinalShift, fieldIndex);
     }
 
     @Override
     public long readLong(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        long value;
-
-        do {
-            currentData = this.currentData;
-            long bitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-            int numBitsForField = currentData.bitsPerField[fieldIndex];
-            value = currentData.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
-        } while(readWasUnsafe(currentData));
-
-        if(value == currentData.nullValueForField[fieldIndex])
-            return Long.MIN_VALUE;
-        return ZigZag.decodeLong(value);
+        return shards[ordinal & shardNumberMask].readLong(ordinal >> shardOrdinalShift, fieldIndex);
     }
 
     @Override
     public Boolean readBoolean(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        long value;
-
-        do {
-            currentData = this.currentData;
-            value = readFixedLengthFieldValue(currentData, ordinal, fieldIndex);
-        } while(readWasUnsafe(currentData));
-
-        if(value == currentData.nullValueForField[fieldIndex])
-            return null;
-        return value == 1 ? Boolean.TRUE : Boolean.FALSE;
-    }
-
-    private long readFixedLengthFieldValue(HollowObjectTypeDataElements currentData, int ordinal, int fieldIndex) {
-        long bitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-        int numBitsForField = currentData.bitsPerField[fieldIndex];
-
-        long value = currentData.fixedLengthData.getElementValue(bitOffset, numBitsForField);
-
-        return value;
+        return shards[ordinal & shardNumberMask].readBoolean(ordinal >> shardOrdinalShift, fieldIndex);
     }
 
     @Override
     public byte[] readBytes(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        byte[] result;
-
-        do {
-            int numBitsForField;
-            long endByte;
-            long startByte;
-
-            do {
-                currentData = this.currentData;
-
-                numBitsForField = currentData.bitsPerField[fieldIndex];
-                long currentBitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-                endByte = currentData.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
-                startByte = ordinal != 0 ? currentData.fixedLengthData.getElementValue(currentBitOffset - currentData.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(currentData));
-
-            if((endByte & (1L << numBitsForField - 1)) != 0)
-                return null;
-
-            startByte &= (1L << numBitsForField - 1) - 1;
-
-            int length = (int)(endByte - startByte);
-            result = new byte[length];
-            for(int i=0;i<length;i++)
-                result[i] = currentData.varLengthData[fieldIndex].get(startByte + i);
-
-        } while(readWasUnsafe(currentData));
-
-        return result;
+        return shards[ordinal & shardNumberMask].readBytes(ordinal >> shardOrdinalShift, fieldIndex);
     }
 
     @Override
     public String readString(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        String result;
-
-        do {
-            int numBitsForField;
-            long endByte;
-            long startByte;
-
-            do {
-                currentData = this.currentData;
-
-                numBitsForField = currentData.bitsPerField[fieldIndex];
-                long currentBitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-                endByte = currentData.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
-                startByte = ordinal != 0 ? currentData.fixedLengthData.getElementValue(currentBitOffset - currentData.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(currentData));
-
-            if((endByte & (1L << numBitsForField - 1)) != 0)
-                return null;
-
-            startByte &= (1L << numBitsForField - 1) - 1;
-
-            int length = (int)(endByte - startByte);
-
-            result = readString(currentData.varLengthData[fieldIndex], startByte, length);
-        } while(readWasUnsafe(currentData));
-
-        return result;
+        return shards[ordinal & shardNumberMask].readString(ordinal >> shardOrdinalShift, fieldIndex);
     }
 
     @Override
     public boolean isStringFieldEqual(int ordinal, int fieldIndex, String testValue) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        boolean result;
-
-        do {
-            int numBitsForField;
-            long endByte;
-            long startByte;
-
-            do {
-                currentData = this.currentData;
-
-                numBitsForField = currentData.bitsPerField[fieldIndex];
-
-                long currentBitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-                endByte = currentData.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
-                startByte = ordinal != 0 ? currentData.fixedLengthData.getElementValue(currentBitOffset - currentData.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(currentData));
-
-            if((endByte & (1L << numBitsForField - 1)) != 0)
-                return testValue == null;
-            if(testValue == null)
-                return false;
-
-            startByte &= (1L << numBitsForField - 1) - 1;
-
-            int length = (int)(endByte - startByte);
-
-            result = testStringEquality(currentData.varLengthData[fieldIndex], startByte, length, testValue);
-        } while(readWasUnsafe(currentData));
-
-        return result;
+        return shards[ordinal & shardNumberMask].isStringFieldEqual(ordinal >> shardOrdinalShift, fieldIndex, testValue);
     }
 
     @Override
     public int findVarLengthFieldHashCode(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-
-        HollowObjectTypeDataElements currentData;
-        int hashCode;
-        do {
-            int numBitsForField;
-            long endByte;
-            long startByte;
-
-            do {
-                currentData = this.currentData;
-
-                numBitsForField = currentData.bitsPerField[fieldIndex];
-                long currentBitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-                endByte = currentData.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
-                startByte = ordinal != 0 ? currentData.fixedLengthData.getElementValue(currentBitOffset - currentData.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(currentData));
-
-            if((endByte & (1L << numBitsForField - 1)) != 0)
-                return -1;
-
-            startByte &= (1L << numBitsForField - 1) - 1;
-
-            int length = (int)(endByte - startByte);
-
-            hashCode = HashCodes.hashCode(currentData.varLengthData[fieldIndex], startByte, length);
-        } while(readWasUnsafe(currentData));
-
-        return hashCode;
+        return shards[ordinal & shardNumberMask].findVarLengthFieldHashCode(ordinal >> shardOrdinalShift, fieldIndex);
     }
 
     /**
      * Warning:  Not thread-safe.  Should only be called within the update thread.
      */
     public int bitsRequiredForField(String fieldName) {
-        int fieldIndex = getSchema().getPosition(fieldName);
-        return fieldIndex == -1 ? 0 : currentData.bitsPerField[fieldIndex];
-    }
-
-    private long fieldOffset(HollowObjectTypeDataElements currentData, int ordinal, int fieldIndex) {
-        return ((long)currentData.bitsPerRecord * ordinal) + currentData.bitOffsetPerField[fieldIndex];
-    }
-
-    /**
-     * Decode a String as a series of VarInts, one per character.<p>
-     *
-     * @param str
-     * @param out
-     * @return
-     */
-    private static final ThreadLocal<char[]> chararr = new ThreadLocal<char[]>();
-
-    private String readString(ByteData data, long position, int length) {
-        long endPosition = position + length;
-
-        char chararr[] = getCharArray();
-
-        if(length > chararr.length)
-            chararr = new char[length];
-
-        int count = 0;
-
-        while(position < endPosition) {
-            int c = VarInt.readVInt(data, position);
-            chararr[count++] = (char)c;
-            position += VarInt.sizeOfVInt(c);
+        int maxBitsRequiredForField = shards[0].bitsRequiredForField(fieldName);
+        
+        for(int i=1;i<shards.length;i++) {
+            int shardRequiredBits = shards[i].bitsRequiredForField(fieldName);
+            if(shardRequiredBits > maxBitsRequiredForField)
+                maxBitsRequiredForField = shardRequiredBits;
         }
-
-        // The number of chars may be fewer than the number of bytes in the serialized data
-        return new String(chararr, 0, count);
+        
+        return maxBitsRequiredForField;
     }
-
-    private boolean testStringEquality(ByteData data, long position, int length, String testValue) {
-        if(length < testValue.length()) // can't check exact length here; the length argument is in bytes, which is equal to or greater than the number of characters.
-            return false;
-
-        long endPosition = position + length;
-
-        int count = 0;
-
-        while(position < endPosition && count < testValue.length()) {
-            int c = VarInt.readVInt(data, position);
-            if(testValue.charAt(count++) != (char)c)
-                return false;
-            position += VarInt.sizeOfVInt(c);
-        }
-
-        // The number of chars may be fewer than the number of bytes in the serialized data
-        return position == endPosition && count == testValue.length();
-    }
-
-    private char[] getCharArray() {
-        char ch[] = chararr.get();
-        if(ch == null) {
-            ch = new char[100];
-            chararr.set(ch);
-        }
-        return ch;
-    }
-
+    
     @Override
     public HollowSampler getSampler() {
         return sampler;
@@ -473,7 +222,8 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
     @Override
     protected void invalidate() {
         stateListeners = EMPTY_LISTENERS;
-        setCurrentData(null);
+        for(int i=0;i<shards.length;i++)
+            shards[i].invalidate();
     }
 
     @Override
@@ -490,18 +240,14 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
     public void ignoreUpdateThreadForSampling(Thread t) {
         sampler.setUpdateThread(t);
     }
-
-    HollowObjectTypeDataElements currentDataElements() {
-        return currentData;
-    }
-
-    private boolean readWasUnsafe(HollowObjectTypeDataElements data) {
-        return data != currentDataVolatile;
-    }
-
-    void setCurrentData(HollowObjectTypeDataElements data) {
-        this.currentData = data;
-        this.currentDataVolatile = data;
+    
+    HollowObjectTypeDataElements[] currentDataElements() {
+        HollowObjectTypeDataElements currentDataElements[] = new HollowObjectTypeDataElements[shards.length];
+        
+        for(int i=0;i<shards.length;i++)
+            currentDataElements[i] = shards[i].currentDataElements();
+        
+        return currentDataElements;
     }
 
     @Override
@@ -509,65 +255,38 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         if(!(withSchema instanceof HollowObjectSchema))
             throw new IllegalArgumentException("HollowObjectTypeReadState can only calculate checksum with a HollowObjectSchema: " + getSchema().getName());
 
-        HollowObjectSchema commonSchema = getSchema().findCommonSchema((HollowObjectSchema)withSchema);
-
-        List<String> commonFieldNames = new ArrayList<String>();
-        for(int i=0;i<commonSchema.numFields();i++)
-            commonFieldNames.add(commonSchema.getFieldName(i));
-        Collections.sort(commonFieldNames);
+        BitSet populatedOrdinals = getPopulatedOrdinals();
         
-        int fieldIndexes[] = new int[commonFieldNames.size()];
-        for(int i=0;i<commonFieldNames.size();i++) {
-            fieldIndexes[i] = getSchema().getPosition(commonFieldNames.get(i));
-        }
-        
-        
-        BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
-
-        int ordinal = populatedOrdinals.nextSetBit(0);
-        while(ordinal != -1) {
-            checksum.applyInt(ordinal);
-            for(int i=0;i<fieldIndexes.length;i++) {
-                int fieldIdx = fieldIndexes[i];
-                if(!getSchema().getFieldType(fieldIdx).isVariableLength()) {
-                    long bitOffset = fieldOffset(currentData, ordinal, fieldIdx);
-                    int numBitsForField = currentData.bitsPerField[fieldIdx];
-                    long fixedLengthValue = numBitsForField <= 56 ?
-                            currentData.fixedLengthData.getElementValue(bitOffset, numBitsForField)
-                            : currentData.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
-
-                    if(fixedLengthValue == currentData.nullValueForField[fieldIdx])
-                        checksum.applyInt(Integer.MAX_VALUE);
-                    else
-                        checksum.applyLong(fixedLengthValue);
-                } else {
-                    checksum.applyInt(findVarLengthFieldHashCode(ordinal, fieldIdx));
-                }
-            }
-
-            ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
-        }
+        for(int i=0;i<shards.length;i++)
+            shards[i].applyToChecksum(checksum, withSchema, populatedOrdinals, i, shards.length);
     }
 
 	@Override
 	public long getApproximateHeapFootprintInBytes() {
-		long bitsPerFixedLengthData = (long)currentData.bitsPerRecord * (currentData.maxOrdinal + 1);
-		
-		long requiredBytes = bitsPerFixedLengthData / 8;
-		
-		for(int i=0;i<currentData.varLengthData.length;i++) {
-			if(currentData.varLengthData[i] != null)
-				requiredBytes += currentData.varLengthData[i].size();
-		}
-		
-		return requiredBytes;
+	    long totalApproximateHeapFootprintInBytes = 0;
+	    
+	    for(int i=0;i<shards.length;i++)
+	        totalApproximateHeapFootprintInBytes += shards[i].getApproximateHeapFootprintInBytes();
+	    
+	    return totalApproximateHeapFootprintInBytes;
 	}
 	
 	@Override
 	public long getApproximateHoleCostInBytes() {
-        BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
-        
-        return ((long)(populatedOrdinals.length() - populatedOrdinals.cardinality()) * (long)currentData.bitsPerRecord) / 8; 
-	}
+	    long totalApproximateHoleCostInBytes = 0;
+	    
+	    BitSet populatedOrdinals = getPopulatedOrdinals();
 
+	    for(int i=0;i<shards.length;i++)
+	        totalApproximateHoleCostInBytes += shards[i].getApproximateHoleCostInBytes(populatedOrdinals);
+        
+	    return totalApproximateHoleCostInBytes;
+	}
+	
+	void setCurrentData(HollowObjectTypeDataElements data) {
+	    if(shards.length > 1)
+	        throw new UnsupportedOperationException("Cannot directly set data on sharded type state");
+	    shards[0].setCurrentData(data);
+	}
+	
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -289,5 +289,10 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 	        throw new UnsupportedOperationException("Cannot directly set data on sharded type state");
 	    shards[0].setCurrentData(data);
 	}
+
+    @Override
+    public int numShards() {
+        return shards.length;
+    }
 	
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -113,6 +113,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
             deltaData.destroy();
             oldData.destroy();
+            stateEngine.getMemoryRecycler().swap();
         }
         
         if(shards.length == 1)

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
@@ -399,12 +399,12 @@ class HollowObjectTypeReadStateShard {
         int ordinal = populatedOrdinals.nextSetBit(0);
         while(ordinal != -1) {
             if((ordinal & (numShards - 1)) == shardNumber) {
-                int translatedOrdinal = ordinal / numShards;
+                int shardOrdinal = ordinal / numShards;
                 checksum.applyInt(ordinal);
                 for(int i=0;i<fieldIndexes.length;i++) {
                     int fieldIdx = fieldIndexes[i];
                     if(!schema.getFieldType(fieldIdx).isVariableLength()) {
-                        long bitOffset = fieldOffset(currentData, translatedOrdinal, fieldIdx);
+                        long bitOffset = fieldOffset(currentData, shardOrdinal, fieldIdx);
                         int numBitsForField = currentData.bitsPerField[fieldIdx];
                         long fixedLengthValue = numBitsForField <= 56 ?
                                 currentData.fixedLengthData.getElementValue(bitOffset, numBitsForField)
@@ -415,7 +415,7 @@ class HollowObjectTypeReadStateShard {
                         else
                             checksum.applyLong(fixedLengthValue);
                     } else {
-                        checksum.applyInt(findVarLengthFieldHashCode(translatedOrdinal, fieldIdx));
+                        checksum.applyInt(findVarLengthFieldHashCode(shardOrdinal, fieldIdx));
                     }
                 }
             }
@@ -448,7 +448,7 @@ class HollowObjectTypeReadStateShard {
             holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
         }
         
-        return (holeBits * (long)currentData.bitsPerRecord) / 8;
+        return holeBits / 8;
     }
     
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
@@ -363,7 +363,7 @@ class HollowObjectTypeReadStateShard {
         return ch;
     }
 
-    protected void invalidate() {
+    void invalidate() {
         setCurrentData(null);
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeDataElements.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeDataElements.java
@@ -83,24 +83,29 @@ public class HollowSetTypeDataElements {
         elementArray = FixedLengthElementArray.deserializeFrom(dis, memoryRecycler);
     }
 
-    static void discardFromStream(DataInputStream dis, boolean isDelta) throws IOException {
-        VarInt.readVInt(dis); // max ordinal
-
-        if(isDelta) {
-            /// addition/removal ordinals
-            GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
-            GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
+    static void discardFromStream(DataInputStream dis, int numShards, boolean isDelta) throws IOException {
+        if(numShards > 1)
+            VarInt.readVInt(dis); // max ordinal
+        
+        for(int i=0;i<numShards;i++) {
+            VarInt.readVInt(dis); // max ordinal
+    
+            if(isDelta) {
+                /// addition/removal ordinals
+                GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
+                GapEncodedVariableLengthIntegerReader.discardEncodedDeltaOrdinals(dis);
+            }
+    
+            /// statistics
+            VarInt.readVInt(dis);
+            VarInt.readVInt(dis);
+            VarInt.readVInt(dis);
+            VarInt.readVLong(dis);
+    
+            /// fixed-length data
+            FixedLengthElementArray.discardFrom(dis);
+            FixedLengthElementArray.discardFrom(dis);
         }
-
-        /// statistics
-        VarInt.readVInt(dis);
-        VarInt.readVInt(dis);
-        VarInt.readVInt(dis);
-        VarInt.readVLong(dis);
-
-        /// fixed-length data
-        FixedLengthElementArray.discardFrom(dis);
-        FixedLengthElementArray.discardFrom(dis);
     }
 
     public void applyDelta(HollowSetTypeDataElements fromData, HollowSetTypeDataElements deltaData) {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -77,7 +77,7 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
         nextData.applyDelta(currentData, deltaData);
         HollowSetTypeDataElements oldData = currentData;
         setCurrentData(nextData);
-        notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions);
+        notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, 0, 1);
         deltaData.destroy();
         oldData.destroy();
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -272,4 +272,9 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
 	        shards[i].setKeyDeriver(keyDeriver);
 	}
 
+    @Override
+    public int numShards() {
+        return shards.length;
+    }
+
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -17,29 +17,27 @@
  */
 package com.netflix.hollow.core.read.engine.set;
 
-import com.netflix.hollow.core.memory.encoding.HashCodes;
-
-import com.netflix.hollow.tools.checksum.HollowChecksum;
-import com.netflix.hollow.core.schema.HollowSchema;
-import com.netflix.hollow.core.schema.HollowSetSchema;
-import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
-import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
-import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
 import com.netflix.hollow.api.sampling.DisabledSamplingDirector;
 import com.netflix.hollow.api.sampling.HollowSampler;
 import com.netflix.hollow.api.sampling.HollowSamplingDirector;
 import com.netflix.hollow.api.sampling.HollowSetSampler;
-import com.netflix.hollow.core.read.filter.HollowFilterConfig;
+import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
+import com.netflix.hollow.core.memory.encoding.VarInt;
+import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.core.read.dataaccess.HollowSetTypeDataAccess;
 import com.netflix.hollow.core.read.engine.HollowCollectionTypeReadState;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
-import com.netflix.hollow.core.read.engine.SetMapKeyHasher;
 import com.netflix.hollow.core.read.engine.SnapshotPopulatedOrdinalsReader;
+import com.netflix.hollow.core.read.filter.HollowFilterConfig;
 import com.netflix.hollow.core.read.iterator.EmptyOrdinalIterator;
 import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
 import com.netflix.hollow.core.read.iterator.HollowSetOrdinalIterator;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSetSchema;
+import com.netflix.hollow.tools.checksum.HollowChecksum;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.BitSet;
@@ -49,69 +47,93 @@ import java.util.BitSet;
  */
 public class HollowSetTypeReadState extends HollowCollectionTypeReadState implements HollowSetTypeDataAccess {
 
-    private HollowSetTypeDataElements currentData;
-    private volatile HollowSetTypeDataElements currentDataVolatile;
-
     private final HollowSetSampler sampler;
     
+    private final int shardNumberMask;
+    private final int shardOrdinalShift;
+    private final HollowSetTypeReadStateShard shards[];
+    
     private HollowPrimaryKeyValueDeriver keyDeriver;
+    
+    private int maxOrdinal;
 
-    public HollowSetTypeReadState(HollowReadStateEngine stateEngine, HollowSetSchema schema) {
+    public HollowSetTypeReadState(HollowReadStateEngine stateEngine, HollowSetSchema schema, int numShards) {
         super(stateEngine, schema);
         this.sampler = new HollowSetSampler(schema.getName(), DisabledSamplingDirector.INSTANCE);
+        this.shardNumberMask = numShards - 1;
+        this.shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(numShards);
+        
+        if(numShards < 1 || 1 << shardOrdinalShift != numShards)
+            throw new IllegalArgumentException("Number of shards must be a power of 2!");
+        
+        HollowSetTypeReadStateShard shards[] = new HollowSetTypeReadStateShard[numShards];
+        for(int i=0;i<shards.length;i++)
+            shards[i] = new HollowSetTypeReadStateShard();
+        
+        this.shards = shards;
+
     }
 
     @Override
     public void readSnapshot(DataInputStream dis, ArraySegmentRecycler memoryRecycler) throws IOException {
-        HollowSetTypeDataElements currentData = new HollowSetTypeDataElements(memoryRecycler);
-        currentData.readSnapshot(dis);
-        setCurrentData(currentData);
+        if(shards.length > 1)
+            maxOrdinal = VarInt.readVInt(dis);
+        
+        for(int i=0;i<shards.length;i++) {
+            HollowSetTypeDataElements snapshotData = new HollowSetTypeDataElements(memoryRecycler);
+            snapshotData.readSnapshot(dis);
+            shards[i].setCurrentData(snapshotData);
+        }
+        
+        if(shards.length == 1)
+            maxOrdinal = shards[0].currentDataElements().maxOrdinal;
+        
         SnapshotPopulatedOrdinalsReader.readOrdinals(dis, stateListeners);
     }
 
     @Override
     public void applyDelta(DataInputStream dis, HollowSchema schema, ArraySegmentRecycler memoryRecycler) throws IOException {
-        HollowSetTypeDataElements deltaData = new HollowSetTypeDataElements(memoryRecycler);
-        HollowSetTypeDataElements nextData = new HollowSetTypeDataElements(memoryRecycler);
-        deltaData.readDelta(dis);
-        nextData.applyDelta(currentData, deltaData);
-        HollowSetTypeDataElements oldData = currentData;
-        setCurrentData(nextData);
-        notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, 0, 1);
-        deltaData.destroy();
-        oldData.destroy();
+        if(shards.length > 1)
+            maxOrdinal = VarInt.readVInt(dis);
+
+        for(int i=0;i<shards.length;i++) {
+            HollowSetTypeDataElements deltaData = new HollowSetTypeDataElements(memoryRecycler);
+            HollowSetTypeDataElements nextData = new HollowSetTypeDataElements(memoryRecycler);
+            deltaData.readDelta(dis);
+            HollowSetTypeDataElements oldData = shards[i].currentDataElements();
+            nextData.applyDelta(oldData, deltaData);
+            shards[i].setCurrentData(nextData);
+            notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+            deltaData.destroy();
+            oldData.destroy();
+        }
+        
+        if(shards.length == 1)
+            maxOrdinal = shards[0].currentDataElements().maxOrdinal;
     }
 
-    public static void discardSnapshot(DataInputStream dis) throws IOException {
-        discardType(dis, false);
+    public static void discardSnapshot(DataInputStream dis, int numShards) throws IOException {
+        discardType(dis, numShards, false);
     }
 
-    public static void discardDelta(DataInputStream dis) throws IOException {
-        discardType(dis, true);
+    public static void discardDelta(DataInputStream dis, int numShards) throws IOException {
+        discardType(dis, numShards, true);
     }
 
-    public static void discardType(DataInputStream dis, boolean delta) throws IOException {
-        HollowSetTypeDataElements.discardFromStream(dis, delta);
+    public static void discardType(DataInputStream dis, int numShards, boolean delta) throws IOException {
+        HollowSetTypeDataElements.discardFromStream(dis, numShards, delta);
         if(!delta)
             SnapshotPopulatedOrdinalsReader.discardOrdinals(dis);
     }
 
     @Override
     public int maxOrdinal() {
-        return currentData.maxOrdinal;
+        return maxOrdinal;
     }
 
     @Override
     public int size(int ordinal) {
-        HollowSetTypeDataElements currentData;
-        int size;
-
-        do {
-            currentData = this.currentData;
-            size = (int)currentData.setPointerAndSizeArray.getElementValue((long)(ordinal * currentData.bitsPerFixedLengthSetPortion) + currentData.bitsPerSetPointer, currentData.bitsPerSetSizeValue);
-        } while(readWasUnsafe(currentData));
-
-        return size;
+        return shards[ordinal & shardNumberMask].size(ordinal >> shardOrdinalShift);
     }
 
     @Override
@@ -121,40 +143,7 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
 
     @Override
     public boolean contains(int ordinal, int value, int hashCode) {
-        HollowSetTypeDataElements currentData;
-        boolean foundData;
-
-        threadsafe:
-        do {
-            long startBucket;
-            long endBucket;
-
-            do {
-                currentData = this.currentData;
-
-                startBucket = getAbsoluteBucketStart(currentData, ordinal);
-                endBucket = currentData.setPointerAndSizeArray.getElementValue((long)ordinal * currentData.bitsPerFixedLengthSetPortion, currentData.bitsPerSetPointer);
-            } while(readWasUnsafe(currentData));
-
-            hashCode = HashCodes.hashInt(hashCode);
-            long bucket = startBucket + (hashCode & (endBucket - startBucket - 1));
-            int bucketOrdinal = absoluteBucketValue(currentData, bucket);
-
-            while(bucketOrdinal != currentData.emptyBucketValue) {
-                if(bucketOrdinal == value) {
-                    foundData = true;
-                    continue threadsafe;
-                }
-                bucket++;
-                if(bucket == endBucket)
-                    bucket = startBucket;
-                bucketOrdinal = absoluteBucketValue(currentData, bucket);
-            }
-
-            foundData = false;
-        } while(readWasUnsafe(currentData));
-
-        return foundData;
+        return shards[ordinal & shardNumberMask].contains(ordinal >> shardOrdinalShift, value, hashCode);
     }
     
     @Override
@@ -167,72 +156,13 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
         if(hashKey.length != fieldTypes.length)
             return -1;
 
-        int hashCode = SetMapKeyHasher.hash(hashKey, fieldTypes);
-
-        HollowSetTypeDataElements currentData;
-
-        threadsafe:
-        do {
-            long startBucket;
-            long endBucket;
-
-            do {
-                currentData = this.currentData;
-
-                startBucket = getAbsoluteBucketStart(currentData, ordinal);
-                endBucket = currentData.setPointerAndSizeArray.getElementValue((long)ordinal * currentData.bitsPerFixedLengthSetPortion, currentData.bitsPerSetPointer);
-            } while(readWasUnsafe(currentData));
-
-            long bucket = startBucket + (hashCode & (endBucket - startBucket - 1));
-            int bucketOrdinal = absoluteBucketValue(currentData, bucket);
-
-            while(bucketOrdinal != currentData.emptyBucketValue) {
-                if(readWasUnsafe(currentData))
-                    continue threadsafe;
-                
-                if(keyDeriver.keyMatches(bucketOrdinal, hashKey))
-                    return bucketOrdinal;
-                
-                bucket++;
-                if(bucket == endBucket)
-                    bucket = startBucket;
-                bucketOrdinal = absoluteBucketValue(currentData, bucket);
-            }
-
-        } while(readWasUnsafe(currentData));
-
-        return -1;
+        return shards[ordinal & shardNumberMask].findElement(ordinal >> shardOrdinalShift, hashKey);
     }
     
 
     @Override
     public int relativeBucketValue(int setOrdinal, int bucketIndex) {
-        HollowSetTypeDataElements currentData;
-        int value;
-
-        do {
-            long startBucket;
-            do {
-                currentData = this.currentData;
-
-                startBucket = getAbsoluteBucketStart(currentData, setOrdinal);
-            } while(readWasUnsafe(currentData));
-
-            value = absoluteBucketValue(currentData, startBucket + bucketIndex);
-
-            if(value == currentData.emptyBucketValue)
-                value = -1;
-        } while(readWasUnsafe(currentData));
-
-        return value;
-    }
-
-    private long getAbsoluteBucketStart(HollowSetTypeDataElements currentData, int ordinal) {
-        return ordinal == 0 ? 0 : currentData.setPointerAndSizeArray.getElementValue((long)(ordinal - 1) * currentData.bitsPerFixedLengthSetPortion, currentData.bitsPerSetPointer);
-    }
-
-    private int absoluteBucketValue(HollowSetTypeDataElements currentData, long absoluteBucketIndex) {
-        return (int)currentData.elementArray.getElementValue(absoluteBucketIndex * currentData.bitsPerElement, currentData.bitsPerElement);
+        return shards[setOrdinal & shardNumberMask].relativeBucketValue(setOrdinal >> shardOrdinalShift, bucketIndex);
     }
 
     @Override
@@ -277,20 +207,23 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
     @Override
     protected void invalidate() {
         stateListeners = EMPTY_LISTENERS;
-        setCurrentData(null);
+        for(int i=0;i<shards.length;i++)
+            shards[i].invalidate();
     }
 
-    HollowSetTypeDataElements currentDataElements() {
-        return currentData;
-    }
-
-    private boolean readWasUnsafe(HollowSetTypeDataElements data) {
-        return data != currentDataVolatile;
+    HollowSetTypeDataElements[] currentDataElements() {
+        HollowSetTypeDataElements currentDataElements[] = new HollowSetTypeDataElements[shards.length];
+        
+        for(int i=0;i<shards.length;i++)
+            currentDataElements[i] = shards[i].currentDataElements();
+        
+        return currentDataElements;
     }
 
     void setCurrentData(HollowSetTypeDataElements data) {
-        this.currentData = data;
-        this.currentDataVolatile = data;
+        if(shards.length > 1)
+            throw new UnsupportedOperationException("Cannot directly set data on sharded type state");
+        shards[0].setCurrentData(data);
     }
 
     @Override
@@ -300,37 +233,30 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
         
         BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
 
-        int ordinal = populatedOrdinals.nextSetBit(0);
-        while(ordinal != -1) {
-            int numBuckets = HashCodes.hashTableSize(size(ordinal));
-            long offset = getAbsoluteBucketStart(currentData, ordinal);
-
-            checksum.applyInt(ordinal);
-            for(int i=0;i<numBuckets;i++) {
-                int bucketValue = absoluteBucketValue(currentData, offset + i);
-                if(bucketValue != currentData.emptyBucketValue) {
-                    checksum.applyInt(i);
-                    checksum.applyInt(bucketValue);
-                }
-            }
-
-            ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
-        }
+        for(int i=0;i<shards.length;i++)
+            shards[i].applyToChecksum(checksum, populatedOrdinals, i, shards.length);
     }
 
 	@Override
 	public long getApproximateHeapFootprintInBytes() {
-		long requiredBitsForSetPointers = (long)currentData.bitsPerFixedLengthSetPortion * (currentData.maxOrdinal + 1);
-		long requiredBitsForBuckets = (long)currentData.bitsPerElement * currentData.totalNumberOfBuckets;
-		long requiredBits = requiredBitsForSetPointers + requiredBitsForBuckets;
-		return requiredBits / 8;
+        long totalApproximateHeapFootprintInBytes = 0;
+        
+        for(int i=0;i<shards.length;i++)
+            totalApproximateHeapFootprintInBytes += shards[i].getApproximateHeapFootprintInBytes();
+        
+        return totalApproximateHeapFootprintInBytes;
 	}
 	
 	@Override
 	public long getApproximateHoleCostInBytes() {
-        BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
+        long totalApproximateHoleCostInBytes = 0;
         
-        return ((long)(populatedOrdinals.length() - populatedOrdinals.cardinality()) * (long)currentData.bitsPerFixedLengthSetPortion) / 8; 
+        BitSet populatedOrdinals = getPopulatedOrdinals();
+
+        for(int i=0;i<shards.length;i++)
+            totalApproximateHoleCostInBytes += shards[i].getApproximateHoleCostInBytes(populatedOrdinals, i, shards.length);
+        
+        return totalApproximateHoleCostInBytes;
 	}
 	
 	public HollowPrimaryKeyValueDeriver getKeyDeriver() {
@@ -340,6 +266,9 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
 	public void buildKeyDeriver() {
 	    if(getSchema().getHashKey() != null)
 	        this.keyDeriver = new HollowPrimaryKeyValueDeriver(getSchema().getHashKey(), getStateEngine());
+	    
+	    for(int i=0;i<shards.length;i++)
+	        shards[i].setKeyDeriver(keyDeriver);
 	}
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -106,6 +106,7 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
             notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
             deltaData.destroy();
             oldData.destroy();
+            stateEngine.getMemoryRecycler().swap();
         }
         
         if(shards.length == 1)

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateShard.java
@@ -6,7 +6,7 @@ import com.netflix.hollow.core.read.engine.SetMapKeyHasher;
 import com.netflix.hollow.tools.checksum.HollowChecksum;
 import java.util.BitSet;
 
-public class HollowSetTypeReadStateShard {
+class HollowSetTypeReadStateShard {
 
     private HollowSetTypeDataElements currentData;
     private volatile HollowSetTypeDataElements currentDataVolatile;
@@ -193,6 +193,4 @@ public class HollowSetTypeReadStateShard {
     public void setKeyDeriver(HollowPrimaryKeyValueDeriver keyDeriver) {
         this.keyDeriver = keyDeriver;
     }
-    
-
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateShard.java
@@ -1,0 +1,198 @@
+package com.netflix.hollow.core.read.engine.set;
+
+import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
+import com.netflix.hollow.core.memory.encoding.HashCodes;
+import com.netflix.hollow.core.read.engine.SetMapKeyHasher;
+import com.netflix.hollow.tools.checksum.HollowChecksum;
+import java.util.BitSet;
+
+public class HollowSetTypeReadStateShard {
+
+    private HollowSetTypeDataElements currentData;
+    private volatile HollowSetTypeDataElements currentDataVolatile;
+
+    private HollowPrimaryKeyValueDeriver keyDeriver;
+
+    public int size(int ordinal) {
+        HollowSetTypeDataElements currentData;
+        int size;
+
+        do {
+            currentData = this.currentData;
+            size = (int)currentData.setPointerAndSizeArray.getElementValue((long)(ordinal * currentData.bitsPerFixedLengthSetPortion) + currentData.bitsPerSetPointer, currentData.bitsPerSetSizeValue);
+        } while(readWasUnsafe(currentData));
+
+        return size;
+    }
+
+    public boolean contains(int ordinal, int value, int hashCode) {
+        HollowSetTypeDataElements currentData;
+        boolean foundData;
+
+        threadsafe:
+        do {
+            long startBucket;
+            long endBucket;
+
+            do {
+                currentData = this.currentData;
+
+                startBucket = getAbsoluteBucketStart(currentData, ordinal);
+                endBucket = currentData.setPointerAndSizeArray.getElementValue((long)ordinal * currentData.bitsPerFixedLengthSetPortion, currentData.bitsPerSetPointer);
+            } while(readWasUnsafe(currentData));
+
+            hashCode = HashCodes.hashInt(hashCode);
+            long bucket = startBucket + (hashCode & (endBucket - startBucket - 1));
+            int bucketOrdinal = absoluteBucketValue(currentData, bucket);
+
+            while(bucketOrdinal != currentData.emptyBucketValue) {
+                if(bucketOrdinal == value) {
+                    foundData = true;
+                    continue threadsafe;
+                }
+                bucket++;
+                if(bucket == endBucket)
+                    bucket = startBucket;
+                bucketOrdinal = absoluteBucketValue(currentData, bucket);
+            }
+
+            foundData = false;
+        } while(readWasUnsafe(currentData));
+
+        return foundData;
+    }
+    
+    public int findElement(int ordinal, Object... hashKey) {
+        int hashCode = SetMapKeyHasher.hash(hashKey, keyDeriver.getFieldTypes());
+
+        HollowSetTypeDataElements currentData;
+
+        threadsafe:
+        do {
+            long startBucket;
+            long endBucket;
+
+            do {
+                currentData = this.currentData;
+
+                startBucket = getAbsoluteBucketStart(currentData, ordinal);
+                endBucket = currentData.setPointerAndSizeArray.getElementValue((long)ordinal * currentData.bitsPerFixedLengthSetPortion, currentData.bitsPerSetPointer);
+            } while(readWasUnsafe(currentData));
+
+            long bucket = startBucket + (hashCode & (endBucket - startBucket - 1));
+            int bucketOrdinal = absoluteBucketValue(currentData, bucket);
+
+            while(bucketOrdinal != currentData.emptyBucketValue) {
+                if(readWasUnsafe(currentData))
+                    continue threadsafe;
+                
+                if(keyDeriver.keyMatches(bucketOrdinal, hashKey))
+                    return bucketOrdinal;
+                
+                bucket++;
+                if(bucket == endBucket)
+                    bucket = startBucket;
+                bucketOrdinal = absoluteBucketValue(currentData, bucket);
+            }
+
+        } while(readWasUnsafe(currentData));
+
+        return -1;
+    }
+    
+
+    public int relativeBucketValue(int setOrdinal, int bucketIndex) {
+        HollowSetTypeDataElements currentData;
+        int value;
+
+        do {
+            long startBucket;
+            do {
+                currentData = this.currentData;
+
+                startBucket = getAbsoluteBucketStart(currentData, setOrdinal);
+            } while(readWasUnsafe(currentData));
+
+            value = absoluteBucketValue(currentData, startBucket + bucketIndex);
+
+            if(value == currentData.emptyBucketValue)
+                value = -1;
+        } while(readWasUnsafe(currentData));
+
+        return value;
+    }
+
+    private long getAbsoluteBucketStart(HollowSetTypeDataElements currentData, int ordinal) {
+        return ordinal == 0 ? 0 : currentData.setPointerAndSizeArray.getElementValue((long)(ordinal - 1) * currentData.bitsPerFixedLengthSetPortion, currentData.bitsPerSetPointer);
+    }
+
+    private int absoluteBucketValue(HollowSetTypeDataElements currentData, long absoluteBucketIndex) {
+        return (int)currentData.elementArray.getElementValue(absoluteBucketIndex * currentData.bitsPerElement, currentData.bitsPerElement);
+    }
+    
+    void invalidate() {
+        setCurrentData(null);
+    }
+
+    HollowSetTypeDataElements currentDataElements() {
+        return currentData;
+    }
+
+    private boolean readWasUnsafe(HollowSetTypeDataElements data) {
+        return data != currentDataVolatile;
+    }
+
+    void setCurrentData(HollowSetTypeDataElements data) {
+        this.currentData = data;
+        this.currentDataVolatile = data;
+    }
+
+    protected void applyToChecksum(HollowChecksum checksum, BitSet populatedOrdinals, int shardNumber, int numShards) {
+        int ordinal = populatedOrdinals.nextSetBit(0);
+        while(ordinal != -1) {
+            if((ordinal & (numShards - 1)) == shardNumber) {
+                int shardOrdinal = ordinal / numShards;
+                int numBuckets = HashCodes.hashTableSize(size(shardOrdinal));
+                long offset = getAbsoluteBucketStart(currentData, shardOrdinal);
+    
+                checksum.applyInt(ordinal);
+                for(int i=0;i<numBuckets;i++) {
+                    int bucketValue = absoluteBucketValue(currentData, offset + i);
+                    if(bucketValue != currentData.emptyBucketValue) {
+                        checksum.applyInt(i);
+                        checksum.applyInt(bucketValue);
+                    }
+                }
+            }
+
+            ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
+        }
+    }
+
+    public long getApproximateHeapFootprintInBytes() {
+        long requiredBitsForSetPointers = (long)currentData.bitsPerFixedLengthSetPortion * (currentData.maxOrdinal + 1);
+        long requiredBitsForBuckets = (long)currentData.bitsPerElement * currentData.totalNumberOfBuckets;
+        long requiredBits = requiredBitsForSetPointers + requiredBitsForBuckets;
+        return requiredBits / 8;
+    }
+    
+    public long getApproximateHoleCostInBytes(BitSet populatedOrdinals, int shardNumber, int numShards) {
+        long holeBits = 0;
+        
+        int holeOrdinal = populatedOrdinals.nextClearBit(0);
+        while(holeOrdinal <= currentData.maxOrdinal) {
+            if((holeOrdinal & (numShards - 1)) == shardNumber)
+                holeBits += currentData.bitsPerFixedLengthSetPortion;
+            
+            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
+        }
+        
+        return holeBits / 8;
+    }
+    
+    public void setKeyDeriver(HollowPrimaryKeyValueDeriver keyDeriver) {
+        this.keyDeriver = keyDeriver;
+    }
+    
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/write/FieldStatistics.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/FieldStatistics.java
@@ -71,6 +71,13 @@ public class FieldStatistics {
             numBitsPerRecord += maxBitsForField[i];
         }
     }
+    
+    public long getTotalSizeOfAllVarLengthData() {
+        long totalVarLengthDataSize = 0;
+        for(int i=0;i<totalSizeOfVarLengthField.length;i++) 
+            totalVarLengthDataSize += totalSizeOfVarLengthField[i];
+        return totalVarLengthDataSize;
+    }
 
     private int bitsRequiredForRepresentation(long value) {
         return 64 - Long.numberOfLeadingZeros(value + 1);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
@@ -72,7 +72,7 @@ public class HollowBlobWriter {
             HollowSchema schema = typeState.getSchema();
             schema.writeTo(dos);
 
-            VarInt.writeVInt(dos, 0); /// forwards-compatibility, can write number of bytes for older readers to skip here.
+            writeNumShards(dos, typeState.getNumShards());
 
             typeState.writeSnapshot(dos);
         }
@@ -115,7 +115,7 @@ public class HollowBlobWriter {
                 HollowSchema schema = typeState.getSchema();
                 schema.writeTo(dos);
 
-                VarInt.writeVInt(dos, 0); /// forwards-compatibility, can write number of bytes for older readers to skip here.
+                writeNumShards(dos, typeState.getNumShards());
 
                 typeState.writeDelta(dos);
             }
@@ -159,7 +159,7 @@ public class HollowBlobWriter {
                 HollowSchema schema = typeState.getSchema();
                 schema.writeTo(dos);
 
-                VarInt.writeVInt(dos, 0); /// forwards-compatibility, can write number of bytes for older readers to skip here.
+                writeNumShards(dos, typeState.getNumShards());
 
                 typeState.writeReverseDelta(dos);
             }
@@ -177,6 +177,15 @@ public class HollowBlobWriter {
         }
 
         return changedTypes;
+    }
+    
+    private void writeNumShards(DataOutputStream dos, int numShards) throws IOException {
+        VarInt.writeVInt(dos, 1 + VarInt.sizeOfVInt(numShards)); /// pre 2.1.0 forwards compatibility:
+                                                                 /// skip new forwards-compatibility and num shards
+        
+        VarInt.writeVInt(dos, 0); /// 2.1.0 forwards-compatibility, can write number of bytes for older readers to skip here.
+        
+        VarInt.writeVInt(dos, numShards);
     }
 
     private void writeHeader(DataOutputStream os, boolean isReverseDelta) throws IOException {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
@@ -74,9 +74,9 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
         int maxElementOrdinal = 0;
 
         maxShardOrdinal = new int[numShards];
-        int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
+        int minRecordLocationsPerShard = (maxOrdinal + 1) / numShards; 
         for(int i=0;i<numShards;i++)
-            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard + 1 : minOrdinalsPerShard;
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minRecordLocationsPerShard : minRecordLocationsPerShard - 1;
         
         ByteData data = ordinalMap.getByteData().getUnderlyingArray();
         

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
@@ -188,6 +188,7 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
 
     @Override
     public void writeSnapshot(DataOutputStream os) throws IOException {
+        /// for unsharded blobs, support pre v2.1.0 clients
         if(numShards == 1) {
             writeSnapshotShard(os, 0);
         } else {
@@ -319,6 +320,7 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
     }
 
     private void writeCalculatedDelta(DataOutputStream os) throws IOException {
+        /// for unsharded blobs, support pre v2.1.0 clients
         if(numShards == 1) {
             writeCalculatedDeltaShard(os, 0);
         } else {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
@@ -49,7 +49,7 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
     private ByteDataBuffer deltaRemovedOrdinals[];
 
     public HollowListTypeWriteState(HollowListSchema schema) {
-        this(schema, 4);
+        this(schema, 1);
     }
     
     public HollowListTypeWriteState(HollowListSchema schema, int numShards) {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
@@ -76,7 +76,7 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
         maxShardOrdinal = new int[numShards];
         int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
         for(int i=0;i<numShards;i++)
-            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard : minOrdinalsPerShard - 1;
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard + 1 : minOrdinalsPerShard;
         
         ByteData data = ordinalMap.getByteData().getUnderlyingArray();
         

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
@@ -47,7 +47,7 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
     private ByteDataBuffer deltaRemovedOrdinals;
 
     public HollowListTypeWriteState(HollowListSchema schema) {
-        super(schema);
+        super(schema, 1);
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
@@ -17,14 +17,13 @@
  */
 package com.netflix.hollow.core.write;
 
-import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
-import com.netflix.hollow.core.memory.encoding.VarInt;
-
-import com.netflix.hollow.core.schema.HollowListSchema;
 import com.netflix.hollow.core.memory.ByteData;
 import com.netflix.hollow.core.memory.ByteDataBuffer;
 import com.netflix.hollow.core.memory.ThreadSafeBitSet;
+import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
+import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.memory.pool.WastefulRecycler;
+import com.netflix.hollow.core.schema.HollowListSchema;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
@@ -248,7 +247,6 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
 
         int listCounter[] = new int[numShards];
         long elementCounter[] = new long[numShards];
-
         int previousRemovedOrdinal[] = new int[numShards];
         int previousAddedOrdinal[] = new int[numShards];
 
@@ -282,7 +280,7 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
         }
     }
 
-    public void writeCalculatedDelta(DataOutputStream os) throws IOException {
+    private void writeCalculatedDelta(DataOutputStream os) throws IOException {
         if(numShards == 1) {
             writeCalculatedDeltaShard(os, 0);
         } else {
@@ -301,7 +299,7 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
     }
 
 
-    public void writeCalculatedDeltaShard(DataOutputStream os, int shardNumber) throws IOException {
+    private void writeCalculatedDeltaShard(DataOutputStream os, int shardNumber) throws IOException {
         /// 1) max shard ordinal
         VarInt.writeVInt(os, maxShardOrdinal[shardNumber]);
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
@@ -79,9 +79,9 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
         int maxOrdinal = ordinalMap.maxOrdinal();
 
         maxShardOrdinal = new int[numShards];
-        int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
+        int minRecordLocationsPerShard = (maxOrdinal + 1) / numShards; 
         for(int i=0;i<numShards;i++)
-            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard + 1 : minOrdinalsPerShard;
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minRecordLocationsPerShard : minRecordLocationsPerShard - 1;
         
         int maxMapSize = 0;
         ByteData data = ordinalMap.getByteData().getUnderlyingArray();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
@@ -17,15 +17,14 @@
  */
 package com.netflix.hollow.core.write;
 
-import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
-import com.netflix.hollow.core.memory.encoding.HashCodes;
-import com.netflix.hollow.core.memory.encoding.VarInt;
-
-import com.netflix.hollow.core.schema.HollowMapSchema;
 import com.netflix.hollow.core.memory.ByteData;
 import com.netflix.hollow.core.memory.ByteDataBuffer;
 import com.netflix.hollow.core.memory.ThreadSafeBitSet;
+import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
+import com.netflix.hollow.core.memory.encoding.HashCodes;
+import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.memory.pool.WastefulRecycler;
+import com.netflix.hollow.core.schema.HollowMapSchema;
 import java.io.DataOutputStream;
 import java.io.IOException;
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
@@ -268,6 +268,7 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
 
     @Override
     public void writeSnapshot(DataOutputStream os) throws IOException {
+        /// for unsharded blobs, support pre v2.1.0 clients
         if(numShards == 1) {
             writeSnapshotShard(os, 0);
         } else {
@@ -440,6 +441,7 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
     }
 
     private void writeCalculatedDelta(DataOutputStream os) throws IOException {
+        /// for unsharded blobs, support pre v2.1.0 clients
         if(numShards == 1) {
             writeCalculatedDeltaShard(os, 0);
         } else {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
@@ -50,7 +50,7 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
     private ByteDataBuffer deltaRemovedOrdinals;
 
     public HollowMapTypeWriteState(HollowMapSchema schema) {
-        super(schema);
+        super(schema, 1);
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
@@ -36,21 +36,26 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
     private int bitsPerMapSizeValue;
     private int bitsPerKeyElement;
     private int bitsPerValueElement;
-    private long totalOfMapBuckets;
+    private long shardTotalOfMapBuckets[];
 
     /// data required for writing snapshot or delta
     private int maxOrdinal;
-    private FixedLengthElementArray mapPointersAndSizesArray;
-    private FixedLengthElementArray entryArray;
+    private int maxShardOrdinal[];
+    private FixedLengthElementArray mapPointersAndSizesArray[];
+    private FixedLengthElementArray entryArray[];
 
     /// additional data required for writing delta
-    private int numMapsInDelta;
-    private long numBucketsInDelta;
-    private ByteDataBuffer deltaAddedOrdinals;
-    private ByteDataBuffer deltaRemovedOrdinals;
+    private int numMapsInDelta[];
+    private long numBucketsInDelta[];
+    private ByteDataBuffer deltaAddedOrdinals[];
+    private ByteDataBuffer deltaRemovedOrdinals[];
 
     public HollowMapTypeWriteState(HollowMapSchema schema) {
-        super(schema, 1);
+        this(schema, 1);
+    }
+    
+    public HollowMapTypeWriteState(HollowMapSchema schema, int numShards) {
+        super(schema, numShards);
     }
 
     @Override
@@ -62,8 +67,6 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
     public void prepareForWrite() {
         super.prepareForWrite();
 
-        totalOfMapBuckets = 0;
-
         gatherStatistics();
     }
 
@@ -72,10 +75,17 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
         int maxValueOrdinal = 0;
 
         int maxOrdinal = ordinalMap.maxOrdinal();
+
+        maxShardOrdinal = new int[numShards];
+        int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
+        for(int i=0;i<numShards;i++)
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard : minOrdinalsPerShard - 1;
+        
         int maxMapSize = 0;
         ByteData data = ordinalMap.getByteData().getUnderlyingArray();
 
-
+        shardTotalOfMapBuckets = new long[numShards];
+        
         for(int i=0;i<=maxOrdinal;i++) {
             if(currentCyclePopulated.get(i) || previousCyclePopulated.get(i)) {
                 long pointer = ordinalMap.getPointerForData(i);
@@ -105,8 +115,14 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
                     pointer += VarInt.nextVLongSize(data, pointer);  /// discard hashed bucket
                 }
 
-                totalOfMapBuckets += numBuckets;
+                shardTotalOfMapBuckets[i & (numShards-1)] += numBuckets;
             }
+        }
+        
+        long maxShardTotalOfMapBuckets = 0;
+        for(int i=0;i<numShards;i++) {
+            if(shardTotalOfMapBuckets[i] > maxShardTotalOfMapBuckets)
+                maxShardTotalOfMapBuckets = shardTotalOfMapBuckets[i];
         }
 
         bitsPerKeyElement = 64 - Long.numberOfLeadingZeros(maxKeyOrdinal + 1);
@@ -114,7 +130,7 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
 
         bitsPerMapSizeValue = 64 - Long.numberOfLeadingZeros(maxMapSize);
 
-        bitsPerMapPointer = 64 - Long.numberOfLeadingZeros(totalOfMapBuckets);
+        bitsPerMapPointer = 64 - Long.numberOfLeadingZeros(maxShardTotalOfMapBuckets);
     }
 
     @Override
@@ -122,34 +138,43 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
         maxOrdinal = ordinalMap.maxOrdinal();
         int bitsPerMapFixedLengthPortion = bitsPerMapSizeValue + bitsPerMapPointer;
         int bitsPerMapEntry = bitsPerKeyElement + bitsPerValueElement;
+        
+        mapPointersAndSizesArray = new FixedLengthElementArray[numShards];
+        entryArray = new FixedLengthElementArray[numShards];
 
-        mapPointersAndSizesArray = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, (long)bitsPerMapFixedLengthPortion * (maxOrdinal + 1));
-        entryArray = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, (long)bitsPerMapEntry * totalOfMapBuckets);
+        for(int i=0;i<numShards;i++) {
+            mapPointersAndSizesArray[i] = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, (long)bitsPerMapFixedLengthPortion * (maxShardOrdinal[i] + 1));
+            entryArray[i] = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, (long)bitsPerMapEntry * shardTotalOfMapBuckets[i]);
+        }
 
         ByteData data = ordinalMap.getByteData().getUnderlyingArray();
 
-        int bucketCounter = 0;
+        int bucketCounter[] = new int[numShards];
+        int shardMask = numShards - 1;
 
         HollowWriteStateEnginePrimaryKeyHasher primaryKeyHasher = null;
 
         if(getSchema().getHashKey() != null)
             primaryKeyHasher = new HollowWriteStateEnginePrimaryKeyHasher(getSchema().getHashKey(), getStateEngine());
         
-        for(int i=0;i<=maxOrdinal;i++) {
-            if(currentCyclePopulated.get(i)) {
-                long readPointer = ordinalMap.getPointerForData(i);
+        for(int ordinal=0;ordinal<=maxOrdinal;ordinal++) {
+            int shardNumber = ordinal & shardMask;
+            int shardOrdinal = ordinal / numShards;
+            
+            if(currentCyclePopulated.get(ordinal)) {
+                long readPointer = ordinalMap.getPointerForData(ordinal);
 
                 int size = VarInt.readVInt(data, readPointer);
                 readPointer += VarInt.sizeOfVInt(size);
 
                 int numBuckets = HashCodes.hashTableSize(size);
 
-                mapPointersAndSizesArray.setElementValue(((long)bitsPerMapFixedLengthPortion * i) + bitsPerMapPointer, bitsPerMapSizeValue, size);
+                mapPointersAndSizesArray[shardNumber].setElementValue(((long)bitsPerMapFixedLengthPortion * shardOrdinal) + bitsPerMapPointer, bitsPerMapSizeValue, size);
 
                 int keyElementOrdinal = 0;
 
                 for(int j=0;j<numBuckets;j++) {
-                    entryArray.setElementValue((long)bitsPerMapEntry * (bucketCounter + j), bitsPerKeyElement, (1L << bitsPerKeyElement) - 1);
+                    entryArray[shardNumber].setElementValue((long)bitsPerMapEntry * (bucketCounter[shardNumber] + j), bitsPerKeyElement, (1L << bitsPerKeyElement) - 1);
                 }
 
                 for(int j=0;j<size;j++) {
@@ -165,58 +190,71 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
                     if(primaryKeyHasher != null)
                         hashedBucket = primaryKeyHasher.getRecordHash(keyElementOrdinal) & (numBuckets - 1);
 
-                    while(entryArray.getElementValue((long)bitsPerMapEntry * (bucketCounter + hashedBucket), bitsPerKeyElement) != ((1L << bitsPerKeyElement) - 1)) {
+                    while(entryArray[shardNumber].getElementValue((long)bitsPerMapEntry * (bucketCounter[shardNumber] + hashedBucket), bitsPerKeyElement) != ((1L << bitsPerKeyElement) - 1)) {
                         hashedBucket++;
                         hashedBucket &= (numBuckets - 1);
                     }
 
-                    long mapEntryBitOffset = bitsPerMapEntry * (bucketCounter + hashedBucket);
-                    entryArray.clearElementValue(mapEntryBitOffset, bitsPerMapEntry);
-                    entryArray.setElementValue(mapEntryBitOffset, bitsPerKeyElement, keyElementOrdinal);
-                    entryArray.setElementValue(mapEntryBitOffset + bitsPerKeyElement, bitsPerValueElement, valueElementOrdinal);
+                    long mapEntryBitOffset = bitsPerMapEntry * (bucketCounter[shardNumber] + hashedBucket);
+                    entryArray[shardNumber].clearElementValue(mapEntryBitOffset, bitsPerMapEntry);
+                    entryArray[shardNumber].setElementValue(mapEntryBitOffset, bitsPerKeyElement, keyElementOrdinal);
+                    entryArray[shardNumber].setElementValue(mapEntryBitOffset + bitsPerKeyElement, bitsPerValueElement, valueElementOrdinal);
                 }
 
-                bucketCounter += numBuckets;
+                bucketCounter[shardNumber] += numBuckets;
             }
 
-            mapPointersAndSizesArray.setElementValue((long)bitsPerMapFixedLengthPortion * i, bitsPerMapPointer, bucketCounter);
+            mapPointersAndSizesArray[shardNumber].setElementValue((long)bitsPerMapFixedLengthPortion * shardOrdinal, bitsPerMapPointer, bucketCounter[shardNumber]);
         }
     }
 
     @Override
     public void writeSnapshot(DataOutputStream os) throws IOException {
+        if(numShards == 1) {
+            writeSnapshotShard(os, 0);
+        } else {
+            /// overall max ordinal
+            VarInt.writeVInt(os, maxOrdinal);
+            
+            for(int i=0;i<numShards;i++) {
+                writeSnapshotShard(os, i);
+            }
+        }
+        
+        /// Populated bits
+        currentCyclePopulated.serializeBitsTo(os);
+
+        mapPointersAndSizesArray = null;
+        entryArray = null;
+    }
+    
+    private void writeSnapshotShard(DataOutputStream os, int shardNumber) throws IOException {
         int bitsPerMapFixedLengthPortion = bitsPerMapSizeValue + bitsPerMapPointer;
         int bitsPerMapEntry = bitsPerKeyElement + bitsPerValueElement;
 
         /// 1) max ordinal
-        VarInt.writeVInt(os, maxOrdinal);
+        VarInt.writeVInt(os, maxShardOrdinal[shardNumber]);
 
         /// 2) statistics
         VarInt.writeVInt(os, bitsPerMapPointer);
         VarInt.writeVInt(os, bitsPerMapSizeValue);
         VarInt.writeVInt(os, bitsPerKeyElement);
         VarInt.writeVInt(os, bitsPerValueElement);
-        VarInt.writeVLong(os, totalOfMapBuckets);
+        VarInt.writeVLong(os, shardTotalOfMapBuckets[shardNumber]);
 
         /// 3) list pointer array
-        int numMapFixedLengthLongs = maxOrdinal == -1 ? 0 : (int)((((long)(maxOrdinal + 1) * bitsPerMapFixedLengthPortion) - 1) / 64) + 1;
+        int numMapFixedLengthLongs = maxShardOrdinal[shardNumber] == -1 ? 0 : (int)((((long)(maxShardOrdinal[shardNumber] + 1) * bitsPerMapFixedLengthPortion) - 1) / 64) + 1;
         VarInt.writeVInt(os, numMapFixedLengthLongs);
         for(int i=0;i<numMapFixedLengthLongs;i++) {
-            os.writeLong(mapPointersAndSizesArray.get(i));
+            os.writeLong(mapPointersAndSizesArray[shardNumber].get(i));
         }
 
         /// 4) element array
-        int numElementLongs = totalOfMapBuckets == 0 ? 0 : (int)(((totalOfMapBuckets * bitsPerMapEntry) - 1) / 64) + 1;
+        int numElementLongs = shardTotalOfMapBuckets[shardNumber] == 0 ? 0 : (int)(((shardTotalOfMapBuckets[shardNumber] * bitsPerMapEntry) - 1) / 64) + 1;
         VarInt.writeVInt(os, numElementLongs);
         for(int i=0;i<numElementLongs;i++) {
-            os.writeLong(entryArray.get(i));
+            os.writeLong(entryArray[shardNumber].get(i));
         }
-
-        /// 5) Populated bits
-        currentCyclePopulated.serializeBitsTo(os);
-
-        mapPointersAndSizesArray = null;
-        entryArray = null;
     }
 
     @Override
@@ -244,45 +282,65 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
         int bitsPerMapFixedLengthPortion = bitsPerMapSizeValue + bitsPerMapPointer;
         int bitsPerMapEntry = bitsPerKeyElement + bitsPerValueElement;
 
+        numMapsInDelta = new int[numShards];
+        numBucketsInDelta = new long[numShards];
+        mapPointersAndSizesArray = new FixedLengthElementArray[numShards];
+        entryArray = new FixedLengthElementArray[numShards];
+        deltaAddedOrdinals = new ByteDataBuffer[numShards];
+        deltaRemovedOrdinals = new ByteDataBuffer[numShards];
+        
         ThreadSafeBitSet deltaAdditions = toCyclePopulated.andNot(fromCyclePopulated);
-        numMapsInDelta = deltaAdditions.cardinality();
-        numBucketsInDelta = calculateNumBucketsInDelta(maxOrdinal, deltaAdditions);
+        
+        int shardMask = numShards - 1;
+        
+        int addedOrdinal = deltaAdditions.nextSetBit(0);
+        while(addedOrdinal != -1) {
+            numMapsInDelta[addedOrdinal & shardMask]++;
+            long readPointer = ordinalMap.getPointerForData(addedOrdinal);
+            int size = VarInt.readVInt(ordinalMap.getByteData().getUnderlyingArray(), readPointer);
+            numBucketsInDelta[addedOrdinal & shardMask] += HashCodes.hashTableSize(size);
 
-        mapPointersAndSizesArray = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, (long)numMapsInDelta * bitsPerMapFixedLengthPortion);
-        entryArray = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, numBucketsInDelta * bitsPerMapEntry);
-        deltaAddedOrdinals = new ByteDataBuffer(WastefulRecycler.DEFAULT_INSTANCE);
-        deltaRemovedOrdinals = new ByteDataBuffer(WastefulRecycler.DEFAULT_INSTANCE);
+            addedOrdinal = deltaAdditions.nextSetBit(addedOrdinal + 1);
+        }
+
+        for(int i=0;i<numShards;i++) {
+            mapPointersAndSizesArray[i] = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, (long)numMapsInDelta[i] * bitsPerMapFixedLengthPortion);
+            entryArray[i] = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, numBucketsInDelta[i] * bitsPerMapEntry);
+            deltaAddedOrdinals[i] = new ByteDataBuffer(WastefulRecycler.DEFAULT_INSTANCE);
+            deltaRemovedOrdinals[i] = new ByteDataBuffer(WastefulRecycler.DEFAULT_INSTANCE);
+        }
 
         ByteData data = ordinalMap.getByteData().getUnderlyingArray();
 
-        int mapCounter = 0;
-        int bucketCounter = 0;
-        int previousRemovedOrdinal = 0;
-        int previousAddedOrdinal = 0;
+        int mapCounter[] = new int[numShards];
+        long bucketCounter[] = new long[numShards];
+        int previousRemovedOrdinal[] = new int[numShards];
+        int previousAddedOrdinal[] = new int[numShards];
         
         HollowWriteStateEnginePrimaryKeyHasher primaryKeyHasher = null;
 
         if(getSchema().getHashKey() != null)
             primaryKeyHasher = new HollowWriteStateEnginePrimaryKeyHasher(getSchema().getHashKey(), getStateEngine());
 
-        for(int i=0;i<=maxOrdinal;i++) {
-            if(toCyclePopulated.get(i) && !fromCyclePopulated.get(i)) {
-                long readPointer = ordinalMap.getPointerForData(i);
+        for(int ordinal=0;ordinal<=maxOrdinal;ordinal++) {
+            int shardNumber = ordinal & shardMask;
+            if(deltaAdditions.get(ordinal)) {
+                long readPointer = ordinalMap.getPointerForData(ordinal);
 
                 int size = VarInt.readVInt(data, readPointer);
                 readPointer += VarInt.sizeOfVInt(size);
 
                 int numBuckets = HashCodes.hashTableSize(size);
 
-                long endBucketPosition = bucketCounter + numBuckets;
+                long endBucketPosition = bucketCounter[shardNumber] + numBuckets;
 
-                mapPointersAndSizesArray.setElementValue((long)bitsPerMapFixedLengthPortion * mapCounter, bitsPerMapPointer, endBucketPosition);
-                mapPointersAndSizesArray.setElementValue(((long)bitsPerMapFixedLengthPortion * mapCounter) + bitsPerMapPointer, bitsPerMapSizeValue, size);
+                mapPointersAndSizesArray[shardNumber].setElementValue((long)bitsPerMapFixedLengthPortion * mapCounter[shardNumber], bitsPerMapPointer, endBucketPosition);
+                mapPointersAndSizesArray[shardNumber].setElementValue(((long)bitsPerMapFixedLengthPortion * mapCounter[shardNumber]) + bitsPerMapPointer, bitsPerMapSizeValue, size);
 
                 int keyElementOrdinal = 0;
 
                 for(int j=0;j<numBuckets;j++) {
-                    entryArray.setElementValue((long)bitsPerMapEntry * (bucketCounter + j), bitsPerKeyElement, (1L << bitsPerKeyElement) - 1);
+                    entryArray[shardNumber].setElementValue((long)bitsPerMapEntry * (bucketCounter[shardNumber] + j), bitsPerKeyElement, (1L << bitsPerKeyElement) - 1);
                 }
 
                 for(int j=0;j<size;j++) {
@@ -298,81 +356,82 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
                     if(primaryKeyHasher != null)
                         hashedBucket = primaryKeyHasher.getRecordHash(keyElementOrdinal) & (numBuckets - 1);
 
-                    while(entryArray.getElementValue((long)bitsPerMapEntry * (bucketCounter + hashedBucket), bitsPerKeyElement) != ((1L << bitsPerKeyElement) - 1)) {
+                    while(entryArray[shardNumber].getElementValue((long)bitsPerMapEntry * (bucketCounter[shardNumber] + hashedBucket), bitsPerKeyElement) != ((1L << bitsPerKeyElement) - 1)) {
                         hashedBucket++;
                         hashedBucket &= (numBuckets - 1);
                     }
 
-                    long mapEntryBitOffset = bitsPerMapEntry * (bucketCounter + hashedBucket);
-                    entryArray.clearElementValue(mapEntryBitOffset, bitsPerMapEntry);
-                    entryArray.setElementValue(mapEntryBitOffset, bitsPerKeyElement, keyElementOrdinal);
-                    entryArray.setElementValue(mapEntryBitOffset + bitsPerKeyElement, bitsPerValueElement, valueElementOrdinal);
+                    long mapEntryBitOffset = bitsPerMapEntry * (bucketCounter[shardNumber] + hashedBucket);
+                    entryArray[shardNumber].clearElementValue(mapEntryBitOffset, bitsPerMapEntry);
+                    entryArray[shardNumber].setElementValue(mapEntryBitOffset, bitsPerKeyElement, keyElementOrdinal);
+                    entryArray[shardNumber].setElementValue(mapEntryBitOffset + bitsPerKeyElement, bitsPerValueElement, valueElementOrdinal);
                 }
 
-                bucketCounter += numBuckets;
-                mapCounter++;
+                bucketCounter[shardNumber] += numBuckets;
+                mapCounter[shardNumber]++;
 
-                VarInt.writeVInt(deltaAddedOrdinals, i - previousAddedOrdinal);
-                previousAddedOrdinal = i;
-            } else if(fromCyclePopulated.get(i) && !toCyclePopulated.get(i)) {
-                VarInt.writeVInt(deltaRemovedOrdinals, i - previousRemovedOrdinal);
-                previousRemovedOrdinal = i;
+                int shardOrdinal = ordinal / numShards;
+                VarInt.writeVInt(deltaAddedOrdinals[shardNumber], shardOrdinal - previousAddedOrdinal[shardNumber]);
+                previousAddedOrdinal[shardNumber] = shardOrdinal;
+            } else if(fromCyclePopulated.get(ordinal) && !toCyclePopulated.get(ordinal)) {
+                int shardOrdinal = ordinal / numShards;
+                VarInt.writeVInt(deltaRemovedOrdinals[shardNumber], shardOrdinal - previousRemovedOrdinal[shardNumber]);
+                previousRemovedOrdinal[shardNumber] = shardOrdinal;
             }
         }
     }
 
     private void writeCalculatedDelta(DataOutputStream os) throws IOException {
+        if(numShards == 1) {
+            writeCalculatedDeltaShard(os, 0);
+        } else {
+            /// overall max ordinal
+            VarInt.writeVInt(os, maxOrdinal);
+            
+            for(int i=0;i<numShards;i++) {
+                writeCalculatedDeltaShard(os, i);
+            }
+        }
+        
+        mapPointersAndSizesArray = null;
+        entryArray = null;
+        deltaAddedOrdinals = null;
+        deltaRemovedOrdinals = null;
+    }
+    
+    private void writeCalculatedDeltaShard(DataOutputStream os, int shardNumber) throws IOException {
+        
         int bitsPerMapFixedLengthPortion = bitsPerMapSizeValue + bitsPerMapPointer;
         int bitsPerMapEntry = bitsPerKeyElement + bitsPerValueElement;
 
         /// 1) max ordinal
-        VarInt.writeVInt(os, maxOrdinal);
+        VarInt.writeVInt(os, maxShardOrdinal[shardNumber]);
 
         /// 2) removal / addition ordinals.
-        VarInt.writeVLong(os, deltaRemovedOrdinals.length());
-        deltaRemovedOrdinals.getUnderlyingArray().writeTo(os, 0, deltaRemovedOrdinals.length());
-        VarInt.writeVLong(os, deltaAddedOrdinals.length());
-        deltaAddedOrdinals.getUnderlyingArray().writeTo(os, 0, deltaAddedOrdinals.length());
+        VarInt.writeVLong(os, deltaRemovedOrdinals[shardNumber].length());
+        deltaRemovedOrdinals[shardNumber].getUnderlyingArray().writeTo(os, 0, deltaRemovedOrdinals[shardNumber].length());
+        VarInt.writeVLong(os, deltaAddedOrdinals[shardNumber].length());
+        deltaAddedOrdinals[shardNumber].getUnderlyingArray().writeTo(os, 0, deltaAddedOrdinals[shardNumber].length());
 
         /// 3) statistics
         VarInt.writeVInt(os, bitsPerMapPointer);
         VarInt.writeVInt(os, bitsPerMapSizeValue);
         VarInt.writeVInt(os, bitsPerKeyElement);
         VarInt.writeVInt(os, bitsPerValueElement);
-        VarInt.writeVLong(os, totalOfMapBuckets);
+        VarInt.writeVLong(os, shardTotalOfMapBuckets[shardNumber]);
 
         /// 4) pointer array
-        int numMapFixedLengthLongs = numMapsInDelta == 0 ? 0 : (int)((((long)numMapsInDelta * bitsPerMapFixedLengthPortion) - 1) / 64) + 1;
+        int numMapFixedLengthLongs = numMapsInDelta[shardNumber] == 0 ? 0 : (int)((((long)numMapsInDelta[shardNumber] * bitsPerMapFixedLengthPortion) - 1) / 64) + 1;
         VarInt.writeVInt(os, numMapFixedLengthLongs);
         for(int i=0;i<numMapFixedLengthLongs;i++) {
-            os.writeLong(mapPointersAndSizesArray.get(i));
+            os.writeLong(mapPointersAndSizesArray[shardNumber].get(i));
         }
 
         /// 5) element array
-        int numElementLongs = numBucketsInDelta == 0 ? 0 : (int)(((numBucketsInDelta * bitsPerMapEntry) - 1) / 64) + 1;
+        int numElementLongs = numBucketsInDelta[shardNumber] == 0 ? 0 : (int)(((numBucketsInDelta[shardNumber] * bitsPerMapEntry) - 1) / 64) + 1;
         VarInt.writeVInt(os, numElementLongs);
         for(int i=0;i<numElementLongs;i++) {
-            os.writeLong(entryArray.get(i));
+            os.writeLong(entryArray[shardNumber].get(i));
         }
-
-        mapPointersAndSizesArray = null;
-        entryArray = null;
-        deltaAddedOrdinals = null;
-        deltaRemovedOrdinals = null;
-    }
-
-    private long calculateNumBucketsInDelta(int maxOrdinal, ThreadSafeBitSet deltaAdditions) {
-        long totalNumberOfBuckets = 0;
-
-        for(int i=0;i<=maxOrdinal;i++) {
-            if(deltaAdditions.get(i)) {
-                long readPointer = ordinalMap.getPointerForData(i);
-                int size = VarInt.readVInt(ordinalMap.getByteData().getUnderlyingArray(), readPointer);
-
-                totalNumberOfBuckets += HashCodes.hashTableSize(size);
-            }
-        }
-
-        return totalNumberOfBuckets;
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
@@ -81,7 +81,7 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
         maxShardOrdinal = new int[numShards];
         int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
         for(int i=0;i<numShards;i++)
-            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard : minOrdinalsPerShard - 1;
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard + 1 : minOrdinalsPerShard;
         
         int maxMapSize = 0;
         ByteData data = ordinalMap.getByteData().getUnderlyingArray();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
@@ -17,15 +17,14 @@
  */
 package com.netflix.hollow.core.write;
 
-import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
-import com.netflix.hollow.core.memory.encoding.VarInt;
-
-import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import com.netflix.hollow.core.memory.ByteData;
 import com.netflix.hollow.core.memory.ByteDataBuffer;
 import com.netflix.hollow.core.memory.ThreadSafeBitSet;
+import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
+import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.memory.pool.WastefulRecycler;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.io.DataOutputStream;
 import java.io.IOException;
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
@@ -88,9 +88,9 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
         }
         
         maxShardOrdinal = new int[numShards];
-        int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
+        int minRecordLocationsPerShard = (maxOrdinal + 1) / numShards; 
         for(int i=0;i<numShards;i++)
-            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard + 1 : minOrdinalsPerShard;
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minRecordLocationsPerShard : minRecordLocationsPerShard - 1;
     }
 
     private void discoverObjectFieldStatisticsForRecord(FieldStatistics fieldStats, int ordinal) {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
@@ -191,6 +191,7 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
     
     @Override
     public void writeSnapshot(DataOutputStream os) throws IOException {
+        /// for unsharded blobs, support pre v2.1.0 clients
         if(numShards == 1) {
             writeSnapshotShard(os, 0);
         } else {
@@ -303,6 +304,7 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
     }
 
     private void writeCalculatedDelta(DataOutputStream os) throws IOException {
+        /// for unsharded blobs, support pre v2.1.0 clients
         if(numShards == 1) {
             writeCalculatedDeltaShard(os, 0);
         } else {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
@@ -90,7 +90,7 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
         maxShardOrdinal = new int[numShards];
         int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
         for(int i=0;i<numShards;i++)
-            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard : minOrdinalsPerShard - 1;
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard + 1 : minOrdinalsPerShard;
     }
 
     private void discoverObjectFieldStatisticsForRecord(FieldStatistics fieldStats, int ordinal) {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
@@ -36,16 +36,21 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
 
     /// data required for writing snapshot or delta
     private int maxOrdinal;
-    private FixedLengthElementArray fixedLengthLongArray;
-    private ByteDataBuffer varLengthByteArrays[];
-    private long recordBitOffset;
+    private int maxShardOrdinal[];
+    private FixedLengthElementArray fixedLengthLongArray[];
+    private ByteDataBuffer varLengthByteArrays[][];
+    private long recordBitOffset[];
 
     /// additional data required for writing delta
-    private ByteDataBuffer deltaAddedOrdinals;
-    private ByteDataBuffer deltaRemovedOrdinals;
+    private ByteDataBuffer deltaAddedOrdinals[];
+    private ByteDataBuffer deltaRemovedOrdinals[];
 
     public HollowObjectTypeWriteState(HollowObjectSchema schema) {
-        super(schema);
+        this(schema, 1);
+    }
+    
+    public HollowObjectTypeWriteState(HollowObjectSchema schema, int numShards) {
+        super(schema, numShards);
     }
 
     @Override
@@ -148,27 +153,58 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
     public void calculateSnapshot() {
         maxOrdinal = ordinalMap.maxOrdinal();
         int numBitsPerRecord = fieldStats.getNumBitsPerRecord();
+        
+        maxShardOrdinal = new int[numShards];
+        fixedLengthLongArray = new FixedLengthElementArray[numShards];
+        varLengthByteArrays = new ByteDataBuffer[numShards][];
+        recordBitOffset = new long[numShards];
+        
+        int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
 
-        fixedLengthLongArray = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, (long)numBitsPerRecord * (maxOrdinal + 1));
-        varLengthByteArrays = new ByteDataBuffer[getSchema().numFields()];
-
-        recordBitOffset = 0;
-
+        for(int i=0;i<numShards;i++) {
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard : minOrdinalsPerShard - 1;
+            fixedLengthLongArray[i] = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, (long)numBitsPerRecord * (maxShardOrdinal[i] + 1));
+            varLengthByteArrays[i] = new ByteDataBuffer[getSchema().numFields()];
+        }
+        
+        int shardMask = numShards - 1;
+    
         for(int i=0;i<=maxOrdinal;i++) {
+            int shardNumber = i & shardMask;
             if(currentCyclePopulated.get(i)) {
-                addRecord(i, recordBitOffset, fixedLengthLongArray, varLengthByteArrays);
+                addRecord(i, recordBitOffset[shardNumber], fixedLengthLongArray[shardNumber], varLengthByteArrays[shardNumber]);
             } else {
-                addNullRecord(i, recordBitOffset, fixedLengthLongArray, varLengthByteArrays);
+                addNullRecord(i, recordBitOffset[shardNumber], fixedLengthLongArray[shardNumber], varLengthByteArrays[shardNumber]);
             }
-            recordBitOffset += numBitsPerRecord;
+            recordBitOffset[shardNumber] += numBitsPerRecord;
         }
     }
-
-
+    
     @Override
     public void writeSnapshot(DataOutputStream os) throws IOException {
-        /// 1) max ordinal
-        VarInt.writeVInt(os, maxOrdinal);
+        if(numShards == 1) {
+            writeSnapshotShard(os, 0);
+        } else {
+            /// overall max ordinal
+            VarInt.writeVInt(os, maxOrdinal);
+            
+            for(int i=0;i<numShards;i++) {
+                writeSnapshotShard(os, i);
+            }
+        }
+
+        /// Populated bits
+        currentCyclePopulated.serializeBitsTo(os);
+        
+        maxShardOrdinal = null;
+        fixedLengthLongArray = null;
+        varLengthByteArrays = null;
+        recordBitOffset = null;
+    }
+
+    private void writeSnapshotShard(DataOutputStream os, int shardNumber) throws IOException {
+        /// 1) shard max ordinal
+        VarInt.writeVInt(os, maxShardOrdinal[shardNumber]);
 
         /// 2) FixedLength field sizes
         for(int i=0;i<getSchema().numFields();i++) {
@@ -176,25 +212,19 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
         }
 
         /// 3) FixedLength data
-        long numBitsRequired = recordBitOffset;
-        long numLongsRequired = recordBitOffset == 0 ? 0 : ((numBitsRequired - 1) / 64) + 1;
-        fixedLengthLongArray.writeTo(os, numLongsRequired);
+        long numBitsRequired = recordBitOffset[shardNumber];
+        long numLongsRequired = recordBitOffset[shardNumber] == 0 ? 0 : ((numBitsRequired - 1) / 64) + 1;
+        fixedLengthLongArray[shardNumber].writeTo(os, numLongsRequired);
 
         /// 4) VarLength data
-        for(int i=0;i<varLengthByteArrays.length;i++) {
-            if(varLengthByteArrays[i] == null) {
+        for(int i=0;i<varLengthByteArrays[shardNumber].length;i++) {
+            if(varLengthByteArrays[shardNumber][i] == null) {
                 VarInt.writeVLong(os, 0);
             } else {
-                VarInt.writeVLong(os, varLengthByteArrays[i].length());
-                varLengthByteArrays[i].getUnderlyingArray().writeTo(os, 0, varLengthByteArrays[i].length());
+                VarInt.writeVLong(os, varLengthByteArrays[shardNumber][i].length());
+                varLengthByteArrays[shardNumber][i].getUnderlyingArray().writeTo(os, 0, varLengthByteArrays[shardNumber][i].length());
             }
         }
-
-        /// 5) Populated bits
-        currentCyclePopulated.serializeBitsTo(os);
-
-        fixedLengthLongArray = null;
-        varLengthByteArrays = null;
     }
 
     @Override
@@ -222,42 +252,82 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
         int numBitsPerRecord = fieldStats.getNumBitsPerRecord();
 
         ThreadSafeBitSet deltaAdditions = toCyclePopulated.andNot(fromCyclePopulated);
-        int numRecordsInDelta = deltaAdditions.cardinality();
 
-        fixedLengthLongArray = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, (long)numRecordsInDelta * numBitsPerRecord);
-        deltaAddedOrdinals = new ByteDataBuffer(WastefulRecycler.DEFAULT_INSTANCE);
-        deltaRemovedOrdinals = new ByteDataBuffer(WastefulRecycler.DEFAULT_INSTANCE);
+        maxShardOrdinal = new int[numShards];
+        fixedLengthLongArray = new FixedLengthElementArray[numShards];
+        deltaAddedOrdinals = new ByteDataBuffer[numShards];
+        deltaRemovedOrdinals = new ByteDataBuffer[numShards];
+        varLengthByteArrays = new ByteDataBuffer[numShards][];
+        recordBitOffset = new long[numShards];
+        int numAddedRecordsInShard[] = new int[numShards];
+        
+        int shardMask = numShards - 1;
+        
+        int addedOrdinal = deltaAdditions.nextSetBit(0);
+        while(addedOrdinal != -1) {
+            numAddedRecordsInShard[addedOrdinal & shardMask]++;
+            addedOrdinal = deltaAdditions.nextSetBit(addedOrdinal + 1);
+        }
+        
+        int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
 
-        varLengthByteArrays = new ByteDataBuffer[getSchema().numFields()];
+        for(int i=0;i<numShards;i++) {
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard : minOrdinalsPerShard - 1;
+            fixedLengthLongArray[i] = new FixedLengthElementArray(WastefulRecycler.DEFAULT_INSTANCE, (long)numAddedRecordsInShard[i] * numBitsPerRecord);
+            deltaAddedOrdinals[i] = new ByteDataBuffer(WastefulRecycler.DEFAULT_INSTANCE);
+            deltaRemovedOrdinals[i] = new ByteDataBuffer(WastefulRecycler.DEFAULT_INSTANCE);
+            varLengthByteArrays[i] = new ByteDataBuffer[getSchema().numFields()];
+        }
 
-        recordBitOffset = 0;
-
-        int previousRemovedOrdinal = 0;
-        int previousAddedOrdinal = 0;
+        int previousRemovedOrdinal[] = new int[numShards];
+        int previousAddedOrdinal[] = new int[numShards];
 
         for(int i=0;i<=maxOrdinal;i++) {
-            if(toCyclePopulated.get(i) && !fromCyclePopulated.get(i)) {
-                addRecord(i, recordBitOffset, fixedLengthLongArray, varLengthByteArrays);
-                recordBitOffset += numBitsPerRecord;
-                VarInt.writeVInt(deltaAddedOrdinals, i - previousAddedOrdinal);
-                previousAddedOrdinal = i;
+            int shardNumber = i & shardMask;
+            if(deltaAdditions.get(i)) {
+                addRecord(i, recordBitOffset[shardNumber], fixedLengthLongArray[shardNumber], varLengthByteArrays[shardNumber]);
+                recordBitOffset[shardNumber] += numBitsPerRecord;
+                int shardOrdinal = i / numShards;
+                VarInt.writeVInt(deltaAddedOrdinals[shardNumber], shardOrdinal - previousAddedOrdinal[shardNumber]);
+                previousAddedOrdinal[shardNumber] = shardOrdinal;
             } else if(fromCyclePopulated.get(i) && !toCyclePopulated.get(i)) {
-                VarInt.writeVInt(deltaRemovedOrdinals, i - previousRemovedOrdinal);
-                previousRemovedOrdinal = i;
+                int shardOrdinal = i / numShards;
+                VarInt.writeVInt(deltaRemovedOrdinals[shardNumber], shardOrdinal - previousRemovedOrdinal[shardNumber]);
+                previousRemovedOrdinal[shardNumber] = shardOrdinal;
             }
         }
     }
 
     private void writeCalculatedDelta(DataOutputStream os) throws IOException {
+        if(numShards == 1) {
+            writeCalculatedDeltaShard(os, 0);
+        } else {
+            /// overall max ordinal
+            VarInt.writeVInt(os, maxOrdinal);
+            
+            for(int i=0;i<numShards;i++) {
+                writeCalculatedDeltaShard(os, i);
+            }
+        }
+        
+        maxShardOrdinal = null;
+        fixedLengthLongArray = null;
+        varLengthByteArrays = null;
+        deltaAddedOrdinals = null;
+        deltaRemovedOrdinals = null;
+        recordBitOffset = null;
+    }
+
+    private void writeCalculatedDeltaShard(DataOutputStream os, int shardNumber) throws IOException {
 
         /// 1) max ordinal
-        VarInt.writeVInt(os, maxOrdinal);
+        VarInt.writeVInt(os, maxShardOrdinal[shardNumber]);
 
         /// 2) removal / addition ordinals.
-        VarInt.writeVLong(os, deltaRemovedOrdinals.length());
-        deltaRemovedOrdinals.getUnderlyingArray().writeTo(os, 0, deltaRemovedOrdinals.length());
-        VarInt.writeVLong(os, deltaAddedOrdinals.length());
-        deltaAddedOrdinals.getUnderlyingArray().writeTo(os, 0, deltaAddedOrdinals.length());
+        VarInt.writeVLong(os, deltaRemovedOrdinals[shardNumber].length());
+        deltaRemovedOrdinals[shardNumber].getUnderlyingArray().writeTo(os, 0, deltaRemovedOrdinals[shardNumber].length());
+        VarInt.writeVLong(os, deltaAddedOrdinals[shardNumber].length());
+        deltaAddedOrdinals[shardNumber].getUnderlyingArray().writeTo(os, 0, deltaAddedOrdinals[shardNumber].length());
 
         /// 3) FixedLength field sizes
         for(int i=0;i<getSchema().numFields();i++) {
@@ -265,24 +335,19 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
         }
 
         /// 4) FixedLength data
-        long numBitsRequired = recordBitOffset;
+        long numBitsRequired = recordBitOffset[shardNumber];
         long numLongsRequired = numBitsRequired == 0 ? 0 : ((numBitsRequired - 1) / 64) + 1;
-        fixedLengthLongArray.writeTo(os, numLongsRequired);
+        fixedLengthLongArray[shardNumber].writeTo(os, numLongsRequired);
 
         /// 5) VarLength data
-        for(int i=0;i<varLengthByteArrays.length;i++) {
-            if(varLengthByteArrays[i] == null) {
+        for(int i=0;i<varLengthByteArrays[shardNumber].length;i++) {
+            if(varLengthByteArrays[shardNumber][i] == null) {
                 VarInt.writeVLong(os, 0);
             } else {
-                VarInt.writeVLong(os, varLengthByteArrays[i].length());
-                varLengthByteArrays[i].getUnderlyingArray().writeTo(os, 0, varLengthByteArrays[i].length());
+                VarInt.writeVLong(os, varLengthByteArrays[shardNumber][i].length());
+                varLengthByteArrays[shardNumber][i].getUnderlyingArray().writeTo(os, 0, varLengthByteArrays[shardNumber][i].length());
             }
         }
-
-        fixedLengthLongArray = null;
-        varLengthByteArrays = null;
-        deltaAddedOrdinals = null;
-        deltaRemovedOrdinals = null;
     }
 
     /// here we need to add the offsets for the variable-length field endings, as they will be read as the start position for the following record.

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
@@ -243,6 +243,7 @@ public class HollowSetTypeWriteState extends HollowTypeWriteState {
 
     @Override
     public void writeSnapshot(DataOutputStream os) throws IOException {
+        /// for unsharded blobs, support pre v2.1.0 clients
         if(numShards == 1) {
             writeSnapshotShard(os, 0);
         } else {
@@ -407,6 +408,7 @@ public class HollowSetTypeWriteState extends HollowTypeWriteState {
     }
 
     private void writeCalculatedDelta(DataOutputStream os) throws IOException {
+        /// for unsharded blobs, support pre v2.1.0 clients
         if(numShards == 1) {
             writeCalculatedDeltaShard(os, 0);
         } else {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
@@ -76,9 +76,9 @@ public class HollowSetTypeWriteState extends HollowTypeWriteState {
         int maxOrdinal = ordinalMap.maxOrdinal();
         
         maxShardOrdinal = new int[numShards];
-        int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
+        int minRecordLocationsPerShard = (maxOrdinal + 1) / numShards; 
         for(int i=0;i<numShards;i++)
-            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard + 1 : minOrdinalsPerShard;
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minRecordLocationsPerShard : minRecordLocationsPerShard - 1;
         
         int maxSetSize = 0;
         ByteData data = ordinalMap.getByteData().getUnderlyingArray();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
@@ -49,7 +49,7 @@ public class HollowSetTypeWriteState extends HollowTypeWriteState {
     private ByteDataBuffer removedOrdinals;
 
     public HollowSetTypeWriteState(HollowSetSchema schema) {
-        super(schema);
+        super(schema, 1);
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
@@ -78,7 +78,7 @@ public class HollowSetTypeWriteState extends HollowTypeWriteState {
         maxShardOrdinal = new int[numShards];
         int minOrdinalsPerShard = (maxOrdinal + 1) / numShards; 
         for(int i=0;i<numShards;i++)
-            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard : minOrdinalsPerShard - 1;
+            maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minOrdinalsPerShard + 1 : minOrdinalsPerShard;
         
         int maxSetSize = 0;
         ByteData data = ordinalMap.getByteData().getUnderlyingArray();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -43,7 +43,7 @@ public abstract class HollowTypeWriteState {
 
     protected final ByteArrayOrdinalMap ordinalMap;
     
-    protected final int numShards;
+    protected int numShards;
 
     protected HollowSchema restoredSchema;
     protected ByteArrayOrdinalMap restoredMap;
@@ -54,7 +54,7 @@ public abstract class HollowTypeWriteState {
 
     private final ThreadLocal<ByteDataBuffer> serializedScratchSpace;
 
-    private HollowWriteStateEngine stateEngine;
+    protected HollowWriteStateEngine stateEngine;
     
     private boolean wroteData = false;
 
@@ -66,7 +66,7 @@ public abstract class HollowTypeWriteState {
         this.previousCyclePopulated = new ThreadSafeBitSet();
         this.numShards = numShards;
         
-        if((numShards & (numShards - 1)) != 0 || numShards <= 0)
+        if(numShards != -1 && ((numShards & (numShards - 1)) != 0 || numShards <= 0))
             throw new IllegalArgumentException("Number of shards must be a power of 2!  Check configuration for type " + schema.getName());
     }
     

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -19,10 +19,8 @@ package com.netflix.hollow.core.write;
 
 import static com.netflix.hollow.core.write.HollowHashableWriteRecord.HashBehavior.IGNORED_HASHES;
 import static com.netflix.hollow.core.write.HollowHashableWriteRecord.HashBehavior.UNMIXED_HASHES;
-
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
-
 import com.netflix.hollow.core.memory.ByteArrayOrdinalMap;
 import com.netflix.hollow.core.memory.ByteDataBuffer;
 import com.netflix.hollow.core.memory.ThreadSafeBitSet;
@@ -44,6 +42,8 @@ public abstract class HollowTypeWriteState {
     protected final HollowSchema schema;
 
     protected final ByteArrayOrdinalMap ordinalMap;
+    
+    protected final int numShards;
 
     protected HollowSchema restoredSchema;
     protected ByteArrayOrdinalMap restoredMap;
@@ -58,12 +58,16 @@ public abstract class HollowTypeWriteState {
     
     private boolean wroteData = false;
 
-    public HollowTypeWriteState(HollowSchema schema) {
+    public HollowTypeWriteState(HollowSchema schema, int numShards) {
         this.schema = schema;
         this.ordinalMap = new ByteArrayOrdinalMap();
         this.serializedScratchSpace = new ThreadLocal<ByteDataBuffer>();
         this.currentCyclePopulated = new ThreadSafeBitSet();
         this.previousCyclePopulated = new ThreadSafeBitSet();
+        this.numShards = numShards;
+        
+        if((numShards & (numShards - 1)) != 0 || numShards <= 0)
+            throw new IllegalArgumentException("Number of shards must be a power of 2!  Check configuration for type " + schema.getName());
     }
     
     /**
@@ -216,6 +220,10 @@ public abstract class HollowTypeWriteState {
     
     public HollowSchema getSchema() {
         return schema;
+    }
+    
+    int getNumShards() {
+        return numShards;
     }
 
     /**

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
@@ -118,6 +118,13 @@ public class HollowWriteStateEngine implements HollowStateEngine {
     public void restoreFrom(HollowReadStateEngine readStateEngine) {
         if(!readStateEngine.isListenToAllPopulatedOrdinals())
             throw new IllegalStateException("The specified HollowReadStateEngine must be listening for all populated ordinals!");
+
+        for(HollowTypeReadState readState : readStateEngine.getTypeStates()) {
+            String typeName = readState.getSchema().getName();
+            HollowTypeWriteState writeState = writeStates.get(typeName);
+            if(writeState != null && writeState.getNumShards() != readState.numShards())
+                throw new IllegalStateException("The specified HollowReadStateEngine does not have the same number of shards as this state engine for type " + typeName);
+        }
         
         restoredStates = new ArrayList<String>();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
@@ -63,7 +63,7 @@ public class HollowWriteStateEngine implements HollowStateEngine {
     private final HollowObjectHashCodeFinder hashCodeFinder;
     
     //// target a maximum shard size to reduce excess memory pool requirement 
-    private long targetMaxTypeShardSize = 25L * 1024L * 1024L;
+    private long targetMaxTypeShardSize = Long.MAX_VALUE;
 
     private List<String> restoredStates;
     private boolean preparedForNextCycle = true;
@@ -363,6 +363,15 @@ public class HollowWriteStateEngine implements HollowStateEngine {
     	this.nextStateRandomizedTag = nextStateRandomizedTag;
     }
     
+    /**
+     * Setting a target max type shard size (specified in bytes) will limit the excess memory pool required to perform delta transitions.
+     * 
+     * For use cases where all consumers are running with hollow v2.1.0 or greater, it is recommended to set this value to 
+     * something reasonably small, for example 25MB.
+     * 
+     * In a future release, this value will default to  (25 * 1024 * 1024).  It is currently set to Long.MAX_VALUE to retain backwards
+     * compatibility with pre v2.1.0 consumers. 
+     */
     public void setTargetMaxTypeShardSize(long targetMaxTypeShardSize) {
         this.targetMaxTypeShardSize = targetMaxTypeShardSize;
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
@@ -39,7 +39,7 @@ public class HollowListTypeMapper extends HollowTypeMapper {
     private final HollowTypeMapper elementMapper;
 
     public HollowListTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, int numShards, boolean ignoreListOrdering, Set<Type> visited) {
-        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, 1, visited);
+        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, -1, visited);
         String typeName = declaredName != null ? declaredName : getDefaultTypeName(type);
         this.schema = new HollowListSchema(typeName, elementMapper.getTypeName());
         this.ignoreListOrdering = ignoreListOrdering;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
@@ -17,16 +17,14 @@
  */
 package com.netflix.hollow.core.write.objectmapper;
 
-import com.netflix.hollow.core.util.IntList;
-
 import com.netflix.hollow.core.schema.HollowListSchema;
+import com.netflix.hollow.core.util.IntList;
 import com.netflix.hollow.core.write.HollowListTypeWriteState;
 import com.netflix.hollow.core.write.HollowListWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -40,14 +38,14 @@ public class HollowListTypeMapper extends HollowTypeMapper {
 
     private final HollowTypeMapper elementMapper;
 
-    public HollowListTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, boolean ignoreListOrdering, Set<Type> visited) {
-        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, visited);
+    public HollowListTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, int numShards, boolean ignoreListOrdering, Set<Type> visited) {
+        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, 1, visited);
         String typeName = declaredName != null ? declaredName : getDefaultTypeName(type);
         this.schema = new HollowListSchema(typeName, elementMapper.getTypeName());
         this.ignoreListOrdering = ignoreListOrdering;
 
         HollowListTypeWriteState existingTypeState = (HollowListTypeWriteState)parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = existingTypeState != null ? existingTypeState : new HollowListTypeWriteState(schema);
+        this.writeState = existingTypeState != null ? existingTypeState : new HollowListTypeWriteState(schema, numShards);
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -41,8 +41,8 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
     private HollowTypeMapper valueMapper;
 
     public HollowMapTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, String[] hashKeyFieldPaths, int numShards, HollowWriteStateEngine stateEngine, boolean useDefaultHashKeys, Set<Type> visited) {
-        this.keyMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, 1, visited);
-        this.valueMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[1], null, null, 1, visited);
+        this.keyMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, -1, visited);
+        this.valueMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[1], null, null, -1, visited);
         String typeName = declaredName != null ? declaredName : getDefaultTypeName(type);
         
         if(hashKeyFieldPaths == null && useDefaultHashKeys && (keyMapper instanceof HollowObjectTypeMapper))

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -40,9 +40,9 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
     private HollowTypeMapper keyMapper;
     private HollowTypeMapper valueMapper;
 
-    public HollowMapTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, String[] hashKeyFieldPaths, HollowWriteStateEngine stateEngine, boolean useDefaultHashKeys, Set<Type> visited) {
-        this.keyMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, visited);
-        this.valueMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[1], null, null, visited);
+    public HollowMapTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, String[] hashKeyFieldPaths, int numShards, HollowWriteStateEngine stateEngine, boolean useDefaultHashKeys, Set<Type> visited) {
+        this.keyMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, 1, visited);
+        this.valueMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[1], null, null, 1, visited);
         String typeName = declaredName != null ? declaredName : getDefaultTypeName(type);
         
         if(hashKeyFieldPaths == null && useDefaultHashKeys && (keyMapper instanceof HollowObjectTypeMapper))
@@ -52,7 +52,7 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
         this.hashCodeFinder = stateEngine.getHashCodeFinder();
 
         HollowMapTypeWriteState typeState = (HollowMapTypeWriteState) parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = typeState != null ? typeState : new HollowMapTypeWriteState(schema);
+        this.writeState = typeState != null ? typeState : new HollowMapTypeWriteState(schema, numShards);
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
@@ -66,7 +66,7 @@ public class HollowObjectMapper {
     }
 
     HollowTypeMapper getTypeMapper(Type type, String declaredName, String[] hashKeyFieldPaths) {
-        return getTypeMapper(type, declaredName, hashKeyFieldPaths, 1, null);
+        return getTypeMapper(type, declaredName, hashKeyFieldPaths, -1, null);
     }
     
     HollowTypeMapper getTypeMapper(Type type, String declaredName, String[] hashKeyFieldPaths, int numShards, Set<Type> visited) {
@@ -90,7 +90,7 @@ public class HollowObjectMapper {
                 } else if(Map.class.isAssignableFrom(clazz)) {
                     typeMapper = new HollowMapTypeMapper(this, parameterizedType, declaredName, hashKeyFieldPaths, numShards, stateEngine, useDefaultHashKeys, visited);
                 } else {
-                    return getTypeMapper(clazz, declaredName, hashKeyFieldPaths, 1, visited);
+                    return getTypeMapper(clazz, declaredName, hashKeyFieldPaths, -1, visited);
                 }
 
             } else {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
@@ -66,10 +66,10 @@ public class HollowObjectMapper {
     }
 
     HollowTypeMapper getTypeMapper(Type type, String declaredName, String[] hashKeyFieldPaths) {
-        return getTypeMapper(type, declaredName, hashKeyFieldPaths, null);
+        return getTypeMapper(type, declaredName, hashKeyFieldPaths, 1, null);
     }
     
-    HollowTypeMapper getTypeMapper(Type type, String declaredName, String[] hashKeyFieldPaths, Set<Type> visited) {
+    HollowTypeMapper getTypeMapper(Type type, String declaredName, String[] hashKeyFieldPaths, int numShards, Set<Type> visited) {
         String typeName = declaredName != null ? declaredName : HollowObjectTypeMapper.getDefaultTypeName(type);
 
         HollowTypeMapper typeMapper = typeMappers.get(typeName);
@@ -84,13 +84,13 @@ public class HollowObjectMapper {
                 Class<?> clazz = (Class<?>) parameterizedType.getRawType();
 
                 if(List.class.isAssignableFrom(clazz)) {
-                    typeMapper = new HollowListTypeMapper(this, parameterizedType, declaredName, ignoreListOrdering, visited);
+                    typeMapper = new HollowListTypeMapper(this, parameterizedType, declaredName, numShards, ignoreListOrdering, visited);
                 } else if(Set.class.isAssignableFrom(clazz)) {
-                    typeMapper = new HollowSetTypeMapper(this, parameterizedType, declaredName, hashKeyFieldPaths, stateEngine, useDefaultHashKeys, visited);
+                    typeMapper = new HollowSetTypeMapper(this, parameterizedType, declaredName, hashKeyFieldPaths, numShards, stateEngine, useDefaultHashKeys, visited);
                 } else if(Map.class.isAssignableFrom(clazz)) {
-                    typeMapper = new HollowMapTypeMapper(this, parameterizedType, declaredName, hashKeyFieldPaths, stateEngine, useDefaultHashKeys, visited);
+                    typeMapper = new HollowMapTypeMapper(this, parameterizedType, declaredName, hashKeyFieldPaths, numShards, stateEngine, useDefaultHashKeys, visited);
                 } else {
-                    return getTypeMapper(clazz, declaredName, hashKeyFieldPaths, visited);
+                    return getTypeMapper(clazz, declaredName, hashKeyFieldPaths, 1, visited);
                 }
 
             } else {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -104,7 +104,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
         HollowShardLargeType numShardsAnnotation = clazz.getAnnotation(HollowShardLargeType.class);
         if(numShardsAnnotation != null)
             return numShardsAnnotation.numShards();
-        return 1;
+        return -1;
     }
 
     @Override
@@ -209,7 +209,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
                 subTypeMapper = parentMapper.getTypeMapper(type, 
                                                            typeNameAnnotation != null ? typeNameAnnotation.name() : null, 
                                                            hashKeyAnnotation != null ? hashKeyAnnotation.fields() : null, 
-                                                           numShardsAnnotation != null ? numShardsAnnotation.numShards() : 1, 
+                                                           numShardsAnnotation != null ? numShardsAnnotation.numShards() : -1, 
                                                            visitedTypes);
                 
                 // once we've safely returned from a leaf node in recursion, we can remove this MappedField's type

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -19,7 +19,6 @@ package com.netflix.hollow.core.write.objectmapper;
 
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
-
 import com.netflix.hollow.core.memory.HollowUnsafeHandle;
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
@@ -55,7 +54,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
         this.clazz = clazz;
         this.typeName = declaredTypeName != null ? declaredTypeName : getDefaultTypeName(clazz);
         this.mappedFields = new ArrayList<MappedField>();
-
+        
         if(clazz == String.class) {
             try {
                 mappedFields.add(new MappedField(clazz.getDeclaredField("value")));
@@ -86,7 +85,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
         }
 
         HollowObjectTypeWriteState existingWriteState = (HollowObjectTypeWriteState) parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = existingWriteState != null ? existingWriteState : new HollowObjectTypeWriteState(schema);
+        this.writeState = existingWriteState != null ? existingWriteState : new HollowObjectTypeWriteState(schema, getNumShards(clazz));
 
         long assignedOrdinalFieldOffset = -1;
         try {
@@ -99,6 +98,13 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
     private static String[] getKeyFieldPaths(Class<?> clazz) {
         HollowPrimaryKey primaryKey = clazz.getAnnotation(HollowPrimaryKey.class);
         return primaryKey == null ? null : primaryKey.fields();
+    }
+    
+    private static int getNumShards(Class<?> clazz) {
+        HollowShardLargeType numShardsAnnotation = clazz.getAnnotation(HollowShardLargeType.class);
+        if(numShardsAnnotation != null)
+            return numShardsAnnotation.numShards();
+        return 1;
     }
 
     @Override
@@ -161,6 +167,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
         private final HollowTypeMapper subTypeMapper;
         private final HollowTypeName typeNameAnnotation;
         private final HollowHashKey hashKeyAnnotation;
+        private final HollowShardLargeType numShardsAnnotation;
         private final boolean isEnumNameField;
 
         private MappedField(Field f) {
@@ -172,6 +179,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             this.type = f.getGenericType();
             this.typeNameAnnotation = f.getAnnotation(HollowTypeName.class);
             this.hashKeyAnnotation = f.getAnnotation(HollowHashKey.class);
+            this.numShardsAnnotation = f.getAnnotation(HollowShardLargeType.class);
             this.isEnumNameField = false;
 
             HollowTypeMapper subTypeMapper = null;
@@ -198,7 +206,12 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
                 }
                 // guard recursion here
                 visitedTypes.add(this.type);
-                subTypeMapper = parentMapper.getTypeMapper(type, typeNameAnnotation != null ? typeNameAnnotation.name() : null, hashKeyAnnotation != null ? hashKeyAnnotation.fields() : null, visitedTypes);
+                subTypeMapper = parentMapper.getTypeMapper(type, 
+                                                           typeNameAnnotation != null ? typeNameAnnotation.name() : null, 
+                                                           hashKeyAnnotation != null ? hashKeyAnnotation.fields() : null, 
+                                                           numShardsAnnotation != null ? numShardsAnnotation.numShards() : 1, 
+                                                           visitedTypes);
+                
                 // once we've safely returned from a leaf node in recursion, we can remove this MappedField's type
                 visitedTypes.remove(this.type);
             }
@@ -212,6 +225,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             this.type = null;
             this.typeNameAnnotation = null;
             this.hashKeyAnnotation = null;
+            this.numShardsAnnotation = null;
             this.fieldName = "_name";
             this.fieldType = FieldType.STRING;
             this.isEnumNameField = true;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -38,8 +38,8 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
 
     private final HollowTypeMapper elementMapper;
 
-    public HollowSetTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, String[] hashKeyFieldPaths, HollowWriteStateEngine stateEngine, boolean useDefaultHashKeys, Set<Type> visited) {
-        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, visited);
+    public HollowSetTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, String[] hashKeyFieldPaths, int numShards, HollowWriteStateEngine stateEngine, boolean useDefaultHashKeys, Set<Type> visited) {
+        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, 1, visited);
         String typeName = declaredName != null ? declaredName : getDefaultTypeName(type);
         
         if(hashKeyFieldPaths == null && useDefaultHashKeys && (elementMapper instanceof HollowObjectTypeMapper))
@@ -49,7 +49,7 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
         this.hashCodeFinder = stateEngine.getHashCodeFinder();
 
         HollowSetTypeWriteState existingTypeState = (HollowSetTypeWriteState) parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = existingTypeState != null ? existingTypeState : new HollowSetTypeWriteState(schema);
+        this.writeState = existingTypeState != null ? existingTypeState : new HollowSetTypeWriteState(schema, numShards);
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -39,7 +39,7 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
     private final HollowTypeMapper elementMapper;
 
     public HollowSetTypeMapper(HollowObjectMapper parentMapper, ParameterizedType type, String declaredName, String[] hashKeyFieldPaths, int numShards, HollowWriteStateEngine stateEngine, boolean useDefaultHashKeys, Set<Type> visited) {
-        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, 1, visited);
+        this.elementMapper = parentMapper.getTypeMapper(type.getActualTypeArguments()[0], null, null, -1, visited);
         String typeName = declaredName != null ? declaredName : getDefaultTypeName(type);
         
         if(hashKeyFieldPaths == null && useDefaultHashKeys && (elementMapper instanceof HollowObjectTypeMapper))

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowShardLargeType.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowShardLargeType.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.write.objectmapper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Retention;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD})
+public @interface HollowShardLargeType {
+    
+    int numShards();
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/tools/filter/FilteredHollowBlobWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/filter/FilteredHollowBlobWriter.java
@@ -141,7 +141,7 @@ public class FilteredHollowBlobWriter {
 
                 if (schema instanceof HollowListSchema) {
                     if(streamsWithType.length == 0)
-                        HollowListTypeReadState.discardType(dis, delta);
+                        HollowListTypeReadState.discardType(dis, numShards, delta);
                     else
                         copyListState(delta, dis, streamsOnly(streamsWithType), numShards);
                 } else if(schema instanceof HollowSetSchema) {

--- a/hollow/src/main/java/com/netflix/hollow/tools/filter/FilteredHollowBlobWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/filter/FilteredHollowBlobWriter.java
@@ -146,7 +146,7 @@ public class FilteredHollowBlobWriter {
                         copyListState(delta, dis, streamsOnly(streamsWithType), numShards);
                 } else if(schema instanceof HollowSetSchema) {
                     if(streamsWithType.length == 0)
-                        HollowSetTypeReadState.discardType(dis, delta);
+                        HollowSetTypeReadState.discardType(dis, numShards, delta);
                     else
                         copySetState(delta, dis, streamsOnly(streamsWithType), numShards);
                 } else if(schema instanceof HollowMapSchema) {

--- a/hollow/src/main/java/com/netflix/hollow/tools/filter/FilteredHollowBlobWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/filter/FilteredHollowBlobWriter.java
@@ -151,7 +151,7 @@ public class FilteredHollowBlobWriter {
                         copySetState(delta, dis, streamsOnly(streamsWithType), numShards);
                 } else if(schema instanceof HollowMapSchema) {
                     if(streamsWithType.length == 0)
-                        HollowMapTypeReadState.discardType(dis, delta);
+                        HollowMapTypeReadState.discardType(dis, numShards, delta);
                     else
                         copyMapState(delta, dis, streamsOnly(streamsWithType), numShards);
                 }

--- a/hollow/src/main/java/com/netflix/hollow/tools/filter/FilteredHollowBlobWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/filter/FilteredHollowBlobWriter.java
@@ -122,41 +122,54 @@ public class FilteredHollowBlobWriter {
         for(int i=0;i<numStates;i++) {
             HollowSchema schema = HollowSchema.readFrom(in);
 
-            skipForwardsCompatibilityBytes(in);
+            int numShards = readNumShards(in);
 
             FilteredHollowBlobWriterStreamAndFilter[] streamsWithType = FilteredHollowBlobWriterStreamAndFilter.withType(schema.getName(), allStreamAndFilters);
 
             if(schema instanceof HollowObjectSchema) {
                 if(streamsWithType.length == 0)
-                    HollowObjectTypeReadState.discardType(dis, (HollowObjectSchema)schema, delta);
+                    HollowObjectTypeReadState.discardType(dis, (HollowObjectSchema)schema, numShards, delta);
                 else
-                    copyFilteredObjectState(delta, dis, streamsWithType, (HollowObjectSchema)schema);
+                    copyFilteredObjectState(delta, dis, streamsWithType, (HollowObjectSchema)schema, numShards);
             } else {
                 for(int j=0;j<streamsWithType.length;j++) {
                     schema.writeTo(streamsWithType[j].getStream());
-                    VarInt.writeVInt(streamsWithType[j].getStream(), 0);
+                    VarInt.writeVInt(streamsWithType[j].getStream(), 1 + VarInt.sizeOfVInt(numShards));
+                    VarInt.writeVInt(streamsWithType[j].getStream(), 0); /// forwards compatibility
+                    VarInt.writeVInt(streamsWithType[j].getStream(), numShards);
                 }
 
                 if (schema instanceof HollowListSchema) {
                     if(streamsWithType.length == 0)
                         HollowListTypeReadState.discardType(dis, delta);
                     else
-                        copyListState(delta, dis, streamsOnly(streamsWithType));
+                        copyListState(delta, dis, streamsOnly(streamsWithType), numShards);
                 } else if(schema instanceof HollowSetSchema) {
                     if(streamsWithType.length == 0)
                         HollowSetTypeReadState.discardType(dis, delta);
                     else
-                        copySetState(delta, dis, streamsOnly(streamsWithType));
+                        copySetState(delta, dis, streamsOnly(streamsWithType), numShards);
                 } else if(schema instanceof HollowMapSchema) {
                     if(streamsWithType.length == 0)
                         HollowMapTypeReadState.discardType(dis, delta);
                     else
-                        copyMapState(delta, dis, streamsOnly(streamsWithType));
+                        copyMapState(delta, dis, streamsOnly(streamsWithType), numShards);
                 }
             }
         }
     }
 
+    private int readNumShards(InputStream is) throws IOException {
+        int backwardsCompatibilityBytes = VarInt.readVInt(is);
+        
+        if(backwardsCompatibilityBytes == 0)
+            return 1;  /// produced by a version of hollow prior to 2.1.0, always only 1 shard.
+        
+        skipForwardsCompatibilityBytes(is);
+        
+        return VarInt.readVInt(is);
+    }
+    
     private void skipForwardsCompatibilityBytes(InputStream is) throws IOException {
         int bytesToSkip = VarInt.readVInt(is);
         while(bytesToSkip > 0) {
@@ -168,7 +181,7 @@ public class FilteredHollowBlobWriter {
     }
 
     @SuppressWarnings("unchecked")
-    private void copyFilteredObjectState(boolean delta, DataInputStream is, FilteredHollowBlobWriterStreamAndFilter[] streamAndFilters, HollowObjectSchema schema) throws IOException {
+    private void copyFilteredObjectState(boolean delta, DataInputStream is, FilteredHollowBlobWriterStreamAndFilter[] streamAndFilters, HollowObjectSchema schema, int numShards) throws IOException {
         DataOutputStream[] os = streamsOnly(streamAndFilters);
         HollowObjectSchema[] filteredObjectSchemas = new HollowObjectSchema[os.length];
 
@@ -176,91 +189,98 @@ public class FilteredHollowBlobWriter {
             HollowObjectSchema filteredObjectSchema = getFilteredObjectSchema(schema, streamAndFilters[i].getConfig());
             filteredObjectSchemas[i] = filteredObjectSchema;
             filteredObjectSchema.writeTo(streamAndFilters[i].getStream());
-            VarInt.writeVInt(streamAndFilters[i].getStream(), 0);
+            
+            VarInt.writeVInt(streamAndFilters[i].getStream(), 1 + VarInt.sizeOfVInt(numShards));
+            VarInt.writeVInt(streamAndFilters[i].getStream(), 0); /// forwards compatibility
+            VarInt.writeVInt(streamAndFilters[i].getStream(), numShards);
         }
 
-
-        int maxOrdinal = copyVInt(is, os);
-
-        if(delta) {
-            GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
-            GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
-        }
-
-        /// SETUP ///
-        int bitsPerField[] = new int[schema.numFields()];
-        for(int i=0;i<schema.numFields();i++)
-            bitsPerField[i] = VarInt.readVInt(is);
-
-        FixedLengthElementArray fixedLengthArraysPerStream[] = new FixedLengthElementArray[os.length];
-        long bitsRequiredPerStream[] = new long[os.length];
-        List<FixedLengthArrayWriter> fixedLengthArraysPerField[] = (List<FixedLengthArrayWriter>[])new List[schema.numFields()];
-        for(int i=0;i<fixedLengthArraysPerField.length;i++)
-            fixedLengthArraysPerField[i] = new ArrayList<FixedLengthArrayWriter>();
-
-        for(int i=0;i<streamAndFilters.length;i++) {
-            long bitsPerRecord = writeBitsPerField(schema, bitsPerField, filteredObjectSchemas[i], streamAndFilters[i].getStream());
-
-            bitsRequiredPerStream[i] = bitsPerRecord * (maxOrdinal + 1);
-            fixedLengthArraysPerStream[i] = new FixedLengthElementArray(memoryRecycler,  bitsRequiredPerStream[i]);
-            FixedLengthArrayWriter filteredArrayWriter = new FixedLengthArrayWriter(fixedLengthArraysPerStream[i]);
-
-            for(int j=0;j<schema.numFields();j++) {
-                if(filteredObjectSchemas[i].getPosition(schema.getFieldName(j)) != -1) {
-                    fixedLengthArraysPerField[j].add(filteredArrayWriter);
+        if(numShards > 1)
+            copyVInt(is, os);
+        
+        for(int shard=0;shard<numShards;shard++) {
+            int maxShardOrdinal = copyVInt(is, os);
+    
+            if(delta) {
+                GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+                GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+            }
+    
+            /// SETUP ///
+            int bitsPerField[] = new int[schema.numFields()];
+            for(int i=0;i<schema.numFields();i++)
+                bitsPerField[i] = VarInt.readVInt(is);
+    
+            FixedLengthElementArray fixedLengthArraysPerStream[] = new FixedLengthElementArray[os.length];
+            long bitsRequiredPerStream[] = new long[os.length];
+            List<FixedLengthArrayWriter> fixedLengthArraysPerField[] = (List<FixedLengthArrayWriter>[])new List[schema.numFields()];
+            for(int i=0;i<fixedLengthArraysPerField.length;i++)
+                fixedLengthArraysPerField[i] = new ArrayList<FixedLengthArrayWriter>();
+    
+            for(int i=0;i<streamAndFilters.length;i++) {
+                long bitsPerRecord = writeBitsPerField(schema, bitsPerField, filteredObjectSchemas[i], streamAndFilters[i].getStream());
+    
+                bitsRequiredPerStream[i] = bitsPerRecord * (maxShardOrdinal + 1);
+                fixedLengthArraysPerStream[i] = new FixedLengthElementArray(memoryRecycler,  bitsRequiredPerStream[i]);
+                FixedLengthArrayWriter filteredArrayWriter = new FixedLengthArrayWriter(fixedLengthArraysPerStream[i]);
+    
+                for(int j=0;j<schema.numFields();j++) {
+                    if(filteredObjectSchemas[i].getPosition(schema.getFieldName(j)) != -1) {
+                        fixedLengthArraysPerField[j].add(filteredArrayWriter);
+                    }
                 }
             }
-        }
-        /// END SETUP ///
-
-        /// read the unfiltered long array into memory
-        FixedLengthElementArray unfilteredFixedLengthFields = FixedLengthElementArray.deserializeFrom(is, memoryRecycler);
-
-        /// populate the filtered arrays (each field just gets written to all FixedLengthArrayWriters assigned to its field index)
-        long bitsPerRecord = 0;
-        for(int fieldBits : bitsPerField)
-            bitsPerRecord += fieldBits;
-
-        long stopBit = bitsPerRecord * (maxOrdinal + 1);
-        long bitCursor = 0;
-        int fieldCursor = 0;
-
-        while(bitCursor < stopBit) {
-            if(!fixedLengthArraysPerField[fieldCursor].isEmpty()) {
-                long fieldValue = bitsPerField[fieldCursor] > 56 ?
-                        unfilteredFixedLengthFields.getLargeElementValue(bitCursor, bitsPerField[fieldCursor])
-                        : unfilteredFixedLengthFields.getElementValue(bitCursor, bitsPerField[fieldCursor]);
-
-                        for(int i=0;i<fixedLengthArraysPerField[fieldCursor].size();i++)
-                            fixedLengthArraysPerField[fieldCursor].get(i).writeField(fieldValue, bitsPerField[fieldCursor]);
+            /// END SETUP ///
+    
+            /// read the unfiltered long array into memory
+            FixedLengthElementArray unfilteredFixedLengthFields = FixedLengthElementArray.deserializeFrom(is, memoryRecycler);
+    
+            /// populate the filtered arrays (each field just gets written to all FixedLengthArrayWriters assigned to its field index)
+            long bitsPerRecord = 0;
+            for(int fieldBits : bitsPerField)
+                bitsPerRecord += fieldBits;
+    
+            long stopBit = bitsPerRecord * (maxShardOrdinal + 1);
+            long bitCursor = 0;
+            int fieldCursor = 0;
+    
+            while(bitCursor < stopBit) {
+                if(!fixedLengthArraysPerField[fieldCursor].isEmpty()) {
+                    long fieldValue = bitsPerField[fieldCursor] > 56 ?
+                            unfilteredFixedLengthFields.getLargeElementValue(bitCursor, bitsPerField[fieldCursor])
+                            : unfilteredFixedLengthFields.getElementValue(bitCursor, bitsPerField[fieldCursor]);
+    
+                            for(int i=0;i<fixedLengthArraysPerField[fieldCursor].size();i++)
+                                fixedLengthArraysPerField[fieldCursor].get(i).writeField(fieldValue, bitsPerField[fieldCursor]);
+                }
+    
+                bitCursor += bitsPerField[fieldCursor];
+                if(++fieldCursor == schema.numFields())
+                    fieldCursor = 0;
+    
             }
-
-            bitCursor += bitsPerField[fieldCursor];
-            if(++fieldCursor == schema.numFields())
-                fieldCursor = 0;
-
-        }
-
-        /// write the filtered arrays
-        for(int i=0;i<os.length;i++) {
-            long numLongsRequired = bitsRequiredPerStream[i] == 0 ? 0 : ((bitsRequiredPerStream[i] - 1) / 64) + 1;
-            fixedLengthArraysPerStream[i].writeTo(os[i], numLongsRequired);
-        }
-
-        /// copy the var length arrays for populated fields
-        for(int i=0;i<schema.numFields();i++) {
-            List<DataOutputStream> streamsWithFieldList = new ArrayList<DataOutputStream>();
-            for(int j=0;j<streamAndFilters.length;j++) {
-                ObjectFilterConfig objectTypeConfig = streamAndFilters[j].getConfig().getObjectTypeConfig(schema.getName());
-                if(objectTypeConfig.includesField(schema.getFieldName(i)))
-                    streamsWithFieldList.add(streamAndFilters[j].getStream());
+    
+            /// write the filtered arrays
+            for(int i=0;i<os.length;i++) {
+                long numLongsRequired = bitsRequiredPerStream[i] == 0 ? 0 : ((bitsRequiredPerStream[i] - 1) / 64) + 1;
+                fixedLengthArraysPerStream[i].writeTo(os[i], numLongsRequired);
             }
-
-            DataOutputStream streamsWithField[] = new DataOutputStream[streamsWithFieldList.size()];
-            streamsWithField = streamsWithFieldList.toArray(streamsWithField);
-
-            long numBytesInVarLengthData = IOUtils.copyVLong(is, streamsWithField);
-            IOUtils.copyBytes(is, streamsWithField, numBytesInVarLengthData);
+    
+            /// copy the var length arrays for populated fields
+            for(int i=0;i<schema.numFields();i++) {
+                List<DataOutputStream> streamsWithFieldList = new ArrayList<DataOutputStream>();
+                for(int j=0;j<streamAndFilters.length;j++) {
+                    ObjectFilterConfig objectTypeConfig = streamAndFilters[j].getConfig().getObjectTypeConfig(schema.getName());
+                    if(objectTypeConfig.includesField(schema.getFieldName(i)))
+                        streamsWithFieldList.add(streamAndFilters[j].getStream());
+                }
+    
+                DataOutputStream streamsWithField[] = new DataOutputStream[streamsWithFieldList.size()];
+                streamsWithField = streamsWithFieldList.toArray(streamsWithField);
+    
+                long numBytesInVarLengthData = IOUtils.copyVLong(is, streamsWithField);
+                IOUtils.copyBytes(is, streamsWithField, numBytesInVarLengthData);
+            }
         }
 
         if(!delta)
@@ -302,61 +322,76 @@ public class FilteredHollowBlobWriter {
         return filteredSchema;
     }
 
-    private void copyListState(boolean delta, DataInputStream is, DataOutputStream[] os) throws IOException {
-        copyVInt(is, os);  /// maxOrdinal
-
-        if(delta) {
-            GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
-            GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+    private void copyListState(boolean delta, DataInputStream is, DataOutputStream[] os, int numShards) throws IOException {
+        if(numShards > 1)
+            copyVInt(is, os);
+        
+        for(int shard=0;shard<numShards;shard++) {
+            copyVInt(is, os);  /// maxOrdinal
+    
+            if(delta) {
+                GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+                GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+            }
+    
+            copyVInt(is, os);  /// bitsPerListPointer
+            copyVInt(is, os);  /// bitsPerElement
+            copyVLong(is, os); /// totalNumberOfElements
+    
+            copySegmentedLongArray(is, os);
+            copySegmentedLongArray(is, os);
         }
-
-        copyVInt(is, os);  /// bitsPerListPointer
-        copyVInt(is, os);  /// bitsPerElement
-        copyVLong(is, os); /// totalNumberOfElements
-
-        copySegmentedLongArray(is, os);
-        copySegmentedLongArray(is, os);
 
         if(!delta)
             copySnapshotPopulatedOrdinals(is, os);
     }
 
-    private void copySetState(boolean delta, DataInputStream is, DataOutputStream[] os) throws IOException {
-        copyVInt(is, os);  /// max ordinal
-
-        if(delta) {
-            GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
-            GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+    private void copySetState(boolean delta, DataInputStream is, DataOutputStream[] os, int numShards) throws IOException {
+        if(numShards > 1)
+            copyVInt(is, os);
+        
+        for(int shard=0;shard<numShards;shard++) {
+            copyVInt(is, os);  /// max ordinal
+    
+            if(delta) {
+                GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+                GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+            }
+    
+            copyVInt(is, os);  /// bitsPerSetPointer
+            copyVInt(is, os);  /// bitsPerSetSizeValue
+            copyVInt(is, os);  /// bitsPerElement
+            copyVLong(is, os); /// totalNumberOfBuckets
+    
+            copySegmentedLongArray(is, os);
+            copySegmentedLongArray(is, os);
         }
-
-        copyVInt(is, os);  /// bitsPerSetPointer
-        copyVInt(is, os);  /// bitsPerSetSizeValue
-        copyVInt(is, os);  /// bitsPerElement
-        copyVLong(is, os); /// totalNumberOfBuckets
-
-        copySegmentedLongArray(is, os);
-        copySegmentedLongArray(is, os);
 
         if(!delta)
             copySnapshotPopulatedOrdinals(is, os);
     }
 
-    private void copyMapState(boolean delta, DataInputStream is, DataOutputStream[] os) throws IOException {
-        copyVInt(is, os);  /// max ordinal
-
-        if(delta) {
-            GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
-            GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+    private void copyMapState(boolean delta, DataInputStream is, DataOutputStream[] os, int numShards) throws IOException {
+        if(numShards > 1)
+            copyVInt(is, os);
+        
+        for(int shard=0;shard<numShards;shard++) {
+            copyVInt(is, os);  /// max ordinal
+    
+            if(delta) {
+                GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+                GapEncodedVariableLengthIntegerReader.copyEncodedDeltaOrdinals(is, os);
+            }
+    
+            copyVInt(is, os);  /// bitsPerMapPointer
+            copyVInt(is, os);  /// bitsPerMapSizeValue
+            copyVInt(is, os);  /// bitsPerKeyElement
+            copyVInt(is, os);  /// bitsPerValueElement
+            copyVLong(is, os); /// totalNumberOfBuckets
+    
+            copySegmentedLongArray(is, os);
+            copySegmentedLongArray(is, os);
         }
-
-        copyVInt(is, os);  /// bitsPerMapPointer
-        copyVInt(is, os);  /// bitsPerMapSizeValue
-        copyVInt(is, os);  /// bitsPerKeyElement
-        copyVInt(is, os);  /// bitsPerValueElement
-        copyVLong(is, os); /// totalNumberOfBuckets
-
-        copySegmentedLongArray(is, os);
-        copySegmentedLongArray(is, os);
 
         if(!delta)
             copySnapshotPopulatedOrdinals(is, os);

--- a/hollow/src/test/java/com/netflix/hollow/core/read/list/HollowListShardedTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/list/HollowListShardedTest.java
@@ -1,0 +1,78 @@
+package com.netflix.hollow.core.read.list;
+
+import com.netflix.hollow.core.AbstractStateEngineTest;
+import com.netflix.hollow.core.read.dataaccess.HollowListTypeDataAccess;
+import com.netflix.hollow.core.schema.HollowListSchema;
+import com.netflix.hollow.core.write.HollowListTypeWriteState;
+import com.netflix.hollow.core.write.HollowListWriteRecord;
+import java.io.IOException;
+import java.util.BitSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HollowListShardedTest extends AbstractStateEngineTest {
+
+    @Before
+    public void setUp() {
+        super.setUp();
+    }
+    
+    @Test
+    public void testShardedData() throws IOException {
+    
+        HollowListWriteRecord rec = new HollowListWriteRecord();
+        
+        for(int i=0;i<2000;i++) {
+            rec.reset();
+            rec.addElement(i);
+            rec.addElement(i+1);
+            rec.addElement(i+2);
+            
+            writeStateEngine.add("TestList", rec);
+        }
+        
+        roundTripSnapshot();
+        
+        Assert.assertEquals(4, readStateEngine.getTypeState("TestList").numShards());
+        
+        HollowListTypeDataAccess listDataAccess = (HollowListTypeDataAccess) readStateEngine.getTypeDataAccess("TestList");
+        for(int i=0;i<1000;i++) {
+            Assert.assertEquals(i, listDataAccess.getElementOrdinal(i, 0));
+            Assert.assertEquals(i+1, listDataAccess.getElementOrdinal(i, 1));
+            Assert.assertEquals(i+2, listDataAccess.getElementOrdinal(i, 2));
+        }
+
+        for(int i=0;i<2000;i++) {
+            rec.reset();
+            rec.addElement(i*2);
+            rec.addElement(i*2+1);
+            rec.addElement(i*2+2);
+            
+            writeStateEngine.add("TestList", rec);
+        }
+        
+        roundTripDelta();
+        
+        int expectedValue = 0;
+        
+        BitSet populatedOrdinals = readStateEngine.getTypeState("TestList").getPopulatedOrdinals();
+        
+        int ordinal = populatedOrdinals.nextSetBit(0);
+        while(ordinal != -1) {
+            Assert.assertEquals(expectedValue, listDataAccess.getElementOrdinal(ordinal, 0));
+            Assert.assertEquals(expectedValue+1, listDataAccess.getElementOrdinal(ordinal, 1));
+            Assert.assertEquals(expectedValue+2, listDataAccess.getElementOrdinal(ordinal, 2));
+            
+            expectedValue += 2;
+            ordinal = populatedOrdinals.nextSetBit(ordinal+1);
+        }
+    }
+    
+    @Override
+    protected void initializeTypeStates() {
+        writeStateEngine.setTargetMaxTypeShardSize(4096);
+        writeStateEngine.addTypeState(new HollowListTypeWriteState(new HollowListSchema("TestList", "TestObject")));
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/list/HollowListShardedTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/list/HollowListShardedTest.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.core.read.list;
 
 import com.netflix.hollow.core.AbstractStateEngineTest;

--- a/hollow/src/test/java/com/netflix/hollow/core/read/map/HollowMapShardedTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/map/HollowMapShardedTest.java
@@ -1,0 +1,80 @@
+package com.netflix.hollow.core.read.map;
+
+import com.netflix.hollow.core.AbstractStateEngineTest;
+import com.netflix.hollow.core.read.dataaccess.HollowMapTypeDataAccess;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.write.HollowMapTypeWriteState;
+import com.netflix.hollow.core.write.HollowMapWriteRecord;
+import java.io.IOException;
+import java.util.BitSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HollowMapShardedTest extends AbstractStateEngineTest {
+
+    @Before
+    public void setUp() {
+        super.setUp();
+    }
+    
+    @Test
+    public void testShardedData() throws IOException {
+    
+        HollowMapWriteRecord rec = new HollowMapWriteRecord();
+        
+        for(int i=0;i<2000;i++) {
+            rec.reset();
+            rec.addEntry(i, i+1);
+            rec.addEntry(i+2, i+3);
+            rec.addEntry(i+4, i+5);
+            
+            writeStateEngine.add("TestMap", rec);
+        }
+        
+        roundTripSnapshot();
+        
+        Assert.assertEquals(8, readStateEngine.getTypeState("TestMap").numShards());
+        
+        HollowMapTypeDataAccess mapDataAccess = (HollowMapTypeDataAccess) readStateEngine.getTypeDataAccess("TestMap");
+        for(int i=0;i<1000;i++) {
+            Assert.assertEquals(3, mapDataAccess.size(i));
+            Assert.assertEquals(i+1, mapDataAccess.get(i, i));
+            Assert.assertEquals(i+3, mapDataAccess.get(i, i+2));
+            Assert.assertEquals(i+5, mapDataAccess.get(i, i+4));
+        }
+
+        for(int i=0;i<2000;i++) {
+            rec.reset();
+            rec.addEntry(i*2, i*2+1);
+            rec.addEntry(i*2+2, i*2+3);
+            rec.addEntry(i*2+4, i*2+5);
+            
+            writeStateEngine.add("TestMap", rec);
+        }
+        
+        roundTripDelta();
+        
+        int expectedValue = 0;
+        
+        BitSet populatedOrdinals = readStateEngine.getTypeState("TestMap").getPopulatedOrdinals();
+        
+        int ordinal = populatedOrdinals.nextSetBit(0);
+        while(ordinal != -1) {
+            Assert.assertEquals(3, mapDataAccess.size(ordinal));
+            Assert.assertEquals(expectedValue+1, mapDataAccess.get(ordinal, expectedValue));
+            Assert.assertEquals(expectedValue+3, mapDataAccess.get(ordinal, expectedValue+2));
+            Assert.assertEquals(expectedValue+5, mapDataAccess.get(ordinal, expectedValue+4));
+            
+            expectedValue += 2;
+            ordinal = populatedOrdinals.nextSetBit(ordinal+1);
+        }
+    }
+    
+    @Override
+    protected void initializeTypeStates() {
+        writeStateEngine.setTargetMaxTypeShardSize(4096);
+        writeStateEngine.addTypeState(new HollowMapTypeWriteState(new HollowMapSchema("TestMap", "TestKey", "TestValue")));
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/map/HollowMapShardedTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/map/HollowMapShardedTest.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.core.read.map;
 
 import com.netflix.hollow.core.AbstractStateEngineTest;

--- a/hollow/src/test/java/com/netflix/hollow/core/read/object/HollowObjectShardedTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/object/HollowObjectShardedTest.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.core.read.object;
 
 import java.util.BitSet;

--- a/hollow/src/test/java/com/netflix/hollow/core/read/object/HollowObjectShardedTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/object/HollowObjectShardedTest.java
@@ -1,0 +1,91 @@
+package com.netflix.hollow.core.read.object;
+
+import java.util.BitSet;
+
+import org.junit.Assert;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import java.io.IOException;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import org.junit.Test;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import org.junit.Before;
+import com.netflix.hollow.core.AbstractStateEngineTest;
+
+public class HollowObjectShardedTest extends AbstractStateEngineTest {
+
+    HollowObjectSchema schema;
+
+    @Before
+    public void setUp() {
+        schema = new HollowObjectSchema("TestObject", 3);
+        schema.addField("longField", FieldType.LONG);
+        schema.addField("intField", FieldType.INT);
+        schema.addField("doubleField", FieldType.DOUBLE);
+
+        super.setUp();
+    }
+    
+    @Test
+    public void testShardedData() throws IOException {
+    
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
+        
+        for(int i=0;i<1000;i++) {
+            rec.reset();
+            rec.setLong("longField", i);
+            rec.setInt("intField", i);
+            rec.setDouble("doubleField", i);
+            
+            writeStateEngine.add("TestObject", rec);
+        }
+        
+        roundTripSnapshot();
+        
+        Assert.assertEquals(4, readStateEngine.getTypeState("TestObject").numShards());
+        
+        for(int i=0;i<1000;i++) {
+            GenericHollowObject obj = new GenericHollowObject(readStateEngine, "TestObject", i); 
+            
+            Assert.assertEquals(i, obj.getLong("longField"));
+            Assert.assertEquals(i, obj.getInt("intField"));
+            Assert.assertEquals((double)i, obj.getDouble("doubleField"), 0);
+        }
+
+        for(int i=0;i<1000;i++) {
+            rec.reset();
+            rec.setLong("longField", i*2);
+            rec.setInt("intField", i*2);
+            rec.setDouble("doubleField", i*2);
+            
+            writeStateEngine.add("TestObject", rec);
+        }
+        
+        roundTripDelta();
+        
+        int expectedValue = 0;
+        
+        BitSet populatedOrdinals = readStateEngine.getTypeState("TestObject").getPopulatedOrdinals();
+        
+        int ordinal = populatedOrdinals.nextSetBit(0);
+        while(ordinal != -1) {
+            GenericHollowObject obj = new GenericHollowObject(readStateEngine, "TestObject", ordinal);
+            
+            Assert.assertEquals(expectedValue, obj.getLong("longField"));
+            Assert.assertEquals(expectedValue, obj.getInt("intField"));
+            Assert.assertEquals(expectedValue, obj.getDouble("doubleField"), 0);
+            
+            expectedValue += 2;
+            ordinal = populatedOrdinals.nextSetBit(ordinal+1);
+        }
+    }
+    
+    @Override
+    protected void initializeTypeStates() {
+        writeStateEngine.setTargetMaxTypeShardSize(4096);
+        writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+    }
+
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/set/HollowSetShardedTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/set/HollowSetShardedTest.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.core.read.set;
 
 import com.netflix.hollow.core.AbstractStateEngineTest;

--- a/hollow/src/test/java/com/netflix/hollow/core/read/set/HollowSetShardedTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/set/HollowSetShardedTest.java
@@ -1,0 +1,80 @@
+package com.netflix.hollow.core.read.set;
+
+import com.netflix.hollow.core.AbstractStateEngineTest;
+import com.netflix.hollow.core.read.dataaccess.HollowSetTypeDataAccess;
+import com.netflix.hollow.core.schema.HollowSetSchema;
+import com.netflix.hollow.core.write.HollowSetTypeWriteState;
+import com.netflix.hollow.core.write.HollowSetWriteRecord;
+import java.io.IOException;
+import java.util.BitSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HollowSetShardedTest extends AbstractStateEngineTest {
+
+    @Before
+    public void setUp() {
+        super.setUp();
+    }
+    
+    @Test
+    public void testShardedData() throws IOException {
+    
+        HollowSetWriteRecord rec = new HollowSetWriteRecord();
+        
+        for(int i=0;i<2000;i++) {
+            rec.reset();
+            rec.addElement(i);
+            rec.addElement(i+1);
+            rec.addElement(i+2);
+            
+            writeStateEngine.add("TestSet", rec);
+        }
+        
+        roundTripSnapshot();
+        
+        Assert.assertEquals(4, readStateEngine.getTypeState("TestSet").numShards());
+        
+        HollowSetTypeDataAccess setDataAccess = (HollowSetTypeDataAccess) readStateEngine.getTypeDataAccess("TestSet");
+        for(int i=0;i<1000;i++) {
+            Assert.assertEquals(3, setDataAccess.size(i));
+            Assert.assertTrue(setDataAccess.contains(i, i));
+            Assert.assertTrue(setDataAccess.contains(i, i+1));
+            Assert.assertTrue(setDataAccess.contains(i, i+2));
+        }
+
+        for(int i=0;i<2000;i++) {
+            rec.reset();
+            rec.addElement(i*2);
+            rec.addElement(i*2+1);
+            rec.addElement(i*2+2);
+            
+            writeStateEngine.add("TestSet", rec);
+        }
+        
+        roundTripDelta();
+        
+        int expectedValue = 0;
+        
+        BitSet populatedOrdinals = readStateEngine.getTypeState("TestSet").getPopulatedOrdinals();
+        
+        int ordinal = populatedOrdinals.nextSetBit(0);
+        while(ordinal != -1) {
+            Assert.assertEquals(3, setDataAccess.size(ordinal));
+            Assert.assertTrue(setDataAccess.contains(ordinal, expectedValue));
+            Assert.assertTrue(setDataAccess.contains(ordinal, expectedValue+1));
+            Assert.assertTrue(setDataAccess.contains(ordinal, expectedValue+2));
+            
+            expectedValue += 2;
+            ordinal = populatedOrdinals.nextSetBit(ordinal+1);
+        }
+    }
+    
+    @Override
+    protected void initializeTypeStates() {
+        writeStateEngine.setTargetMaxTypeShardSize(4096);
+        writeStateEngine.addTypeState(new HollowSetTypeWriteState(new HollowSetSchema("TestSet", "TestObject")));
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/set/HollowSetTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/set/HollowSetTest.java
@@ -75,7 +75,7 @@ public class HollowSetTest extends AbstractStateEngineTest {
 
         HollowSetTypeReadState typeState = (HollowSetTypeReadState) readStateEngine.getTypeState("TestSet");
 
-        Assert.assertEquals(0, typeState.size(1));
+        Assert.assertEquals(1, typeState.size(0));
         Assert.assertEquals(0, typeState.maxOrdinal());
 
         HollowOrdinalIterator iter = typeState.ordinalIterator(0);


### PR DESCRIPTION
What was the problem?
---------------------

Currently, during a delta transition each individual record type builds the entire next state of the type in memory while the current state is retained to answer requests.  This means that the memory pool Hollow reserves needs to be large enough to compose an extra copy of the largest type.  This is a miniaturized version of the [double snapshot](http://hollow.how/advanced-topics/#double-snapshots) problem.

What is the solution?
---------------------

With this change, large types can be transparently sharded into smaller individual chunks, each of which can update independently.  The effect of this change is that Hollow only needs to draw on the memory pool enough to update the largest chunk across all types.  