### PR TITLE
Fixes #33 Allow the user to specify an ExecutorService to be used by the

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowAnnouncementWatcher.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowAnnouncementWatcher.java
@@ -36,6 +36,30 @@ import java.util.concurrent.ThreadFactory;
  */
 public abstract class HollowAnnouncementWatcher {
 
+    private final ExecutorService refreshExecutor;
+
+    /**
+     * Construct a HollowAnnouncementWatcher with a default ExecutorService.
+     */
+    public HollowAnnouncementWatcher() {
+        refreshExecutor = Executors.newFixedThreadPool(1, new ThreadFactory() {
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r);
+                t.setDaemon(true);
+                return t;
+            }
+        });
+    }
+
+    /**
+     * Construct a HollowAnnouncementWatcher with the specified ExecutorService.
+     *
+     * @param refreshExecutor the ExecutorService to use for asynchronous state refresh.
+     */
+    public HollowAnnouncementWatcher(ExecutorService refreshExecutor) {
+        this.refreshExecutor = refreshExecutor;
+    }
+
     /**
      * Return the latest announced version.
      * @return
@@ -119,17 +143,17 @@ public abstract class HollowAnnouncementWatcher {
         subscribeToEvents();
     }
 
-    private final ExecutorService refreshExecutor = Executors.newFixedThreadPool(1, new ThreadFactory() {
-        public Thread newThread(Runnable r) {
-            Thread t = new Thread(r);
-            t.setDaemon(true);
-            return t;
-        }
-    });
-
     public static class DefaultWatcher extends HollowAnnouncementWatcher {
 
         private long latestVersion = Long.MAX_VALUE;
+
+        public DefaultWatcher() {
+            super();
+        }
+
+        public DefaultWatcher(ExecutorService refreshExecutor) {
+            super(refreshExecutor);
+        }
 
         @Override
         public long getLatestVersion() {


### PR DESCRIPTION
HollowAnnouncementWatcher so that many HollowClient instances can
potentially share the same ExecutorService instance.
