### PR TITLE
Fixes #80 Ensure that the RefreshListener is called for every transit…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/build/
 **/bin/
+**/out/
 **/.classpath
 **/.project
 **/.settings

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/HollowHistoryRefreshListener.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/HollowHistoryRefreshListener.java
@@ -17,14 +17,14 @@
  */
 package com.netflix.hollow.history.ui;
 
+import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.consumer.HollowConsumer.Blob;
-import com.netflix.hollow.api.consumer.HollowConsumer.RefreshListener;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.tools.history.HollowHistory;
 
-public class HollowHistoryRefreshListener implements RefreshListener {
-	
+public class HollowHistoryRefreshListener extends HollowConsumer.AbstractRefreshListener {
+
     private final HollowHistory history;
     
     public HollowHistoryRefreshListener(HollowHistory history) {

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientConsumerBridge.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientConsumerBridge.java
@@ -75,8 +75,9 @@ class HollowClientConsumerBridge {
     }
     
     static HollowConsumer.RefreshListener consumerRefreshListenerFor(final HollowUpdateListener listener) {
-        return new HollowConsumer.RefreshListener() {
             
+        return new HollowConsumer.AbstractRefreshListener() {
+
             @Override
             public void refreshStarted(long currentVersion, long requestedVersion) {
                 listener.refreshStarted(currentVersion, requestedVersion);

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowRefreshListenerTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowRefreshListenerTests.java
@@ -1,0 +1,206 @@
+package com.netflix.hollow.api.consumer;
+
+import com.netflix.hollow.api.consumer.HollowConsumer.ObjectLongevityConfig;
+
+import com.netflix.hollow.api.consumer.HollowConsumer.AbstractRefreshListener;
+import com.netflix.hollow.api.consumer.HollowConsumer.Blob;
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.HollowProducer.Populator;
+import com.netflix.hollow.api.producer.HollowProducer.WriteState;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HollowRefreshListenerTests {
+
+    private InMemoryBlobStore blobStore;
+    private RecordingRefreshListener listener;
+    
+    private HollowProducer producer;
+    private HollowConsumer consumer;
+
+    @Before
+    public void setUp() {
+        blobStore = new InMemoryBlobStore();
+        listener = new RecordingRefreshListener();
+        producer = HollowProducer.withPublisher(blobStore)
+                                 .withBlobStager(new HollowInMemoryBlobStager())
+                                 .withNumStatesBetweenSnapshots(Integer.MAX_VALUE)
+                                 .build();
+        
+        consumer = HollowConsumer.withBlobRetriever(blobStore)
+                                 .withRefreshListener(listener)
+                                 .withObjectLongevityConfig(new ObjectLongevityConfig() {
+                                        @Override public long usageDetectionPeriodMillis() { return 100L; }
+                                        @Override public long gracePeriodMillis() { return 100L; }
+                                        @Override public boolean forceDropData() { return false; }
+                                        @Override public boolean enableLongLivedObjectSupport() { return true; }
+                                        @Override public boolean enableExpiredUsageStackTraces() { return false; }
+                                        @Override public boolean dropDataAutomatically() { return true; }
+                                 })
+                                 .build();
+    }
+    
+    @Test
+    public void testMethodSemanticsOnInitialRefresh() {
+        long v1 = runCycle(producer, 1);
+        long v2 = runCycle(producer, 2);
+        long v3 = runCycle(producer, 3);
+        long v4 = runCycle(producer, 4);
+        long v5 = runCycle(producer, 5);
+        
+        consumer.triggerRefreshTo(v5+1);
+        
+        /// update occurred semantics
+        Assert.assertEquals(1, listener.snapshotUpdateOccurredVersions.size());
+        Assert.assertEquals(v5, listener.snapshotUpdateOccurredVersions.get(0).longValue());
+        
+        Assert.assertTrue(listener.deltaUpdateOccurredVersions.isEmpty());
+        
+        /// applied semantics
+        Assert.assertEquals(1, listener.snapshotAppliedVersions.size());
+        Assert.assertEquals(v1, listener.snapshotAppliedVersions.get(0).longValue());
+        
+        Assert.assertEquals(4, listener.deltaAppliedVersions.size());
+        Assert.assertEquals(v2, listener.deltaAppliedVersions.get(0).longValue());
+        Assert.assertEquals(v3, listener.deltaAppliedVersions.get(1).longValue());
+        Assert.assertEquals(v4, listener.deltaAppliedVersions.get(2).longValue());
+        Assert.assertEquals(v5, listener.deltaAppliedVersions.get(3).longValue());
+        
+        /// blobs loaded semantics
+        Assert.assertEquals(5, listener.blobsLoadedVersions.size());
+        Assert.assertEquals(v1, listener.blobsLoadedVersions.get(0).longValue());
+        Assert.assertEquals(v2, listener.blobsLoadedVersions.get(1).longValue());
+        Assert.assertEquals(v3, listener.blobsLoadedVersions.get(2).longValue());
+        Assert.assertEquals(v4, listener.blobsLoadedVersions.get(3).longValue());
+        Assert.assertEquals(v5, listener.blobsLoadedVersions.get(4).longValue());
+        
+        Assert.assertEquals(Long.MIN_VALUE, listener.refreshStartCurrentVersion);
+        Assert.assertEquals(v5+1, listener.refreshStartRequestedVersion);
+        
+        Assert.assertEquals(Long.MIN_VALUE, listener.refreshSuccessBeforeVersion);
+        Assert.assertEquals(v5, listener.refreshSuccessAfterVersion);
+        Assert.assertEquals(v5+1, listener.refreshSuccessRequestedVersion);
+    }
+    
+    @Test
+    public void testMethodSemanticsOnSubsequentRefreshes() {
+        long v0 = runCycle(producer, 0);
+        consumer.triggerRefreshTo(v0);
+        listener.clear();
+        long v1 = runCycle(producer, 1);
+        long v2 = runCycle(producer, 2);
+        long v3 = runCycle(producer, 3);
+        consumer.triggerRefreshTo(v3);
+
+        /// update occurred semantics
+        Assert.assertEquals(0, listener.snapshotUpdateOccurredVersions.size());
+
+        Assert.assertEquals(3, listener.deltaUpdateOccurredVersions.size());
+        Assert.assertEquals(v1, listener.deltaUpdateOccurredVersions.get(0).longValue());
+        Assert.assertEquals(v2, listener.deltaUpdateOccurredVersions.get(1).longValue());
+        Assert.assertEquals(v3, listener.deltaUpdateOccurredVersions.get(2).longValue());
+        
+        /// applied semantics
+        Assert.assertEquals(0, listener.snapshotAppliedVersions.size());
+
+        Assert.assertEquals(3, listener.deltaAppliedVersions.size());
+        Assert.assertEquals(v1, listener.deltaAppliedVersions.get(0).longValue());
+        Assert.assertEquals(v2, listener.deltaAppliedVersions.get(1).longValue());
+        Assert.assertEquals(v3, listener.deltaAppliedVersions.get(2).longValue());
+
+        /// blobs loaded semantics
+        Assert.assertEquals(3, listener.blobsLoadedVersions.size());
+        Assert.assertEquals(v1, listener.blobsLoadedVersions.get(0).longValue());
+        Assert.assertEquals(v2, listener.blobsLoadedVersions.get(1).longValue());
+        Assert.assertEquals(v3, listener.blobsLoadedVersions.get(2).longValue());
+
+        Assert.assertEquals(v0, listener.refreshStartCurrentVersion);
+        Assert.assertEquals(v3, listener.refreshStartRequestedVersion);
+
+        Assert.assertEquals(v0, listener.refreshSuccessBeforeVersion);
+        Assert.assertEquals(v3, listener.refreshSuccessAfterVersion);
+        Assert.assertEquals(v3, listener.refreshSuccessRequestedVersion);
+    }
+    
+    private long runCycle(HollowProducer producer, final int cycleNumber) {
+        return producer.runCycle(new Populator() {
+            public void populate(WriteState state) throws Exception {
+                state.add(Integer.valueOf(cycleNumber));
+            }
+        });
+    }
+    
+    private class RecordingRefreshListener extends AbstractRefreshListener {
+
+        long refreshStartCurrentVersion;
+        long refreshStartRequestedVersion;
+        
+        long refreshSuccessBeforeVersion;
+        long refreshSuccessAfterVersion;
+        long refreshSuccessRequestedVersion; 
+        
+        List<Long> snapshotUpdateOccurredVersions = new ArrayList<Long>();
+        List<Long> deltaUpdateOccurredVersions = new ArrayList<Long>();
+
+        List<Long> blobsLoadedVersions = new ArrayList<Long>();
+        
+        List<Long> snapshotAppliedVersions = new ArrayList<Long>();
+        List<Long> deltaAppliedVersions = new ArrayList<Long>();
+        
+        @Override
+        public void refreshStarted(long currentVersion, long requestedVersion) {
+            this.refreshStartCurrentVersion = currentVersion;
+            this.refreshStartRequestedVersion = requestedVersion;
+        }
+
+        @Override
+        public void snapshotUpdateOccurred(HollowAPI api, HollowReadStateEngine stateEngine, long version) throws Exception {
+            snapshotUpdateOccurredVersions.add(version);
+        }
+
+        @Override
+        public void deltaUpdateOccurred(HollowAPI api, HollowReadStateEngine stateEngine, long version) throws Exception {
+            deltaUpdateOccurredVersions.add(version);
+        }
+
+        @Override
+        public void blobLoaded(Blob transition) {
+            blobsLoadedVersions.add(transition.getToVersion());
+        }
+
+        @Override
+        public void refreshSuccessful(long beforeVersion, long afterVersion, long requestedVersion) {
+            refreshSuccessBeforeVersion = beforeVersion;
+            refreshSuccessAfterVersion = afterVersion;
+            refreshSuccessRequestedVersion = requestedVersion;
+        }
+
+        @Override
+        public void refreshFailed(long beforeVersion, long afterVersion, long requestedVersion, Throwable failureCause) {
+        }
+
+        @Override
+        public void snapshotApplied(HollowAPI api, HollowReadStateEngine stateEngine, long version) throws Exception {
+            snapshotAppliedVersions.add(version);
+        }
+
+        @Override
+        public void deltaApplied(HollowAPI api, HollowReadStateEngine stateEngine, long version) throws Exception {
+            deltaAppliedVersions.add(version);
+        }
+        
+        public void clear() {
+            snapshotUpdateOccurredVersions.clear();
+            deltaUpdateOccurredVersions.clear();
+            blobsLoadedVersions.clear();
+            snapshotAppliedVersions.clear();
+            deltaAppliedVersions.clear();
+        }
+    }
+}


### PR DESCRIPTION
…ion when applying initial transitions.

@dkoszewnik Of course another option, non-breaking, would be to keep existing ``snapshotUpdateOccurred()`` behavior and introduce new methods that are called on every transition.  *The challenge here is in the naming...*

In the *"who reads javadocs?"* world, in which I admit residing, based on the existing method naming of ``RefreshListener``, I *thought* that I understood the contract.  The fact that the behavior was not evident in the naming is, to this coder, a code smell.

But as noted above, a non-breaking option would be to introduce additional methods.  That is encompassed in this pull request.

As an aside, is there any intention to move to Java 8?  Declaring all of the methods as ``default`` with empty bodies would make transitions like this easier.  Instead, I have added an ``AbstractRefreshListener`` with empty method bodies -- useful not only internally but also for users (but better still would be Java 8).

