### PR TITLE
Feature/boolean field ergonomics

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIGenerator.java
@@ -63,6 +63,7 @@ public class HollowAPIGenerator {
     private String classPostfix = "Hollow";
     private String getterPrefix = "_";
     private boolean useAggressiveSubstitutions = false;
+    private boolean useBooleanFieldErgonomics = false;
 
     /**
      * @param apiClassname the class name of the generated implementation of {@link HollowAPI}
@@ -94,8 +95,7 @@ public class HollowAPIGenerator {
     public HollowAPIGenerator(String apiClassname, String packageName, HollowDataset dataset, Set<String> parameterizeSpecificTypeNames) {
         this(apiClassname, packageName, dataset, parameterizeSpecificTypeNames, false, false);
     }
-    
-    
+
     private HollowAPIGenerator(String apiClassname, String packageName, HollowDataset dataset, Set<String> parameterizedTypes, boolean parameterizeAllClassNames, boolean useErgonomicShortcuts) {
         this.apiClassname = apiClassname;
         this.packageName = packageName;
@@ -126,6 +126,15 @@ public class HollowAPIGenerator {
      */
     public void setUseAggressiveSubstitutions(boolean useAggressiveSubstitutions) {
         this.useAggressiveSubstitutions = useAggressiveSubstitutions;
+    }
+
+    /**
+     * Use this method to specify to use new boolean field ergonomics for generated API
+     * 
+     * Defaults to false to be backwards compatible
+     */
+    public void setUseBooleanFieldErgonomics(boolean useBooleanFieldErgonomics) {
+        this.useBooleanFieldErgonomics = useBooleanFieldErgonomics;
     }
 
     
@@ -184,7 +193,7 @@ public class HollowAPIGenerator {
 
     private HollowJavaFileGenerator getHollowObjectGenerator(HollowSchema schema) {
         if(schema instanceof HollowObjectSchema) {
-            return new HollowObjectJavaGenerator(packageName, apiClassname, (HollowObjectSchema) schema, parameterizedTypes, parameterizeClassNames, classPostfix, getterPrefix, useAggressiveSubstitutions, ergonomicShortcuts);
+            return new HollowObjectJavaGenerator(packageName, apiClassname, (HollowObjectSchema) schema, parameterizedTypes, parameterizeClassNames, classPostfix, getterPrefix, useAggressiveSubstitutions, ergonomicShortcuts, useBooleanFieldErgonomics);
         } else if(schema instanceof HollowListSchema) {
             return new HollowListJavaGenerator(packageName, apiClassname, (HollowListSchema) schema, parameterizedTypes, parameterizeClassNames, classPostfix, useAggressiveSubstitutions);
         } else if(schema instanceof HollowSetSchema) {
@@ -210,6 +219,7 @@ public class HollowAPIGenerator {
         private String getterPrefix = "";
         private boolean useAggressiveSubstitutions = false;
         private boolean useErgonomicShortcuts = false;
+        private boolean useBooleanFieldErgonomics = false;
         
         public Builder withAPIClassname(String apiClassname) {
             this.apiClassname = apiClassname;
@@ -250,9 +260,14 @@ public class HollowAPIGenerator {
             this.useAggressiveSubstitutions = useAggressiveSubstitutions;
             return this;
         }
-        
+
         public Builder withErgonomicShortcuts() {
             this.useErgonomicShortcuts = true;
+            return this;
+        }
+
+        public Builder withBooleanFieldErgonomics(boolean useBooleanFieldErgonomics) {
+            this.useBooleanFieldErgonomics = useBooleanFieldErgonomics;
             return this;
         }
         
@@ -268,6 +283,7 @@ public class HollowAPIGenerator {
             generator.setClassPostfix(classPostfix);
             generator.setGetterPrefix(getterPrefix);
             generator.setUseAggressiveSubstitutions(useAggressiveSubstitutions);
+            generator.setUseBooleanFieldErgonomics(useBooleanFieldErgonomics);
             return generator;
         }
         

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
@@ -310,7 +310,8 @@ public class HollowCodeGenerationUtils {
      *
      *      boolean isPrimary - isPrimary()
      *      boolean hasStreams - hasStreams()
-     *      boolean playable - isPlayable()
+     *      boolean playable - getPlayable()
+     *      boolean value - getValue()
      *
      * other field type: prepend "get" + upper case first char
      *

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
@@ -32,21 +32,12 @@ import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSetSchema;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.tools.JavaCompiler;
-import javax.tools.ToolProvider;
 
 /**
  * A class containing convenience methods for the {@link HollowAPIGenerator}.  Not intended for external consumption.

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
@@ -300,7 +300,7 @@ public class HollowCodeGenerationUtils {
 
     private static final Set<String> booleanMethodPrefixes = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             "is", "has", "do", "should", "was", "contains", "enable", "disable", "get")));
-    public static Set<String> getBooleanMethodPrefixes() { return Collections.unmodifiableSet(booleanMethodPrefixes); }
+    public static Set<String> getBooleanMethodPrefixes() { return booleanMethodPrefixes; }
 
     /**
      * Rules: prepend "get" / "is" + upper case first char of field name

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
@@ -32,8 +32,21 @@ import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSetSchema;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
 
 /**
  * A class containing convenience methods for the {@link HollowAPIGenerator}.  Not intended for external consumption.
@@ -292,5 +305,49 @@ public class HollowCodeGenerationUtils {
             return "String";
         }
         throw new IllegalArgumentException("Java scalar type is not known for FieldType." + fieldType.toString());
+    }
+
+    private static final Set<String> booleanMethodPrefixes = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "is", "has", "do", "should", "was", "contains", "enable", "disable", "get")));
+    public static Set<String> getBooleanMethodPrefixes() { return Collections.unmodifiableSet(booleanMethodPrefixes); }
+
+    /**
+     * Rules: prepend "get" / "is" + upper case first char of field name
+     *
+     * boolean/Boolean field:
+     *    - has a boolean prefix (@see {@link #booleanMethodPrefixes}), just return it; otherwise, prepend "get" + upper case first char
+     *
+     *      boolean isPrimary - isPrimary()
+     *      boolean hasStreams - hasStreams()
+     *      boolean playable - isPlayable()
+     *
+     * other field type: prepend "get" + upper case first char
+     *
+     *      String title - getTitle()
+     *
+     * @param fieldName
+     *            name of field
+     * @param clazz
+     *            type of field
+     * @return accessor method name
+     */
+    public static String generateAccessortMethodName(String fieldName, Class<?> clazz) {
+        String prefix = "get";
+        if (boolean.class.equals(clazz) || Boolean.class.equals(clazz)) {
+            for (String booleanPrefix : booleanMethodPrefixes) {
+                if (fieldName.startsWith(booleanPrefix) && fieldName.length() > booleanPrefix.length()) {
+                    char firstCharAfterBooleanPrefix = fieldName.charAt(booleanPrefix.length());
+                    if (Character.isUpperCase(firstCharAfterBooleanPrefix)) {
+                        return fieldName;
+                    }
+                }
+            }
+        }
+
+        return substituteInvalidChars(prefix + uppercase(fieldName));
+    }
+
+    public static String generateBooleanAccessorMethodName(String fieldName, boolean useBooleanFieldErgonomics) {
+           return useBooleanFieldErgonomics ? generateAccessortMethodName(fieldName, boolean.class) : "get" + uppercase(fieldName);
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -20,13 +20,13 @@ public class HollowAPIGeneratorTest {
 
     @Test
     public void testBooleanFieldErgonimics() throws Exception {
-        // Setup Folders
+        // Setup
         String packageName = "booleanfieldergo";
         String srcDir = String.format("%s/%s/src/", baseDir, packageName);
         System.out.println("Generated Source under: " + srcDir);
         HollowCodeGenerationCompileUtil.cleanupFolder(new File(srcDir), null);
 
-        // Init ObjectMapper 
+        // Init TypeState 
         HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
         HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
         mapper.initializeTypeState(Movie.class);

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -3,18 +3,11 @@ package com.netflix.hollow.api.codegen;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import java.io.File;
-import java.io.IOException;
-import org.junit.Before;
-import org.junit.Test;
 
 public class HollowAPIGeneratorTest {
-    private String baseDir = "/tmp"; //System.getProperty("java.io.tmpdir");
+    public static void main(String[] args) throws Exception {
+        String baseDir = System.getProperty("java.io.tmpdir");
 
-    @Before
-    public void setUp() throws IOException {}
-
-    @Test
-    public void testBooleanFieldErgonimics() throws Exception {
         // Setup
         String packageName = "booleanfieldergo";
         String srcDir = String.format("%s/%s/src/", baseDir, packageName);

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -8,15 +8,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class HollowAPIGeneratorTest {
-    private String baseDir = System.getProperty("java.io.tmpdir");
+    private String baseDir = "/tmp"; //System.getProperty("java.io.tmpdir");
 
     @Before
     public void setUp() throws IOException {}
-
-    @Test
-    public void clearTmp() {
-        HollowCodeGenerationCompileUtil.cleanupFolder(new File(baseDir), null);
-    }
 
     @Test
     public void testBooleanFieldErgonimics() throws Exception {

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -1,0 +1,55 @@
+package com.netflix.hollow.api.codegen;
+
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+import java.io.File;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HollowAPIGeneratorTest {
+    private String baseDir = "/tmp/HollowAPIGeneratorTest";
+
+    @Before
+    public void setUp() throws IOException {}
+
+    @Test
+    public void clearTmp() {
+        HollowCodeGenerationCompileUtil.cleanupFolder(new File(baseDir), null);
+    }
+
+    @Test
+    public void testBooleanFieldErgonimics() throws Exception {
+        // Setup Folders
+        String packageName = "booleanfieldergo";
+        String srcDir = String.format("%s/%s/src/", baseDir, packageName);
+        HollowCodeGenerationCompileUtil.cleanupFolder(new File(srcDir), null);
+
+        // Init ObjectMapper 
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
+        mapper.initializeTypeState(Movie.class);
+
+        // Run Generator
+        HollowAPIGenerator generator = new HollowAPIGenerator.Builder()
+                .withDataModel(writeEngine)
+                .withAPIClassname("MovieAPI")
+                .withPackageName(packageName)
+                //.withErgonomicShortcuts()
+                .withBooleanFieldErgonomics(true)
+                .build();
+        generator.generateFiles(srcDir + packageName.replace('.', '/'));
+
+        // Compile to validate generated files
+        HollowCodeGenerationCompileUtil.compileSrcFiles(srcDir, baseDir + "/classes");
+    }
+
+    static class Movie {
+        int id;
+        boolean playable;
+        boolean isAction;
+        Boolean hasSubtitles;
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -2,7 +2,6 @@ package com.netflix.hollow.api.codegen;
 
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
-import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 import java.io.File;
 import java.io.IOException;
 import org.junit.Before;

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -8,7 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class HollowAPIGeneratorTest {
-    private String baseDir = "/tmp/HollowAPIGeneratorTest";
+    private String baseDir = System.getProperty("java.io.tmpdir");
 
     @Before
     public void setUp() throws IOException {}
@@ -23,6 +23,7 @@ public class HollowAPIGeneratorTest {
         // Setup Folders
         String packageName = "booleanfieldergo";
         String srcDir = String.format("%s/%s/src/", baseDir, packageName);
+        System.out.println("Generated Source under: " + srcDir);
         HollowCodeGenerationCompileUtil.cleanupFolder(new File(srcDir), null);
 
         // Init ObjectMapper 
@@ -47,6 +48,7 @@ public class HollowAPIGeneratorTest {
     static class Movie {
         int id;
         boolean playable;
+        boolean value;
         boolean isAction;
         Boolean hasSubtitles;
     }

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowCodeGenerationCompileUtil.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowCodeGenerationCompileUtil.java
@@ -1,0 +1,77 @@
+package com.netflix.hollow.api.codegen;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+public class HollowCodeGenerationCompileUtil {
+    public static void compileSrcFiles(String sourceDirPath, String classDirPath) throws Exception {
+        List<String> srcFiles = new ArrayList<>();
+        addAllJavaFiles(new File(sourceDirPath), srcFiles);
+
+        File classDir = new File(classDirPath);
+        classDir.mkdir();
+
+
+        List<String> argList = new ArrayList<>();
+        argList.add("-d");
+        argList.add(classDir.getAbsolutePath());
+        //argList.add("-Xlint:unchecked");
+        argList.add("-classpath");
+        argList.add(System.getProperty("java.class.path") + ":" + classDirPath);
+        argList.addAll(srcFiles);
+
+        // argList.toArray() for large size had trouble
+        String[] args = new String[argList.size()];
+        for (int i = 0; i < argList.size(); i++) {
+            args[i] = argList.get(i);
+        }
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        int err = compiler.run(null, System.out, System.out, args);
+        if (err != 0)
+            throw new RuntimeException("compiler errors, see system.out");
+    }
+
+    private static void addAllJavaFiles(File folder, List<String> result) throws IOException {
+        for (File f : folder.listFiles()) {
+            if (f.isDirectory()) {
+                addAllJavaFiles(f, result);
+            } else if (f.getName().endsWith(".java")) {
+                result.add(f.toString());
+
+                System.out.println("Java file: " + f.getName());
+                System.out.println("------------------------------\n");
+                Path path = f.toPath();
+                Files.copy(path, System.out);
+                System.out.println("\n------------------------------\n");
+            }
+        }
+    }
+    
+    /**
+     * Cleanup specified folder based on file older than specified timestamp
+     *
+     * @param folder - folder to be cleaned up
+     * @param timestamp - specify timestamp to cleanup older files
+     */
+    public static void cleanupFolder(File folder, Long timestamp) {
+        System.out.println("Cleaning up folder: " + folder.getAbsolutePath());
+        if (folder.exists()) {
+            for (File file : folder.listFiles()) {
+                if (file.isDirectory()) {
+                    cleanupFolder(file, timestamp);
+                } else if (timestamp == null || (timestamp.longValue() - file.lastModified() >= 5000)) { // cleanup file if it is older than specified timestamp with some buffer time
+                    System.out.println(String.format("\t deleting file: %s, lastModified=%s", file.getName(), new Date(file.lastModified())));
+                    file.delete();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduce boolean field ergonomics for generated client api

- created accessors without "get" prefix when boolean fields has the following prefix: "is", "has", "do", "should", "was", "contains", "enable", "disable", "get"



