### PR TITLE
Allow passing a custom Writer to HollowRecordStringifier

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifier.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifier.java
@@ -78,75 +78,59 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
         return this;
     }
 
-
-    /**
-     * Create a JSON representation of the provided {@link HollowRecord}.
-     */
     @Override
     public String stringify(HollowRecord record) {
         return stringify(record.getTypeDataAccess().getDataAccess(), record.getSchema().getName(), record.getOrdinal());
     }
 
-
-    /**
-     * Create a JSON representation of the record in the provided dataset, of the given type, with the specified ordinal.
-     */
     @Override
-    public String stringify(HollowDataAccess dataAccess, String type, int ordinal) {
-        StringWriter builder = new StringWriter();
-
-        try {
-            appendStringify(builder, dataAccess, type, ordinal, 0);
-        } catch(IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        return builder.toString();
-    }
-
-    /**
-     * Write a JSON representation of the provided {@link HollowRecord} to the provided Writer.
-     */
     public void stringify(Writer writer, HollowRecord record) throws IOException {
         stringify(writer, record.getTypeDataAccess().getDataAccess(), record.getSchema().getName(), record.getOrdinal());
     }
 
-    /**
-     * Write a JSON representation of the record in the provided dataset, of the given type, with the specified ordinal.
-     *
-     * The representation will be written to the provided Writer.
-     */
+    @Override
+    public String stringify(HollowDataAccess dataAccess, String type, int ordinal) {
+        try {
+            StringWriter writer = new StringWriter();
+            appendStringify(writer, dataAccess, type, ordinal, 0);
+            return writer.toString();
+        } catch (IOException e) {
+            throw new RuntimeException("Error using StringWriter", e);
+        }
+    }
+
+    @Override
     public void stringify(Writer writer, HollowDataAccess dataAccess, String type, int ordinal) throws IOException {
         appendStringify(writer, dataAccess, type, ordinal, 0);
     }
 
-    private void appendStringify(Writer builder, HollowDataAccess dataAccess, String type, int ordinal, int indentation) throws IOException {
+    private void appendStringify(Writer writer, HollowDataAccess dataAccess, String type, int ordinal, int indentation) throws IOException {
         if (excludeObjectTypes.contains(type)) {
-            builder.append("null");
+            writer.append("null");
             return;
         }
 
         HollowTypeDataAccess typeDataAccess = dataAccess.getTypeDataAccess(type);
 
         if(typeDataAccess == null) {
-            builder.append("{ }");
+            writer.append("{ }");
         } else if (ordinal == -1) {
-            builder.append("null");
+            writer.append("null");
         } else {
             if(typeDataAccess instanceof HollowObjectTypeDataAccess) {
-                appendObjectStringify(builder, dataAccess, (HollowObjectTypeDataAccess)typeDataAccess, ordinal, indentation);
+                appendObjectStringify(writer, dataAccess, (HollowObjectTypeDataAccess)typeDataAccess, ordinal, indentation);
             } else if(typeDataAccess instanceof HollowListTypeDataAccess) {
-                appendListStringify(builder, dataAccess, (HollowListTypeDataAccess)typeDataAccess, ordinal, indentation);
+                appendListStringify(writer, dataAccess, (HollowListTypeDataAccess)typeDataAccess, ordinal, indentation);
             } else if(typeDataAccess instanceof HollowSetTypeDataAccess) {
-                appendSetStringify(builder, dataAccess, (HollowSetTypeDataAccess)typeDataAccess, ordinal, indentation);
+                appendSetStringify(writer, dataAccess, (HollowSetTypeDataAccess)typeDataAccess, ordinal, indentation);
             } else if(typeDataAccess instanceof HollowMapTypeDataAccess) {
-                appendMapStringify(builder, dataAccess, (HollowMapTypeDataAccess)typeDataAccess, ordinal, indentation);
+                appendMapStringify(writer, dataAccess, (HollowMapTypeDataAccess)typeDataAccess, ordinal, indentation);
             }
         }
 
     }
 
-    private void appendMapStringify(Writer builder, HollowDataAccess dataAccess, HollowMapTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
+    private void appendMapStringify(Writer writer, HollowDataAccess dataAccess, HollowMapTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
         HollowMapSchema schema = typeDataAccess.getSchema();
 
         indentation++;
@@ -154,7 +138,7 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
         int size = typeDataAccess.size(ordinal);
 
         if(size == 0) {
-            builder.append("{ }");
+            writer.append("{ }");
         } else {
             String keyType = schema.getKeyType();
             String valueType = schema.getValueType();
@@ -164,9 +148,9 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
             HollowMapEntryOrdinalIterator ordinalIterator = typeDataAccess.ordinalIterator(ordinal);
 
             if(keySchema.numFields() == 1) {
-                builder.append("{");
+                writer.append("{");
                 if(prettyPrint)
-                    builder.append("\n");
+                    writer.append(NEWLINE);
 
                 boolean firstEntry = true;
 
@@ -174,39 +158,39 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
                     if(firstEntry) {
                         firstEntry = false;
                     } else {
-                        builder.append(",");
+                        writer.append(",");
                         if(prettyPrint)
-                            builder.append("\n");
+                            writer.append(NEWLINE);
                     }
 
                     if(prettyPrint)
-                        appendIndentation(builder, indentation);
+                        appendIndentation(writer, indentation);
 
                     boolean needToQuoteKey = keySchema.getFieldType(0) != FieldType.STRING;
 
                     if(needToQuoteKey)
-                        builder.append("\"");
+                        writer.append("\"");
 
                     int keyOrdinal = ordinalIterator.getKey();
-                    appendFieldStringify(builder, dataAccess, indentation, keySchema, keyTypeDataAccess, keyOrdinal, 0);
+                    appendFieldStringify(writer, dataAccess, indentation, keySchema, keyTypeDataAccess, keyOrdinal, 0);
 
                     if(needToQuoteKey)
-                        builder.append("\"");
+                        writer.append("\"");
 
-                    builder.append(": ");
+                    writer.append(": ");
 
-                    appendStringify(builder, dataAccess, valueType, ordinalIterator.getValue(), indentation);
+                    appendStringify(writer, dataAccess, valueType, ordinalIterator.getValue(), indentation);
                 }
 
                 if(prettyPrint && !firstEntry) {
-                    builder.append("\n");
-                    appendIndentation(builder, indentation - 1);
+                    writer.append(NEWLINE);
+                    appendIndentation(writer, indentation - 1);
                 }
-                builder.append("}");
+                writer.append("}");
             } else {
-                builder.append("[");
+                writer.append("[");
                 if(prettyPrint)
-                    builder.append("\n");
+                    writer.append(NEWLINE);
 
                 boolean firstEntry = true;
 
@@ -214,48 +198,48 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
                     if(firstEntry) {
                         firstEntry = false;
                     } else {
-                        builder.append(",");
+                        writer.append(",");
                         if(prettyPrint)
-                            builder.append("\n");
+                            writer.append(NEWLINE);
                     }
                     if(prettyPrint) {
-                        appendIndentation(builder, indentation - 1);
+                        appendIndentation(writer, indentation - 1);
                     }
 
-                    builder.append("{");
+                    writer.append("{");
 
                     if(prettyPrint) {
-                        builder.append("\n");
-                        appendIndentation(builder, indentation);
+                        writer.append(NEWLINE);
+                        appendIndentation(writer, indentation);
                     }
 
-                    builder.append("\"key\":");
-                    appendStringify(builder, dataAccess, keyType, ordinalIterator.getKey(), indentation + 1);
-                    builder.append(",");
+                    writer.append("\"key\":");
+                    appendStringify(writer, dataAccess, keyType, ordinalIterator.getKey(), indentation + 1);
+                    writer.append(",");
                     if(prettyPrint) {
-                        builder.append("\n");
-                        appendIndentation(builder, indentation);
+                        writer.append(NEWLINE);
+                        appendIndentation(writer, indentation);
                     }
-                    builder.append("\"value\":");
-                    appendStringify(builder, dataAccess, valueType, ordinalIterator.getValue(), indentation + 1);
+                    writer.append("\"value\":");
+                    appendStringify(writer, dataAccess, valueType, ordinalIterator.getValue(), indentation + 1);
 
                     if(prettyPrint) {
-                        builder.append("\n");
-                        appendIndentation(builder, indentation - 1);
+                        writer.append(NEWLINE);
+                        appendIndentation(writer, indentation - 1);
                     }
 
-                    builder.append("}");
+                    writer.append("}");
                 }
 
 
 
-                builder.append("]");
+                writer.append("]");
             }
         }
 
     }
 
-    private void appendSetStringify(Writer builder, HollowDataAccess dataAccess, HollowSetTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
+    private void appendSetStringify(Writer writer, HollowDataAccess dataAccess, HollowSetTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
         HollowSetSchema schema = typeDataAccess.getSchema();
 
         indentation++;
@@ -267,37 +251,37 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
         int elementOrdinal = iter.next();
 
         if(elementOrdinal == HollowOrdinalIterator.NO_MORE_ORDINALS) {
-            builder.append("[]");
+            writer.append("[]");
         } else {
             boolean firstElement = true;
-            builder.append("[");
+            writer.append("[");
             if(prettyPrint)
-                builder.append("\n");
+                writer.append(NEWLINE);
 
             while(elementOrdinal != HollowOrdinalIterator.NO_MORE_ORDINALS) {
                 if(firstElement)
                     firstElement = false;
                 else
-                    builder.append(",");
+                    writer.append(",");
 
                 if(prettyPrint)
-                    appendIndentation(builder, indentation);
+                    appendIndentation(writer, indentation);
 
-                appendStringify(builder, dataAccess, elementType, elementOrdinal, indentation);
+                appendStringify(writer, dataAccess, elementType, elementOrdinal, indentation);
 
                 elementOrdinal = iter.next();
             }
 
             if(prettyPrint) {
-                builder.append("\n");
-                appendIndentation(builder, indentation - 1);
+                writer.append(NEWLINE);
+                appendIndentation(writer, indentation - 1);
             }
 
-            builder.append("]");
+            writer.append("]");
         }
     }
 
-    private void appendListStringify(Writer builder, HollowDataAccess dataAccess, HollowListTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
+    private void appendListStringify(Writer writer, HollowDataAccess dataAccess, HollowListTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
         HollowListSchema schema = typeDataAccess.getSchema();
 
         indentation++;
@@ -305,9 +289,9 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
         int size = typeDataAccess.size(ordinal);
 
         if(size == 0) {
-            builder.append("[]");
+            writer.append("[]");
         } else {
-            builder.append("[\n");
+            writer.append("[\n");
 
             String elementType = schema.getElementType();
 
@@ -315,30 +299,30 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
                 int elementOrdinal = typeDataAccess.getElementOrdinal(ordinal, i);
 
                 if(prettyPrint)
-                    appendIndentation(builder, indentation);
+                    appendIndentation(writer, indentation);
 
-                appendStringify(builder, dataAccess, elementType, elementOrdinal, indentation);
+                appendStringify(writer, dataAccess, elementType, elementOrdinal, indentation);
 
                 if(i < size - 1)
-                    builder.append(",\n");
+                    writer.append(",\n");
             }
 
             if(prettyPrint) {
-                builder.append("\n");
-                appendIndentation(builder, indentation - 1);
+                writer.append(NEWLINE);
+                appendIndentation(writer, indentation - 1);
             }
-            builder.append("]");
+            writer.append("]");
         }
     }
 
-    private void appendObjectStringify(Writer builder, HollowDataAccess dataAccess, HollowObjectTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
+    private void appendObjectStringify(Writer writer, HollowDataAccess dataAccess, HollowObjectTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
         HollowObjectSchema schema = typeDataAccess.getSchema();
 
         if(schema.numFields() == 1 && (collapseAllSingleFieldObjects || collapseObjectTypes.contains(schema.getName()))) {
-            appendFieldStringify(builder, dataAccess, indentation, schema, typeDataAccess, ordinal, 0);
+            appendFieldStringify(writer, dataAccess, indentation, schema, typeDataAccess, ordinal, 0);
         } else {
 
-            builder.append("{");
+            writer.append("{");
             boolean firstField = true;
             indentation++;
 
@@ -349,53 +333,53 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
                     if(firstField)
                         firstField = false;
                     else
-                        builder.append(",");
+                        writer.append(",");
 
                     if(prettyPrint) {
-                        builder.append("\n");
-                        appendIndentation(builder, indentation);
+                        writer.append(NEWLINE);
+                        appendIndentation(writer, indentation);
                     }
 
-                    builder.append("\"").append(fieldName).append("\": ");
-                    appendFieldStringify(builder, dataAccess, indentation, schema, typeDataAccess, ordinal, i);
+                    writer.append("\"").append(fieldName).append("\": ");
+                    appendFieldStringify(writer, dataAccess, indentation, schema, typeDataAccess, ordinal, i);
                 }
 
             }
 
             if(prettyPrint && !firstField) {
-                builder.append("\n");
-                appendIndentation(builder, indentation - 1);
+                writer.append(NEWLINE);
+                appendIndentation(writer, indentation - 1);
             }
-            builder.append("}");
+            writer.append("}");
         }
     }
 
-    private void appendFieldStringify(Writer builder, HollowDataAccess dataAccess, int indentation, HollowObjectSchema schema, HollowObjectTypeDataAccess typeDataAccess, int ordinal, int fieldIdx) throws IOException {
+    private void appendFieldStringify(Writer writer, HollowDataAccess dataAccess, int indentation, HollowObjectSchema schema, HollowObjectTypeDataAccess typeDataAccess, int ordinal, int fieldIdx) throws IOException {
         switch(schema.getFieldType(fieldIdx)) {
             case BOOLEAN:
-                builder.append(typeDataAccess.readBoolean(ordinal, fieldIdx).booleanValue() ? "true" : "false");
+                writer.append(typeDataAccess.readBoolean(ordinal, fieldIdx).booleanValue() ? "true" : "false");
                 return;
             case BYTES:
-                builder.append(Arrays.toString(typeDataAccess.readBytes(ordinal, fieldIdx)));
+                writer.append(Arrays.toString(typeDataAccess.readBytes(ordinal, fieldIdx)));
                 return;
             case DOUBLE:
-                builder.append(String.valueOf(typeDataAccess.readDouble(ordinal, fieldIdx)));
+                writer.append(String.valueOf(typeDataAccess.readDouble(ordinal, fieldIdx)));
                 return;
             case FLOAT:
-                builder.append(String.valueOf(typeDataAccess.readFloat(ordinal, fieldIdx)));
+                writer.append(String.valueOf(typeDataAccess.readFloat(ordinal, fieldIdx)));
                 return;
             case INT:
-                builder.append(String.valueOf(typeDataAccess.readInt(ordinal, fieldIdx)));
+                writer.append(String.valueOf(typeDataAccess.readInt(ordinal, fieldIdx)));
                 return;
             case LONG:
-                builder.append(String.valueOf(typeDataAccess.readLong(ordinal, fieldIdx)));
+                writer.append(String.valueOf(typeDataAccess.readLong(ordinal, fieldIdx)));
                 return;
             case STRING:
-                builder.append("\"").append(escapeString(typeDataAccess.readString(ordinal, fieldIdx))).append("\"");
+                writer.append("\"").append(escapeString(typeDataAccess.readString(ordinal, fieldIdx))).append("\"");
                 return;
             case REFERENCE:
                 int refOrdinal = typeDataAccess.readOrdinal(ordinal, fieldIdx);
-                appendStringify(builder, dataAccess, schema.getReferencedType(fieldIdx), refOrdinal, indentation);
+                appendStringify(writer, dataAccess, schema.getReferencedType(fieldIdx), refOrdinal, indentation);
                 return;
         }
     }
@@ -406,40 +390,40 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
         return str.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
-    private void appendIndentation(Writer builder, int indentation) throws IOException {
+    private void appendIndentation(Writer writer, int indentation) throws IOException {
         switch(indentation) {
             case 0:
                 return;
             case 1:
-                builder.append("  ");
+                writer.append(INDENT);
                 return;
             case 2:
-                builder.append("    ");
+                writer.append(INDENT + INDENT);
                 return;
             case 3:
-                builder.append("      ");
+                writer.append(INDENT + INDENT + INDENT);
                 return;
             case 4:
-                builder.append("        ");
+                writer.append(INDENT + INDENT + INDENT + INDENT);
                 return;
             case 5:
-                builder.append("          ");
+                writer.append(INDENT + INDENT + INDENT + INDENT + INDENT);
                 return;
             case 6:
-                builder.append("            ");
+                writer.append(INDENT + INDENT + INDENT + INDENT + INDENT + INDENT);
                 return;
             case 7:
-                builder.append("              ");
+                writer.append(INDENT + INDENT + INDENT + INDENT + INDENT + INDENT + INDENT);
                 return;
             case 8:
-                builder.append("                ");
+                writer.append(INDENT + INDENT + INDENT + INDENT + INDENT + INDENT + INDENT + INDENT);
                 return;
             case 9:
-                builder.append("                  ");
+                writer.append(INDENT + INDENT + INDENT + INDENT + INDENT + INDENT + INDENT + INDENT + INDENT);
                 return;
             default:
                 for(int i=0;i<indentation;i++) {
-                    builder.append("  ");
+                    writer.append(INDENT);
                 }
         }
     }

--- a/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowRecordStringifier.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowRecordStringifier.java
@@ -34,6 +34,9 @@ import com.netflix.hollow.core.read.dataaccess.HollowSetTypeDataAccess;
 import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
 import com.netflix.hollow.core.read.iterator.HollowMapEntryOrdinalIterator;
 import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -42,7 +45,6 @@ import java.util.Set;
  * Produces human-readable String representations of Hollow records.
  */
 public class HollowRecordStringifier implements HollowStringifier<HollowRecordStringifier> {
-
     private final Set<String> excludeObjectTypes = new HashSet<String>();
     private final boolean showOrdinals;
     private final boolean showTypes;
@@ -67,60 +69,70 @@ public class HollowRecordStringifier implements HollowStringifier<HollowRecordSt
     }
 
 
-    /**
-     * create a String representation of the specified {@link HollowRecord}.
-     */
     @Override
     public String stringify(HollowRecord record) {
-        return stringify(record.getTypeDataAccess().getDataAccess(), record.getSchema().getName(), record.getOrdinal());
+        return stringify(record.getTypeDataAccess().getDataAccess(),
+                record.getSchema().getName(), record.getOrdinal());
     }
 
-    /**
-     * create a String representation of the record in the provided dataset, of the given type, with the specified ordinal.
-     */
+    @Override
+    public void stringify(Writer writer, HollowRecord record) throws IOException {
+        stringify(writer, record.getTypeDataAccess().getDataAccess(), record.getSchema().getName(),
+                record.getOrdinal());
+    }
+
     @Override
     public String stringify(HollowDataAccess dataAccess, String type, int ordinal) {
-        StringBuilder builder = new StringBuilder();
-
-        appendStringify(builder, dataAccess, type, ordinal, 0);
-
-        return builder.toString();
+        try {
+            StringWriter writer = new StringWriter();
+            stringify(writer, dataAccess, type, ordinal);
+            return writer.toString();
+        } catch (IOException e) {
+            throw new RuntimeException("Unexpected exception using StringWriter", e);
+        }
     }
 
-    private void appendStringify(StringBuilder builder, HollowDataAccess dataAccess, String type, int ordinal, int indentation) {
+    @Override
+    public void stringify(Writer writer, HollowDataAccess dataAccess, String type, int ordinal) throws IOException {
+        appendStringify(writer, dataAccess, type, ordinal, 0);
+    }
+
+    private void appendStringify(Writer writer, HollowDataAccess dataAccess, String type, int ordinal,
+            int indentation) throws IOException {
         if (excludeObjectTypes.contains(type)) {
-            builder.append("null");
+            writer.append("null");
             return;
         }
 
         HollowTypeDataAccess typeDataAccess = dataAccess.getTypeDataAccess(type);
 
         if(typeDataAccess == null) {
-            builder.append("[missing type " + type + "]");
+            writer.append("[missing type " + type + "]");
         } else if (ordinal == -1) {
-            builder.append("null");
+            writer.append("null");
         } else {
             if(typeDataAccess instanceof HollowObjectTypeDataAccess) {
-                appendObjectStringify(builder, dataAccess, (HollowObjectTypeDataAccess)typeDataAccess, ordinal, indentation);
+                appendObjectStringify(writer, dataAccess, (HollowObjectTypeDataAccess)typeDataAccess, ordinal, indentation);
             } else if(typeDataAccess instanceof HollowListTypeDataAccess) {
-                appendListStringify(builder, dataAccess, (HollowListTypeDataAccess)typeDataAccess, ordinal, indentation);
+                appendListStringify(writer, dataAccess, (HollowListTypeDataAccess)typeDataAccess, ordinal, indentation);
             } else if(typeDataAccess instanceof HollowSetTypeDataAccess) {
-                appendSetStringify(builder, dataAccess, (HollowSetTypeDataAccess)typeDataAccess, ordinal, indentation);
+                appendSetStringify(writer, dataAccess, (HollowSetTypeDataAccess)typeDataAccess, ordinal, indentation);
             } else if(typeDataAccess instanceof HollowMapTypeDataAccess) {
-                appendMapStringify(builder, dataAccess, (HollowMapTypeDataAccess)typeDataAccess, ordinal, indentation);
+                appendMapStringify(writer, dataAccess, (HollowMapTypeDataAccess)typeDataAccess, ordinal, indentation);
             }
         }
 
     }
 
-    private void appendMapStringify(StringBuilder builder, HollowDataAccess dataAccess, HollowMapTypeDataAccess typeDataAccess, int ordinal, int indentation) {
+    private void appendMapStringify(Writer writer, HollowDataAccess dataAccess,
+            HollowMapTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
         HollowMapSchema schema = typeDataAccess.getSchema();
 
         if(showTypes)
-            builder.append("(").append(schema.getName()).append(")");
+            writer.append("(").append(schema.getName()).append(")");
 
         if(showOrdinals)
-            builder.append(" (ordinal ").append(ordinal).append(")");
+            writer.append(" (ordinal ").append(Integer.toString(ordinal)).append(")");
 
         indentation++;
 
@@ -130,26 +142,27 @@ public class HollowRecordStringifier implements HollowStringifier<HollowRecordSt
         HollowMapEntryOrdinalIterator iter = typeDataAccess.ordinalIterator(ordinal);
 
         while(iter.next()) {
-            builder.append("\n");
+            writer.append(NEWLINE);
 
-            appendIndentation(builder, indentation);
-            builder.append("k: ");
-            appendStringify(builder, dataAccess, keyType, iter.getKey(), indentation);
-            builder.append("\n");
-            appendIndentation(builder, indentation);
-            builder.append("v: ");
-            appendStringify(builder, dataAccess, valueType, iter.getValue(), indentation);
+            appendIndentation(writer, indentation);
+            writer.append("k: ");
+            appendStringify(writer, dataAccess, keyType, iter.getKey(), indentation);
+            writer.append(NEWLINE);
+            appendIndentation(writer, indentation);
+            writer.append("v: ");
+            appendStringify(writer, dataAccess, valueType, iter.getValue(), indentation);
         }
 
     }
 
-    private void appendSetStringify(StringBuilder builder, HollowDataAccess dataAccess, HollowSetTypeDataAccess typeDataAccess, int ordinal, int indentation) {
+    private void appendSetStringify(Writer writer, HollowDataAccess dataAccess,
+            HollowSetTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
         HollowSetSchema schema = typeDataAccess.getSchema();
         if(showTypes)
-            builder.append("(").append(schema.getName()).append(")");
+            writer.append("(").append(schema.getName()).append(")");
 
         if(showOrdinals)
-            builder.append(" (ordinal ").append(ordinal).append(")");
+            writer.append(" (ordinal ").append(Integer.toString(ordinal)).append(")");
 
         indentation++;
 
@@ -160,24 +173,25 @@ public class HollowRecordStringifier implements HollowStringifier<HollowRecordSt
         int elementOrdinal = iter.next();
 
         while(elementOrdinal != NO_MORE_ORDINALS) {
-            builder.append("\n");
+            writer.append(NEWLINE);
 
-            appendIndentation(builder, indentation);
-            builder.append("e: ");
+            appendIndentation(writer, indentation);
+            writer.append("e: ");
 
-            appendStringify(builder, dataAccess, elementType, elementOrdinal, indentation);
+            appendStringify(writer, dataAccess, elementType, elementOrdinal, indentation);
 
             elementOrdinal = iter.next();
         }
     }
 
-    private void appendListStringify(StringBuilder builder, HollowDataAccess dataAccess, HollowListTypeDataAccess typeDataAccess, int ordinal, int indentation) {
+    private void appendListStringify(Writer writer, HollowDataAccess dataAccess,
+            HollowListTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
         HollowListSchema schema = typeDataAccess.getSchema();
         if(showTypes)
-            builder.append("(").append(schema.getName()).append(")");
+            writer.append("(").append(schema.getName()).append(")");
 
         if(showOrdinals)
-            builder.append(" (ordinal ").append(ordinal).append(")");
+            writer.append(" (ordinal ").append(Integer.toString(ordinal)).append(")");
 
         indentation++;
 
@@ -186,83 +200,85 @@ public class HollowRecordStringifier implements HollowStringifier<HollowRecordSt
         String elementType = schema.getElementType();
 
         for(int i=0;i<size;i++) {
-            builder.append("\n");
+            writer.append(NEWLINE);
 
             int elementOrdinal = typeDataAccess.getElementOrdinal(ordinal, i);
 
-            appendIndentation(builder, indentation);
-            builder.append("e" + i + ": ");
+            appendIndentation(writer, indentation);
+            writer.append("e" + i + ": ");
 
-            appendStringify(builder, dataAccess, elementType, elementOrdinal, indentation);
+            appendStringify(writer, dataAccess, elementType, elementOrdinal, indentation);
         }
     }
 
-    private void appendObjectStringify(StringBuilder builder, HollowDataAccess dataAccess, HollowObjectTypeDataAccess typeDataAccess, int ordinal, int indentation) {
+    private void appendObjectStringify(Writer writer, HollowDataAccess dataAccess,
+            HollowObjectTypeDataAccess typeDataAccess, int ordinal, int indentation) throws IOException {
         HollowObjectSchema schema = typeDataAccess.getSchema();
 
         GenericHollowObject obj = new GenericHollowObject(typeDataAccess, ordinal);
 
         if(collapseSingleFieldObjects && typeDataAccess.getSchema().numFields() == 1) {
-            appendFieldStringify(builder, dataAccess, indentation, schema, obj, 0, schema.getFieldName(0));
+            appendFieldStringify(writer, dataAccess, indentation, schema, obj, 0, schema.getFieldName(0));
         } else {
             if(showTypes)
-                builder.append("(").append(schema.getName()).append(")");
+                writer.append("(").append(schema.getName()).append(")");
 
             if(showOrdinals)
-                builder.append(" (ordinal ").append(ordinal).append(")");
+                writer.append(" (ordinal ").append(Integer.toString(ordinal)).append(")");
 
             indentation++;
 
             for(int i=0;i<schema.numFields();i++) {
-                builder.append("\n");
+                writer.append(NEWLINE);
 
                 String fieldName = schema.getFieldName(i);
 
-                appendIndentation(builder, indentation);
-                builder.append(fieldName).append(": ");
+                appendIndentation(writer, indentation);
+                writer.append(fieldName).append(": ");
 
-                appendFieldStringify(builder, dataAccess, indentation, schema, obj, i, fieldName);
+                appendFieldStringify(writer, dataAccess, indentation, schema, obj, i, fieldName);
             }
         }
     }
 
-    private void appendFieldStringify(StringBuilder builder, HollowDataAccess dataAccess, int indentation, HollowObjectSchema schema, GenericHollowObject obj, int i, String fieldName) {
+    private void appendFieldStringify(Writer writer, HollowDataAccess dataAccess, int indentation,
+            HollowObjectSchema schema, GenericHollowObject obj, int i, String fieldName) throws IOException {
         if(obj.isNull(fieldName)) {
-            builder.append("null");
+            writer.append("null");
         } else {
             switch(schema.getFieldType(i)) {
                 case BOOLEAN:
-                    builder.append(obj.getBoolean(fieldName));
+                    writer.append(Boolean.toString(obj.getBoolean(fieldName)));
                     break;
                 case BYTES:
-                    builder.append(Arrays.toString(obj.getBytes(fieldName)));
+                    writer.append(Arrays.toString(obj.getBytes(fieldName)));
                     break;
                 case DOUBLE:
-                    builder.append(obj.getDouble(fieldName));
+                    writer.append(Double.toString(obj.getDouble(fieldName)));
                     break;
                 case FLOAT:
-                    builder.append(obj.getFloat(fieldName));
+                    writer.append(Float.toString(obj.getFloat(fieldName)));
                     break;
                 case INT:
-                    builder.append(obj.getInt(fieldName));
+                    writer.append(Integer.toString(obj.getInt(fieldName)));
                     break;
                 case LONG:
-                    builder.append(obj.getLong(fieldName));
+                    writer.append(Long.toString(obj.getLong(fieldName)));
                     break;
                 case STRING:
-                    builder.append(obj.getString(fieldName));
+                    writer.append(obj.getString(fieldName));
                     break;
                 case REFERENCE:
                     int refOrdinal = obj.getOrdinal(fieldName);
-                    appendStringify(builder, dataAccess, schema.getReferencedType(i), refOrdinal, indentation);
+                    appendStringify(writer, dataAccess, schema.getReferencedType(i), refOrdinal, indentation);
                     break;
             }
         }
     }
 
-    private void appendIndentation(StringBuilder builder, int indentation) {
+    private void appendIndentation(Writer writer, int indentation) throws IOException {
         for(int i=0;i<indentation;i++) {
-            builder.append("  ");
+            writer.append(INDENT);
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowStringifier.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowStringifier.java
@@ -18,24 +18,42 @@
 package com.netflix.hollow.tools.stringifier;
 
 import com.netflix.hollow.api.objects.HollowRecord;
-
 import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import java.io.IOException;
+import java.io.Writer;
 
 @SuppressWarnings("rawtypes")
 public interface HollowStringifier<T extends HollowStringifier> {
+    String NEWLINE = "\n";
+    String INDENT = "  ";
 
     /**
-     * Exclude specified object types (replace output with null)
+     * Exclude specified object types (replace output with null).
      */
     public T addExcludeObjectTypes(String... types);
 
     /**
-     * create a String representation of the specified {@link HollowRecord}.
+     * Create a String representation of the specified {@link HollowRecord}.
      */
     public String stringify(HollowRecord record);
 
     /**
-     * create a String representation of the record in the provided dataset, of the given type, with the specified ordinal.
+     * Writes a String representation of the specified {@link HollowRecord} to the provided Writer.
+     *
+     * @throws IOException thrown if there is an error writing to the Writer
+     */
+    public void stringify(Writer writer, HollowRecord record) throws IOException;
+
+    /**
+     * Create a String representation of the record in the provided dataset, of the given type, with the specified ordinal.
      */
     public String stringify(HollowDataAccess dataAccess, String type, int ordinal);
+
+    /**
+     * Writes a String representation of the record in the provided dataset, of the given type, with the specified ordinal.
+     *
+     * @throws IOException thrown if there is an error writing to the Writer
+     */
+    public void stringify(Writer writer, HollowDataAccess dataAccess, String type, int ordinal)
+        throws IOException;
 }

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/AbstractHollowRecordStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/AbstractHollowRecordStringifierTest.java
@@ -1,0 +1,104 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.tools.stringifier;
+
+import static com.netflix.hollow.tools.stringifier.HollowStringifier.NEWLINE;
+
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.io.IOException;
+import java.io.StringWriter;
+
+/**
+ * Code shared between HollowRecordStringifierTest and HollowRecordJsonStringifierTest.
+ */
+public class AbstractHollowRecordStringifierTest {
+    static class TypeWithString {
+        private final String value;
+
+        public TypeWithString(String value) {
+            this.value = value;
+        }
+    }
+
+    static class TypeWithPrimitive {
+        private final int value;
+
+        public TypeWithPrimitive(int value) {
+            this.value = value;
+        }
+    }
+
+    static class TypeWithNonPrimitive {
+        private final Integer value;
+
+        public TypeWithNonPrimitive(Integer value) {
+            this.value = value;
+        }
+    }
+
+    static class TypeWithNestedPrimitive {
+        private final Double value;
+        private final TypeWithPrimitive nestedType;
+
+        public TypeWithNestedPrimitive(Double value, TypeWithPrimitive nestedType) {
+            this.value = value;
+            this.nestedType = nestedType;
+        }
+    }
+
+    static class TypeWithNestedNonPrimitive {
+        private final Double value;
+        private final TypeWithNonPrimitive nestedType;
+
+        public TypeWithNestedNonPrimitive(Double value, TypeWithNonPrimitive nestedType) {
+            this.value = value;
+            this.nestedType = nestedType;
+        }
+    }
+
+
+    /**
+     * Sends instances of a type through the HollowRecordStringifier. This concatenates records
+     * for all the instances, separated by newlines.
+     */
+    protected static <T, S extends HollowStringifier> String stringifyType(
+            Class<T> clazz, HollowStringifier<S> stringifier, T... instances) throws IOException {
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowObjectMapper objectMapper = new HollowObjectMapper(writeStateEngine);
+        // add our types and records to the writeStateEngine
+        objectMapper.initializeTypeState(clazz);
+        for (T instance : instances) {
+            objectMapper.add(instance);
+        }
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        // simulate a roundtrip to copy our types and records into the readStateEngine
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine, null);
+        StringWriter writer = new StringWriter();
+        // use the version of stringify that takes a Writer, since the non-Writer version calls this
+        stringifier.stringify(writer, readStateEngine, clazz.getSimpleName(), 0);
+        // join all records with newlines
+        for (int i = 1; i < instances.length; i++) {
+            writer.append(NEWLINE);
+            stringifier.stringify(writer, readStateEngine, clazz.getSimpleName(), i);
+        }
+        return writer.toString();
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
@@ -1,0 +1,122 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.tools.stringifier;
+
+import static com.netflix.hollow.tools.stringifier.HollowStringifier.INDENT;
+import static com.netflix.hollow.tools.stringifier.HollowStringifier.NEWLINE;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.io.IOException;
+
+public class HollowRecordJsonStringifierTest extends AbstractHollowRecordStringifierTest {
+    @Test
+    public void testStringifyTypeWithString() throws IOException {
+        String msg = "String types should be printed correctly";
+        Assert.assertEquals(msg, "\"foo\"",
+                stringifyType(TypeWithString.class, false, new TypeWithString("foo")));
+        Assert.assertEquals(msg, "{" + NEWLINE
+                + INDENT + "\"value\": {" + NEWLINE
+                + INDENT + INDENT + "\"value\": \"foo\"" + NEWLINE
+                + INDENT + "}" + NEWLINE
+                + "}", 
+                stringifyType(TypeWithString.class, true, new TypeWithString("foo")));
+    }
+
+    @Test
+    public void testStringifyTypeWithPrimitive() throws IOException {
+        String msg = "Primitive types should be printed correctly";
+        Assert.assertEquals(msg, "1337",
+                stringifyType(TypeWithPrimitive.class, false, new TypeWithPrimitive(1337)));
+        Assert.assertEquals(msg, "{" + NEWLINE
+                + INDENT + "\"value\": 1337" + NEWLINE
+                + "}",
+                stringifyType(TypeWithPrimitive.class, true, new TypeWithPrimitive(1337)));
+    }
+
+    @Test
+    public void testStringifyTypeWithNonPrimitive() throws IOException {
+        String msg = "Non-primitive types should be printed correctly";
+        Assert.assertEquals(msg, "31337",
+                stringifyType(TypeWithNonPrimitive.class, false, new TypeWithNonPrimitive(31337)));
+        Assert.assertEquals(msg, "{" + NEWLINE
+                + INDENT + "\"value\": {" + NEWLINE
+                + INDENT + INDENT + "\"value\": 31337" + NEWLINE
+                + INDENT + "}" + NEWLINE
+                + "}",
+                stringifyType(TypeWithNonPrimitive.class, true, new TypeWithNonPrimitive(31337)));
+    }
+
+    @Test
+    public void testStringifyTypeWithNestedPrimitiveType() throws IOException {
+        String msg = "Types with nested primitives should be printed correctly";
+        Assert.assertEquals(msg, "{" + NEWLINE
+                + INDENT + "\"value\": 42.0," + NEWLINE
+                + INDENT + "\"nestedType\": 42" + NEWLINE
+                + "}", 
+                stringifyType(TypeWithNestedPrimitive.class, false,
+                    new TypeWithNestedPrimitive(42.0, new TypeWithPrimitive(42))));
+        Assert.assertEquals(msg, "{" + NEWLINE
+                + INDENT + "\"value\": {" + NEWLINE
+                + INDENT + INDENT + "\"value\": 42.0" + NEWLINE
+                + INDENT + "}," + NEWLINE
+                + INDENT + "\"nestedType\": {" + NEWLINE
+                + INDENT + INDENT + "\"value\": 42" + NEWLINE
+                + INDENT + "}" + NEWLINE
+                + "}",
+                stringifyType(TypeWithNestedPrimitive.class, true,
+                    new TypeWithNestedPrimitive(42.0, new TypeWithPrimitive(42))));
+    }
+
+    @Test
+    public void testStringifyTypeWithNestedNonPrimitiveType() throws IOException {
+        String msg = "Types with nested non-primitives should be printed correctly";
+        Assert.assertEquals(msg, "{" + NEWLINE
+                + INDENT + "\"value\": 42.0," + NEWLINE
+                + INDENT + "\"nestedType\": 42" + NEWLINE
+                + "}", 
+                stringifyType(TypeWithNestedNonPrimitive.class, false,
+                    new TypeWithNestedNonPrimitive(42.0, new TypeWithNonPrimitive(42))));
+        Assert.assertEquals(msg, "{" + NEWLINE
+                + INDENT + "\"value\": {" + NEWLINE
+                + INDENT + INDENT + "\"value\": 42.0" + NEWLINE
+                + INDENT + "}," + NEWLINE
+                + INDENT + "\"nestedType\": {" + NEWLINE
+                + INDENT + INDENT + "\"value\": {" + NEWLINE
+                + INDENT + INDENT + INDENT + "\"value\": 42" + NEWLINE
+                + INDENT + INDENT + "}" + NEWLINE
+                + INDENT + "}" + NEWLINE
+                + "}",
+                stringifyType(TypeWithNestedNonPrimitive.class, true,
+                    new TypeWithNestedNonPrimitive(42.0, new TypeWithNonPrimitive(42))));
+    }
+
+    @Test
+    public void testStringifyMultipleRecords() throws IOException {
+        Assert.assertEquals("Multiple records should be printed correctly",
+                "\"foo\"" + NEWLINE + "\"bar\"",
+                stringifyType(TypeWithString.class, false,
+                    new TypeWithString("foo"), new TypeWithString("bar")));
+    }
+
+    private static <T> String stringifyType(Class<T> clazz, boolean expanded, T... instances) throws IOException {
+        HollowRecordJsonStringifier stringifier = expanded
+            ? new HollowRecordJsonStringifier(true, false) : new HollowRecordJsonStringifier();
+        return stringifyType(clazz, stringifier, instances);
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordStringifierTest.java
@@ -1,0 +1,111 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.tools.stringifier;
+
+import static com.netflix.hollow.tools.stringifier.HollowStringifier.INDENT;
+import static com.netflix.hollow.tools.stringifier.HollowStringifier.NEWLINE;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Unit tests for the HollowRecordStringifier.
+ */
+public class HollowRecordStringifierTest extends AbstractHollowRecordStringifierTest {
+    @Test
+    public void testStringifyTypeWithString() throws IOException {
+        String msg = "String types should be printed correctly";
+        Assert.assertEquals(msg, "foo",
+                stringifyType(TypeWithString.class, false, new TypeWithString("foo")));
+        Assert.assertEquals(msg, "(TypeWithString) (ordinal 0)" + NEWLINE
+                + INDENT + "value: (String) (ordinal 0)" + NEWLINE
+                + INDENT + INDENT + "value: foo",
+                stringifyType(TypeWithString.class, true, new TypeWithString("foo")));
+    }
+
+    @Test
+    public void testStringifyTypeWithPrimitive() throws IOException {
+        String msg = "Primitive types should be printed correctly";
+        Assert.assertEquals(msg, "1337",
+                stringifyType(TypeWithPrimitive.class, false, new TypeWithPrimitive(1337)));
+        Assert.assertEquals(msg,
+                "(TypeWithPrimitive) (ordinal 0)" + NEWLINE + INDENT + "value: 1337",
+                stringifyType(TypeWithPrimitive.class, true, new TypeWithPrimitive(1337)));
+    }
+
+    @Test
+    public void testStringifyTypeWithNonPrimitive() throws IOException {
+        String msg = "Non-primitive types should be printed correctly";
+        Assert.assertEquals(msg, "31337",
+                stringifyType(TypeWithNonPrimitive.class, false, new TypeWithNonPrimitive(31337)));
+        Assert.assertEquals(msg, "(TypeWithNonPrimitive) (ordinal 0)" + NEWLINE
+                + INDENT + "value: (Integer) (ordinal 0)" + NEWLINE
+                + INDENT + INDENT + "value: 31337",
+                stringifyType(TypeWithNonPrimitive.class, true, new TypeWithNonPrimitive(31337)));
+    }
+
+    @Test
+    public void testStringifyTypeWithNestedPrimitiveType() throws IOException {
+        String msg = "Types with nested primitives should be printed correctly";
+        Assert.assertEquals(msg, NEWLINE + INDENT + "value: 42.0" + NEWLINE
+                + INDENT + "nestedType: 42",
+                stringifyType(TypeWithNestedPrimitive.class, false,
+                    new TypeWithNestedPrimitive(42.0, new TypeWithPrimitive(42))));
+        Assert.assertEquals(msg, "(TypeWithNestedPrimitive) (ordinal 0)" + NEWLINE
+                + INDENT + "value: (Double) (ordinal 0)" + NEWLINE
+                + INDENT + INDENT + "value: 42.0" + NEWLINE
+                + INDENT + "nestedType: (TypeWithPrimitive) (ordinal 0)" + NEWLINE
+                + INDENT + INDENT + "value: 42",
+                stringifyType(TypeWithNestedPrimitive.class, true,
+                    new TypeWithNestedPrimitive(42.0, new TypeWithPrimitive(42))));
+    }
+
+    @Test
+    public void testStringifyTypeWithNestedNonPrimitiveType() throws IOException {
+        String msg = "Types with nested non-primitives should be printed correctly";
+        Assert.assertEquals(msg, NEWLINE + INDENT + "value: 42.0" + NEWLINE
+                + INDENT + "nestedType: 42",
+                stringifyType(TypeWithNestedNonPrimitive.class, false,
+                    new TypeWithNestedNonPrimitive(42.0, new TypeWithNonPrimitive(42))));
+        Assert.assertEquals(msg, "(TypeWithNestedNonPrimitive) (ordinal 0)" + NEWLINE
+                + INDENT + "value: (Double) (ordinal 0)" + NEWLINE
+                + INDENT + INDENT
+                + "value: 42.0"
+                + NEWLINE + INDENT + "nestedType: (TypeWithNonPrimitive) (ordinal 0)" + NEWLINE
+                + INDENT + INDENT + "value: (Integer) (ordinal 0)" + NEWLINE
+                + INDENT + INDENT + INDENT + "value: 42",
+                stringifyType(TypeWithNestedNonPrimitive.class, true,
+                    new TypeWithNestedNonPrimitive(42.0, new TypeWithNonPrimitive(42))));
+    }
+
+    @Test
+    public void testStringifyMultipleRecords() throws IOException {
+        Assert.assertEquals("Multiple records should be printed correctly",
+                "foo" + NEWLINE + "bar",
+                stringifyType(TypeWithString.class, false,
+                    new TypeWithString("foo"), new TypeWithString("bar")));
+    }
+
+    private static <T> String stringifyType(Class<T> clazz, boolean expanded, T... instances) throws IOException {
+        HollowRecordStringifier stringifier = expanded
+            ? new HollowRecordStringifier(true, true, false) : new HollowRecordStringifier();
+        return stringifyType(clazz, stringifier, instances);
+    }
+}


### PR DESCRIPTION
For cases where a record has a large amount of data,
stringifying it can result in the underlying StringBuilder
running out of memory. Expose a version of the stringify
methods that take Writer objects instead and write records
using the provided Writer.