### PR TITLE
Feature/hollow producer restore

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowAnnouncementWatcher.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowAnnouncementWatcher.java
@@ -58,6 +58,13 @@ public abstract class HollowAnnouncementWatcher {
     }
 
     /**
+     * Will force a double snapshot refresh on the next update.
+     */
+    protected void forceDoubleSnapshotNextUpdate() {
+        client.forceDoubleSnapshotNextUpdate();
+    }
+
+    /**
      * Triggers a refresh in a new thread immediately.
      */
     public void triggerAsyncRefresh() {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -49,8 +49,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -146,7 +144,7 @@ public class HollowProducer {
     }
 
     private static HollowObjectMapper createNewHollowObjectMapperFromExisting(HollowObjectMapper objectMapper) {
-        List<HollowSchema> schemas = objectMapper.getStateEngine().getSchemas();
+        Collection<HollowSchema> schemas = objectMapper.getStateEngine().getSchemas();
         HollowWriteStateEngine writeEngine = HollowWriteStateCreator.createWithSchemas(schemas);
         return new HollowObjectMapper(writeEngine);
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducerListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducerListener.java
@@ -275,7 +275,7 @@ public interface HollowProducerListener extends EventListener {
             return readState;
         }
 
-        static final class Builder {
+        public static final class Builder {
             private final long start;
             private long end;
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowFilesystemAnnouncer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowFilesystemAnnouncer.java
@@ -25,7 +25,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
+import java.util.Map;
 import com.netflix.hollow.api.producer.HollowProducer;
 
 public class HollowFilesystemAnnouncer implements HollowProducer.Announcer {
@@ -47,7 +47,7 @@ public class HollowFilesystemAnnouncer implements HollowProducer.Announcer {
     }
 
     @Override
-    public void announce(long stateVersion) {
+    public void announce(long stateVersion, Map<String, String> metadata) {
         BufferedWriter writer = null;
         try {
             createDirectories(publishPath);

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowFilesystemAnnouncer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowFilesystemAnnouncer.java
@@ -25,6 +25,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
 import com.netflix.hollow.api.producer.HollowProducer;
 
 public class HollowFilesystemAnnouncer implements HollowProducer.Announcer {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowFilesystemAnnouncer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowFilesystemAnnouncer.java
@@ -47,7 +47,7 @@ public class HollowFilesystemAnnouncer implements HollowProducer.Announcer {
     }
 
     @Override
-    public void announce(long stateVersion, Map<String, String> metadata) {
+    public void announce(long stateVersion) {
         BufferedWriter writer = null;
         try {
             createDirectories(publishPath);

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowFilesystemAnnouncer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowFilesystemAnnouncer.java
@@ -25,7 +25,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Map;
 import com.netflix.hollow.api.producer.HollowProducer;
 
 public class HollowFilesystemAnnouncer implements HollowProducer.Announcer {

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
@@ -94,7 +94,6 @@ public class HollowProducerTest {
         long fakeVersion = 101;
 
         { // NOT FATAL
-            producer.setRestoreFailureFatal(false);
             producer.restore(fakeVersion, blobRetriever);
             Assert.assertNotNull(lastRestoreStatus);
             Assert.assertEquals(Status.FAIL, lastRestoreStatus.getStatus());
@@ -102,8 +101,7 @@ public class HollowProducerTest {
 
         Throwable restoreFailure = null;
         try { // FATAL
-            producer.setRestoreFailureFatal(true);
-            producer.restore(fakeVersion, blobRetriever);
+            producer.restoreAndReturnReadState(fakeVersion, blobRetriever);
         } catch (Throwable ex) {
             restoreFailure = ex;
         }
@@ -111,7 +109,7 @@ public class HollowProducerTest {
     }
 
     @Test
-    public void testPublishAndRestore() {
+    public void testPublishAndRestore() throws Exception {
         HollowProducer producer = createProducer(tmpFolder, schema);
         long version = testPublishV1(producer, 2, 10);
 
@@ -122,7 +120,7 @@ public class HollowProducerTest {
     }
 
     @Test
-    public void testMultipleRestores() {
+    public void testMultipleRestores() throws Exception {
         HollowProducer producer = createProducer(tmpFolder, schema);
 
         System.out.println("\n\n------------ Publish a few versions ------------\n");
@@ -154,7 +152,7 @@ public class HollowProducerTest {
     }
 
     @Test
-    public void testAlternatingPublishAndRestores() {
+    public void testAlternatingPublishAndRestores() throws Exception {
         HollowProducer producer = createProducer(tmpFolder, schema);
 
         List<Long> versions = new ArrayList<>();
@@ -169,7 +167,7 @@ public class HollowProducerTest {
     }
 
     @Test
-    public void testPublishAndRestoreWithSchemaChanges() {
+    public void testPublishAndRestoreWithSchemaChanges() throws Exception {
         int sizeV1 = 3;
         int valueMultiplierV1 = 20;
 
@@ -210,11 +208,11 @@ public class HollowProducerTest {
         }
     }
 
-    private void restoreAndAssert(HollowProducer producer, long version, int size, int valueMultiplier) {
+    private void restoreAndAssert(HollowProducer producer, long version, int size, int valueMultiplier) throws Exception {
         restoreAndAssert(producer, version, size, valueMultiplier, 1);
     }
 
-    private void restoreAndAssert(HollowProducer producer, long version, int size, int valueMultiplier, int valueFieldCount) {
+    private void restoreAndAssert(HollowProducer producer, long version, int size, int valueMultiplier, int valueFieldCount) throws Exception {
         ReadState readState = producer.restoreAndReturnReadState(version, blobRetriever);
         Assert.assertNotNull(lastRestoreStatus);
         Assert.assertEquals(Status.SUCCESS, lastRestoreStatus.getStatus());

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
@@ -89,23 +89,22 @@ public class HollowProducerTest {
     }
 
     @Test
-    public void testRestoreFatal() {
+    public void testRestoreFailure() {
         HollowProducer producer = createProducer(tmpFolder, schema);
         long fakeVersion = 101;
 
-        { // NOT FATAL
+        {
             producer.restore(fakeVersion, blobRetriever);
             Assert.assertNotNull(lastRestoreStatus);
             Assert.assertEquals(Status.FAIL, lastRestoreStatus.getStatus());
         }
 
-        Throwable restoreFailure = null;
-        try { // FATAL
-            producer.restoreAndReturnReadState(fakeVersion, blobRetriever);
-        } catch (Throwable ex) {
-            restoreFailure = ex;
+        {
+            ReadState readState = producer.restoreAndReturnReadState(fakeVersion, blobRetriever);
+            Assert.assertNull(readState);
+            Assert.assertNotNull(lastRestoreStatus);
+            Assert.assertEquals(Status.FAIL, lastRestoreStatus.getStatus());
         }
-        Assert.assertNotNull(restoreFailure);
     }
 
     @Test


### PR DESCRIPTION
Enhancement to enable HollowProducer to restore blob even after it has existing non empty state 

- Restore after it was already published states
- Add ability to indicate whether Restore Failure is Fatal (throw RuntimeException)
- Add support for announcement metadata
- 