### PR TITLE
Enhance field path

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
@@ -1,8 +1,27 @@
+/*
+*
+*  Copyright 2017 Netflix, Inc.
+*
+*     Licensed under the Apache License, Version 2.0 (the "License");
+*     you may not use this file except in compliance with the License.
+*     You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0
+*
+*     Unless required by applicable law or agreed to in writing, software
+*     distributed under the License is distributed on an "AS IS" BASIS,
+*     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*     See the License for the specific language governing permissions and
+*     limitations under the License.
+*
+*/
+
 package com.netflix.hollow.core.index;
 
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
 import com.netflix.hollow.core.read.engine.HollowCollectionTypeReadState;
-import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
-import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.read.engine.map.HollowMapTypeReadState;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.read.iterator.HollowMapEntryOrdinalIterator;
@@ -10,13 +29,12 @@ import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
 import com.netflix.hollow.core.schema.HollowCollectionSchema;
 import com.netflix.hollow.core.schema.HollowMapSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
+import static com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import com.netflix.hollow.core.schema.HollowSchema;
+import static com.netflix.hollow.core.schema.HollowSchema.SchemaType;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * This class is used to represent a field path. A field path is a "." separated list of fields that are used for traversal when looking up values for a type and ordinal of that type.
@@ -24,59 +42,50 @@ import java.util.Set;
  * <p>
  * Upon initializing a instance of this class with given parameters, it does the following checks
  * <ul>
- * <li>valid types in the HollowReadStateEngine</li>
+ * <li>validates the path by traversing it and making sure all types are present in the HollowDataAccess</li>
  * <li>auto-expands the path for collections (appending ".element" if missing), and a reference type (e.g String/Integer appending ".value" if missing) with single field. (except for Map schema)</li>
- * <li>and checks that the field path leads to one of the valid field types provided in the constructor</li>
- * <li>for map schema type, specify "key" to iterate over key types and "value" to iterate over value types.</li>
+ * <li>for map schema type, the class looks for "key" to iterate over key types and "value" to iterate over value types.</li>
  * </ul>
  * <p>
- * This class also has a convenience method to find values following the field path and given a start field position.
- * This class is meant as a utility class to read deeply nested fields for a given type and its ordinal.
+ * This class has a convenience method to find values following the field path and given a start field position.
  */
 public class FieldPath {
 
     private final String fieldPath;
-    private final HollowReadStateEngine readStateEngine;
+    private final HollowDataAccess hollowDataAccess;
     private final String type;
-    private final Set<HollowObjectSchema.FieldType> validFieldTypes;
 
     private String[] fields;
     private int[] fieldPositions;
-    private HollowObjectSchema.FieldType[] fieldTypes;
+    private FieldType[] fieldTypes;
     private String lastRefTypeInPath;
 
-    private boolean autoExpand = true;
+    private boolean autoExpand;
 
     /**
      * Create new FieldPath with auto-expand feature.
      *
-     * @param readStateEngine read state engine
-     * @param type            parent type of the field path
-     * @param fieldPath       "." separated fields
-     * @param validFieldType  field path should end with one of the given field type.
+     * @param hollowDataAccess hollow data access
+     * @param type             parent type of the field path
+     * @param fieldPath        "." separated fields
      */
-    protected FieldPath(HollowReadStateEngine readStateEngine, String type, String fieldPath, HollowObjectSchema.FieldType validFieldType) {
-        this(readStateEngine, type, fieldPath, new HashSet<>(Arrays.asList(validFieldType)), true);
+    public FieldPath(HollowDataAccess hollowDataAccess, String type, String fieldPath) {
+        this(hollowDataAccess, type, fieldPath, true);
     }
+
 
     /**
      * Create new FieldPath.
      *
-     * @param readStateEngine read state engine
-     * @param type            parent type of the field path
-     * @param fieldPath       "." separated fields
-     * @param validFieldType  field path should end with one of the given field type.
-     * @param autoExpand      if the field path should be auto-expand collections and references with one field.
+     * @param hollowDataAccess hollow data access
+     * @param type             parent type of the field path
+     * @param fieldPath        "." separated fields
+     * @param autoExpand       if the field path should be auto-expand collections and references with one field.
      */
-    protected FieldPath(HollowReadStateEngine readStateEngine, String type, String fieldPath, HollowObjectSchema.FieldType validFieldType, boolean autoExpand) {
-        this(readStateEngine, type, fieldPath, new HashSet<>(Arrays.asList(validFieldType)), autoExpand);
-    }
-
-    private FieldPath(HollowReadStateEngine readStateEngine, String type, String fieldPath, Set<HollowObjectSchema.FieldType> validFieldTypes, boolean autoExpand) {
+    public FieldPath(HollowDataAccess hollowDataAccess, String type, String fieldPath, boolean autoExpand) {
         this.fieldPath = fieldPath;
-        this.readStateEngine = readStateEngine;
+        this.hollowDataAccess = hollowDataAccess;
         this.type = type;
-        this.validFieldTypes = validFieldTypes;
         this.autoExpand = autoExpand;
         initialize();
     }
@@ -85,7 +94,7 @@ public class FieldPath {
         String[] fieldParts = fieldPath.split("\\.");
         List<String> fields = new ArrayList<>();
         List<Integer> fieldPositions = new ArrayList<>();
-        List<HollowObjectSchema.FieldType> fieldTypes = new ArrayList<>();
+        List<FieldType> fieldTypes = new ArrayList<>();
 
         // traverse through the field path to save field position and types.
         String refType = type;
@@ -93,16 +102,16 @@ public class FieldPath {
         int i = 0;
         while (i < fieldParts.length || refType != null) {
 
-            HollowSchema schema = readStateEngine.getSchema(refType);
+            HollowSchema schema = hollowDataAccess.getSchema(refType);
             if (schema == null)
                 throw new IllegalArgumentException("Schema not found for the type : " + refType);
-            HollowSchema.SchemaType schemaType = readStateEngine.getSchema(refType).getSchemaType();
+            SchemaType schemaType = hollowDataAccess.getSchema(refType).getSchemaType();
 
             String fieldName = null;
             int fieldPosition = 0;
-            HollowObjectSchema.FieldType fieldType = HollowObjectSchema.FieldType.REFERENCE;
+            FieldType fieldType = FieldType.REFERENCE;
 
-            if (schemaType.equals(HollowSchema.SchemaType.OBJECT)) {
+            if (schemaType.equals(SchemaType.OBJECT)) {
 
                 HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
 
@@ -122,16 +131,18 @@ public class FieldPath {
                 fieldType = objectSchema.getFieldType(fieldPosition);
 
                 // check field type.
-                if (fieldType.equals(HollowObjectSchema.FieldType.REFERENCE)) {
+                if (fieldType.equals(FieldType.REFERENCE)) {
                     refType = objectSchema.getReferencedType(fieldName);
-                } else if (validFieldTypes.contains(fieldType)) {
+                } else if (i >= fieldParts.length) {
+                    // reached the end of field path
                     lastRefType = refType;
                     refType = null;
                 } else {
-                    throw new IllegalArgumentException("Field path should contain references and should lead to a field of type :" + Arrays.toString(validFieldTypes.toArray()));
+                    // if not end of the field path and found a value type, then throw the exception.
+                    throw new IllegalArgumentException("Field path should contain references and should lead to a field primitive field type");
                 }
 
-            } else if (schemaType.equals(HollowSchema.SchemaType.LIST) || schemaType.equals(HollowSchema.SchemaType.SET)) {
+            } else if (schemaType.equals(SchemaType.LIST) || schemaType.equals(SchemaType.SET)) {
 
                 if (autoExpand && (i >= fieldParts.length || (i < fieldParts.length && !fieldParts[i].equals("element")))) {
                     fieldName = "element";
@@ -142,7 +153,7 @@ public class FieldPath {
                 // update ref type to element type.
                 refType = ((HollowCollectionSchema) schema).getElementType();
 
-            } else if (schemaType.equals(HollowSchema.SchemaType.MAP)) {
+            } else if (schemaType.equals(SchemaType.MAP)) {
 
                 if ((i >= fieldParts.length) || (!fieldParts[i].equals("value") && !fieldParts[i].equals("key")))
                     throw new IllegalArgumentException("When using Map in field path, please specify key or value. Cannot auto-expand on Map type field");
@@ -166,17 +177,11 @@ public class FieldPath {
         this.fields = fields.toArray(new String[fields.size()]);
         this.fieldPositions = new int[fieldPositions.size()];
         for (i = 0; i < fieldPositions.size(); i++) this.fieldPositions[i] = fieldPositions.get(i);
-        this.fieldTypes = fieldTypes.toArray(new HollowObjectSchema.FieldType[fieldTypes.size()]);
+        this.fieldTypes = fieldTypes.toArray(new FieldType[fieldTypes.size()]);
         this.lastRefTypeInPath = lastRefType;
-
-        // field path should ultimately lead down to one of the valid type.
-        if (!validFieldTypes.contains(this.fieldTypes[this.fields.length - 1])) {
-            throw new IllegalArgumentException("Field path should resolve to the one of the valid types :" + Arrays.toString(validFieldTypes.toArray()));
-        }
-
     }
 
-    protected String getLastRefTypeInPath() {
+    public String getLastRefTypeInPath() {
         return lastRefTypeInPath;
     }
 
@@ -186,20 +191,83 @@ public class FieldPath {
      * @param ordinal ordinal record for the given type in field path
      * @return Array of values found at the field path for the given ordinal record in the type.
      */
-    protected Object[] findValuesFollowingPath(int ordinal) {
-        return findValuesFollowingPath(ordinal, type, 0);
+    public Object[] findValues(int ordinal) {
+        return getAllValues(ordinal, type, 0);
+    }
+
+    /**
+     * Recursively find a value following the path. If the path contains a collection, then the first value is picked.
+     *
+     * @param ordinal
+     * @return A value found at the field path for the given ordinal record in the type.
+     */
+    public Object findValue(int ordinal) {
+        return getValue(ordinal, type, 0);
+    }
+
+    private Object getValue(int ordinal, String type, int fieldIndex) {
+        Object value = null;
+        HollowTypeDataAccess typeDataAccess = hollowDataAccess.getTypeDataAccess(type);
+        SchemaType schemaType = hollowDataAccess.getSchema(type).getSchemaType();
+        HollowSchema schema = hollowDataAccess.getSchema(type);
+
+        if (schemaType.equals(SchemaType.LIST) || schemaType.equals(SchemaType.SET)) {
+
+            HollowCollectionTypeReadState collectionTypeReadState = (HollowCollectionTypeReadState) typeDataAccess;
+            HollowCollectionSchema collectionSchema = (HollowCollectionSchema) schema;
+            String elementType = collectionSchema.getElementType();
+
+            HollowOrdinalIterator it = collectionTypeReadState.ordinalIterator(ordinal);
+            int refOrdinal = it.next();
+            if (refOrdinal != HollowOrdinalIterator.NO_MORE_ORDINALS) {
+                value = getValue(refOrdinal, elementType, fieldIndex + 1);
+            }
+            return value;
+
+        } else if (schemaType.equals(SchemaType.MAP)) {
+            // Map type
+            HollowMapTypeReadState mapTypeReadState = (HollowMapTypeReadState) typeDataAccess;
+            HollowMapSchema mapSchema = (HollowMapSchema) schema;
+
+            // what to iterate on in map
+            boolean iterateThroughKeys = fields[fieldIndex].equals("key");
+            String keyOrValueType = iterateThroughKeys ? mapSchema.getKeyType() : mapSchema.getValueType();
+
+            HollowMapEntryOrdinalIterator mapEntryIterator = mapTypeReadState.ordinalIterator(ordinal);
+            if (mapEntryIterator.next()) {
+                int keyOrValueOrdinal = iterateThroughKeys ? mapEntryIterator.getKey() : mapEntryIterator.getValue();
+                value = getValue(keyOrValueOrdinal, keyOrValueType, fieldIndex + 1);
+            }
+            return value;
+
+        } else {
+            // Object type
+            HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
+            HollowObjectTypeReadState objectTypeReadState = (HollowObjectTypeReadState) typeDataAccess;
+
+            if (fieldTypes[fieldIndex].equals(FieldType.REFERENCE)) {
+
+                int refOrdinal = objectTypeReadState.readOrdinal(ordinal, fieldPositions[fieldIndex]);
+                String refType = objectSchema.getReferencedType(fieldPositions[fieldIndex]);
+                value = getValue(refOrdinal, refType, fieldIndex + 1);
+
+            } else {
+                value = readFromObject(objectTypeReadState, ordinal, fieldTypes[fieldIndex], fieldPositions[fieldIndex]);
+            }
+        }
+        return value;
     }
 
 
-    private Object[] findValuesFollowingPath(int ordinal, String type, int fieldIndex) {
+    private Object[] getAllValues(int ordinal, String type, int fieldIndex) {
         Object[] values;
-        HollowTypeReadState typeReadState = readStateEngine.getTypeState(type);
-        HollowSchema.SchemaType schemaType = readStateEngine.getSchema(type).getSchemaType();
-        HollowSchema schema = readStateEngine.getSchema(type);
+        HollowTypeDataAccess typeDataAccess = hollowDataAccess.getTypeDataAccess(type);
+        SchemaType schemaType = hollowDataAccess.getSchema(type).getSchemaType();
+        HollowSchema schema = hollowDataAccess.getSchema(type);
 
-        if (schemaType.equals(HollowSchema.SchemaType.LIST) || schemaType.equals(HollowSchema.SchemaType.SET)) {
+        if (schemaType.equals(SchemaType.LIST) || schemaType.equals(SchemaType.SET)) {
 
-            HollowCollectionTypeReadState collectionTypeReadState = (HollowCollectionTypeReadState) typeReadState;
+            HollowCollectionTypeReadState collectionTypeReadState = (HollowCollectionTypeReadState) typeDataAccess;
             HollowCollectionSchema collectionSchema = (HollowCollectionSchema) schema;
             String elementType = collectionSchema.getElementType();
 
@@ -207,7 +275,7 @@ public class FieldPath {
             List<Object> valueList = new ArrayList<>();
             int refOrdinal = it.next();
             while (refOrdinal != HollowOrdinalIterator.NO_MORE_ORDINALS) {
-                Object[] refValues = findValuesFollowingPath(refOrdinal, elementType, fieldIndex + 1);
+                Object[] refValues = getAllValues(refOrdinal, elementType, fieldIndex + 1);
                 for (Object value : refValues)
                     valueList.add(value);
                 refOrdinal = it.next();
@@ -215,9 +283,9 @@ public class FieldPath {
             values = new Object[valueList.size()];
             valueList.toArray(values);
 
-        } else if (schemaType.equals(HollowSchema.SchemaType.MAP)) {
+        } else if (schemaType.equals(SchemaType.MAP)) {
             // Map type
-            HollowMapTypeReadState mapTypeReadState = (HollowMapTypeReadState) typeReadState;
+            HollowMapTypeReadState mapTypeReadState = (HollowMapTypeReadState) typeDataAccess;
             HollowMapSchema mapSchema = (HollowMapSchema) schema;
 
             // what to iterate on in map
@@ -228,7 +296,7 @@ public class FieldPath {
             List<Object> valueList = new ArrayList<>();
             while (mapEntryIterator.next()) {
                 int keyOrValueOrdinal = iterateThroughKeys ? mapEntryIterator.getKey() : mapEntryIterator.getValue();
-                Object[] refValues = findValuesFollowingPath(keyOrValueOrdinal, keyOrValueType, fieldIndex + 1);
+                Object[] refValues = getAllValues(keyOrValueOrdinal, keyOrValueType, fieldIndex + 1);
                 for (Object value : refValues)
                     valueList.add(value);
             }
@@ -239,38 +307,44 @@ public class FieldPath {
         } else {
             // Object type
             HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
-            HollowObjectTypeReadState objectTypeReadState = (HollowObjectTypeReadState) typeReadState;
+            HollowObjectTypeReadState objectTypeReadState = (HollowObjectTypeReadState) typeDataAccess;
 
-            if (fieldTypes[fieldIndex].equals(HollowObjectSchema.FieldType.REFERENCE)) {
+            if (fieldTypes[fieldIndex].equals(FieldType.REFERENCE)) {
                 int refOrdinal = objectTypeReadState.readOrdinal(ordinal, fieldPositions[fieldIndex]);
                 String refType = objectSchema.getReferencedType(fieldPositions[fieldIndex]);
-                return findValuesFollowingPath(refOrdinal, refType, fieldIndex + 1);
+                return getAllValues(refOrdinal, refType, fieldIndex + 1);
             } else {
-                switch (fieldTypes[fieldIndex]) {
-                    case INT:
-                        values = new Integer[]{objectTypeReadState.readInt(ordinal, fieldPositions[fieldIndex])};
-                        break;
-                    case LONG:
-                        values = new Long[]{objectTypeReadState.readLong(ordinal, fieldPositions[fieldIndex])};
-                        break;
-                    case DOUBLE:
-                        values = new Double[]{objectTypeReadState.readDouble(ordinal, fieldPositions[fieldIndex])};
-                        break;
-                    case FLOAT:
-                        values = new Float[]{objectTypeReadState.readFloat(ordinal, fieldPositions[fieldIndex])};
-                        break;
-                    case BOOLEAN:
-                        values = new Boolean[]{objectTypeReadState.readBoolean(ordinal, fieldPositions[fieldIndex])};
-                        break;
-                    case STRING:
-                        values = new String[]{objectTypeReadState.readString(ordinal, fieldPositions[fieldIndex])};
-                        break;
-                    default:
-                        throw new IllegalStateException("Invalid field type :" + fieldTypes[fieldIndex] + " cannot read values for this type");
-
-                }
+                return new Object[]{readFromObject(objectTypeReadState, ordinal, fieldTypes[fieldIndex], fieldPositions[fieldIndex])};
             }
         }
         return values;
+    }
+
+    private Object readFromObject(HollowObjectTypeDataAccess objectTypeDataAccess, int ordinal, FieldType fieldType, int fieldPosition) {
+        Object value;
+        switch (fieldType) {
+            case INT:
+                value = objectTypeDataAccess.readInt(ordinal, fieldPosition);
+                break;
+            case LONG:
+                value = objectTypeDataAccess.readLong(ordinal, fieldPosition);
+                break;
+            case DOUBLE:
+                value = objectTypeDataAccess.readDouble(ordinal, fieldPosition);
+                break;
+            case FLOAT:
+                value = objectTypeDataAccess.readFloat(ordinal, fieldPosition);
+                break;
+            case BOOLEAN:
+                value = objectTypeDataAccess.readBoolean(ordinal, fieldPosition);
+                break;
+            case STRING:
+                value = objectTypeDataAccess.readString(ordinal, fieldPosition);
+                break;
+            default:
+                throw new IllegalStateException("Invalid field type :" + fieldType + " cannot read values for this type");
+
+        }
+        return value;
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
@@ -18,12 +18,11 @@
 
 package com.netflix.hollow.core.index;
 
+import com.netflix.hollow.core.read.dataaccess.HollowCollectionTypeDataAccess;
 import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowMapTypeDataAccess;
 import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
 import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
-import com.netflix.hollow.core.read.engine.HollowCollectionTypeReadState;
-import com.netflix.hollow.core.read.engine.map.HollowMapTypeReadState;
-import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.read.iterator.HollowMapEntryOrdinalIterator;
 import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
 import com.netflix.hollow.core.schema.HollowCollectionSchema;
@@ -217,11 +216,11 @@ public class FieldPath {
 
         if (schemaType.equals(SchemaType.LIST) || schemaType.equals(SchemaType.SET)) {
 
-            HollowCollectionTypeReadState collectionTypeReadState = (HollowCollectionTypeReadState) typeDataAccess;
+            HollowCollectionTypeDataAccess collectionTypeDataAccess = (HollowCollectionTypeDataAccess) typeDataAccess;
             HollowCollectionSchema collectionSchema = (HollowCollectionSchema) schema;
             String elementType = collectionSchema.getElementType();
 
-            HollowOrdinalIterator it = collectionTypeReadState.ordinalIterator(ordinal);
+            HollowOrdinalIterator it = collectionTypeDataAccess.ordinalIterator(ordinal);
             int refOrdinal = it.next();
             if (refOrdinal != HollowOrdinalIterator.NO_MORE_ORDINALS) {
                 value = getValue(refOrdinal, elementType, fieldIndex + 1);
@@ -230,14 +229,14 @@ public class FieldPath {
 
         } else if (schemaType.equals(SchemaType.MAP)) {
             // Map type
-            HollowMapTypeReadState mapTypeReadState = (HollowMapTypeReadState) typeDataAccess;
+            HollowMapTypeDataAccess mapTypeDataAccess = (HollowMapTypeDataAccess) typeDataAccess;
             HollowMapSchema mapSchema = (HollowMapSchema) schema;
 
             // what to iterate on in map
             boolean iterateThroughKeys = fields[fieldIndex].equals("key");
             String keyOrValueType = iterateThroughKeys ? mapSchema.getKeyType() : mapSchema.getValueType();
 
-            HollowMapEntryOrdinalIterator mapEntryIterator = mapTypeReadState.ordinalIterator(ordinal);
+            HollowMapEntryOrdinalIterator mapEntryIterator = mapTypeDataAccess.ordinalIterator(ordinal);
             if (mapEntryIterator.next()) {
                 int keyOrValueOrdinal = iterateThroughKeys ? mapEntryIterator.getKey() : mapEntryIterator.getValue();
                 value = getValue(keyOrValueOrdinal, keyOrValueType, fieldIndex + 1);
@@ -247,18 +246,18 @@ public class FieldPath {
         } else {
             // Object type
             HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
-            HollowObjectTypeReadState objectTypeReadState = (HollowObjectTypeReadState) typeDataAccess;
+            HollowObjectTypeDataAccess objectTypeDataAccess = (HollowObjectTypeDataAccess) typeDataAccess;
 
             if (fieldTypes[fieldIndex].equals(FieldType.REFERENCE)) {
 
-                int refOrdinal = objectTypeReadState.readOrdinal(ordinal, fieldPositions[fieldIndex]);
+                int refOrdinal = objectTypeDataAccess.readOrdinal(ordinal, fieldPositions[fieldIndex]);
                 if (refOrdinal >= 0) {
                     String refType = objectSchema.getReferencedType(fieldPositions[fieldIndex]);
                     value = getValue(refOrdinal, refType, fieldIndex + 1);
                 }
 
             } else {
-                value = readFromObject(objectTypeReadState, ordinal, fieldTypes[fieldIndex], fieldPositions[fieldIndex]);
+                value = readFromObject(objectTypeDataAccess, ordinal, fieldTypes[fieldIndex], fieldPositions[fieldIndex]);
             }
         }
         return value;
@@ -273,11 +272,11 @@ public class FieldPath {
 
         if (schemaType.equals(SchemaType.LIST) || schemaType.equals(SchemaType.SET)) {
 
-            HollowCollectionTypeReadState collectionTypeReadState = (HollowCollectionTypeReadState) typeDataAccess;
+            HollowCollectionTypeDataAccess collectionTypeDataAccess = (HollowCollectionTypeDataAccess) typeDataAccess;
             HollowCollectionSchema collectionSchema = (HollowCollectionSchema) schema;
             String elementType = collectionSchema.getElementType();
 
-            HollowOrdinalIterator it = collectionTypeReadState.ordinalIterator(ordinal);
+            HollowOrdinalIterator it = collectionTypeDataAccess.ordinalIterator(ordinal);
             List<Object> valueList = new ArrayList<>();
             int refOrdinal = it.next();
             while (refOrdinal != HollowOrdinalIterator.NO_MORE_ORDINALS) {
@@ -291,14 +290,14 @@ public class FieldPath {
 
         } else if (schemaType.equals(SchemaType.MAP)) {
             // Map type
-            HollowMapTypeReadState mapTypeReadState = (HollowMapTypeReadState) typeDataAccess;
+            HollowMapTypeDataAccess mapTypeDataAccess = (HollowMapTypeDataAccess) typeDataAccess;
             HollowMapSchema mapSchema = (HollowMapSchema) schema;
 
             // what to iterate on in map
             boolean iterateThroughKeys = fields[fieldIndex].equals("key");
             String keyOrValueType = iterateThroughKeys ? mapSchema.getKeyType() : mapSchema.getValueType();
 
-            HollowMapEntryOrdinalIterator mapEntryIterator = mapTypeReadState.ordinalIterator(ordinal);
+            HollowMapEntryOrdinalIterator mapEntryIterator = mapTypeDataAccess.ordinalIterator(ordinal);
             List<Object> valueList = new ArrayList<>();
             while (mapEntryIterator.next()) {
                 int keyOrValueOrdinal = iterateThroughKeys ? mapEntryIterator.getKey() : mapEntryIterator.getValue();
@@ -313,17 +312,17 @@ public class FieldPath {
         } else {
             // Object type
             HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
-            HollowObjectTypeReadState objectTypeReadState = (HollowObjectTypeReadState) typeDataAccess;
+            HollowObjectTypeDataAccess objectTypeDataAccess = (HollowObjectTypeDataAccess) typeDataAccess;
 
             if (fieldTypes[fieldIndex].equals(FieldType.REFERENCE)) {
-                int refOrdinal = objectTypeReadState.readOrdinal(ordinal, fieldPositions[fieldIndex]);
+                int refOrdinal = objectTypeDataAccess.readOrdinal(ordinal, fieldPositions[fieldIndex]);
                 if (refOrdinal >= 0) {
                     String refType = objectSchema.getReferencedType(fieldPositions[fieldIndex]);
                     return getAllValues(refOrdinal, refType, fieldIndex + 1);
                 }
                 return new Object[]{};
             } else {
-                return new Object[]{readFromObject(objectTypeReadState, ordinal, fieldTypes[fieldIndex], fieldPositions[fieldIndex])};
+                return new Object[]{readFromObject(objectTypeDataAccess, ordinal, fieldTypes[fieldIndex], fieldPositions[fieldIndex])};
             }
         }
         return values;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
@@ -252,8 +252,10 @@ public class FieldPath {
             if (fieldTypes[fieldIndex].equals(FieldType.REFERENCE)) {
 
                 int refOrdinal = objectTypeReadState.readOrdinal(ordinal, fieldPositions[fieldIndex]);
-                String refType = objectSchema.getReferencedType(fieldPositions[fieldIndex]);
-                value = getValue(refOrdinal, refType, fieldIndex + 1);
+                if (refOrdinal >= 0) {
+                    String refType = objectSchema.getReferencedType(fieldPositions[fieldIndex]);
+                    value = getValue(refOrdinal, refType, fieldIndex + 1);
+                }
 
             } else {
                 value = readFromObject(objectTypeReadState, ordinal, fieldTypes[fieldIndex], fieldPositions[fieldIndex]);
@@ -315,8 +317,11 @@ public class FieldPath {
 
             if (fieldTypes[fieldIndex].equals(FieldType.REFERENCE)) {
                 int refOrdinal = objectTypeReadState.readOrdinal(ordinal, fieldPositions[fieldIndex]);
-                String refType = objectSchema.getReferencedType(fieldPositions[fieldIndex]);
-                return getAllValues(refOrdinal, refType, fieldIndex + 1);
+                if (refOrdinal >= 0) {
+                    String refType = objectSchema.getReferencedType(fieldPositions[fieldIndex]);
+                    return getAllValues(refOrdinal, refType, fieldIndex + 1);
+                }
+                return new Object[]{};
             } else {
                 return new Object[]{readFromObject(objectTypeReadState, ordinal, fieldTypes[fieldIndex], fieldPositions[fieldIndex])};
             }

--- a/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
@@ -185,6 +185,10 @@ public class FieldPath {
         return lastRefTypeInPath;
     }
 
+    public FieldType getLastFieldType() {
+        return fieldTypes[this.fields.length - 1];
+    }
+
     /**
      * Recursively find all the values following the field path.
      *

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
@@ -71,7 +71,7 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
 
         this.readStateEngine = readStateEngine;
         this.type = type;
-        this.fieldPath = new FieldPath(readStateEngine, type, fieldPath, HollowObjectSchema.FieldType.STRING);
+        this.fieldPath = new FieldPath(readStateEngine, type, fieldPath);
 
         // create memory recycle for using shared memory pools.
         memoryRecycle = WastefulRecycler.DEFAULT_INSTANCE;
@@ -155,7 +155,7 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
      * @return keys to index.
      */
     protected String[] getKeys(int ordinal) {
-        Object[] values = fieldPath.findValuesFollowingPath(ordinal);
+        Object[] values = fieldPath.findValues(ordinal);
         String[] stringValues = new String[values.length];
         for (int i = 0; i < values.length; i++) {
             stringValues[i] = ((String) values[i]).toLowerCase();

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
@@ -72,6 +72,8 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
         this.readStateEngine = readStateEngine;
         this.type = type;
         this.fieldPath = new FieldPath(readStateEngine, type, fieldPath);
+        if (!this.fieldPath.getLastFieldType().equals(HollowObjectSchema.FieldType.STRING))
+            throw new IllegalArgumentException("Field path should lead to a string type");
 
         // create memory recycle for using shared memory pools.
         memoryRecycle = WastefulRecycler.DEFAULT_INSTANCE;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowSparseIntegerSet.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowSparseIntegerSet.java
@@ -88,7 +88,7 @@ public class HollowSparseIntegerSet implements HollowTypeStateListener {
 
         this.readStateEngine = readStateEngine;
         this.type = type;
-        this.fieldPath = new FieldPath(readStateEngine, type, fieldPath, HollowObjectSchema.FieldType.INT);
+        this.fieldPath = new FieldPath(readStateEngine, type, fieldPath);
         this.predicate = predicate;
         this.valuesToSet = new HashSet<>();
         this.valuesToClear = new HashSet<>();
@@ -104,7 +104,7 @@ public class HollowSparseIntegerSet implements HollowTypeStateListener {
             // check predicate
             if (predicate.shouldIndex(ordinal)) {
                 // get integer values
-                Object[] values = fieldPath.findValuesFollowingPath(ordinal);
+                Object[] values = fieldPath.findValues(ordinal);
                 if (values != null && values.length > 0) {
                     for (Object value : values) {
                         if (!set.get((int) value)) set.set((int) value);
@@ -200,7 +200,7 @@ public class HollowSparseIntegerSet implements HollowTypeStateListener {
     @Override
     public void addedOrdinal(int ordinal) {
         if (predicate.shouldIndex(ordinal)) {
-            Object[] values = fieldPath.findValuesFollowingPath(ordinal);
+            Object[] values = fieldPath.findValues(ordinal);
             for (Object value : values) {
                 valuesToSet.add((int) value);
                 if (maxValueToSet < (int) value) maxValueToSet = (int) value;
@@ -210,7 +210,7 @@ public class HollowSparseIntegerSet implements HollowTypeStateListener {
 
     @Override
     public void removedOrdinal(int ordinal) {
-        Object[] values = fieldPath.findValuesFollowingPath(ordinal);
+        Object[] values = fieldPath.findValues(ordinal);
         for (Object value : values)
             valuesToClear.add((int) value);
     }

--- a/hollow/src/test/java/com/netflix/hollow/core/index/FieldPathTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/FieldPathTest.java
@@ -1,7 +1,6 @@
 package com.netflix.hollow.core.index;
 
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
-import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.util.StateEngineRoundTripper;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
@@ -52,13 +51,15 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         // with auto-expand feature on
-        FieldPath fieldPath = new FieldPath(readStateEngine, "SimpleValue", "id", HollowObjectSchema.FieldType.INT);
-        Integer[] values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        FieldPath fieldPath = new FieldPath(readStateEngine, "SimpleValue", "id");
+        Object[] values = fieldPath.findValues(0);
         Assert.assertEquals(3, (int) values[0]);
+        Object value = fieldPath.findValue(0);
+        Assert.assertEquals(3, (int) value);
 
         // with auto-expand feature off
-        fieldPath = new FieldPath(readStateEngine, "SimpleValue", "id", HollowObjectSchema.FieldType.INT, false);
-        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "SimpleValue", "id", false);
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, (int) values[0]);
     }
 
@@ -70,18 +71,20 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         //with auto expand
-        FieldPath fieldPath = new FieldPath(readStateEngine, "IntegerReference", "id", HollowObjectSchema.FieldType.INT);
-        Integer[] values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        FieldPath fieldPath = new FieldPath(readStateEngine, "IntegerReference", "id");
+        Object[] values = fieldPath.findValues(0);
         Assert.assertEquals(3, (int) values[0]);
+        Object value = fieldPath.findValue(0);
+        Assert.assertEquals(3, (int) value);
 
         // with auto expand but giving full field path
-        fieldPath = new FieldPath(readStateEngine, "IntegerReference", "id.value", HollowObjectSchema.FieldType.INT);
-        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "IntegerReference", "id.value");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, (int) values[0]);
 
         // without auto expand feature
-        fieldPath = new FieldPath(readStateEngine, "IntegerReference", "id.value", HollowObjectSchema.FieldType.INT);
-        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "IntegerReference", "id.value");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, (int) values[0]);
     }
 
@@ -93,7 +96,7 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         //with auto expand
-        new FieldPath(readStateEngine, "IntegerReference", "id", HollowObjectSchema.FieldType.INT, false);
+        new FieldPath(readStateEngine, "IntegerReference", "id", false);
     }
 
     @Test
@@ -108,23 +111,25 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         //with auto expand -> this case works because there is only one path possible leading to a scalar value.
-        FieldPath fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference", HollowObjectSchema.FieldType.INT);
-        Integer[] values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        FieldPath fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference");
+        Object[] values = fieldPath.findValues(0);
         Assert.assertEquals(3, (int) values[0]);
+        Object value = fieldPath.findValue(0);
+        Assert.assertEquals(3, (int) value);
 
         // with partial auto-expand
-        fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference.id", HollowObjectSchema.FieldType.INT);
-        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference.id");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, (int) values[0]);
 
         // with auto-expand but complete path
-        fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference.id.value", HollowObjectSchema.FieldType.INT);
-        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference.id.value");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, (int) values[0]);
 
         // without auto-expand but complete path
-        fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference.id.value", HollowObjectSchema.FieldType.INT);
-        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference.id.value");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, (int) values[0]);
     }
 
@@ -141,7 +146,7 @@ public class FieldPathTest {
 
         // with partial path
         try {
-            new FieldPath(readStateEngine, "ObjectReference", "reference.id", HollowObjectSchema.FieldType.INT, false);
+            new FieldPath(readStateEngine, "ObjectReference", "reference.id", false);
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("Incomplete field path at type :Integer. Please enter the field names in type to complete the path.", e.getMessage());
             throw e;
@@ -174,17 +179,17 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         // with auto-expand
-        FieldPath fieldPath = new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue.intRef", HollowObjectSchema.FieldType.INT);
-        Object[] values = fieldPath.findValuesFollowingPath(0);
+        FieldPath fieldPath = new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue.intRef");
+        Object[] values = fieldPath.findValues(0);
         Assert.assertEquals(3, ((int) values[0]));
 
-        fieldPath = new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue.intRef.id.value", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue.intRef.id.value");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, ((int) values[0]));
 
         //without auto-complete but full path given
-        fieldPath = new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue.intRef.id.value", HollowObjectSchema.FieldType.INT, false);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue.intRef.id.value", false);
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, ((int) values[0]));
     }
 
@@ -205,7 +210,7 @@ public class FieldPathTest {
 
         // with auto-expand but incomplete, since reference has two fields, cannot auto-expand
         try {
-            new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue", HollowObjectSchema.FieldType.STRING);
+            new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue");
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("Incomplete field path at type :MultiValue. Please enter the field names in type to complete the path.", e.getMessage());
             throw e;
@@ -232,29 +237,31 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         //with auto expand
-        FieldPath fieldPath = new FieldPath(readStateEngine, "ListType", "intValues", HollowObjectSchema.FieldType.INT);
-        Object[] values = fieldPath.findValuesFollowingPath(0);
+        FieldPath fieldPath = new FieldPath(readStateEngine, "ListType", "intValues");
+        Object[] values = fieldPath.findValues(0);
         Assert.assertEquals(1, (int) values[0]);
         Assert.assertEquals(2, (int) values[1]);
         Assert.assertEquals(3, (int) values[2]);
+        Object value = fieldPath.findValue(0);
+        Assert.assertEquals(1, (int) value);
 
         //with partial auto expand
-        fieldPath = new FieldPath(readStateEngine, "ListType", "intValues.element", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "ListType", "intValues.element");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(1, (int) values[0]);
         Assert.assertEquals(2, (int) values[1]);
         Assert.assertEquals(3, (int) values[2]);
 
         //with auto expand but full path given
-        fieldPath = new FieldPath(readStateEngine, "ListType", "intValues.element.value", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "ListType", "intValues.element.value");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(1, (int) values[0]);
         Assert.assertEquals(2, (int) values[1]);
         Assert.assertEquals(3, (int) values[2]);
 
         //without auto expand but full path given
-        fieldPath = new FieldPath(readStateEngine, "ListType", "intValues.element.value", HollowObjectSchema.FieldType.INT, false);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "ListType", "intValues.element.value", false);
+        values = fieldPath.findValues(0);
         Assert.assertEquals(1, (int) values[0]);
         Assert.assertEquals(2, (int) values[1]);
         Assert.assertEquals(3, (int) values[2]);
@@ -275,20 +282,20 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         //with auto expand
-        FieldPath fieldPath = new FieldPath(readStateEngine, "ListObjectReference", "intValues", HollowObjectSchema.FieldType.INT);
-        Object[] values = fieldPath.findValuesFollowingPath(0);
+        FieldPath fieldPath = new FieldPath(readStateEngine, "ListObjectReference", "intValues");
+        Object[] values = fieldPath.findValues(0);
         Assert.assertEquals(1, (int) values[0]);
         Assert.assertEquals(2, (int) values[1]);
 
         //with partial auto expand
-        fieldPath = new FieldPath(readStateEngine, "ListObjectReference", "intValues.element", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "ListObjectReference", "intValues.element");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(1, (int) values[0]);
         Assert.assertEquals(2, (int) values[1]);
 
         //without auto expand
-        fieldPath = new FieldPath(readStateEngine, "ListObjectReference", "intValues.element.id", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "ListObjectReference", "intValues.element.id");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(1, (int) values[0]);
         Assert.assertEquals(2, (int) values[1]);
     }
@@ -309,19 +316,21 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         //with auto expand
-        FieldPath fieldPath = new FieldPath(readStateEngine, "SetType", "intValues", HollowObjectSchema.FieldType.INT);
-        Object[] values = fieldPath.findValuesFollowingPath(0);
+        FieldPath fieldPath = new FieldPath(readStateEngine, "SetType", "intValues");
+        Object[] values = fieldPath.findValues(0);
         Assert.assertEquals(3, values.length);
         Set<Integer> valuesAsSet = new HashSet<>();
         for (Object v : values) valuesAsSet.add((int) v);
+        Object value = fieldPath.findValue(0);
+        Assert.assertTrue(((int) value == 1) || ((int) value == 2) || ((int) value == 3));
 
         Assert.assertTrue(valuesAsSet.contains(1));
         Assert.assertTrue(valuesAsSet.contains(2));
         Assert.assertTrue(valuesAsSet.contains(3));
 
         //with partial auto expand
-        fieldPath = new FieldPath(readStateEngine, "SetType", "intValues.element", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "SetType", "intValues.element");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, values.length);
         valuesAsSet = new HashSet<>();
         for (Object v : values) valuesAsSet.add((int) v);
@@ -331,8 +340,8 @@ public class FieldPathTest {
         Assert.assertTrue(valuesAsSet.contains(3));
 
         //with partial auto expand
-        fieldPath = new FieldPath(readStateEngine, "SetType", "intValues.value", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "SetType", "intValues.value");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, values.length);
         valuesAsSet = new HashSet<>();
         for (Object v : values) valuesAsSet.add((int) v);
@@ -342,8 +351,8 @@ public class FieldPathTest {
         Assert.assertTrue(valuesAsSet.contains(3));
 
         //without auto expand
-        fieldPath = new FieldPath(readStateEngine, "SetType", "intValues.element.value", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "SetType", "intValues.element.value");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, values.length);
         valuesAsSet = new HashSet<>();
         for (Object v : values) valuesAsSet.add((int) v);
@@ -374,8 +383,8 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         // no auto-expand for a map
-        FieldPath fieldPath = new FieldPath(readStateEngine, "MapReference", "mapValues.value", HollowObjectSchema.FieldType.STRING);
-        Object[] values = fieldPath.findValuesFollowingPath(0);
+        FieldPath fieldPath = new FieldPath(readStateEngine, "MapReference", "mapValues.value");
+        Object[] values = fieldPath.findValues(0);
         Assert.assertEquals(2, values.length);
         Set<String> valuesAsSet = new HashSet<>();
         for (Object v : values) valuesAsSet.add((String) v);
@@ -409,8 +418,8 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         // for values
-        FieldPath fieldPath = new FieldPath(readStateEngine, "MapObjectReference", "mapValues.value", HollowObjectSchema.FieldType.STRING);
-        Object[] values = fieldPath.findValuesFollowingPath(0);
+        FieldPath fieldPath = new FieldPath(readStateEngine, "MapObjectReference", "mapValues.value");
+        Object[] values = fieldPath.findValues(0);
         Assert.assertEquals(2, values.length);
         Set<String> valuesAsSet = new HashSet<>();
         for (Object v : values) valuesAsSet.add((String) v);
@@ -418,8 +427,8 @@ public class FieldPathTest {
         Assert.assertTrue(valuesAsSet.contains("two"));
 
         // for keys
-        fieldPath = new FieldPath(readStateEngine, "MapObjectReference", "mapValues.key", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "MapObjectReference", "mapValues.key");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(2, values.length);
         Set<Integer> keysAsSet = new HashSet<>();
         for (Object v : values) keysAsSet.add((int) v);
@@ -447,17 +456,17 @@ public class FieldPathTest {
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
 
         // auto-expands the list
-        FieldPath fieldPath = new FieldPath(readStateEngine, "MapKeyReferenceAsList", "mapValues.key", HollowObjectSchema.FieldType.INT);
-        Object[] values = fieldPath.findValuesFollowingPath(0);
+        FieldPath fieldPath = new FieldPath(readStateEngine, "MapKeyReferenceAsList", "mapValues.key");
+        Object[] values = fieldPath.findValues(0);
         Assert.assertEquals(3, values.length);
 
         // partial auto-expand list path
-        fieldPath = new FieldPath(readStateEngine, "MapKeyReferenceAsList", "mapValues.key.intValues", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "MapKeyReferenceAsList", "mapValues.key.intValues");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, values.length);
 
-        fieldPath = new FieldPath(readStateEngine, "MapKeyReferenceAsList", "mapValues.key.intValues.element.value", HollowObjectSchema.FieldType.INT);
-        values = fieldPath.findValuesFollowingPath(0);
+        fieldPath = new FieldPath(readStateEngine, "MapKeyReferenceAsList", "mapValues.key.intValues.element.value");
+        values = fieldPath.findValues(0);
         Assert.assertEquals(3, values.length);
 
     }

--- a/hollow/src/test/java/com/netflix/hollow/core/index/FieldPathTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/FieldPathTest.java
@@ -1,0 +1,465 @@
+package com.netflix.hollow.core.index;
+
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Test cases for FieldPath class.
+ */
+public class FieldPathTest {
+
+    private HollowWriteStateEngine writeStateEngine;
+    private HollowReadStateEngine readStateEngine;
+    private HollowObjectMapper objectMapper;
+
+    @Before
+    public void beforeTestSetup() {
+        writeStateEngine = new HollowWriteStateEngine();
+        readStateEngine = new HollowReadStateEngine();
+        objectMapper = new HollowObjectMapper(writeStateEngine);
+    }
+
+    private static class SimpleValue {
+        int id;
+    }
+
+    private static class IntegerReference {
+        Integer id;
+    }
+
+    private static class ObjectReference {
+        IntegerReference reference;
+    }
+
+    @Test
+    public void testSimpleValue() throws Exception {
+        SimpleValue simpleValue = new SimpleValue();
+        simpleValue.id = 3;
+        objectMapper.add(simpleValue);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // with auto-expand feature on
+        FieldPath fieldPath = new FieldPath(readStateEngine, "SimpleValue", "id", HollowObjectSchema.FieldType.INT);
+        Integer[] values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, (int) values[0]);
+
+        // with auto-expand feature off
+        fieldPath = new FieldPath(readStateEngine, "SimpleValue", "id", HollowObjectSchema.FieldType.INT, false);
+        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, (int) values[0]);
+    }
+
+    @Test
+    public void testSimpleReference() throws Exception {
+        IntegerReference integerReference = new IntegerReference();
+        integerReference.id = 3;
+        objectMapper.add(integerReference);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        //with auto expand
+        FieldPath fieldPath = new FieldPath(readStateEngine, "IntegerReference", "id", HollowObjectSchema.FieldType.INT);
+        Integer[] values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, (int) values[0]);
+
+        // with auto expand but giving full field path
+        fieldPath = new FieldPath(readStateEngine, "IntegerReference", "id.value", HollowObjectSchema.FieldType.INT);
+        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, (int) values[0]);
+
+        // without auto expand feature
+        fieldPath = new FieldPath(readStateEngine, "IntegerReference", "id.value", HollowObjectSchema.FieldType.INT);
+        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, (int) values[0]);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSimpleReferenceWithoutAutoExpand() throws Exception {
+        IntegerReference integerReference = new IntegerReference();
+        integerReference.id = 3;
+        objectMapper.add(integerReference);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        //with auto expand
+        new FieldPath(readStateEngine, "IntegerReference", "id", HollowObjectSchema.FieldType.INT, false);
+    }
+
+    @Test
+    public void testObjectReference() throws Exception {
+        IntegerReference integerReference = new IntegerReference();
+        integerReference.id = 3;
+
+        ObjectReference ref = new ObjectReference();
+        ref.reference = integerReference;
+
+        objectMapper.add(ref);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        //with auto expand -> this case works because there is only one path possible leading to a scalar value.
+        FieldPath fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference", HollowObjectSchema.FieldType.INT);
+        Integer[] values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, (int) values[0]);
+
+        // with partial auto-expand
+        fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference.id", HollowObjectSchema.FieldType.INT);
+        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, (int) values[0]);
+
+        // with auto-expand but complete path
+        fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference.id.value", HollowObjectSchema.FieldType.INT);
+        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, (int) values[0]);
+
+        // without auto-expand but complete path
+        fieldPath = new FieldPath(readStateEngine, "ObjectReference", "reference.id.value", HollowObjectSchema.FieldType.INT);
+        values = (Integer[]) fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, (int) values[0]);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testObjectReferenceWithoutAutoExpand() throws Exception {
+        IntegerReference integerReference = new IntegerReference();
+        integerReference.id = 3;
+
+        ObjectReference ref = new ObjectReference();
+        ref.reference = integerReference;
+
+        objectMapper.add(ref);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // with partial path
+        try {
+            new FieldPath(readStateEngine, "ObjectReference", "reference.id", HollowObjectSchema.FieldType.INT, false);
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("Incomplete field path at type :Integer. Please enter the field names in type to complete the path.", e.getMessage());
+            throw e;
+        }
+    }
+
+    private static class MultiValue {
+        int id;
+        IntegerReference intRef;
+    }
+
+    private static class ObjectReferenceToMultiValue {
+        int refId;
+        MultiValue multiValue;
+    }
+
+    @Test
+    public void testMultiFieldReference() throws Exception {
+        IntegerReference simpleValue = new IntegerReference();
+        simpleValue.id = 3;
+        MultiValue multiValue = new MultiValue();
+        multiValue.id = 2;
+        multiValue.intRef = simpleValue;
+
+        ObjectReferenceToMultiValue referenceToMultiValue = new ObjectReferenceToMultiValue();
+        referenceToMultiValue.multiValue = multiValue;
+        referenceToMultiValue.refId = 1;
+
+        objectMapper.add(referenceToMultiValue);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // with auto-expand
+        FieldPath fieldPath = new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue.intRef", HollowObjectSchema.FieldType.INT);
+        Object[] values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, ((int) values[0]));
+
+        fieldPath = new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue.intRef.id.value", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, ((int) values[0]));
+
+        //without auto-complete but full path given
+        fieldPath = new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue.intRef.id.value", HollowObjectSchema.FieldType.INT, false);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, ((int) values[0]));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultiFieldReferenceIncomplete() throws Exception {
+        IntegerReference simpleValue = new IntegerReference();
+        simpleValue.id = 3;
+        MultiValue multiValue = new MultiValue();
+        multiValue.id = 2;
+        multiValue.intRef = simpleValue;
+
+        ObjectReferenceToMultiValue referenceToMultiValue = new ObjectReferenceToMultiValue();
+        referenceToMultiValue.multiValue = multiValue;
+        referenceToMultiValue.refId = 1;
+
+        objectMapper.add(referenceToMultiValue);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // with auto-expand but incomplete, since reference has two fields, cannot auto-expand
+        try {
+            new FieldPath(readStateEngine, "ObjectReferenceToMultiValue", "multiValue", HollowObjectSchema.FieldType.STRING);
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("Incomplete field path at type :MultiValue. Please enter the field names in type to complete the path.", e.getMessage());
+            throw e;
+        }
+    }
+
+
+    // ------- unit tests for LIST type -------
+
+    private static class ListType {
+        List<Integer> intValues;
+    }
+
+    private static class ListObjectReference {
+        List<SimpleValue> intValues;
+    }
+
+    @Test
+    public void testListIntegerReference() throws Exception {
+        ListType listType = new ListType();
+        listType.intValues = Arrays.asList(1, 2, 3);
+
+        objectMapper.add(listType);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        //with auto expand
+        FieldPath fieldPath = new FieldPath(readStateEngine, "ListType", "intValues", HollowObjectSchema.FieldType.INT);
+        Object[] values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(1, (int) values[0]);
+        Assert.assertEquals(2, (int) values[1]);
+        Assert.assertEquals(3, (int) values[2]);
+
+        //with partial auto expand
+        fieldPath = new FieldPath(readStateEngine, "ListType", "intValues.element", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(1, (int) values[0]);
+        Assert.assertEquals(2, (int) values[1]);
+        Assert.assertEquals(3, (int) values[2]);
+
+        //with auto expand but full path given
+        fieldPath = new FieldPath(readStateEngine, "ListType", "intValues.element.value", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(1, (int) values[0]);
+        Assert.assertEquals(2, (int) values[1]);
+        Assert.assertEquals(3, (int) values[2]);
+
+        //without auto expand but full path given
+        fieldPath = new FieldPath(readStateEngine, "ListType", "intValues.element.value", HollowObjectSchema.FieldType.INT, false);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(1, (int) values[0]);
+        Assert.assertEquals(2, (int) values[1]);
+        Assert.assertEquals(3, (int) values[2]);
+
+    }
+
+    @Test
+    public void testListObjectReference() throws Exception {
+        ListObjectReference listType = new ListObjectReference();
+        SimpleValue val1 = new SimpleValue();
+        val1.id = 1;
+        SimpleValue val2 = new SimpleValue();
+        val2.id = 2;
+
+        listType.intValues = Arrays.asList(val1, val2);
+
+        objectMapper.add(listType);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        //with auto expand
+        FieldPath fieldPath = new FieldPath(readStateEngine, "ListObjectReference", "intValues", HollowObjectSchema.FieldType.INT);
+        Object[] values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(1, (int) values[0]);
+        Assert.assertEquals(2, (int) values[1]);
+
+        //with partial auto expand
+        fieldPath = new FieldPath(readStateEngine, "ListObjectReference", "intValues.element", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(1, (int) values[0]);
+        Assert.assertEquals(2, (int) values[1]);
+
+        //without auto expand
+        fieldPath = new FieldPath(readStateEngine, "ListObjectReference", "intValues.element.id", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(1, (int) values[0]);
+        Assert.assertEquals(2, (int) values[1]);
+    }
+
+
+    // ------- unit tests for SET type -------
+
+    private static class SetType {
+        Set<Integer> intValues;
+    }
+
+    @Test
+    public void testSetIntegerReference() throws Exception {
+        SetType setType = new SetType();
+        setType.intValues = new HashSet<>(Arrays.asList(1, 2, 3));
+
+        objectMapper.add(setType);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        //with auto expand
+        FieldPath fieldPath = new FieldPath(readStateEngine, "SetType", "intValues", HollowObjectSchema.FieldType.INT);
+        Object[] values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, values.length);
+        Set<Integer> valuesAsSet = new HashSet<>();
+        for (Object v : values) valuesAsSet.add((int) v);
+
+        Assert.assertTrue(valuesAsSet.contains(1));
+        Assert.assertTrue(valuesAsSet.contains(2));
+        Assert.assertTrue(valuesAsSet.contains(3));
+
+        //with partial auto expand
+        fieldPath = new FieldPath(readStateEngine, "SetType", "intValues.element", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, values.length);
+        valuesAsSet = new HashSet<>();
+        for (Object v : values) valuesAsSet.add((int) v);
+
+        Assert.assertTrue(valuesAsSet.contains(1));
+        Assert.assertTrue(valuesAsSet.contains(2));
+        Assert.assertTrue(valuesAsSet.contains(3));
+
+        //with partial auto expand
+        fieldPath = new FieldPath(readStateEngine, "SetType", "intValues.value", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, values.length);
+        valuesAsSet = new HashSet<>();
+        for (Object v : values) valuesAsSet.add((int) v);
+
+        Assert.assertTrue(valuesAsSet.contains(1));
+        Assert.assertTrue(valuesAsSet.contains(2));
+        Assert.assertTrue(valuesAsSet.contains(3));
+
+        //without auto expand
+        fieldPath = new FieldPath(readStateEngine, "SetType", "intValues.element.value", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, values.length);
+        valuesAsSet = new HashSet<>();
+        for (Object v : values) valuesAsSet.add((int) v);
+
+        Assert.assertTrue(valuesAsSet.contains(1));
+        Assert.assertTrue(valuesAsSet.contains(2));
+        Assert.assertTrue(valuesAsSet.contains(3));
+    }
+
+
+    // ------- unit tests for MAP type -------
+
+
+    private static class MapReference {
+        Map<Integer, String> mapValues;
+    }
+
+    @Test
+    public void testMapReference() throws Exception {
+        Map<Integer, String> map = new HashMap<>();
+        map.put(1, "one");
+        map.put(2, "two");
+
+        MapReference mapReference = new MapReference();
+        mapReference.mapValues = map;
+
+        objectMapper.add(mapReference);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // no auto-expand for a map
+        FieldPath fieldPath = new FieldPath(readStateEngine, "MapReference", "mapValues.value", HollowObjectSchema.FieldType.STRING);
+        Object[] values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(2, values.length);
+        Set<String> valuesAsSet = new HashSet<>();
+        for (Object v : values) valuesAsSet.add((String) v);
+        Assert.assertTrue(valuesAsSet.contains("one"));
+        Assert.assertTrue(valuesAsSet.contains("two"));
+    }
+
+    private static class MapObjectReference {
+        Map<Integer, MapValue> mapValues;
+    }
+
+    private static class MapValue {
+        String val;
+    }
+
+    @Test
+    public void testMapObjectValueReference() throws Exception {
+        MapValue val1 = new MapValue();
+        val1.val = "one";
+
+        MapValue val2 = new MapValue();
+        val2.val = "two";
+        Map<Integer, MapValue> map = new HashMap<>();
+        map.put(1, val1);
+        map.put(2, val2);
+
+        MapObjectReference mapObjectReference = new MapObjectReference();
+        mapObjectReference.mapValues = map;
+
+        objectMapper.add(mapObjectReference);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // for values
+        FieldPath fieldPath = new FieldPath(readStateEngine, "MapObjectReference", "mapValues.value", HollowObjectSchema.FieldType.STRING);
+        Object[] values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(2, values.length);
+        Set<String> valuesAsSet = new HashSet<>();
+        for (Object v : values) valuesAsSet.add((String) v);
+        Assert.assertTrue(valuesAsSet.contains("one"));
+        Assert.assertTrue(valuesAsSet.contains("two"));
+
+        // for keys
+        fieldPath = new FieldPath(readStateEngine, "MapObjectReference", "mapValues.key", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(2, values.length);
+        Set<Integer> keysAsSet = new HashSet<>();
+        for (Object v : values) keysAsSet.add((int) v);
+        Assert.assertTrue(keysAsSet.contains(1));
+        Assert.assertTrue(keysAsSet.contains(2));
+    }
+
+    // Map key is a list
+    private static class MapKeyReferenceAsList {
+        Map<ListType, Integer> mapValues;
+    }
+
+    @Test
+    public void testMapKeyReferenceToList() throws Exception {
+        ListType listType = new ListType();
+        listType.intValues = Arrays.asList(1, 2, 3);
+
+        Map<ListType, Integer> map = new HashMap<>();
+        map.put(listType, 1);
+
+        MapKeyReferenceAsList mapKeyReferenceAsList = new MapKeyReferenceAsList();
+        mapKeyReferenceAsList.mapValues = map;
+
+        objectMapper.add(mapKeyReferenceAsList);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // auto-expands the list
+        FieldPath fieldPath = new FieldPath(readStateEngine, "MapKeyReferenceAsList", "mapValues.key", HollowObjectSchema.FieldType.INT);
+        Object[] values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, values.length);
+
+        // partial auto-expand list path
+        fieldPath = new FieldPath(readStateEngine, "MapKeyReferenceAsList", "mapValues.key.intValues", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, values.length);
+
+        fieldPath = new FieldPath(readStateEngine, "MapKeyReferenceAsList", "mapValues.key.intValues.element.value", HollowObjectSchema.FieldType.INT);
+        values = fieldPath.findValuesFollowingPath(0);
+        Assert.assertEquals(3, values.length);
+
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrefixIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrefixIndexTest.java
@@ -194,7 +194,7 @@ public class HollowPrefixIndexTest {
         MovieMapReference movieMapReference = new MovieMapReference(1, 1999, "The Matrix", idActorMap);
         objectMapper.add(movieMapReference);
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
-        HollowPrefixIndex prefixIndex = new HollowPrefixIndex(readStateEngine, "MovieMapReference", "idActorNameMap");
+        HollowPrefixIndex prefixIndex = new HollowPrefixIndex(readStateEngine, "MovieMapReference", "idActorNameMap.value");
         Set<Integer> ordinals = toSet(prefixIndex.findKeysWithPrefix("kea"));
         Assert.assertTrue(ordinals.size() == 1);
     }
@@ -208,7 +208,7 @@ public class HollowPrefixIndexTest {
         MovieActorMapReference movieActorMapReference = new MovieActorMapReference(1, 1999, "The Matrix", idActorMap);
         objectMapper.add(movieActorMapReference);
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
-        HollowPrefixIndex prefixIndex = new HollowPrefixIndex(readStateEngine, "MovieActorMapReference", "idActorNameMap");
+        HollowPrefixIndex prefixIndex = new HollowPrefixIndex(readStateEngine, "MovieActorMapReference", "idActorNameMap.value");
         Set<Integer> ordinals = toSet(prefixIndex.findKeysWithPrefix("carr"));
         Assert.assertTrue(ordinals.size() == 1);
         ordinals = toSet(prefixIndex.findKeysWithPrefix("aaa"));


### PR DESCRIPTION
Updated FieldPath class with following changes
- Changed the functionality of field path when referencing a Map schema. It does not auto-expand the field path. When using a Map type in field path, it is necessary to add "key" or "value" in the path.
- Added a flag to turn-off auto-expand
- Updated documentation for the class
- Added many unit tests for testing the functioning of FieldPath.