### PR TITLE
Keeping constructor for HollowConsumer backwards incompatible 

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -45,71 +45,71 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 
 /**
- * 
- * A HollowConsumer is the top-level class used by consumers of Hollow data to initialize and keep up-to-date a local in-memory 
- * copy of a hollow dataset.  The interactions between the "blob" transition store and announcement listener are defined by 
- * this class, and the implementations of the data retrieval, announcement mechanism are abstracted in the interfaces which 
+ *
+ * A HollowConsumer is the top-level class used by consumers of Hollow data to initialize and keep up-to-date a local in-memory
+ * copy of a hollow dataset.  The interactions between the "blob" transition store and announcement listener are defined by
+ * this class, and the implementations of the data retrieval, announcement mechanism are abstracted in the interfaces which
  * are provided to this class.
- * 
+ *
  * To obtain a HollowConsumer, you should use a builder pattern, for example:
- * 
+ *
  * <pre>
  * {@code
- * 
+ *
  * HollowConsumer consumer = HollowConsumer.withBlobRetriever(retriever)
  *                                         .withAnnouncementWatcher(watcher)
  *                                         .withGeneratedAPIClass(MovieAPI.class)
  *                                         .build();
  * }
  * </pre>
- * 
- * The following components are injectable, but only an implementation of the HollowConsumer.BlobRetriever is 
- * required to be injected, all other components are optional. :     
- * 
+ *
+ * The following components are injectable, but only an implementation of the HollowConsumer.BlobRetriever is
+ * required to be injected, all other components are optional. :
+ *
  * <dl>
  *      <dt>{@link HollowConsumer.BlobRetriever}</dt>
  *      <dd>Implementations of this class define how to retrieve blob data from the blob store.</dd>
- *      
+ *
  *      <dt>{@link HollowConsumer.AnnouncementWatcher}</dt>
- *      <dd>Implementations of this class define the announcement mechanism, which is used to track the version of the 
+ *      <dd>Implementations of this class define the announcement mechanism, which is used to track the version of the
  *          currently announced state.  It's also expected that implementations will trigger a refresh each time current
  *          data version is updated.</dd>
- *          
+ *
  *      <dt>a List of {@link HollowConsumer.RefreshListener}s</dt>
  *      <dd>RefreshListener implementations will define what to do when various events happen before, during, and after updating
  *          local in-memory copies of hollow data sets.</dd>
- *          
+ *
  *      <dt>the Class representing a generated Hollow API</dt>
- *      <dd>Defines how to create a {@link HollowAPI} for the dataset, useful when wrapping a dataset with an api which has 
+ *      <dd>Defines how to create a {@link HollowAPI} for the dataset, useful when wrapping a dataset with an api which has
  *          been generated (via the {@link HollowAPIClassJavaGenerator})</dd>
- *          
+ *
  *      <dt>{@link HollowFilterConfig}</dt>
  *      <dd>Defines what types and fields to load (or not load) into memory from hollow datasets.  Generally useful to reduce
  *          heap footprint on consumers which do not require visibility of an entire dataset.</dd>
- *          
+ *
  *      <dt>{@link HollowConsumer.DoubleSnapshotConfig}</dt>
  *      <dd>Defines whether this consumer may attempt a double snapshot, and how many deltas will be attempted during a single refresh.
  *          A double snapshot will allow your consumer to update in case of a broken delta chain, but will also result in a doubling of
  *          the heap footprint while the double snapshot is occurring.</dd>
- *          
+ *
  *      <dt>{@link HollowConsumer.ObjectLongevityConfig}</dt>
- *      <dd>Object longevity is used to guarantee that Hollow objects which are backed by removed records will remain usable and 
- *          consistent until old references are discarded.  This behavior is turned off by default.  Implementations of this config 
+ *      <dd>Object longevity is used to guarantee that Hollow objects which are backed by removed records will remain usable and
+ *          consistent until old references are discarded.  This behavior is turned off by default.  Implementations of this config
  *          can be used to enable and configure this behavior.</dd>
- *          
+ *
  *      <dt>{@link HollowConsumer.ObjectLongevityDetector}</dt>
  *      <dd>Implementations of this config will be notified when usage of expired Hollow object references is attempted.</dd>
- *      
+ *
  *      <dt>An Executor</dt>
  *      <dd>The Executor which will be used to perform updates when {@link #triggerAsyncRefresh()} is called.  This will
  *          default to a new fixed thread pool with a single refresh thread.</dd>
- *      
- *          
- *      
+ *
+ *
+ *
  * </dl>
  */
 public class HollowConsumer {
-    
+
     protected final AnnouncementWatcher announcementWatcher;
     protected final HollowClientUpdater updater;
     protected final ReadWriteLock refreshLock;
@@ -126,16 +126,29 @@ public class HollowConsumer {
                              ObjectLongevityDetector objectLongevityDetector,
                              DoubleSnapshotConfig doubleSnapshotConfig,
                              HollowObjectHashCodeFinder hashCodeFinder,
+                             Executor refreshExecutor) {
+        this(blobRetriever, announcementWatcher, updateListeners, apiFactory, dataFilter, objectLongevityConfig, objectLongevityDetector, doubleSnapshotConfig, hashCodeFinder, refreshExecutor, null);
+    }
+
+    protected HollowConsumer(BlobRetriever blobRetriever,
+                             AnnouncementWatcher announcementWatcher,
+                             List<RefreshListener> updateListeners,
+                             HollowAPIFactory apiFactory,
+                             HollowFilterConfig dataFilter,
+                             ObjectLongevityConfig objectLongevityConfig,
+                             ObjectLongevityDetector objectLongevityDetector,
+                             DoubleSnapshotConfig doubleSnapshotConfig,
+                             HollowObjectHashCodeFinder hashCodeFinder,
                              Executor refreshExecutor,
                              HollowMetricsCollector<HollowConsumerMetrics> metricsCollector) {
 
         this.metrics = new HollowConsumerMetrics();
         this.updater = new HollowClientUpdater(blobRetriever,
-                                               updateListeners, 
-                                               apiFactory, 
+                                               updateListeners,
+                                               apiFactory,
                                                doubleSnapshotConfig,
-                                               hashCodeFinder, 
-                                               objectLongevityConfig, 
+                                               hashCodeFinder,
+                                               objectLongevityConfig,
                                                objectLongevityDetector,
                                                metrics,
                                                metricsCollector);
@@ -146,12 +159,12 @@ public class HollowConsumer {
         if(announcementWatcher != null)
             announcementWatcher.subscribeToUpdates(this);
     }
-    
+
     /**
      * Triggers a refresh to the latest version specified by the {@link HollowConsumer.AnnouncementWatcher}.
      * If already on the latest version, this operation is a no-op.
-     * 
-     * If a {@link HollowConsumer.AnnouncementWatcher} is not present, this call trigger a refresh to the 
+     *
+     * If a {@link HollowConsumer.AnnouncementWatcher} is not present, this call trigger a refresh to the
      * latest version available in the blob store.
      *
      * This is a blocking call.
@@ -168,12 +181,12 @@ public class HollowConsumer {
     }
 
     /**
-     * Immediately triggers a refresh in a different thread to the latest version 
-     * specified by the {@link HollowConsumer.AnnouncementWatcher}. If already on 
+     * Immediately triggers a refresh in a different thread to the latest version
+     * specified by the {@link HollowConsumer.AnnouncementWatcher}. If already on
      * the latest version, this operation is a no-op.
-     * 
-     * If a {@link HollowConsumer.AnnouncementWatcher} is not present, this call trigger a refresh to the 
-     * latest version available in the blob store.     
+     *
+     * If a {@link HollowConsumer.AnnouncementWatcher} is not present, this call trigger a refresh to the
+     * latest version available in the blob store.
      *
      * This is an asynchronous call.
      */
@@ -219,7 +232,7 @@ public class HollowConsumer {
     public void triggerRefreshTo(long version) {
         if(announcementWatcher != null)
             throw new UnsupportedOperationException("Cannot trigger refresh to specified version when a HollowConsumer.AnnouncementWatcher is present");
-        
+
         try {
             updater.updateTo(version);
         } catch(Throwable th) {
@@ -247,7 +260,7 @@ public class HollowConsumer {
     public HollowAPI getAPI() {
         return updater.getAPI();
     }
-    
+
     /**
      * Will force a double snapshot refresh on the next update.
      */
@@ -261,16 +274,16 @@ public class HollowConsumer {
     public void clearFailedTransitions() {
         updater.clearFailedTransitions();
     }
-    
+
     /**
      * Returns a {@link ReadWriteLock#readLock()}, the corresponding writeLock() of which is used to synchronize refreshes.
-     * 
+     *
      * This is useful if performing long-running operations which require a consistent view of the entire dataset in a single data state, to guarantee that updates do not happen while the operation runs.
      */
     public Lock getRefreshLock() {
         return refreshLock.readLock();
     }
-    
+
     /**
      * Add a {@link RefreshListener} to this consumer.
      */
@@ -293,10 +306,10 @@ public class HollowConsumer {
     }
 
     /**
-     * An interface which defines the necessary interactions of Hollow with a blob data store. 
-     * 
+     * An interface which defines the necessary interactions of Hollow with a blob data store.
+     *
      * Implementations will define how to retrieve blob data from a data store.
-     * 
+     *
      */
     public interface BlobRetriever {
 
@@ -316,18 +329,18 @@ public class HollowConsumer {
         public HollowConsumer.Blob retrieveReverseDeltaBlob(long currentVersion);
 
     }
-    
+
     /**
      * A Blob, which is either a snapshot or a delta, defines three things:
-     * 
+     *
      * <dl>
      *      <dt>The "from" version</dt>
      *      <dd>The unique identifier of the state to which a delta transition should be applied.  If
      *          this is a snapshot, then this value is Long.MIN_VALUE</dd>
-     *          
+     *
      *      <dt>The "to" version</dt>
      *      <dd>The unique identifier of the state at which a dataset will arrive after this blob is applied.</dd>
-     *      
+     *
      *      <dt>The actual blob data</dt>
      *      <dd>Implementations will define how to retrieve the actual blob data for this specific blob from a data store as an InputStream.</dd>
      * </dl>
@@ -346,7 +359,7 @@ public class HollowConsumer {
         }
 
         /**
-         * Instantiate a delta from one data state version to another. 
+         * Instantiate a delta from one data state version to another.
          */
         public Blob(long fromVersion, long toVersion) {
             this.fromVersion = fromVersion;
@@ -355,10 +368,10 @@ public class HollowConsumer {
 
         /**
          * Implementations will define how to retrieve the actual blob data for this specific transition from a data store.
-         * 
+         *
          * It is expected that the returned InputStream will not be interrupted.  For this reason, it is a good idea to
          * retrieve the entire blob (e.g. to disk) from a remote datastore prior to returning this stream.
-         *     
+         *
          * @return
          * @throws IOException
          */
@@ -371,9 +384,9 @@ public class HollowConsumer {
         public boolean isReverseDelta() {
             return toVersion < fromVersion;
         }
-        
+
         public boolean isDelta() {
-            return !isSnapshot() && !isReverseDelta(); 
+            return !isSnapshot() && !isReverseDelta();
         }
 
         public long getFromVersion() {
@@ -383,18 +396,18 @@ public class HollowConsumer {
         public long getToVersion() {
             return toVersion;
         }
-    }    
+    }
 
     /**
      * Implementations of this class are responsible for two things:
      *
      * 1) Tracking the latest announced data state version.
      * 2) Keeping the client up to date by calling triggerAsyncRefresh() on self when the latest version changes.
-     * 
+     *
      * If an AnnouncementWatcher is provided to a HollowConsumer, then calling HollowConsumer#triggerRefreshTo() is unsupported.
      */
     public static interface AnnouncementWatcher {
-        
+
         public static final long NO_ANNOUNCEMENT_AVAILABLE = Long.MIN_VALUE;
 
         /**
@@ -405,36 +418,36 @@ public class HollowConsumer {
 
         /**
          * Implementations of this method should subscribe a HollowConsumer to updates to announced versions.
-         * 
+         *
          * When announcements are received via a push mechanism, or polling reveals a new version, a call should be placed to one
          * of the flavors of {@link HollowConsumer#triggerRefresh()} on the provided HollowConsumer.
          */
         public abstract void subscribeToUpdates(HollowConsumer consumer);
     }
-    
+
     public static interface DoubleSnapshotConfig {
-        
+
         public boolean allowDoubleSnapshot();
 
         public int maxDeltasBeforeDoubleSnapshot();
-        
+
         public static DoubleSnapshotConfig DEFAULT_CONFIG = new DoubleSnapshotConfig() {
             @Override public int maxDeltasBeforeDoubleSnapshot() { return 32; }
             @Override public boolean allowDoubleSnapshot() { return true; }
         };
     }
 
-    
+
     public interface ObjectLongevityConfig {
 
         /**
          * Whether or not long-lived object support is enabled.
-         * 
+         *
          * Because Hollow reuses pooled memory, if references to Hollow records are held too long, the underlying data may
          * be overwritten.  When long-lived object support is enabled, Hollow records referenced via a {@link HollowAPI} will,
          * after an update, be backed by a reserved copy of the data at the time the reference was created.  This guarantees
          * that even if a reference is held for a long time, it will continue to return the same data when interrogated.
-         * 
+         *
          * These reserved copies are backed by the {@link HollowHistory} data structure.
          */
         public boolean enableLongLivedObjectSupport();
@@ -444,7 +457,7 @@ public class HollowConsumer {
         /**
          * If long-lived object support is enabled, this returns the number of milliseconds before the {@link StaleHollowReferenceDetector}
          * will begin flagging usage of stale objects.
-         * 
+         *
          * @return
          */
         public long gracePeriodMillis();
@@ -452,18 +465,18 @@ public class HollowConsumer {
         /**
          * If long-lived object support is enabled, this defines the number of milliseconds, after the grace period, during which
          * data is still available in stale references, but usage will be flagged by the {@link StaleHollowReferenceDetector}.
-         * 
+         *
          * After the grace period + usage detection period have expired, the data from stale references will become inaccessible if
          * dropDataAutomatically() is enabled.
-         * 
+         *
          * @return
          */
         public long usageDetectionPeriodMillis();
 
         /**
          * Whether or not to drop data behind stale references after the grace period + usage detection period has elapsed, assuming
-         * that no usage was detected during the usage detection period. 
-         * 
+         * that no usage was detected during the usage detection period.
+         *
          * @return
          */
         public boolean dropDataAutomatically();
@@ -483,15 +496,15 @@ public class HollowConsumer {
             @Override public long gracePeriodMillis() { return 60 * 60 * 1000; }
         };
     }
-    
+
     /**
-     * Listens for stale Hollow object usage 
+     * Listens for stale Hollow object usage
      */
     public interface ObjectLongevityDetector {
 
         /**
          * Stale reference detection hint.  This will be called every ~30 seconds.
-         * 
+         *
          * If a nonzero value is reported, then stale references to Hollow objects may be cached somewhere in your codebase.
          *
          * This signal can be noisy, and a nonzero value indicates that some reference to stale data exists somewhere.
@@ -500,20 +513,20 @@ public class HollowConsumer {
 
         /**
          * Stale reference USAGE detection.  This will be called every ~30 seconds.
-         * 
+         *
          * If a nonzero value is reported, then stale references to Hollow objects are being accessed from somewhere in your codebase.
          *
          * This signal is noiseless, and a nonzero value indicates that some reference to stale data is USED somewhere.
          */
         public void staleReferenceUsageDetected(int count);
-        
+
         public static ObjectLongevityDetector DEFAULT_DETECTOR = new ObjectLongevityDetector() {
             @Override public void staleReferenceUsageDetected(int count) { }
             @Override public void staleReferenceExistenceDetected(int count) { }
         };
 
     }
-    
+
     /**
      * Implementations of this class will define what to do when various events happen before, during, and after updating
      * local in-memory copies of hollow data sets.
@@ -522,14 +535,14 @@ public class HollowConsumer {
 
         /**
          * Indicates that a refresh has begun.  Generally useful for logging.
-         * 
-         * A refresh is the process of a consumer getting from a current version to a desired version.  
-         * 
+         *
+         * A refresh is the process of a consumer getting from a current version to a desired version.
+         *
          * A refresh will consist of one of the following:
          * <ul>
          * <li>one or more deltas</li>
          * <li>a snapshot load, plus zero or more deltas</li>
-         * </ul> 
+         * </ul>
          * @param currentVersion the current state version
          * @param requestedVersion the version to which the refresh is progressing
          */
@@ -558,10 +571,10 @@ public class HollowConsumer {
          * occurs.
          *
          * Implementations should incrementally update any indexing which is critical to keep in-sync with the data.
-         * 
+         *
          * If this method is called, it means that the current refresh consists of one or more deltas, and does not include
          * a snapshot load.
-         * 
+         *
          * This method may be called multiple times per refresh, once for each time a delta is applied.
          *
          * @param api the {@link HollowAPI} instance
@@ -573,11 +586,11 @@ public class HollowConsumer {
 
         /**
          * Called to indicate a blob was loaded (either a snapshot or delta).  Generally useful for logging or tracing of applied updates.
-         * 
+         *
          * @param transition The transition which was applied.
          */
         public void blobLoaded(HollowConsumer.Blob transition);
-        
+
         /**
          * Indicates that a refresh completed successfully.
          *
@@ -628,7 +641,7 @@ public class HollowConsumer {
          * @throws Exception thrown if an error occurs in processing
          */
         public void deltaApplied(HollowAPI api, HollowReadStateEngine stateEngine, long version) throws Exception;
-    	
+
     }
 
     public static class AbstractRefreshListener implements TransitionAwareRefreshListener {
@@ -677,12 +690,12 @@ public class HollowConsumer {
         HollowConsumer.Builder builder = new Builder();
         return builder.withBlobRetriever(blobRetriever);
     }
-    
+
     public static HollowConsumer.Builder withLocalBlobStore(File localBlobStoreDir) {
         HollowConsumer.Builder builder = new Builder();
         return builder.withLocalBlobStore(localBlobStoreDir);
     }
-    
+
     public static class Builder {
         private HollowConsumer.BlobRetriever blobRetriever = null;
         private HollowConsumer.AnnouncementWatcher announcementWatcher = null;
@@ -696,58 +709,58 @@ public class HollowConsumer {
         private File localBlobStoreDir = null;
         private Executor refreshExecutor = null;
         private HollowMetricsCollector<HollowConsumerMetrics> metricsCollector;
-        
+
         public HollowConsumer.Builder withBlobRetriever(HollowConsumer.BlobRetriever blobRetriever) {
             this.blobRetriever = blobRetriever;
             return this;
         }
-        
+
         public HollowConsumer.Builder withLocalBlobStore(File localBlobStoreDir) {
             this.localBlobStoreDir = localBlobStoreDir;
             return this;
         }
-        
+
         public HollowConsumer.Builder withAnnouncementWatcher(HollowConsumer.AnnouncementWatcher announcementWatcher) {
             this.announcementWatcher = announcementWatcher;
             return this;
         }
-        
+
         public HollowConsumer.Builder withRefreshListener(HollowConsumer.RefreshListener refreshListener) {
             refreshListeners.add(refreshListener);
             return this;
         }
-        
+
         public HollowConsumer.Builder withRefreshListeners(HollowConsumer.RefreshListener... refreshListeners) {
             for(HollowConsumer.RefreshListener refreshListener : refreshListeners)
                 this.refreshListeners.add(refreshListener);
             return this;
         }
-        
+
         public <T extends HollowAPI> HollowConsumer.Builder withGeneratedAPIClass(Class<T> generatedAPIClass) {
             this.apiFactory = new HollowAPIFactory.ForGeneratedAPI<T>(generatedAPIClass);
             return this;
         }
-        
+
         public HollowConsumer.Builder withFilterConfig(HollowFilterConfig filterConfig) {
             this.filterConfig = filterConfig;
             return this;
         }
-        
+
         public HollowConsumer.Builder withDoubleSnapshotConfig(HollowConsumer.DoubleSnapshotConfig doubleSnapshotConfig) {
             this.doubleSnapshotConfig = doubleSnapshotConfig;
             return this;
         }
-        
+
         public HollowConsumer.Builder withObjectLongevityConfig(HollowConsumer.ObjectLongevityConfig objectLongevityConfig) {
             this.objectLongevityConfig = objectLongevityConfig;
             return this;
         }
-        
+
         public HollowConsumer.Builder withObjectLongevityDetector(HollowConsumer.ObjectLongevityDetector objectLongevityDetector) {
             this.objectLongevityDetector = objectLongevityDetector;
             return this;
         }
-        
+
         public HollowConsumer.Builder withRefreshExecutor(Executor refreshExecutor) {
             this.refreshExecutor = refreshExecutor;
             return this;
@@ -763,15 +776,15 @@ public class HollowConsumer {
             this.hashCodeFinder = hashCodeFinder;
             return this;
         }
-        
+
         public HollowConsumer build() {
-            if(blobRetriever == null && localBlobStoreDir == null) 
+            if(blobRetriever == null && localBlobStoreDir == null)
                 throw new IllegalArgumentException("A HollowBlobRetriever or local blob store directory must be specified when building a HollowClient");
-            
+
             BlobRetriever blobRetriever = this.blobRetriever;
             if(localBlobStoreDir != null)
                 blobRetriever = new HollowFilesystemBlobRetriever(localBlobStoreDir, blobRetriever);
-            
+
             if(refreshExecutor == null)
                 refreshExecutor = Executors.newSingleThreadExecutor(new ThreadFactory() {
                     @Override
@@ -781,20 +794,20 @@ public class HollowConsumer {
                         return t;
                     }
                 });
-            
-            
-            return new HollowConsumer(blobRetriever, 
+
+
+            return new HollowConsumer(blobRetriever,
                                       announcementWatcher,
                                       refreshListeners,
-                                      apiFactory, 
-                                      filterConfig, 
-                                      objectLongevityConfig, 
-                                      objectLongevityDetector, 
-                                      doubleSnapshotConfig, 
-                                      hashCodeFinder, 
+                                      apiFactory,
+                                      filterConfig,
+                                      objectLongevityConfig,
+                                      objectLongevityDetector,
+                                      doubleSnapshotConfig,
+                                      hashCodeFinder,
                                       refreshExecutor,
                                       metricsCollector);
         }
     }
-    
+
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/metrics/HollowMetricsCollectorTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/metrics/HollowMetricsCollectorTests.java
@@ -18,6 +18,24 @@ public class HollowMetricsCollectorTests {
     }
 
     @Test
+    public void testNullMetricsCollector() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                                                .withBlobStager(new HollowInMemoryBlobStager())
+                                                .build();
+
+        long version = producer.runCycle(new HollowProducer.Populator() {
+            public void populate(HollowProducer.WriteState state) throws Exception {
+                state.add(Integer.valueOf(1));
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                                                .withMetricsCollector(null)
+                                                .build();
+        consumer.triggerRefreshTo(version);
+    }
+
+    @Test
     public void metricsCollectorWhenPublishingSnapshot() {
         FakePublisherHollowMetricsCollector metricsCollector = new FakePublisherHollowMetricsCollector();
         HollowProducer producer = HollowProducer.withPublisher(blobStore)


### PR DESCRIPTION
In order to keep constructor for HollowConsumer backwards incompatible, we are passing a null for HollowMetricsCollector. HollowMetricsCollector was recently added to hollow. It used by HollowClientUpdater as a way to use metrics collected by consumer. Passing null is quick fix for now to fix breaking changes (HollowClientUpdater has null checks before using the collector). There will be quick follow up to replace null with a default implementation for HollowMetricsCollector.