### PR TITLE
Add HollowIncrementalProducer support for withThreadsPerCpu

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -53,7 +53,7 @@ public class HollowIncrementalProducer {
         this(producer, 1.0d);
     }
     
-    protected HollowIncrementalProducer(HollowProducer producer, double threadsPerCpu) {
+    public HollowIncrementalProducer(HollowProducer producer, double threadsPerCpu) {
         this.producer = producer;
         this.threadsPerCpu = threadsPerCpu;
         this.mutations = new ConcurrentHashMap<RecordPrimaryKey, Object>();
@@ -75,33 +75,6 @@ public class HollowIncrementalProducer {
     
     public void delete(RecordPrimaryKey key) {
         mutations.put(key, DELETE_RECORD);
-    }
-
-    public static HollowIncrementalProducer.Builder withProducer(HollowProducer producer) {
-        HollowIncrementalProducer.Builder builder = new HollowIncrementalProducer.Builder();
-        return builder.withProducer(producer);
-    }
-    
-    public static class Builder {
-        private HollowProducer producer;
-        private double threadsPerCpu = 1.0d; //Default to 1 thread per CPU
-
-        public Builder withProducer(HollowProducer hollowProducer) {
-            this.producer = hollowProducer;
-            return this;
-        }
-
-        public Builder withThreadsPerCpu(double threadsPerCpu) {
-            this.threadsPerCpu = threadsPerCpu;
-            return this;
-        }
-
-        public HollowIncrementalProducer build() {
-            if(producer == null)
-                throw new IllegalArgumentException("HollowProducer must be specified");
-
-            return new HollowIncrementalProducer(producer, threadsPerCpu);
-        }
     }
     
     public long runCycle() {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -52,13 +52,13 @@ public class HollowIncrementalProducer {
     public HollowIncrementalProducer(HollowProducer producer) {
         this(producer, 1.0d);
     }
-
+    
     public HollowIncrementalProducer(HollowProducer producer, double threadsPerCpu) {
         this.producer = producer;
         this.threadsPerCpu = threadsPerCpu;
         this.mutations = new ConcurrentHashMap<RecordPrimaryKey, Object>();
     }
-
+    
     public void restore(long versionDesired, BlobRetriever blobRetriever) {
         producer.hardRestore(versionDesired, blobRetriever);
     }
@@ -81,7 +81,7 @@ public class HollowIncrementalProducer {
         HollowIncrementalProducer.Builder builder = new HollowIncrementalProducer.Builder();
         return builder.withProducer(producer);
     }
-
+    
     public static class Builder {
         private HollowProducer producer;
         private double threadsPerCpu = 1.0d; //Default to 1 thread per CPU
@@ -103,7 +103,7 @@ public class HollowIncrementalProducer {
             return new HollowIncrementalProducer(producer, threadsPerCpu);
         }
     }
-
+    
     public long runCycle() {
         return producer.runCycle(new Populator() {
             public void populate(WriteState newState) throws Exception {
@@ -172,7 +172,7 @@ public class HollowIncrementalProducer {
                     }
                 }
             }
-
+            
             private void addRecords(final WriteState newState) {
                 SimultaneousExecutor executor = new SimultaneousExecutor(threadsPerCpu);
                 for(final Map.Entry<RecordPrimaryKey, Object> entry : mutations.entrySet()) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -53,7 +53,7 @@ public class HollowIncrementalProducer {
         this(producer, 1.0d);
     }
     
-    public HollowIncrementalProducer(HollowProducer producer, double threadsPerCpu) {
+    protected HollowIncrementalProducer(HollowProducer producer, double threadsPerCpu) {
         this.producer = producer;
         this.threadsPerCpu = threadsPerCpu;
         this.mutations = new ConcurrentHashMap<RecordPrimaryKey, Object>();

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
@@ -165,9 +165,7 @@ public class HollowIncrementalProducerTest {
         initializeData(producer);
 
         /// now we'll be incrementally updating the state by mutating individual records
-        HollowIncrementalProducer incrementalProducer = HollowIncrementalProducer.withProducer(producer)
-                .withThreadsPerCpu(2.0d)
-                .build();
+        HollowIncrementalProducer incrementalProducer = new HollowIncrementalProducer(producer, 2.0d);
 
         incrementalProducer.addOrModify(new TypeA(1, "one", 100));
         incrementalProducer.addOrModify(new TypeA(2, "two", 2));


### PR DESCRIPTION
This introduces the `threadsPerCpu ` for `HollowIncrementalProducer`.

```
HollowIncrementalProducer incrementalProducer = new HollowIncrementalProducer(producer, 2.0d);
```

Devs can still use the constructor as before 

```
HollowIncrementalProducer incrementalProducer = new HollowIncrementalProducer(producer);
```

It also introduces the usage of `SimultaneousExecutor` in `addRecords` while running a cycle. By default it uses `1.0d` threads per CPU 