### PR TITLE
Add com.netflix.hollow.core.type support for Byte

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
@@ -50,11 +50,12 @@ public class HollowCodeGenerationUtils {
     private static final Map<String,String> AGGRESSIVE_CLASS_NAME_SUBSTITUTIONS = new HashMap<String,String>();
 
     static {
-        for(Class<?> clzz : Arrays.asList(Boolean.class, Integer.class, Long.class, Float.class, Double.class, String.class)) {
+        for(Class<?> clzz : Arrays.asList(Boolean.class, Integer.class, Long.class, Float.class, Double.class, String.class, Byte.class)) {
             PRIMITIVE_TYPES.add(clzz.getSimpleName());
         }
 
         DEFAULT_CLASS_NAME_SUBSTITUTIONS.put("String", "HString");
+        DEFAULT_CLASS_NAME_SUBSTITUTIONS.put("Byte", "HByte");
         DEFAULT_CLASS_NAME_SUBSTITUTIONS.put("Integer", "HInteger");
         DEFAULT_CLASS_NAME_SUBSTITUTIONS.put("Long", "HLong");
         DEFAULT_CLASS_NAME_SUBSTITUTIONS.put("Float", "HFloat");

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumerAPI.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumerAPI.java
@@ -16,6 +16,7 @@
 package com.netflix.hollow.api.consumer;
 
 import com.netflix.hollow.core.type.HBoolean;
+import com.netflix.hollow.core.type.HByte;
 import com.netflix.hollow.core.type.HDouble;
 import com.netflix.hollow.core.type.HFloat;
 import com.netflix.hollow.core.type.HInteger;
@@ -29,6 +30,12 @@ public interface HollowConsumerAPI {
         public Collection<HBoolean> getAllHBoolean();
 
         public HBoolean getHBoolean(int ordinal);
+    }
+
+    public interface ByteRetriever {
+        public Collection<HByte> getAllHByte();
+
+        public HByte getHByte(int ordinal);
     }
 
     public interface DoubleRetriever {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/missing/DefaultMissingDataHandler.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/missing/DefaultMissingDataHandler.java
@@ -42,6 +42,11 @@ public class DefaultMissingDataHandler implements MissingDataHandler {
     }
 
     @Override
+    public byte handleByte(String type, int ordinal, String field) {
+        return Byte.MIN_VALUE;
+    }
+
+    @Override
     public int handleInt(String type, int ordinal, String field) {
         return Integer.MIN_VALUE;
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/missing/MissingDataHandler.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/missing/MissingDataHandler.java
@@ -36,6 +36,8 @@ public interface MissingDataHandler {
 
     public int handleReferencedOrdinal(String type, int ordinal, String field);
 
+    public byte handleByte(String type, int ordinal, String field);
+
     public int handleInt(String type, int ordinal, String field);
 
     public long handleLong(String type, int ordinal, String field);

--- a/hollow/src/main/java/com/netflix/hollow/core/type/ByteHollowFactory.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/type/ByteHollowFactory.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.type;
+
+import com.netflix.hollow.api.objects.provider.HollowFactory;
+import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
+import com.netflix.hollow.core.type.delegate.ByteDelegateCachedImpl;
+import com.netflix.hollow.api.custom.HollowTypeAPI;
+
+public class ByteHollowFactory extends HollowFactory<HByte> {
+
+    @Override
+    public HByte newHollowObject(HollowTypeDataAccess dataAccess, HollowTypeAPI typeAPI, int ordinal) {
+        return new HByte(((ByteTypeAPI)typeAPI).getDelegateLookupImpl(), ordinal);
+    }
+
+    @Override
+    public HByte newCachedHollowObject(HollowTypeDataAccess dataAccess, HollowTypeAPI typeAPI, int ordinal) {
+        return new HByte(new ByteDelegateCachedImpl((ByteTypeAPI)typeAPI, ordinal), ordinal);
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/type/ByteTypeAPI.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/type/ByteTypeAPI.java
@@ -1,0 +1,60 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.type;
+
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.api.custom.HollowObjectTypeAPI;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.type.delegate.ByteDelegateLookupImpl;
+
+public class ByteTypeAPI extends HollowObjectTypeAPI {
+
+    private final ByteDelegateLookupImpl delegateLookupImpl;
+
+    public ByteTypeAPI(HollowAPI api, HollowObjectTypeDataAccess typeDataAccess) {
+        super(api, typeDataAccess, new String[] {
+            "value"
+        });
+        this.delegateLookupImpl = new ByteDelegateLookupImpl(this);
+    }
+
+    public int getValue(int ordinal) {
+        if(fieldIndex[0] == -1)
+            return missingDataHandler().handleByte("Byte", ordinal, "value");
+        // bytes are actually stored as ints
+        return getTypeDataAccess().readInt(ordinal, fieldIndex[0]);
+    }
+
+    public Integer getValueBoxed(int ordinal) {
+        int i;
+        if(fieldIndex[0] == -1) {
+            i = missingDataHandler().handleByte("Byte", ordinal, "value");
+        } else {
+            boxedFieldAccessSampler.recordFieldAccess(fieldIndex[0]);
+            // bytes are actually stored as ints
+            i = getTypeDataAccess().readInt(ordinal, fieldIndex[0]);
+        }
+        if ((i & (1 << 7)) != 0) // safety check - if not a byte, return null
+            return null;
+        return Integer.valueOf(i);
+    }
+
+    public ByteDelegateLookupImpl getDelegateLookupImpl() {
+        return delegateLookupImpl;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/type/HByte.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/type/HByte.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.type;
+
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.core.type.delegate.ByteDelegate;
+
+public class HByte extends HollowObject {
+
+    public HByte(ByteDelegate delegate, int ordinal) {
+        super(delegate, ordinal);
+    }
+
+    public byte getValue() {
+        return delegate().getValue(ordinal);
+    }
+
+    public Byte getValueBoxed() {
+        return delegate().getValueBoxed(ordinal);
+    }
+
+    public HollowAPI api() {
+        return typeApi().getAPI();
+    }
+
+    public ByteTypeAPI typeApi() {
+        return delegate().getTypeAPI();
+    }
+
+    protected ByteDelegate delegate() {
+        return (ByteDelegate) delegate;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/type/accessor/ByteDataAccessor.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/type/accessor/ByteDataAccessor.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.type.accessor;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.HollowConsumerAPI;
+import com.netflix.hollow.api.consumer.data.AbstractHollowDataAccessor;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.type.HByte;
+
+public class ByteDataAccessor extends AbstractHollowDataAccessor<Byte> {
+    public static final String TYPE = "Byte";
+
+    private HollowConsumerAPI.ByteRetriever api;
+
+    public ByteDataAccessor(HollowConsumer consumer) {
+        this(consumer.getStateEngine(), (HollowConsumerAPI.ByteRetriever)consumer.getAPI());
+    }
+
+    public ByteDataAccessor(HollowReadStateEngine rStateEngine, HollowConsumerAPI.ByteRetriever api) {
+        super(rStateEngine, TYPE, "value");
+        this.api = api;
+    }
+
+    @Override public Byte getRecord(int ordinal){
+        HByte val = api.getHByte(ordinal);
+        return val == null ? null : val.getValueBoxed();
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/type/delegate/ByteDelegate.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/type/delegate/ByteDelegate.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.type.delegate;
+
+import com.netflix.hollow.api.objects.delegate.HollowObjectDelegate;
+import com.netflix.hollow.core.type.ByteTypeAPI;
+
+public interface ByteDelegate extends HollowObjectDelegate {
+
+    public byte getValue(int ordinal);
+
+    public Byte getValueBoxed(int ordinal);
+
+    @Override
+    public ByteTypeAPI getTypeAPI();
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/type/delegate/ByteDelegateCachedImpl.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/type/delegate/ByteDelegateCachedImpl.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.type.delegate;
+
+import com.netflix.hollow.api.objects.delegate.HollowObjectAbstractDelegate;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.type.ByteTypeAPI;
+import com.netflix.hollow.api.custom.HollowTypeAPI;
+import com.netflix.hollow.api.objects.delegate.HollowCachedDelegate;
+
+public class ByteDelegateCachedImpl extends HollowObjectAbstractDelegate implements HollowCachedDelegate, ByteDelegate {
+
+    private final Byte value;
+    private ByteTypeAPI typeAPI;
+
+    public ByteDelegateCachedImpl(ByteTypeAPI typeAPI, int ordinal) {
+        Integer v = typeAPI.getValueBoxed(ordinal);
+        this.value = v == null ? null : v.byteValue();
+        this.typeAPI = typeAPI;
+    }
+
+    @Override
+    public byte getValue(int ordinal) {
+        if(value == null)
+            return Byte.MIN_VALUE;
+        return value.byteValue();
+    }
+
+    @Override
+    public Byte getValueBoxed(int ordinal) {
+        return value;
+    }
+
+    @Override
+    public HollowObjectSchema getSchema() {
+        return typeAPI.getTypeDataAccess().getSchema();
+    }
+
+    @Override
+    public HollowObjectTypeDataAccess getTypeDataAccess() {
+        return typeAPI.getTypeDataAccess();
+    }
+
+    @Override
+    public ByteTypeAPI getTypeAPI() {
+        return typeAPI;
+    }
+
+    @Override
+    public void updateTypeAPI(HollowTypeAPI typeAPI) {
+        this.typeAPI = (ByteTypeAPI) typeAPI;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/type/delegate/ByteDelegateLookupImpl.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/type/delegate/ByteDelegateLookupImpl.java
@@ -1,0 +1,58 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.type.delegate;
+
+import com.netflix.hollow.api.objects.delegate.HollowObjectAbstractDelegate;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.type.ByteTypeAPI;
+
+public class ByteDelegateLookupImpl extends HollowObjectAbstractDelegate implements ByteDelegate {
+
+    private final ByteTypeAPI typeAPI;
+
+    public ByteDelegateLookupImpl(ByteTypeAPI typeAPI) {
+        this.typeAPI = typeAPI;
+    }
+
+    @Override
+    public byte getValue(int ordinal) {
+        return (byte) typeAPI.getValue(ordinal);
+    }
+
+    @Override
+    public Byte getValueBoxed(int ordinal) {
+        Integer v = typeAPI.getValueBoxed(ordinal); // bytes are stored as ints
+        return v == null ? null : v.byteValue();
+    }
+
+    @Override
+    public ByteTypeAPI getTypeAPI() {
+        return typeAPI;
+    }
+
+    @Override
+    public HollowObjectSchema getSchema() {
+        return typeAPI.getTypeDataAccess().getSchema();
+    }
+
+    @Override
+    public HollowObjectTypeDataAccess getTypeDataAccess() {
+        return typeAPI.getTypeDataAccess();
+    }
+}


### PR DESCRIPTION
Rather than generating Byte classes when we encouunter a
Byte as part of another Type, introduce a top-level Byte
type as part of the core hollow types. Bytes are stored
as integers under the hood, and the generated classes will
use integers, similar to how a primitive byte gets converted
to an int.
Adding support for byte to the hollow schema is out of scope
for this PR.