### PR TITLE
Allow IncrementalProducer to discard changes 

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -57,9 +57,18 @@ public class HollowIncrementalProducer {
         RecordPrimaryKey pk = producer.getObjectMapper().extractPrimaryKey(obj);
         delete(pk);
     }
+
+    public void discard(Object obj) {
+        RecordPrimaryKey pk = producer.getObjectMapper().extractPrimaryKey(obj);
+        discard(pk);
+    }
     
     public void delete(RecordPrimaryKey key) {
         mutations.put(key, DELETE_RECORD);
+    }
+
+    public void discard(RecordPrimaryKey key) {
+        mutations.remove(key);
     }
 
     public void clearChanges() {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -49,17 +49,17 @@ public class HollowIncrementalProducer {
     }
     
     public void addOrModify(Object obj) {
-        RecordPrimaryKey pk = producer.getObjectMapper().extractPrimaryKey(obj);
+        RecordPrimaryKey pk = extractRecordPrimaryKey(obj);
         mutations.put(pk, obj);
     }
     
     public void delete(Object obj) {
-        RecordPrimaryKey pk = producer.getObjectMapper().extractPrimaryKey(obj);
+        RecordPrimaryKey pk = extractRecordPrimaryKey(obj);
         delete(pk);
     }
 
     public void discard(Object obj) {
-        RecordPrimaryKey pk = producer.getObjectMapper().extractPrimaryKey(obj);
+        RecordPrimaryKey pk = extractRecordPrimaryKey(obj);
         discard(pk);
     }
     
@@ -86,5 +86,9 @@ public class HollowIncrementalProducer {
         long version = producer.runCycle(populator);
         clearChanges();
         return version;
+    }
+
+    private RecordPrimaryKey extractRecordPrimaryKey(Object obj) {
+        return producer.getObjectMapper().extractPrimaryKey(obj);
     }
 }


### PR DESCRIPTION
Hi @toolbear,

Was playing around with the `HollowIncrementalProducer` and thought that it would be nice if `discard` was introduced. This way if a user adds/modify/delete something and later executes some business logic and determines that the change shouldn't be reflected, they could just `discard` that particular record. 

With this, users now could clear all by using `cleanChanges` or clear/discard a specific record with `discard`, either with an object that contains the primary key or a `RecordPrimaryKey`... same was as `delete`.

Let me know your thoughts. 

