### PR TITLE
Hollow incremental populator cleanup

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalCyclePopulator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalCyclePopulator.java
@@ -1,0 +1,114 @@
+package com.netflix.hollow.api.producer;
+
+import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.engine.HollowTypeReadState;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.util.SimultaneousExecutor;
+import com.netflix.hollow.core.write.HollowTypeWriteState;
+import com.netflix.hollow.core.write.objectmapper.RecordPrimaryKey;
+import com.netflix.hollow.tools.traverse.TransitiveSetTraverser;
+
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HollowIncrementalCyclePopulator implements HollowProducer.Populator {
+
+    public static final Object DELETE_RECORD = new Object();
+
+    private final double threadsPerCpu;
+    private final Map<RecordPrimaryKey, Object> mutations;
+
+    HollowIncrementalCyclePopulator(Map<RecordPrimaryKey, Object> mutations, double threadsPerCpu) {
+        this.mutations = mutations;
+        this.threadsPerCpu = threadsPerCpu;
+    }
+
+    @Override
+    public void populate(HollowProducer.WriteState newState) throws Exception {
+        newState.getStateEngine().addAllObjectsFromPreviousCycle();
+        removeRecords(newState);
+        addRecords(newState);
+    }
+
+    private void removeRecords(HollowProducer.WriteState newState) {
+        Map<String, BitSet> recordsToRemove = findTypesWithRemovedRecords(newState.getPriorState());
+        markRecordsToRemove(newState.getPriorState(), recordsToRemove);
+        removeRecordsFromNewState(newState, recordsToRemove);
+    }
+
+    private Map<String, BitSet> findTypesWithRemovedRecords(HollowProducer.ReadState readState) {
+        Map<String, BitSet> recordsToRemove = new HashMap<String, BitSet>();
+        for(RecordPrimaryKey key : mutations.keySet()) {
+            if(!recordsToRemove.containsKey(key.getType())) {
+                HollowTypeReadState typeState = readState.getStateEngine().getTypeState(key.getType());
+                if(typeState != null) {
+                    BitSet bs = new BitSet(typeState.getPopulatedOrdinals().length());
+                    recordsToRemove.put(key.getType(), bs);
+                }
+            }
+        }
+        return recordsToRemove;
+    }
+
+    private void markRecordsToRemove(HollowProducer.ReadState priorState, Map<String, BitSet> recordsToRemove) {
+        HollowReadStateEngine priorStateEngine = priorState.getStateEngine();
+
+        for(Map.Entry<String, BitSet> removalEntry : recordsToRemove.entrySet()) {
+            markTypeRecordsToRemove(priorStateEngine, removalEntry.getKey(), removalEntry.getValue());
+        }
+
+        TransitiveSetTraverser.addTransitiveMatches(priorStateEngine, recordsToRemove);
+        TransitiveSetTraverser.removeReferencedOutsideClosure(priorStateEngine, recordsToRemove);
+    }
+
+    private void markTypeRecordsToRemove(HollowReadStateEngine priorStateEngine, String type, BitSet typeRecordsToRemove) {
+        HollowTypeReadState priorReadState = priorStateEngine.getTypeState(type);
+        HollowSchema schema = priorReadState.getSchema();
+        if(schema.getSchemaType() == HollowSchema.SchemaType.OBJECT) {
+            HollowPrimaryKeyIndex idx = new HollowPrimaryKeyIndex(priorStateEngine, ((HollowObjectSchema) schema).getPrimaryKey()); ///TODO: Should we scan instead?  Can we create this once and do delta updates?
+
+            for(Map.Entry<RecordPrimaryKey, Object> entry : mutations.entrySet()) {
+                if(entry.getKey().getType().equals(type)) {
+                    int priorOrdinal = idx.getMatchingOrdinal(entry.getKey().getKey());
+
+                    if(priorOrdinal != -1)
+                        typeRecordsToRemove.set(priorOrdinal);
+                }
+            }
+        }
+    }
+
+    private void removeRecordsFromNewState(HollowProducer.WriteState newState, Map<String, BitSet> recordsToRemove) {
+        for(Map.Entry<String, BitSet> removalEntry : recordsToRemove.entrySet()) {
+            HollowTypeWriteState writeState = newState.getStateEngine().getTypeState(removalEntry.getKey());
+            BitSet typeRecordsToRemove = removalEntry.getValue();
+
+            int ordinalToRemove = typeRecordsToRemove.nextSetBit(0);
+            while(ordinalToRemove != -1) {
+                writeState.removeOrdinalFromThisCycle(ordinalToRemove);
+                ordinalToRemove = typeRecordsToRemove.nextSetBit(ordinalToRemove+1);
+            }
+        }
+    }
+
+    private void addRecords(final HollowProducer.WriteState newState) {
+        SimultaneousExecutor executor = new SimultaneousExecutor(threadsPerCpu);
+        for(final Map.Entry<RecordPrimaryKey, Object> entry : mutations.entrySet()) {
+            executor.execute(new Runnable() {
+                public void run() {
+                    if(entry.getValue() != DELETE_RECORD)
+                        newState.add(entry.getValue());
+                }
+            });
+        }
+
+        try {
+            executor.awaitSuccessfulCompletion();
+        } catch(Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalCyclePopulator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalCyclePopulator.java
@@ -14,6 +14,10 @@ import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Used by HollowIncrementalProducer for Delta-Based Producer Input
+ * @since 2.9.9
+ */
 public class HollowIncrementalCyclePopulator implements HollowProducer.Populator {
 
     public static final Object DELETE_RECORD = new Object();

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -18,22 +18,7 @@
 package com.netflix.hollow.api.producer;
 
 import com.netflix.hollow.api.consumer.HollowConsumer.BlobRetriever;
-import com.netflix.hollow.api.producer.HollowProducer.Populator;
-import com.netflix.hollow.api.producer.HollowProducer.ReadState;
-import com.netflix.hollow.api.producer.HollowProducer.WriteState;
-import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
-import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
-import com.netflix.hollow.core.read.engine.HollowTypeReadState;
-import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.schema.HollowSchema;
-import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
-import com.netflix.hollow.core.util.SimultaneousExecutor;
-import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.objectmapper.RecordPrimaryKey;
-import com.netflix.hollow.tools.traverse.TransitiveSetTraverser;
-import java.util.BitSet;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -47,18 +32,18 @@ public class HollowIncrementalProducer {
 
     private final HollowProducer producer;
     private final ConcurrentHashMap<RecordPrimaryKey, Object> mutations;
-    private final double threadsPerCpu;
+    private final HollowProducer.Populator populator;
     
     public HollowIncrementalProducer(HollowProducer producer) {
         this(producer, 1.0d);
     }
-    
+
     public HollowIncrementalProducer(HollowProducer producer, double threadsPerCpu) {
         this.producer = producer;
-        this.threadsPerCpu = threadsPerCpu;
         this.mutations = new ConcurrentHashMap<RecordPrimaryKey, Object>();
+        this.populator = new HollowIncrementalCyclePopulator(this.mutations, threadsPerCpu);
     }
-    
+
     public void restore(long versionDesired, BlobRetriever blobRetriever) {
         producer.hardRestore(versionDesired, blobRetriever);
     }
@@ -84,94 +69,8 @@ public class HollowIncrementalProducer {
     public boolean hasChanges() { return this.mutations.size() > 0; }
 
     public long runCycle() {
-        return producer.runCycle(new Populator() {
-            public void populate(WriteState newState) throws Exception {
-                newState.getStateEngine().addAllObjectsFromPreviousCycle();
-                removeRecords(newState);
-                addRecords(newState);
-                clearChanges();
-            }
-
-            private void removeRecords(WriteState newState) {
-                Map<String, BitSet> recordsToRemove = findTypesWithRemovedRecords(newState.getPriorState());
-                markRecordsToRemove(newState.getPriorState(), recordsToRemove);
-                removeRecordsFromNewState(newState, recordsToRemove);
-            }
-
-            private Map<String, BitSet> findTypesWithRemovedRecords(ReadState readState) {
-                Map<String, BitSet> recordsToRemove = new HashMap<String, BitSet>();
-                for(RecordPrimaryKey key : mutations.keySet()) {
-                    if(!recordsToRemove.containsKey(key.getType())) {
-                        HollowTypeReadState typeState = readState.getStateEngine().getTypeState(key.getType());
-                        if(typeState != null) {
-                            BitSet bs = new BitSet(typeState.getPopulatedOrdinals().length());
-                            recordsToRemove.put(key.getType(), bs);
-                        }
-                    }
-                }
-                return recordsToRemove;
-            }
-
-            private void markRecordsToRemove(ReadState priorState, Map<String, BitSet> recordsToRemove) {
-                HollowReadStateEngine priorStateEngine = priorState.getStateEngine();
-                
-                for(Map.Entry<String, BitSet> removalEntry : recordsToRemove.entrySet()) {
-                    markTypeRecordsToRemove(priorStateEngine, removalEntry.getKey(), removalEntry.getValue());
-                }
-                
-                TransitiveSetTraverser.addTransitiveMatches(priorStateEngine, recordsToRemove);
-                TransitiveSetTraverser.removeReferencedOutsideClosure(priorStateEngine, recordsToRemove);
-            }
-
-            private void markTypeRecordsToRemove(HollowReadStateEngine priorStateEngine, String type, BitSet typeRecordsToRemove) {
-                HollowTypeReadState priorReadState = priorStateEngine.getTypeState(type);
-                HollowSchema schema = priorReadState.getSchema();
-                if(schema.getSchemaType() == SchemaType.OBJECT) {
-                    HollowPrimaryKeyIndex idx = new HollowPrimaryKeyIndex(priorStateEngine, ((HollowObjectSchema) schema).getPrimaryKey()); ///TODO: Should we scan instead?  Can we create this once and do delta updates?
-                    
-                    for(Map.Entry<RecordPrimaryKey, Object> entry : mutations.entrySet()) {
-                        if(entry.getKey().getType().equals(type)) {
-                            int priorOrdinal = idx.getMatchingOrdinal(entry.getKey().getKey());
-                            
-                            if(priorOrdinal != -1)
-                                typeRecordsToRemove.set(priorOrdinal);
-                        }
-                    }
-                }
-            }
-            
-            private void removeRecordsFromNewState(WriteState newState, Map<String, BitSet> recordsToRemove) {
-                for(Map.Entry<String, BitSet> removalEntry : recordsToRemove.entrySet()) {
-                    HollowTypeWriteState writeState = newState.getStateEngine().getTypeState(removalEntry.getKey());
-                    BitSet typeRecordsToRemove = removalEntry.getValue();
-                    
-                    int ordinalToRemove = typeRecordsToRemove.nextSetBit(0);
-                    while(ordinalToRemove != -1) {
-                        writeState.removeOrdinalFromThisCycle(ordinalToRemove);
-                        ordinalToRemove = typeRecordsToRemove.nextSetBit(ordinalToRemove+1);
-                    }
-                }
-            }
-            
-            private void addRecords(final WriteState newState) {
-                SimultaneousExecutor executor = new SimultaneousExecutor(threadsPerCpu);
-                for(final Map.Entry<RecordPrimaryKey, Object> entry : mutations.entrySet()) {
-                    executor.execute(new Runnable() {
-                        public void run() {
-                            if(entry.getValue() != DELETE_RECORD)
-                                newState.add(entry.getValue());
-                        }
-                    });
-                }
-
-                try {
-                    executor.awaitSuccessfulCompletion();
-                } catch(Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-        });
+        long version = producer.runCycle(populator);
+        clearChanges();
+        return version;
     }
-
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -41,7 +41,7 @@ public class HollowIncrementalProducer {
     public HollowIncrementalProducer(HollowProducer producer, double threadsPerCpu) {
         this.producer = producer;
         this.mutations = new ConcurrentHashMap<RecordPrimaryKey, Object>();
-        this.populator = new HollowIncrementalCyclePopulator(this.mutations, threadsPerCpu);
+        this.populator = new HollowIncrementalCyclePopulator(mutations, threadsPerCpu);
     }
 
     public void restore(long versionDesired, BlobRetriever blobRetriever) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -68,6 +68,11 @@ public class HollowIncrementalProducer {
 
     public boolean hasChanges() { return this.mutations.size() > 0; }
 
+    /**
+     * Runs a Hollow Cycle, if successful, cleans the mutations map.
+     * @since 2.9.9
+     * @return
+     */
     public long runCycle() {
         long version = producer.runCycle(populator);
         clearChanges();


### PR DESCRIPTION
 Did some code re-arrangement (introduced `HollowIncrementalCyclePopulator` and now `HollowIncrementalProducer` is simpler. Also found that clearChanges was executed before producing a new state https://github.com/Netflix/hollow/blob/master/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java#L435, so a failure there could end-up losing all the mutations for the next cycle. I read your comments on https://github.com/Netflix/hollow/issues/137#issuecomment-356174169 and found that out.

Now `clearChanges` gets executed after we get a version from `runCycle` in `HollowIncrementalProducer` https://github.com/rpalcolea/hollow/blob/c22a096b408a5de234c72bfdfa219acd23babeee/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java#L73

The tests didn’t change at all, just moving code here and there.

I was thinking on adding a cleanup method to the `Populator` interface and invoke it at the end of `runCycle` -> https://github.com/Netflix/hollow/blob/master/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java#L482 but didn’t know if that was something you’d want. Wondering if people would like to cleanup populator’s states… for now I think it makes more sense to just clean the mutations map as before.

Let me know your thoughts
