### PR TITLE
Signal encountering an interface when initializing schema

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -74,6 +74,9 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             Class<?> currentClass = clazz;
             
             while(currentClass != Object.class && currentClass != Enum.class) {
+                if(currentClass.isInterface()) {
+                    throw new IllegalArgumentException("Unexpected interface " + currentClass.getSimpleName() + " passed as field.");
+                }
                 Field[] declaredFields = currentClass.getDeclaredFields();
     
                 for(int i=0;i<declaredFields.length;i++) {
@@ -122,7 +125,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
 
     private static String[] getKeyFieldPaths(Class<?> clazz) {
         HollowPrimaryKey primaryKey = clazz.getAnnotation(HollowPrimaryKey.class);
-        while(primaryKey == null && clazz != Object.class) {
+        while(primaryKey == null && clazz != Object.class && clazz.isInterface()) {
             clazz = clazz.getSuperclass();
             primaryKey = clazz.getAnnotation(HollowPrimaryKey.class);
         }


### PR DESCRIPTION
In case one of the fields encountered by the HollowObjectTypeMapper while looking for fields in the hierarchy (since 7a722cab82eb069014a9007ec248cd0c67471c56) is an interface, ```Class#getSuperclass()``` would return null, resulting in a ```NullPointerException```. (I guess it's the same as #44). A more suitable exception would be ```IllegalArgumentException```

As I see it, the ```NullPointerException``` is visible since #14. Now I start to wonder if it would be a good idea to ignore this kind of fields and just skip them.