### PR TITLE
throw IllegalArgumentException when encountering an array as field

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -76,6 +76,8 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             while(currentClass != Object.class && currentClass != Enum.class) {
                 if(currentClass.isInterface()) {
                     throw new IllegalArgumentException("Unexpected interface " + currentClass.getSimpleName() + " passed as field.");
+                } if (currentClass.isArray()) {
+                    throw new IllegalArgumentException("Unexpected array " + currentClass.getSimpleName() + " passed as field. Consider using collections or marking as transient.");
                 }
                 Field[] declaredFields = currentClass.getDeclaredFields();
     


### PR DESCRIPTION
In case the HollowObjectMapper encounters an array, it will end up in generating code that will not compile (as described in #43 )
As a fix, we can throw a IllegalArgumentException when we encounter an array and recommend either porting to collections or marking the field as transient.