### PR TITLE
calculate producer metrics when state engine is not available

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowMetrics.java
@@ -31,6 +31,10 @@ abstract class HollowMetrics {
     private long totalHeapFootprint = 0L;
     private int totalPopulatedOrdinals = 0;
 
+    public void update(long version) {
+        setCurrentVersion(version);
+    }
+
     public void update(HollowReadStateEngine hollowReadStateEngine, long version) {
         setCurrentVersion(version);
         calculateTypeMetrics(hollowReadStateEngine);

--- a/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowMetrics.java
@@ -31,11 +31,11 @@ abstract class HollowMetrics {
     private long totalHeapFootprint = 0L;
     private int totalPopulatedOrdinals = 0;
 
-    public void update(long version) {
+    protected void update(long version) {
         setCurrentVersion(version);
     }
 
-    public void update(HollowReadStateEngine hollowReadStateEngine, long version) {
+    protected void update(HollowReadStateEngine hollowReadStateEngine, long version) {
         setCurrentVersion(version);
         calculateTypeMetrics(hollowReadStateEngine);
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowProducerMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowProducerMetrics.java
@@ -45,8 +45,13 @@ public class HollowProducerMetrics extends HollowMetrics {
             return;
         }
         cyclesSucceeded++;
-        HollowReadStateEngine hollowReadStateEngine = producerStatus.getReadState().getStateEngine();
-        super.update(hollowReadStateEngine, producerStatus.getVersion());
+
+        if(producerStatus.getReadState() != null) {
+            HollowReadStateEngine hollowReadStateEngine = producerStatus.getReadState().getStateEngine();
+            super.update(hollowReadStateEngine, producerStatus.getVersion());
+        } else {
+            super.update(producerStatus.getVersion());
+        }
     }
 
     public void updateBlobTypeMetrics(HollowProducerListener.PublishStatus publishStatus) {

--- a/hollow/src/test/java/com/netflix/hollow/api/metrics/HollowProducerMetricsTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/metrics/HollowProducerMetricsTests.java
@@ -2,18 +2,39 @@ package com.netflix.hollow.api.metrics;
 
 import com.netflix.hollow.api.consumer.InMemoryBlobStore;
 import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.HollowProducerFakeListener;
+import com.netflix.hollow.api.producer.HollowProducerListener;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+
 public class HollowProducerMetricsTests {
 
     private InMemoryBlobStore blobStore;
+    private HollowProducerMetrics hollowProducerMetrics;
+    private HollowProducerFakeListener hollowProducerFakeListener;
 
     @Before
     public void setUp() {
         blobStore = new InMemoryBlobStore();
+        hollowProducerMetrics = new HollowProducerMetrics();
+        hollowProducerFakeListener = new HollowProducerFakeListener();
+    }
+
+    @Test
+    public void metricsDoNotBreakWithNullStateEngineInSuccess() {
+        HollowProducerListener.ProducerStatus producerStatus = hollowProducerFakeListener.getSuccessFakeStatus(1L);
+        hollowProducerMetrics.updateCycleMetrics(producerStatus);
+        Assert.assertEquals(hollowProducerMetrics.getCyclesSucceeded(), 1);
+    }
+
+    @Test
+    public void metricsDoNotBreakWithNullStateEngineInFail() {
+        HollowProducerListener.ProducerStatus producerStatus = hollowProducerFakeListener.getFailFakeStatus(1L);
+        hollowProducerMetrics.updateCycleMetrics(producerStatus);
+        Assert.assertEquals(hollowProducerMetrics.getCycleFailed(), 1);
     }
 
     @Test

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerFakeListener.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerFakeListener.java
@@ -1,0 +1,68 @@
+package com.netflix.hollow.api.producer;
+
+import java.util.concurrent.TimeUnit;
+
+public class HollowProducerFakeListener  implements HollowProducerListener {
+
+    public ProducerStatus getSuccessFakeStatus(long version) {
+        return HollowProducerFakeListener.ProducerStatus.success(version);
+    }
+
+    public ProducerStatus getFailFakeStatus(long version) {
+        return HollowProducerFakeListener.ProducerStatus.fail(version);
+    }
+
+    @Override
+    public void onProducerInit(long elapsed, TimeUnit unit) { }
+
+    @Override
+    public void onProducerRestoreStart(long restoreVersion) { }
+
+    @Override
+    public void onProducerRestoreComplete(RestoreStatus status, long elapsed, TimeUnit unit) { }
+
+    @Override
+    public void onNewDeltaChain(long version) { }
+
+    @Override
+    public void onCycleStart(long version) { }
+
+    @Override
+    public void onCycleComplete(ProducerStatus status, long elapsed, TimeUnit unit) { }
+
+    @Override
+    public void onNoDeltaAvailable(long version) { }
+
+    @Override
+    public void onPopulateStart(long version) { }
+
+    @Override
+    public void onPopulateComplete(ProducerStatus status, long elapsed, TimeUnit unit) { }
+
+    @Override
+    public void onPublishStart(long version) { }
+
+    @Override
+    public void onPublishComplete(ProducerStatus status, long elapsed, TimeUnit unit) { }
+
+    @Override
+    public void onArtifactPublish(PublishStatus publishStatus, long elapsed, TimeUnit unit) { }
+
+    @Override
+    public void onIntegrityCheckStart(long version) { }
+
+    @Override
+    public void onIntegrityCheckComplete(ProducerStatus status, long elapsed, TimeUnit unit) { }
+
+    @Override
+    public void onValidationStart(long version) { }
+
+    @Override
+    public void onValidationComplete(ProducerStatus status, long elapsed, TimeUnit unit) { }
+
+    @Override
+    public void onAnnouncementStart(long version) { }
+
+    @Override
+    public void onAnnouncementComplete(ProducerStatus status, long elapsed, TimeUnit unit) { }
+}


### PR DESCRIPTION
This is a fix for issue reported in https://github.com/Netflix/hollow/pull/95#issuecomment-333373011