### PR TITLE
Ergonomic API shortcuts for referenced fields

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
@@ -17,14 +17,6 @@
  */
 package com.netflix.hollow.api.codegen;
 
-import java.util.Map;
-
-import java.util.HashMap;
-import com.netflix.hollow.core.schema.HollowListSchema;
-import com.netflix.hollow.core.schema.HollowMapSchema;
-import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.schema.HollowSchema;
-import com.netflix.hollow.core.schema.HollowSetSchema;
 import com.netflix.hollow.api.objects.delegate.HollowListCachedDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowListDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowListLookupDelegate;
@@ -34,6 +26,14 @@ import com.netflix.hollow.api.objects.delegate.HollowMapLookupDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowSetCachedDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowSetDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowSetLookupDelegate;
+import com.netflix.hollow.core.schema.HollowListSchema;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSetSchema;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A class containing convenience methods for the {@link HollowAPIGenerator}.  Not intended for external consumption.
@@ -250,5 +250,47 @@ public class HollowCodeGenerationUtils {
         str = str.replace(' ', '_');
         str = str.replace('.', '_');
         return str;
+    }
+    
+    public static String getJavaBoxedType(FieldType fieldType) {
+        switch(fieldType) {
+        case BOOLEAN:
+            return "Boolean";
+        case BYTES:
+            return "byte[]";
+        case DOUBLE:
+            return "Double";
+        case FLOAT:
+            return "Float";
+        case LONG:
+            return "Long";
+        case INT:
+        case REFERENCE:
+            return "Integer";
+        case STRING:
+            return "String";
+        }
+        throw new IllegalArgumentException("Java boxed type is not known for FieldType." + fieldType.toString());
+    }
+    
+    public static String getJavaScalarType(FieldType fieldType) {
+        switch(fieldType) {
+        case BOOLEAN:
+            return "boolean";
+        case BYTES:
+            return "byte[]";
+        case DOUBLE:
+            return "double";
+        case FLOAT:
+            return "float";
+        case LONG:
+            return "long";
+        case INT:
+        case REFERENCE:
+            return "int";
+        case STRING:
+            return "String";
+        }
+        throw new IllegalArgumentException("Java scalar type is not known for FieldType." + fieldType.toString());
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowErgonomicAPIShortcuts.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowErgonomicAPIShortcuts.java
@@ -1,0 +1,137 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen;
+
+import java.util.Collections;
+
+import java.util.Arrays;
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HollowErgonomicAPIShortcuts {
+    
+    public static final HollowErgonomicAPIShortcuts NO_SHORTCUTS = new HollowErgonomicAPIShortcuts();
+    
+    private final Map<String, Shortcut> shortcutFieldPaths;
+    
+    private HollowErgonomicAPIShortcuts() {
+        this.shortcutFieldPaths = Collections.emptyMap();
+    }
+    
+    HollowErgonomicAPIShortcuts(HollowDataset dataset) {
+        this.shortcutFieldPaths = new HashMap<String, Shortcut>();
+        populatePaths(dataset);
+    }
+    
+    public Shortcut getShortcut(String typeField) {
+        return shortcutFieldPaths.get(typeField);
+    }
+    
+    int numShortcuts() {
+        return shortcutFieldPaths.size();
+    }
+    
+    private void populatePaths(HollowDataset dataset) {
+        for(HollowSchema schema : dataset.getSchemas()) {
+            if(schema.getSchemaType() == SchemaType.OBJECT) {
+                HollowObjectSchema objSchema = (HollowObjectSchema)schema;
+                
+                for(int i=0;i<objSchema.numFields();i++) {
+                    if(objSchema.getFieldType(i) == FieldType.REFERENCE) {
+                        HollowSchema refSchema = dataset.getSchema(objSchema.getReferencedType(i));
+                        if(refSchema != null) {
+                            Shortcut shortcut = getShortcutFieldPath(dataset, refSchema);
+                            if(shortcut != null) {
+                                String key = objSchema.getName() + "." + objSchema.getFieldName(i);
+                                shortcutFieldPaths.put(key, shortcut);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    private Shortcut getShortcutFieldPath(HollowDataset dataset, HollowSchema schema) {
+        if(schema.getSchemaType() == SchemaType.OBJECT) {
+            HollowObjectSchema objSchema = (HollowObjectSchema)schema;
+            if(objSchema.numFields() == 1) {
+                if(objSchema.getFieldType(0) == FieldType.REFERENCE) {
+                    HollowSchema refSchema = dataset.getSchema(objSchema.getReferencedType(0));
+                    if(refSchema != null) {
+                        Shortcut childShortcut = getShortcutFieldPath(dataset, refSchema);
+                        if(childShortcut != null) {
+                            String[] shortcutPathTypes = new String[childShortcut.getPathTypes().length+1];
+                            String[] shortcutPath = new String[childShortcut.getPath().length+1];
+                            shortcutPathTypes[0] = objSchema.getName();
+                            shortcutPath[0] = objSchema.getFieldName(0);
+                            System.arraycopy(childShortcut.getPath(), 0, shortcutPath, 1, childShortcut.getPath().length);
+                            System.arraycopy(childShortcut.getPathTypes(), 0, shortcutPathTypes, 1, childShortcut.getPathTypes().length);
+                            return new Shortcut(shortcutPathTypes, shortcutPath, childShortcut.getType());
+                        }
+                    }
+                } else {
+                    return new Shortcut(new String[] { objSchema.getName() }, new String[] { objSchema.getFieldName(0) }, objSchema.getFieldType(0));
+                }
+            }
+        }
+        
+        return null;
+    }
+    
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        for(Map.Entry<String, Shortcut> entry : shortcutFieldPaths.entrySet()) {
+            builder.append(entry.getKey() + ": " + entry.getValue()).append("\n");
+        }
+        return builder.toString();
+    }
+    
+    public static class Shortcut {
+        public final String[] pathTypes;
+        public final String[] path;
+        public final FieldType type;
+        
+        public Shortcut(String[] pathTypes, String[] path, FieldType type) {
+            this.pathTypes = pathTypes;
+            this.path = path;
+            this.type = type;
+        }
+        
+        public String[] getPath() {
+            return path;
+        }
+        
+        public String[] getPathTypes() {
+            return pathTypes;
+        }
+        
+        public FieldType getType() {
+            return type;
+        }
+        
+        public String toString() {
+            return Arrays.toString(path) + " (" + type.toString() + ")";
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateInterfaceGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateInterfaceGenerator.java
@@ -22,31 +22,33 @@ import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.substitut
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.typeAPIClassname;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.uppercase;
 
-import com.netflix.hollow.api.custom.HollowAPI;
-
-import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.api.codegen.HollowAPIGenerator;
+import com.netflix.hollow.api.codegen.HollowCodeGenerationUtils;
+import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts;
+import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts.Shortcut;
 import com.netflix.hollow.api.codegen.HollowJavaFileGenerator;
+import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.objects.delegate.HollowObjectDelegate;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
 
 /**
  * This class contains template logic for generating a {@link HollowAPI} implementation.  Not intended for external consumption.
  * 
  * @see HollowAPIGenerator
  * 
- * @author dkoszewnik
- *
  */
 public class HollowObjectDelegateInterfaceGenerator implements HollowJavaFileGenerator {
 
     private final String packageName;
     private final HollowObjectSchema schema;
     private final String className;
+    private final HollowErgonomicAPIShortcuts ergonomicShortcuts;
 
-    public HollowObjectDelegateInterfaceGenerator(String packageName, HollowObjectSchema schema) {
+    public HollowObjectDelegateInterfaceGenerator(String packageName, HollowObjectSchema schema, HollowErgonomicAPIShortcuts ergonomicShortcuts) {
         this.packageName = packageName;
         this.schema = schema;
         this.className = delegateInterfaceName(schema.getName());
+        this.ergonomicShortcuts = ergonomicShortcuts;
     }
 
 
@@ -93,6 +95,29 @@ public class HollowObjectDelegateInterfaceGenerator implements HollowJavaFileGen
                 classBuilder.append("    public Long get").append(methodFieldName).append("Boxed(int ordinal);\n\n");
                 break;
             case REFERENCE:
+                Shortcut shortcut = ergonomicShortcuts.getShortcut(schema.getName() + "." + schema.getFieldName(i));
+                if(shortcut != null) {
+                    switch(shortcut.getType()) {
+                    case BOOLEAN:
+                    case DOUBLE:
+                    case FLOAT:
+                    case INT:
+                    case LONG:
+                        classBuilder.append("    public " + HollowCodeGenerationUtils.getJavaScalarType(shortcut.getType()) + " get").append(methodFieldName).append("(int ordinal);\n\n");
+                        classBuilder.append("    public " + HollowCodeGenerationUtils.getJavaBoxedType(shortcut.getType()) + " get").append(methodFieldName).append("Boxed(int ordinal);\n\n");
+                        break;
+                    case BYTES:
+                        classBuilder.append("    public byte[] get").append(methodFieldName).append("(int ordinal);\n\n");
+                        break;
+                    case STRING:
+                        classBuilder.append("    public String get").append(methodFieldName).append("(int ordinal);\n\n");
+                        classBuilder.append("    public boolean is").append(methodFieldName).append("Equal(int ordinal, String testValue);\n\n");
+                        break;
+                    case REFERENCE:
+                    default:
+                    }
+                }
+                
                 classBuilder.append("    public int get").append(methodFieldName).append("Ordinal(int ordinal);\n\n");
                 break;
             case STRING:

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateLookupImplGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateLookupImplGenerator.java
@@ -23,32 +23,33 @@ import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.substitut
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.typeAPIClassname;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.uppercase;
 
-import com.netflix.hollow.api.custom.HollowAPI;
-
-import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.api.codegen.HollowAPIGenerator;
+import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts;
+import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts.Shortcut;
 import com.netflix.hollow.api.codegen.HollowJavaFileGenerator;
+import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.objects.delegate.HollowObjectAbstractDelegate;
 import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
 
 /**
  * This class contains template logic for generating a {@link HollowAPI} implementation.  Not intended for external consumption.
  * 
  * @see HollowAPIGenerator
  * 
- * @author dkoszewnik
- *
  */
 public class HollowObjectDelegateLookupImplGenerator implements HollowJavaFileGenerator {
 
     private final String packageName;
     private final HollowObjectSchema schema;
     private final String className;
+    private final HollowErgonomicAPIShortcuts ergonomicShortcuts;
 
-    public HollowObjectDelegateLookupImplGenerator(String packageName, HollowObjectSchema schema) {
+    public HollowObjectDelegateLookupImplGenerator(String packageName, HollowObjectSchema schema, HollowErgonomicAPIShortcuts ergonomicShortcuts) {
         this.packageName = packageName;
         this.schema = schema;
         this.className = delegateLookupImplName(schema.getName());
+        this.ergonomicShortcuts = ergonomicShortcuts;
     }
 
     @Override
@@ -58,7 +59,6 @@ public class HollowObjectDelegateLookupImplGenerator implements HollowJavaFileGe
 
     @Override
     public String generate() {
-
         StringBuilder builder = new StringBuilder();
 
         builder.append("package ").append(packageName).append(";\n\n");
@@ -125,17 +125,22 @@ public class HollowObjectDelegateLookupImplGenerator implements HollowJavaFileGe
                 builder.append("        return typeAPI.get").append(methodFieldName).append("Boxed(ordinal);\n");
                 builder.append("    }\n\n");
                 break;
-            case REFERENCE:
-                builder.append("    public int get").append(methodFieldName).append("Ordinal(int ordinal) {\n");
-                builder.append("        return typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
-                builder.append("    }\n\n");
-                break;
             case STRING:
                 builder.append("    public String get").append(methodFieldName).append("(int ordinal) {\n");
                 builder.append("        return typeAPI.get").append(methodFieldName).append("(ordinal);\n");
                 builder.append("    }\n\n");
                 builder.append("    public boolean is").append(methodFieldName).append("Equal(int ordinal, String testValue) {\n");
                 builder.append("        return typeAPI.is").append(methodFieldName).append("Equal(ordinal, testValue);\n");
+                builder.append("    }\n\n");
+                break;
+            case REFERENCE:
+                Shortcut shortcut = ergonomicShortcuts.getShortcut(schema.getName() + "." + schema.getFieldName(i));
+                if(shortcut != null) {
+                    addShortcutAccessMethod(builder, methodFieldName, shortcut);
+                }
+                
+                builder.append("    public int get").append(methodFieldName).append("Ordinal(int ordinal) {\n");
+                builder.append("        return typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
                 builder.append("    }\n\n");
                 break;
             }
@@ -159,6 +164,102 @@ public class HollowObjectDelegateLookupImplGenerator implements HollowJavaFileGe
 
         return builder.toString();
 
+    }
+
+    private void addShortcutAccessMethod(StringBuilder builder, String methodFieldName, Shortcut shortcut) {
+        String finalFieldName = substituteInvalidChars(uppercase(shortcut.getPath()[shortcut.getPath().length-1]));
+        String finalTypeAPI = typeAPIClassname(shortcut.getPathTypes()[shortcut.getPathTypes().length-1]);
+        
+        switch(shortcut.getType()) {
+        case BOOLEAN:
+            builder.append("    public boolean get").append(methodFieldName).append("(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? false : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("(ordinal);\n");
+            builder.append("    }\n\n");
+            builder.append("    public Boolean get").append(methodFieldName).append("Boxed(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? null : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("Boxed(ordinal);\n");
+            builder.append("    }\n\n");
+            break;
+        case BYTES:
+            builder.append("    public byte[] get").append(methodFieldName).append("(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? null : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("(ordinal);\n");
+            builder.append("    }\n\n");
+            break;
+        case DOUBLE:
+            builder.append("    public double get").append(methodFieldName).append("(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? Double.NaN : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("(ordinal);\n");
+            builder.append("    }\n\n");
+            builder.append("    public Double get").append(methodFieldName).append("Boxed(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? null : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("Boxed(ordinal);\n");
+            builder.append("    }\n\n");
+            break;
+        case FLOAT:
+            builder.append("    public float get").append(methodFieldName).append("(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? Float.NaN : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("(ordinal);\n");
+            builder.append("    }\n\n");
+            builder.append("    public Float get").append(methodFieldName).append("Boxed(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? null : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("Boxed(ordinal);\n");
+            builder.append("    }\n\n");
+            break;
+        case INT:
+            builder.append("    public int get").append(methodFieldName).append("(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? Integer.MIN_VALUE : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("(ordinal);\n");
+            builder.append("    }\n\n");
+            builder.append("    public Integer get").append(methodFieldName).append("Boxed(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? null : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("Boxed(ordinal);\n");
+            builder.append("    }\n\n");
+            break;
+        case LONG:
+            builder.append("    public long get").append(methodFieldName).append("(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? Long.MIN_VALUE : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("(ordinal);\n");
+            builder.append("    }\n\n");
+            builder.append("    public Long get").append(methodFieldName).append("Boxed(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? null : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("Boxed(ordinal);\n");
+            builder.append("    }\n\n");
+            break;
+        case STRING:
+            builder.append("    public String get").append(methodFieldName).append("(int ordinal) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? null : typeAPI.getAPI().get" + finalTypeAPI + "().get").append(finalFieldName).append("(ordinal);\n");
+            builder.append("    }\n\n");
+            builder.append("    public boolean is").append(methodFieldName).append("Equal(int ordinal, String testValue) {\n");
+            builder.append("        ordinal = typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+            addShortcutTraversal(builder, shortcut);
+            builder.append("        return ordinal == -1 ? testValue == null : typeAPI.getAPI().get" + finalTypeAPI + "().is").append(finalFieldName).append("Equal(ordinal, testValue);\n");
+            builder.append("    }\n\n");
+            break;
+        default:
+            throw new IllegalArgumentException();
+        }
+    }
+    
+    private void addShortcutTraversal(StringBuilder builder, Shortcut shortcut) {
+        for(int i=0;i<shortcut.getPath().length-1;i++) {
+            String typeAPIClassname = typeAPIClassname(shortcut.getPathTypes()[i]);
+            builder.append("        if(ordinal != -1) ordinal = typeAPI.getAPI().get" + typeAPIClassname + "().get" + uppercase(shortcut.getPath()[i]) + "Ordinal(ordinal);\n"); 
+        }
     }
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowMapJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowMapJavaGenerator.java
@@ -20,16 +20,17 @@ package com.netflix.hollow.api.codegen.objects;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.hollowImplClassname;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.typeAPIClassname;
 
-import com.netflix.hollow.api.custom.HollowAPI;
-
-import com.netflix.hollow.core.schema.HollowMapSchema;
-import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.api.codegen.HollowAPIGenerator;
+import com.netflix.hollow.api.codegen.HollowCodeGenerationUtils;
 import com.netflix.hollow.api.codegen.HollowJavaFileGenerator;
+import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.objects.HollowMap;
 import com.netflix.hollow.api.objects.delegate.HollowMapDelegate;
 import com.netflix.hollow.api.objects.generic.GenericHollowRecordHelper;
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.util.Set;
 
 /**
@@ -182,23 +183,9 @@ public class HollowMapJavaGenerator implements HollowJavaFileGenerator {
                 idx++;
             }
             
-            switch(keySchema.getFieldType(keySchema.getPosition(fieldPathElements[idx]))) {
-            case BOOLEAN:
-                return "Boolean";
-            case BYTES:
-                return "byte[]";
-            case DOUBLE:
-                return "Double";
-            case FLOAT:
-                return "Float";
-            case LONG:
-                return "Long";
-            case INT:
-            case REFERENCE:
-                return "Integer";
-            case STRING:
-                return "String";
-            }
+            FieldType fieldType = keySchema.getFieldType(keySchema.getPosition(fieldPathElements[idx]));
+
+            return HollowCodeGenerationUtils.getJavaBoxedType(fieldType);
         } catch(Throwable th) { }
         throw new IllegalArgumentException("Field path '" + fieldPath + "' specified incorrectly for type: " + schema.getName());
     }

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowErgonomicAPIShortcutsTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowErgonomicAPIShortcutsTest.java
@@ -1,0 +1,83 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen;
+
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+
+import org.junit.Assert;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowInline;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.io.IOException;
+import org.junit.Test;
+
+public class HollowErgonomicAPIShortcutsTest {
+
+    @Test
+    public void test() throws IOException {
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
+        mapper.initializeTypeState(TypeA.class);
+
+        HollowErgonomicAPIShortcuts shortcuts = new HollowErgonomicAPIShortcuts(writeEngine);
+
+        Assert.assertEquals(5, shortcuts.numShortcuts());
+        
+        Assert.assertArrayEquals(new String[] { "value" }, shortcuts.getShortcut("StringReferenceReference.ref").getPath());
+        Assert.assertArrayEquals(new String[] { "StringReference" }, shortcuts.getShortcut("StringReferenceReference.ref").getPathTypes());
+        Assert.assertArrayEquals(new String[] { "value" }, shortcuts.getShortcut("TypeA.a2").getPath());
+        Assert.assertArrayEquals(new String[] { "StringReference" }, shortcuts.getShortcut("TypeA.a2").getPathTypes());
+        Assert.assertArrayEquals(new String[] { "value" }, shortcuts.getShortcut("TypeB.b1").getPath());
+        Assert.assertArrayEquals(new String[] { "StringReference" }, shortcuts.getShortcut("TypeB.b1").getPathTypes());
+        Assert.assertArrayEquals(new String[] { "ref", "value" }, shortcuts.getShortcut("TypeA.a3").getPath());
+        Assert.assertArrayEquals(new String[] { "StringReferenceReference", "StringReference" }, shortcuts.getShortcut("TypeA.a3").getPathTypes());
+        Assert.assertArrayEquals(new String[] { "ref", "value" }, shortcuts.getShortcut("TypeB.b2").getPath());
+        Assert.assertArrayEquals(new String[] { "StringReferenceReference", "StringReference" }, shortcuts.getShortcut("TypeB.b2").getPathTypes());
+
+        Assert.assertEquals(FieldType.STRING, shortcuts.getShortcut("StringReferenceReference.ref").getType());
+        Assert.assertEquals(FieldType.STRING, shortcuts.getShortcut("TypeA.a2").getType());
+        Assert.assertEquals(FieldType.STRING, shortcuts.getShortcut("TypeB.b1").getType());
+        Assert.assertEquals(FieldType.STRING, shortcuts.getShortcut("TypeA.a3").getType());
+        Assert.assertEquals(FieldType.STRING, shortcuts.getShortcut("TypeB.b2").getType());
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeA {
+        int a1;
+        StringReference a2;
+        StringReferenceReference a3;
+        TypeB a4;
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeB {
+        StringReference b1;
+        StringReferenceReference b2;
+        @HollowInline String b3;
+    }
+
+    @SuppressWarnings("unused")
+    private static class StringReferenceReference {
+        StringReference ref;
+    }
+
+    private static class StringReference {
+        @HollowInline String value;
+    }
+
+}


### PR DESCRIPTION
Referenced fields like `Movie.id`:
```
Movie {
    MovieId id;
}

MovieId {
    int value;
}
```


Are currently accessed with code like:

`movie.getId().getValue()`

But when ergonomic shortcuts are enabled, the pattern is shortened to:

`movie.getId()`

And yet the Hollow reference to ID is still accessible via:

`movie.getIdHollowReference()`

Turn this feature on with `HollowAPIGenerator.Builder.withErgonomicShortcuts()`.