### PR TITLE
Generated api customizations

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
@@ -62,13 +62,15 @@ public class HollowAPIClassJavaGenerator implements HollowJavaFileGenerator {
     private final String className;
     private final HollowDataset dataset;
     private final boolean parameterizeClassNames;
+    private final String classPostfix;
 
 
-    public HollowAPIClassJavaGenerator(String packageName, String apiClassname, HollowDataset dataset, boolean parameterizeClassNames) {
+    public HollowAPIClassJavaGenerator(String packageName, String apiClassname, HollowDataset dataset, boolean parameterizeClassNames, String classPostfix) {
         this.packageName = packageName;
         this.className = apiClassname;
         this.dataset = dataset;
         this.parameterizeClassNames = parameterizeClassNames;
+        this.classPostfix = classPostfix;
     }
 
     @Override
@@ -194,20 +196,20 @@ public class HollowAPIClassJavaGenerator implements HollowJavaFileGenerator {
         for(int i=0;i<schemaList.size();i++) {
             HollowSchema schema = schemaList.get(i);
             if(parameterizeClassNames) {
-                builder.append("    public <T> Collection<T> getAll").append(hollowImplClassname(schema.getName())).append("() {\n");
+                builder.append("    public <T> Collection<T> getAll").append(hollowImplClassname(schema.getName(), classPostfix)).append("() {\n");
                 builder.append("        return new AllHollowRecordCollection<T>(getDataAccess().getTypeDataAccess(\"").append(schema.getName()).append("\").getTypeState()) {\n");
                 builder.append("            protected T getForOrdinal(int ordinal) {\n");
-                builder.append("                return get").append(hollowImplClassname(schema.getName())).append("(ordinal);\n");
+                builder.append("                return get").append(hollowImplClassname(schema.getName(), classPostfix)).append("(ordinal);\n");
                 builder.append("            }\n");
                 builder.append("        };\n");
                 builder.append("    }\n");
                 
-                builder.append("    public <T> T get").append(hollowImplClassname(schema.getName())).append("(int ordinal) {\n");
+                builder.append("    public <T> T get").append(hollowImplClassname(schema.getName(), classPostfix)).append("(int ordinal) {\n");
                 builder.append("        objectCreationSampler.recordCreation(").append(i).append(");\n");
                 builder.append("        return (T) ").append(hollowObjectProviderName(schema.getName())).append(".getHollowObject(ordinal);\n");
                 builder.append("    }\n");
             } else {
-                String hollowImplClassname = hollowImplClassname(schema.getName());
+                String hollowImplClassname = hollowImplClassname(schema.getName(), classPostfix);
                 
                 builder.append("    public Collection<"+hollowImplClassname+"> getAll").append(hollowImplClassname).append("() {\n");
                 builder.append("        return new AllHollowRecordCollection<"+hollowImplClassname+">(getDataAccess().getTypeDataAccess(\"").append(schema.getName()).append("\").getTypeState()) {\n");

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIGenerator.java
@@ -56,6 +56,9 @@ public class HollowAPIGenerator {
     private final HollowDataset dataset;
     private final Set<String> parameterizedTypes;
     private final boolean parameterizeClassNames;
+    
+    private String classPostfix = "Hollow";
+    private String getterPrefix = "_";
 
     /**
      * @param apiClassname the class name of the generated implementation of {@link HollowAPI}
@@ -96,6 +99,20 @@ public class HollowAPIGenerator {
         this.parameterizedTypes = parameterizedTypes;
         this.parameterizeClassNames = parameterizeAllClassNames;
     }
+    
+    /**
+     * Use this method to override the default postfix "Hollow" for all generated Hollow object classes. 
+     */
+    public void setClassPostfix(String classPostfix) {
+        this.classPostfix = classPostfix;
+    }
+    
+    /**
+     * Use this method to override the default prefix "_" for all getters on all generated Hollow object classes. 
+     */
+    public void setGetterPrefix(String getterPrefix) {
+        this.getterPrefix = getterPrefix;
+    }
 
     
     public void generateFiles(String directory) throws IOException {
@@ -105,7 +122,7 @@ public class HollowAPIGenerator {
     public void generateFiles(File directory) throws IOException {
         directory.mkdirs();
         
-        HollowAPIClassJavaGenerator apiClassGenerator = new HollowAPIClassJavaGenerator(packageName, apiClassname, dataset, parameterizeClassNames);
+        HollowAPIClassJavaGenerator apiClassGenerator = new HollowAPIClassJavaGenerator(packageName, apiClassname, dataset, parameterizeClassNames, classPostfix);
         HollowAPIFactoryJavaGenerator apiFactoryGenerator = new HollowAPIFactoryJavaGenerator(packageName, apiClassname);
 
         generateFile(directory, apiClassGenerator);
@@ -150,20 +167,20 @@ public class HollowAPIGenerator {
 
     private HollowJavaFileGenerator getHollowObjectGenerator(HollowSchema schema) {
         if(schema instanceof HollowObjectSchema) {
-            return new HollowObjectJavaGenerator(packageName, apiClassname, (HollowObjectSchema) schema, parameterizedTypes, parameterizeClassNames);
+            return new HollowObjectJavaGenerator(packageName, apiClassname, (HollowObjectSchema) schema, parameterizedTypes, parameterizeClassNames, classPostfix, getterPrefix);
         } else if(schema instanceof HollowListSchema) {
-            return new HollowListJavaGenerator(packageName, apiClassname, (HollowListSchema) schema, parameterizedTypes, parameterizeClassNames);
+            return new HollowListJavaGenerator(packageName, apiClassname, (HollowListSchema) schema, parameterizedTypes, parameterizeClassNames, classPostfix);
         } else if(schema instanceof HollowSetSchema) {
-            return new HollowSetJavaGenerator(packageName, apiClassname, (HollowSetSchema) schema, parameterizedTypes, parameterizeClassNames);
+            return new HollowSetJavaGenerator(packageName, apiClassname, (HollowSetSchema) schema, parameterizedTypes, parameterizeClassNames, classPostfix);
         } else if(schema instanceof HollowMapSchema) {
-            return new HollowMapJavaGenerator(packageName, apiClassname, (HollowMapSchema) schema, dataset, parameterizedTypes, parameterizeClassNames);
+            return new HollowMapJavaGenerator(packageName, apiClassname, (HollowMapSchema) schema, dataset, parameterizedTypes, parameterizeClassNames, classPostfix);
         }
 
         throw new UnsupportedOperationException("What kind of schema is a " + schema.getClass().getName() + "?");
     }
 
     private HollowFactoryJavaGenerator getHollowFactoryGenerator(HollowSchema schema) {
-        return new HollowFactoryJavaGenerator(packageName, schema);
+        return new HollowFactoryJavaGenerator(packageName, schema, classPostfix);
     }
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
@@ -17,12 +17,14 @@
  */
 package com.netflix.hollow.api.codegen;
 
+import java.util.Map;
+
+import java.util.HashMap;
 import com.netflix.hollow.core.schema.HollowListSchema;
 import com.netflix.hollow.core.schema.HollowMapSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSetSchema;
-
 import com.netflix.hollow.api.objects.delegate.HollowListCachedDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowListDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowListLookupDelegate;
@@ -37,6 +39,17 @@ import com.netflix.hollow.api.objects.delegate.HollowSetLookupDelegate;
  * A class containing convenience methods for the {@link HollowAPIGenerator}.  Not intended for external consumption.
  */
 public class HollowCodeGenerationUtils {
+    
+    private static final Map<String,String> CLASS_NAME_SUBSTITUTIONS = new HashMap<String,String>();
+    
+    static {
+        CLASS_NAME_SUBSTITUTIONS.put("String", "HString");
+        CLASS_NAME_SUBSTITUTIONS.put("Integer", "HInteger");
+        CLASS_NAME_SUBSTITUTIONS.put("Long", "HLong");
+        CLASS_NAME_SUBSTITUTIONS.put("Float", "HFloat");
+        CLASS_NAME_SUBSTITUTIONS.put("Double", "HDouble");
+        CLASS_NAME_SUBSTITUTIONS.put("Boolean", "HBoolean");
+    }
 
     public static String typeAPIClassname(String typeName) {
         return uppercase(typeName) + "TypeAPI";
@@ -51,7 +64,13 @@ public class HollowCodeGenerationUtils {
     }
 
     public static String hollowImplClassname(String typeName, String classPostfix) {
-        return substituteInvalidChars(uppercase(typeName)) + classPostfix;
+        String classname = substituteInvalidChars(uppercase(typeName)) + classPostfix;
+        
+        String sub = CLASS_NAME_SUBSTITUTIONS.get(classname);
+        if(sub != null)
+            return sub;
+        
+        return classname;
     }
 
     public static String delegateInterfaceName(String typeName) {

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
@@ -35,9 +35,6 @@ import com.netflix.hollow.api.objects.delegate.HollowSetLookupDelegate;
 
 /**
  * A class containing convenience methods for the {@link HollowAPIGenerator}.  Not intended for external consumption.
- * 
- * @author dkoszewnik
- *
  */
 public class HollowCodeGenerationUtils {
 
@@ -46,15 +43,15 @@ public class HollowCodeGenerationUtils {
     }
 
     public static String hollowFactoryClassname(String typeName) {
-        return hollowImplClassname(typeName) + "Factory";
+        return hollowImplClassname(typeName, "Hollow") + "Factory";
     }
 
     public static String hollowObjectProviderName(String typeName) {
         return substituteInvalidChars(lowercase(typeName)) + "Provider";
     }
 
-    public static String hollowImplClassname(String typeName) {
-        return substituteInvalidChars(uppercase(typeName)) + "Hollow";
+    public static String hollowImplClassname(String typeName, String classPostfix) {
+        return substituteInvalidChars(uppercase(typeName)) + classPostfix;
     }
 
     public static String delegateInterfaceName(String typeName) {

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowStateEngineClassJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowStateEngineClassJavaGenerator.java
@@ -64,8 +64,6 @@ import java.util.Set;
  * 
  * @see HollowAPIGenerator
  * 
- * @author dkoszewnik
- *
  */
 public class HollowStateEngineClassJavaGenerator implements HollowJavaFileGenerator {
 
@@ -73,12 +71,14 @@ public class HollowStateEngineClassJavaGenerator implements HollowJavaFileGenera
     private final String className;
     private final HollowStateEngine stateEngine;
     private final boolean parameterizeClassNames;
+    private final String classPostfix;
 
-    public HollowStateEngineClassJavaGenerator(String packageName, String className, HollowStateEngine stateEngine, boolean parameterizeClassNames) {
+    public HollowStateEngineClassJavaGenerator(String packageName, String className, HollowStateEngine stateEngine, boolean parameterizeClassNames, String classPostfix) {
         this.packageName = packageName;
         this.className = className;
         this.stateEngine = stateEngine;
         this.parameterizeClassNames = parameterizeClassNames;
+        this.classPostfix = classPostfix;
     }
 
     @Override
@@ -218,7 +218,7 @@ public class HollowStateEngineClassJavaGenerator implements HollowJavaFileGenera
 
         for (int i=0;i<schemaList.size();i++) {
             HollowSchema schema = schemaList.get(i);
-            String hollowImplClassname = hollowImplClassname(schema.getName());
+            String hollowImplClassname = hollowImplClassname(schema.getName(), classPostfix);
             if(parameterizeClassNames)
                 builder.append("    public <T> T get").append(hollowImplClassname).append("(int ordinal){\n");
             else

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowFactoryJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowFactoryJavaGenerator.java
@@ -42,8 +42,6 @@ import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
  * 
  * @see HollowAPIGenerator
  * 
- * @author dkoszewnik
- *
  */
 public class HollowFactoryJavaGenerator implements HollowJavaFileGenerator {
 
@@ -52,9 +50,9 @@ public class HollowFactoryJavaGenerator implements HollowJavaFileGenerator {
     private final String className;
     private final HollowSchema schema;
 
-    public HollowFactoryJavaGenerator(String packageName, HollowSchema schema) {
+    public HollowFactoryJavaGenerator(String packageName, HollowSchema schema, String classPostfix) {
         this.packageName = packageName;
-        this.objectClassName = hollowImplClassname(schema.getName());
+        this.objectClassName = hollowImplClassname(schema.getName(), classPostfix);
         this.className = hollowFactoryClassname(schema.getName());
         this.schema = schema;
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowListJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowListJavaGenerator.java
@@ -35,8 +35,6 @@ import java.util.Set;
  * 
  * @see HollowAPIGenerator
  * 
- * @author dkoszewnik
- *
  */
 public class HollowListJavaGenerator implements HollowJavaFileGenerator {
 
@@ -47,12 +45,12 @@ public class HollowListJavaGenerator implements HollowJavaFileGenerator {
     private final String elementClassName;
     private final boolean parameterize;
 
-    public HollowListJavaGenerator(String packageName, String apiClassname, HollowListSchema schema, Set<String> parameterizedTypes, boolean parameterizeClassNames) {
+    public HollowListJavaGenerator(String packageName, String apiClassname, HollowListSchema schema, Set<String> parameterizedTypes, boolean parameterizeClassNames, String classPostfix) {
         this.packageName = packageName;
         this.apiClassname = apiClassname;
         this.schema = schema;
-        this.className = hollowImplClassname(schema.getName());
-        this.elementClassName = hollowImplClassname(schema.getElementType());
+        this.className = hollowImplClassname(schema.getName(), classPostfix);
+        this.elementClassName = hollowImplClassname(schema.getElementType(), classPostfix);
         this.parameterize = parameterizeClassNames || parameterizedTypes.contains(schema.getElementType());
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowMapJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowMapJavaGenerator.java
@@ -37,8 +37,6 @@ import java.util.Set;
  * 
  * @see HollowAPIGenerator
  * 
- * @author dkoszewnik
- *
  */
 public class HollowMapJavaGenerator implements HollowJavaFileGenerator {
 
@@ -53,14 +51,14 @@ public class HollowMapJavaGenerator implements HollowJavaFileGenerator {
     private final boolean parameterizeKey;
     private final boolean parameterizeValue;
 
-    public HollowMapJavaGenerator(String packageName, String apiClassname, HollowMapSchema schema, HollowDataset dataset, Set<String> parameterizedTypes, boolean parameterizeClassNames) {
+    public HollowMapJavaGenerator(String packageName, String apiClassname, HollowMapSchema schema, HollowDataset dataset, Set<String> parameterizedTypes, boolean parameterizeClassNames, String classPostfix) {
         this.packageName = packageName;
         this.apiClassname = apiClassname;
         this.schema = schema;
         this.dataset = dataset;
-        this.className = hollowImplClassname(schema.getName());
-        this.keyClassName = hollowImplClassname(schema.getKeyType());
-        this.valueClassName = hollowImplClassname(schema.getValueType());
+        this.className = hollowImplClassname(schema.getName(), classPostfix);
+        this.keyClassName = hollowImplClassname(schema.getKeyType(), classPostfix);
+        this.valueClassName = hollowImplClassname(schema.getValueType(), classPostfix);
         this.parameterizeKey = parameterizeClassNames || parameterizedTypes.contains(schema.getKeyType());
         this.parameterizeValue = parameterizeClassNames || parameterizedTypes.contains(schema.getValueType());
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
@@ -36,8 +36,6 @@ import java.util.Set;
  * 
  * @see HollowAPIGenerator
  * 
- * @author dkoszewnik
- *
  */
 public class HollowObjectJavaGenerator implements HollowJavaFileGenerator {
 
@@ -47,14 +45,18 @@ public class HollowObjectJavaGenerator implements HollowJavaFileGenerator {
     private final String className;
     private final Set<String> parameterizedTypes;
     private final boolean parameterizeClassNames;
+    private final String classPostfix;
+    private final String getterPrefix;
 
-    public HollowObjectJavaGenerator(String packageName, String apiClassname, HollowObjectSchema schema, Set<String> parameterizedTypes, boolean parameterizeClassNames) {
+    public HollowObjectJavaGenerator(String packageName, String apiClassname, HollowObjectSchema schema, Set<String> parameterizedTypes, boolean parameterizeClassNames, String classPostfix, String getterPrefix) {
         this.packageName = packageName;
         this.apiClassname = apiClassname;
         this.schema = schema;
-        this.className = hollowImplClassname(schema.getName());
+        this.className = hollowImplClassname(schema.getName(), classPostfix);
         this.parameterizedTypes = parameterizedTypes;
         this.parameterizeClassNames = parameterizeClassNames;
+        this.classPostfix = classPostfix;
+        this.getterPrefix = getterPrefix;
     }
 
     @Override
@@ -132,7 +134,7 @@ public class HollowObjectJavaGenerator implements HollowJavaFileGenerator {
 
         String fieldName = substituteInvalidChars(schema.getFieldName(fieldNum));
 
-        builder.append("    public byte[] _get" + uppercase(fieldName) + "() {\n");
+        builder.append("    public byte[] ").append(getterPrefix).append("get" + uppercase(fieldName) + "() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "(ordinal);\n");
         builder.append("    }");
 
@@ -144,11 +146,11 @@ public class HollowObjectJavaGenerator implements HollowJavaFileGenerator {
 
         String fieldName = substituteInvalidChars(schema.getFieldName(fieldNum));
 
-        builder.append("    public String _get" + uppercase(fieldName) + "() {\n");
+        builder.append("    public String ").append(getterPrefix).append("get" + uppercase(fieldName) + "() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "(ordinal);\n");
         builder.append("    }\n\n");
 
-        builder.append("    public boolean _is" + uppercase(fieldName) + "Equal(String testValue) {\n");
+        builder.append("    public boolean ").append(getterPrefix).append("is" + uppercase(fieldName) + "Equal(String testValue) {\n");
         builder.append("        return delegate().is" + uppercase(fieldName) + "Equal(ordinal, testValue);\n");
         builder.append("    }");
 
@@ -164,14 +166,14 @@ public class HollowObjectJavaGenerator implements HollowJavaFileGenerator {
         boolean parameterize = parameterizeClassNames || parameterizedTypes.contains(referencedType);
 
         if(parameterize)
-            builder.append("    public <T> T _get"+ uppercase(fieldName) + "() {\n");
+            builder.append("    public <T> T ").append(getterPrefix).append("get"+ uppercase(fieldName) + "() {\n");
         else
-            builder.append("    public ").append(hollowImplClassname(referencedType)).append(" _get"+ uppercase(fieldName) + "() {\n");
+            builder.append("    public ").append(hollowImplClassname(referencedType, classPostfix)).append(" ").append(getterPrefix).append("get"+ uppercase(fieldName) + "() {\n");
 
         builder.append("        int refOrdinal = delegate().get" + uppercase(fieldName) + "Ordinal(ordinal);\n");
         builder.append("        if(refOrdinal == -1)\n");
         builder.append("            return null;\n");
-        builder.append("        return ").append(parameterize ? "(T)" : "").append(" api().get" + hollowImplClassname(referencedType) + "(refOrdinal);\n");
+        builder.append("        return ").append(parameterize ? "(T)" : "").append(" api().get" + hollowImplClassname(referencedType, classPostfix) + "(refOrdinal);\n");
         builder.append("    }");
 
         return builder.toString();
@@ -182,11 +184,11 @@ public class HollowObjectJavaGenerator implements HollowJavaFileGenerator {
 
         String fieldName = substituteInvalidChars(schema.getFieldName(fieldNum));
 
-        builder.append("    public float _get").append(uppercase(fieldName)).append("() {\n");
+        builder.append("    public float ").append(getterPrefix).append("get").append(uppercase(fieldName)).append("() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "(ordinal);\n");
         builder.append("    }\n\n");
 
-        builder.append("    public Float _get").append(uppercase(fieldName)).append("Boxed() {\n");
+        builder.append("    public Float ").append(getterPrefix).append("get").append(uppercase(fieldName)).append("Boxed() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "Boxed(ordinal);\n");
         builder.append("    }");
 
@@ -199,11 +201,11 @@ public class HollowObjectJavaGenerator implements HollowJavaFileGenerator {
 
         String fieldName = substituteInvalidChars(schema.getFieldName(fieldNum));
 
-        builder.append("    public double _get").append(uppercase(fieldName)).append("() {\n");
+        builder.append("    public double ").append(getterPrefix).append("get").append(uppercase(fieldName)).append("() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "(ordinal);\n");
         builder.append("    }\n\n");
 
-        builder.append("    public Double _get").append(uppercase(fieldName)).append("Boxed() {\n");
+        builder.append("    public Double ").append(getterPrefix).append("get").append(uppercase(fieldName)).append("Boxed() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "Boxed(ordinal);\n");
         builder.append("    }");
 
@@ -215,11 +217,11 @@ public class HollowObjectJavaGenerator implements HollowJavaFileGenerator {
 
         String fieldName = substituteInvalidChars(schema.getFieldName(fieldNum));
 
-        builder.append("    public long _get").append(uppercase(fieldName)).append("() {\n");
+        builder.append("    public long ").append(getterPrefix).append("get").append(uppercase(fieldName)).append("() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "(ordinal);\n");
         builder.append("    }\n\n");
 
-        builder.append("    public Long _get").append(uppercase(fieldName)).append("Boxed() {\n");
+        builder.append("    public Long ").append(getterPrefix).append("get").append(uppercase(fieldName)).append("Boxed() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "Boxed(ordinal);\n");
         builder.append("    }");
 
@@ -231,11 +233,11 @@ public class HollowObjectJavaGenerator implements HollowJavaFileGenerator {
 
         String fieldName = substituteInvalidChars(schema.getFieldName(fieldNum));
 
-        builder.append("    public int _get").append(uppercase(fieldName)).append("() {\n");
+        builder.append("    public int ").append(getterPrefix).append("get").append(uppercase(fieldName)).append("() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "(ordinal);\n");
         builder.append("    }\n\n");
 
-        builder.append("    public Integer _get").append(uppercase(fieldName)).append("Boxed() {\n");
+        builder.append("    public Integer ").append(getterPrefix).append("get").append(uppercase(fieldName)).append("Boxed() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "Boxed(ordinal);\n");
         builder.append("    }");
 
@@ -247,11 +249,11 @@ public class HollowObjectJavaGenerator implements HollowJavaFileGenerator {
 
         String fieldName = substituteInvalidChars(schema.getFieldName(fieldNum));
 
-        builder.append("    public boolean _get").append(uppercase(fieldName)).append("() {\n");
+        builder.append("    public boolean ").append(getterPrefix).append("get").append(uppercase(fieldName)).append("() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "(ordinal);\n");
         builder.append("    }\n\n");
 
-        builder.append("    public Boolean _get").append(uppercase(fieldName)).append("Boxed() {\n");
+        builder.append("    public Boolean ").append(getterPrefix).append("get").append(uppercase(fieldName)).append("Boxed() {\n");
         builder.append("        return delegate().get" + uppercase(fieldName) + "Boxed(ordinal);\n");
         builder.append("    }");
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowSetJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowSetJavaGenerator.java
@@ -35,8 +35,6 @@ import java.util.Set;
  * 
  * @see HollowAPIGenerator
  * 
- * @author dkoszewnik
- *
  */
 public class HollowSetJavaGenerator implements HollowJavaFileGenerator {
 
@@ -47,12 +45,12 @@ public class HollowSetJavaGenerator implements HollowJavaFileGenerator {
     private final String elementClassName;
     private final boolean parameterize;
 
-    public HollowSetJavaGenerator(String packageName, String apiClassname, HollowSetSchema schema, Set<String> parameterizedTypes, boolean parameterizeClassNames) {
+    public HollowSetJavaGenerator(String packageName, String apiClassname, HollowSetSchema schema, Set<String> parameterizedTypes, boolean parameterizeClassNames, String classPostfix) {
         this.packageName = packageName;
         this.apiClassname = apiClassname;
         this.schema = schema;
-        this.className = hollowImplClassname(schema.getName());
-        this.elementClassName = hollowImplClassname(schema.getElementType());
+        this.className = hollowImplClassname(schema.getName(), classPostfix);
+        this.elementClassName = hollowImplClassname(schema.getElementType(), classPostfix);
         this.parameterize = parameterizeClassNames || parameterizedTypes.contains(schema.getElementType());
     }
 


### PR DESCRIPTION
* Allow for specification (or removal) of generated Hollow API object getter method prefix
* Allow for specification (or removal) of generated Hollow API class names
* Defaults are `"_"` and `"Hollow"`, respectively, to preserve backwards compatibility.