### PR TITLE
Use version of HollowStringifier#stringify that streams to Writer

### DIFF
--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSchemaPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSchemaPage.java
@@ -55,7 +55,7 @@ public class BrowseSchemaPage extends HollowExplorerPage {
     }
 
     @Override
-    protected void renderPage(VelocityContext ctx, Writer writer) {
+    protected void renderPage(HttpServletRequest req, VelocityContext ctx, Writer writer) {
         ui.getVelocityEngine().getTemplate("browse-schema.vm").merge(ctx, writer);
     }
     

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSchemaPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSchemaPage.java
@@ -17,18 +17,19 @@
  */
 package com.netflix.hollow.explorer.ui.pages;
 
-import com.netflix.hollow.explorer.ui.model.SchemaDisplayField;
-
 import com.netflix.hollow.explorer.ui.HollowExplorerUI;
 import com.netflix.hollow.explorer.ui.model.SchemaDisplay;
+import com.netflix.hollow.explorer.ui.model.SchemaDisplayField;
 import com.netflix.hollow.ui.HollowUISession;
-import javax.servlet.http.HttpServletRequest;
 import org.apache.velocity.VelocityContext;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.Writer;
 
 public class BrowseSchemaPage extends HollowExplorerPage {
 
     public BrowseSchemaPage(HollowExplorerUI ui) {
-        super(ui, "browse-schema.vm");
+        super(ui);
     }
 
     @Override
@@ -52,6 +53,11 @@ public class BrowseSchemaPage extends HollowExplorerPage {
         ctx.put("schemaDisplay", schemaDisplay);
         ctx.put("type", type);
     }
+
+    @Override
+    protected void renderPage(VelocityContext ctx, Writer writer) {
+        ui.getVelocityEngine().getTemplate("browse-schema.vm").merge(ctx, writer);
+    }
     
     private void expandOrCollapse(SchemaDisplay display, String fieldPaths[], int cursor, boolean isExpand) {
         if(display == null)
@@ -67,5 +73,4 @@ public class BrowseSchemaPage extends HollowExplorerPage {
                 expandOrCollapse(field.getReferencedType(), fieldPaths, cursor+1, isExpand);
         }
     }
-
 }

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
@@ -32,16 +32,18 @@ import com.netflix.hollow.explorer.ui.model.TypeKey;
 import com.netflix.hollow.tools.stringifier.HollowRecordJsonStringifier;
 import com.netflix.hollow.tools.stringifier.HollowRecordStringifier;
 import com.netflix.hollow.ui.HollowUISession;
+import org.apache.velocity.VelocityContext;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
-import org.apache.velocity.VelocityContext;
 
 public class BrowseSelectedTypePage extends HollowExplorerPage {
 
     public BrowseSelectedTypePage(HollowExplorerUI ui) {
-        super(ui, "browse-selected-type.vm");
+        super(ui);
     }
 
     @Override
@@ -137,6 +139,11 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
         ctx.put("key", key);
         ctx.put("ordinal", ordinal);
         ctx.put("display", displayFormat);
+    }
+
+    @Override
+    protected void renderPage(VelocityContext ctx, Writer writer) {
+        ui.getVelocityEngine().getTemplate("browse-selected-type.vm").merge(ctx, writer);
     }
 
     private void displayRecord(VelocityContext ctx, String displayFormat, HollowTypeReadState typeState, int ordinal) {

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/HollowExplorerPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/HollowExplorerPage.java
@@ -17,26 +17,24 @@
  */
 package com.netflix.hollow.explorer.ui.pages;
 
-import com.netflix.hollow.ui.HollowUISession;
-
 import com.netflix.hollow.explorer.ui.HollowExplorerUI;
-import java.io.Writer;
-import javax.servlet.http.HttpServletRequest;
+import com.netflix.hollow.ui.HollowUISession;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.Writer;
 
 public abstract class HollowExplorerPage {
     
     protected final HollowExplorerUI ui;
     
-    protected final Template template;
-    protected final Template headerTemplate;
-    protected final Template footerTemplate;
+    private final Template headerTemplate;
+    private final Template footerTemplate;
 
     
-    public HollowExplorerPage(HollowExplorerUI ui, String templateName) {
+    public HollowExplorerPage(HollowExplorerUI ui) {
         this.ui = ui;
-        this.template = ui.getVelocityEngine().getTemplate(templateName);
         this.headerTemplate = ui.getVelocityEngine().getTemplate("explorer-header.vm");
         this.footerTemplate = ui.getVelocityEngine().getTemplate("explorer-footer.vm");
     }
@@ -55,10 +53,18 @@ public abstract class HollowExplorerPage {
         setUpContext(req, session, ctx);
 
         headerTemplate.merge(ctx, writer);
-        template.merge(ctx, writer);
+        renderPage(ctx, writer);
         footerTemplate.merge(ctx, writer);
     }
 
+    /**
+     * Renders the page to the provided Writer, using the provided VelocityContext.
+     */
+    protected abstract void renderPage(VelocityContext ctx, Writer writer);
+
+    /**
+     * Populates the provided VelocityContext.
+     */
     protected abstract void setUpContext(HttpServletRequest req, HollowUISession session, VelocityContext ctx);
 
 }

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/HollowExplorerPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/HollowExplorerPage.java
@@ -53,14 +53,14 @@ public abstract class HollowExplorerPage {
         setUpContext(req, session, ctx);
 
         headerTemplate.merge(ctx, writer);
-        renderPage(ctx, writer);
+        renderPage(req, ctx, writer);
         footerTemplate.merge(ctx, writer);
     }
 
     /**
      * Renders the page to the provided Writer, using the provided VelocityContext.
      */
-    protected abstract void renderPage(VelocityContext ctx, Writer writer);
+    protected abstract void renderPage(HttpServletRequest req, VelocityContext ctx, Writer writer);
 
     /**
      * Populates the provided VelocityContext.

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/QueryPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/QueryPage.java
@@ -23,16 +23,18 @@ import com.netflix.hollow.explorer.ui.HollowExplorerUI;
 import com.netflix.hollow.explorer.ui.model.QueryResult;
 import com.netflix.hollow.explorer.ui.model.QueryResult.QueryClause;
 import com.netflix.hollow.ui.HollowUISession;
+import org.apache.velocity.VelocityContext;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
-import org.apache.velocity.VelocityContext;
 
 public class QueryPage extends HollowExplorerPage {
 
     public QueryPage(HollowExplorerUI ui) {
-        super(ui, "query.vm");
+        super(ui);
     }
 
     @Override
@@ -80,6 +82,9 @@ public class QueryPage extends HollowExplorerPage {
         ctx.put("queryValue", queryValue);
         ctx.put("queryResult", session.getAttribute("query-result"));
     }
-    
 
+    @Override
+    protected void renderPage(VelocityContext ctx, Writer writer) {
+        ui.getVelocityEngine().getTemplate("query.vm").merge(ctx, writer);
+    }
 }

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/QueryPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/QueryPage.java
@@ -84,7 +84,7 @@ public class QueryPage extends HollowExplorerPage {
     }
 
     @Override
-    protected void renderPage(VelocityContext ctx, Writer writer) {
+    protected void renderPage(HttpServletRequest req, VelocityContext ctx, Writer writer) {
         ui.getVelocityEngine().getTemplate("query.vm").merge(ctx, writer);
     }
 }

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
@@ -97,7 +97,7 @@ public class ShowAllTypesPage extends HollowExplorerPage {
     }
 
     @Override
-    protected void renderPage(VelocityContext ctx, Writer writer) {
+    protected void renderPage(HttpServletRequest req, VelocityContext ctx, Writer writer) {
         ui.getVelocityEngine().getTemplate("show-all-types.vm").merge(ctx, writer);
     }
     

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
@@ -25,17 +25,19 @@ import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
 import com.netflix.hollow.explorer.ui.HollowExplorerUI;
 import com.netflix.hollow.explorer.ui.model.TypeOverview;
 import com.netflix.hollow.ui.HollowUISession;
+import org.apache.velocity.VelocityContext;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
-import org.apache.velocity.VelocityContext;
 
 public class ShowAllTypesPage extends HollowExplorerPage {
 
     public ShowAllTypesPage(HollowExplorerUI ui) {
-        super(ui, "show-all-types.vm");
+        super(ui);
     }
 
     @Override
@@ -93,6 +95,11 @@ public class ShowAllTypesPage extends HollowExplorerPage {
         ctx.put("totalHeapFootprint", totalApproximateHeapFootprint(typeOverviews));
         ctx.put("typeOverviews", typeOverviews);
     }
+
+    @Override
+    protected void renderPage(VelocityContext ctx, Writer writer) {
+        ui.getVelocityEngine().getTemplate("show-all-types.vm").merge(ctx, writer);
+    }
     
     private String totalApproximateHeapFootprint(List<TypeOverview> allTypes) {
         long totalHeapFootprint = 0;
@@ -100,9 +107,4 @@ public class ShowAllTypesPage extends HollowExplorerPage {
             totalHeapFootprint += type.getApproxHeapFootprintLong();
         return TypeOverview.heapFootprintDisplayString(totalHeapFootprint);
     }
-    
-    
-    
-    
-
 }

--- a/hollow-explorer-ui/src/main/resources/browse-selected-type-bottom.vm
+++ b/hollow-explorer-ui/src/main/resources/browse-selected-type-bottom.vm
@@ -1,0 +1,23 @@
+#**
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+*#
+#if($ordinal)</pre>#end
+						</div>
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>

--- a/hollow-explorer-ui/src/main/resources/browse-selected-type-top.vm
+++ b/hollow-explorer-ui/src/main/resources/browse-selected-type-top.vm
@@ -14,7 +14,6 @@
  *     limitations under the License.
 *#
 
-
 #if($filteredByQuery)
 NOTE: Results are filtered by query <span style="font-family: monospace;">$filteredByQuery</span>.  <a href="$basePath/type?type=$type&key=$key&ordinal=$ordinal&display=$display&clearQuery=true">clear</a>
 #end
@@ -38,7 +37,7 @@ NOTE: Results are filtered by query <span style="font-family: monospace;">$filte
 				<a href="$basePath/type?type=$type&key=$key&ordinal=$ordinal&display=$display&page=$nextPage&pageSize=$pageSize">NEXT</a>
 			#end
 		</td>
-		#if($selectedRecordData)
+		#if($ordinal)
 			<td class="nav">
 				FORMAT: 
 				<a href="$basePath/type?type=$type&key=$key&ordinal=$ordinal&page=$page&pageSize=$pageSize&display=text">text</a> 
@@ -90,7 +89,7 @@ NOTE: Results are filtered by query <span style="font-family: monospace;">$filte
 						</form>
 					</td>
 				</tr>
-				#if($selectedRecordData)
+				#if($ordinal)
 					<tr valign=top>
 						<th align=right nowrap>Showing Record: </th>
 						<td id="recLink">
@@ -107,15 +106,4 @@ NOTE: Results are filtered by query <span style="font-family: monospace;">$filte
 					</th>
 					<td>
 						<div style="min-height:400px">
-							#if($selectedRecordData)
-								<pre>
-$selectedRecordData
-								</pre>
-							#end
-						</div>
-					</td>
-				</tr>
-			</table>
-		</td>
-	</tr>
-</table>
+							#if($ordinal)<pre>#end


### PR DESCRIPTION
This is a follow-up to #169. Now that we have a version of a stringify that takes a Writer, use it in the hollow explorer UI.