### PR TITLE
add test for resuming work when announcement fails

### DIFF
--- a/hollow/build.gradle
+++ b/hollow/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java'
  
 dependencies {
     testCompile 'junit:junit:4.11'
+    testCompile "org.mockito:mockito-core:2.13.0"
 }
 
 // quiet warnings about sun.misc.Unsafe

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
@@ -30,6 +30,7 @@ import com.netflix.hollow.core.write.objectmapper.RecordPrimaryKey;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class HollowIncrementalProducerTest {
 
@@ -304,6 +305,62 @@ public class HollowIncrementalProducerTest {
         incrementalProducer.runCycle();
 
         Assert.assertFalse(incrementalProducer.hasChanges());
+    }
+
+    @Test
+    public void resumeWorkAfterAnnouncementFail() {
+        FakeAnnouncer fakeAnnouncer = new FakeAnnouncer();
+        FakeAnnouncer fakeAnnouncerSpy = Mockito.spy(fakeAnnouncer);
+        HollowProducer producer =  HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withAnnouncer(fakeAnnouncerSpy)
+                .withVersionMinter(new HollowProducer.VersionMinter() {
+                    long counter = 0;
+                    public long mint() {
+                        return ++counter;
+                    }
+                })
+                .withNumStatesBetweenSnapshots(5)
+                .build();
+
+        initializeData(producer);
+
+        HollowIncrementalProducer incrementalProducer = new HollowIncrementalProducer(producer);
+        incrementalProducer.addOrModify(new TypeA(11, "eleven", 11));
+        incrementalProducer.runCycle();
+
+        incrementalProducer.addOrModify(new TypeA(1, "one", 100));
+        incrementalProducer.addOrModify(new TypeA(2, "two", 2));
+        incrementalProducer.addOrModify(new TypeA(3, "three", 300));
+
+        //Fail announcement on this cycle
+        Mockito.doThrow(new RuntimeException("oops")).when(fakeAnnouncerSpy).announce(3);
+
+        try {
+            incrementalProducer.runCycle();
+        } catch (RuntimeException e) {
+        }
+
+        //Incremental producer still has changes
+        Assert.assertTrue(incrementalProducer.hasChanges());
+
+        incrementalProducer.addOrModify(new TypeA(10, "ten", 100));
+        long version = incrementalProducer.runCycle();
+
+        Assert.assertFalse(incrementalProducer.hasChanges());
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefreshTo(version);
+
+        HollowPrimaryKeyIndex idx = new HollowPrimaryKeyIndex(consumer.getStateEngine(), "TypeA", "id1", "id2");
+        Assert.assertFalse(idx.containsDuplicates());
+
+        assertTypeA(idx, 10, "ten", 100L);
+    }
+
+    private static class FakeAnnouncer implements HollowProducer.Announcer {
+        @Override
+        public void announce(long stateVersion) { }
     }
 
     private HollowProducer createInMemoryProducer() {


### PR DESCRIPTION
Found an issue in our side while trying to resume work on incremntal producer after an announcement failure.

I think it would be nice to have a test to cover this

thoughts?