### PR TITLE
clear mutations in hollow incremental producer between states

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -81,9 +81,7 @@ public class HollowIncrementalProducer {
         this.mutations.clear();
     }
 
-    protected ConcurrentHashMap<RecordPrimaryKey, Object> getMutations() {
-        return this.mutations;
-    }
+    public boolean hasMutations() { return this.mutations.size() > 0; }
 
     public long runCycle() {
         return producer.runCycle(new Populator() {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -77,11 +77,11 @@ public class HollowIncrementalProducer {
         mutations.put(key, DELETE_RECORD);
     }
 
-    public void clearMutations() {
+    public void clearChanges() {
         this.mutations.clear();
     }
 
-    public boolean hasMutations() { return this.mutations.size() > 0; }
+    public boolean hasChanges() { return this.mutations.size() > 0; }
 
     public long runCycle() {
         return producer.runCycle(new Populator() {
@@ -89,7 +89,7 @@ public class HollowIncrementalProducer {
                 newState.getStateEngine().addAllObjectsFromPreviousCycle();
                 removeRecords(newState);
                 addRecords(newState);
-                clearMutations();
+                clearChanges();
             }
 
             private void removeRecords(WriteState newState) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -76,13 +76,22 @@ public class HollowIncrementalProducer {
     public void delete(RecordPrimaryKey key) {
         mutations.put(key, DELETE_RECORD);
     }
-    
+
+    public void clearMutations() {
+        this.mutations.clear();
+    }
+
+    protected ConcurrentHashMap<RecordPrimaryKey, Object> getMutations() {
+        return this.mutations;
+    }
+
     public long runCycle() {
         return producer.runCycle(new Populator() {
             public void populate(WriteState newState) throws Exception {
                 newState.getStateEngine().addAllObjectsFromPreviousCycle();
                 removeRecords(newState);
                 addRecords(newState);
+                clearMutations();
             }
 
             private void removeRecords(WriteState newState) {

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
@@ -245,12 +245,12 @@ public class HollowIncrementalProducerTest {
         incrementalProducer.addOrModify(new TypeB(5, "6"));
         incrementalProducer.delete(new RecordPrimaryKey("TypeB", new Object[] { 3 }));
 
-        Assert.assertEquals(8, incrementalProducer.getMutations().size());
+        Assert.assertTrue(incrementalProducer.hasMutations());
 
         /// .runCycle() flushes the changes to a new data state.
-        long nextVersion = incrementalProducer.runCycle();
+        incrementalProducer.runCycle();
 
-        Assert.assertEquals(0, incrementalProducer.getMutations().size());
+        Assert.assertFalse(incrementalProducer.hasMutations());
     }
 
     private HollowProducer createInMemoryProducer() {

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
@@ -223,6 +223,36 @@ public class HollowIncrementalProducerTest {
         assertTypeA(idx, 5, "five", null);
     }
 
+    @Test
+    public void clearMutations() {
+        HollowProducer producer = createInMemoryProducer();
+
+        /// initialize the data -- classic producer creates the first state in the delta chain.
+        initializeData(producer);
+
+        /// now we'll be incrementally updating the state by mutating individual records
+        HollowIncrementalProducer incrementalProducer = new HollowIncrementalProducer(producer);
+
+        incrementalProducer.addOrModify(new TypeA(1, "one", 100));
+        incrementalProducer.addOrModify(new TypeA(2, "two", 2));
+        incrementalProducer.addOrModify(new TypeA(3, "three", 300));
+        incrementalProducer.addOrModify(new TypeA(3, "three", 3));
+        incrementalProducer.addOrModify(new TypeA(4, "five", 6));
+        incrementalProducer.delete(new TypeA(5, "five", 5));
+
+        incrementalProducer.delete(new TypeB(2, "3"));
+        incrementalProducer.addOrModify(new TypeB(5, "5"));
+        incrementalProducer.addOrModify(new TypeB(5, "6"));
+        incrementalProducer.delete(new RecordPrimaryKey("TypeB", new Object[] { 3 }));
+
+        Assert.assertEquals(8, incrementalProducer.getMutations().size());
+
+        /// .runCycle() flushes the changes to a new data state.
+        long nextVersion = incrementalProducer.runCycle();
+
+        Assert.assertEquals(0, incrementalProducer.getMutations().size());
+    }
+
     private HollowProducer createInMemoryProducer() {
         return HollowProducer.withPublisher(blobStore)
                 .withBlobStager(new HollowInMemoryBlobStager())

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
@@ -245,12 +245,12 @@ public class HollowIncrementalProducerTest {
         incrementalProducer.addOrModify(new TypeB(5, "6"));
         incrementalProducer.delete(new RecordPrimaryKey("TypeB", new Object[] { 3 }));
 
-        Assert.assertTrue(incrementalProducer.hasMutations());
+        Assert.assertTrue(incrementalProducer.hasChanges());
 
         /// .runCycle() flushes the changes to a new data state.
         incrementalProducer.runCycle();
 
-        Assert.assertFalse(incrementalProducer.hasMutations());
+        Assert.assertFalse(incrementalProducer.hasChanges());
     }
 
     private HollowProducer createInMemoryProducer() {


### PR DESCRIPTION
Hi @toolbear @dkoszewnik 

We found that the mutations map in the hollow inc producer was eating up memory. Since `mutations` is shared between states if you only create one instance of `HollowIncrementalProducer`, you keep all the `mutations` over time and carrying over references to objects from previous cycles, growing memory exponentially. I'm not a garbage collector expert but, do you think this could be causing java to avoid collecting old instances from previous cycles? Since you keep the reference in the `mutations` map, java thinks that they are in use so it doesn't collect them.

As a workaround, we created an instance of `HollowIncrementalProducer` on every cycle but we thought that it would be nice to just cleanup the mutations at the end of `populate` because you still keep several `HollowIncrementalProducer` instances for a while. 

Please let me know your thoughts 