### PR TITLE
make HollowMetrics public

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowMetrics.java
@@ -23,7 +23,7 @@ import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import java.util.Collection;
 import java.util.HashMap;
 
-abstract class HollowMetrics {
+public abstract class HollowMetrics {
 
     private HashMap<String, Long> typeHeapFootprint = new HashMap<>();
     private HashMap<String, Integer> typePopulatedOrdinals = new HashMap<>();


### PR DESCRIPTION
Making this abstract class public to allow users the creation of generic metrics collector, for example:

```
public class TestCollector extends HollowMetricsCollector {
    @Override
    public void collect(HollowMetrics metrics) {
        
    }
}
```