### PR TITLE
Add v2 producer listener and use it to fire "cycle skipped" event

### DIFF
--- a/hollow/build.gradle
+++ b/hollow/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java'
  
 dependencies {
     testCompile 'junit:junit:4.11'
+    testCompile 'org.mockito:mockito-core:2.15.0'
 }
 
 // quiet warnings about sun.misc.Unsafe

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/BaseHollowProducerListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/BaseHollowProducerListener.java
@@ -1,0 +1,106 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A trivial implementation of {@link HollowProducerListenerV2} which does nothing.
+ * Implementations of HollowProducerListenerV2 should subclass this class for convenience.
+ */
+public class BaseHollowProducerListener implements HollowProducerListenerV2 {
+    @Override
+    public void onProducerInit(long elapsed, TimeUnit unit) {
+    }
+
+    @Override
+    public void onProducerRestoreStart(long restoreVersion) {
+    }
+
+    @Override
+    public void onProducerRestoreComplete(RestoreStatus status, long elapsed,
+        TimeUnit unit) {
+    }
+
+    @Override
+    public void onNewDeltaChain(long version) {
+    }
+
+    @Override
+    public void onCycleSkip(CycleSkipReason reason) {
+    }
+
+    @Override
+    public void onCycleStart(long version) {
+    }
+
+    @Override
+    public void onCycleComplete(ProducerStatus status, long elapsed, TimeUnit unit) {
+    }
+
+    @Override
+    public void onNoDeltaAvailable(long version) {
+    }
+
+    @Override
+    public void onPopulateStart(long version) {
+    }
+
+    @Override
+    public void onPopulateComplete(ProducerStatus status, long elapsed, TimeUnit unit) {
+    }
+
+    @Override
+    public void onPublishStart(long version) {
+    }
+
+    @Override
+    public void onPublishComplete(ProducerStatus status, long elapsed, TimeUnit unit) {
+    }
+
+    @Override
+    public void onArtifactPublish(PublishStatus publishStatus, long elapsed,
+        TimeUnit unit) {
+    }
+
+    @Override
+    public void onIntegrityCheckStart(long version) {
+    }
+
+    @Override
+    public void onIntegrityCheckComplete(ProducerStatus status, long elapsed,
+        TimeUnit unit) {
+    }
+
+    @Override
+    public void onValidationStart(long version) {
+    }
+
+    @Override
+    public void onValidationComplete(ProducerStatus status, long elapsed, TimeUnit unit) {
+    }
+
+    @Override
+    public void onAnnouncementStart(long version) {
+    }
+
+    @Override
+    public void onAnnouncementComplete(ProducerStatus status, long elapsed,
+        TimeUnit unit) {
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -41,6 +41,7 @@ import com.netflix.hollow.api.producer.HollowProducer.Validator.ValidationExcept
 import com.netflix.hollow.api.producer.HollowProducerListener.ProducerStatus;
 import com.netflix.hollow.api.producer.HollowProducerListener.PublishStatus;
 import com.netflix.hollow.api.producer.HollowProducerListener.RestoreStatus;
+import com.netflix.hollow.api.producer.HollowProducerListenerV2.CycleSkipReason;
 import com.netflix.hollow.api.producer.enforcer.BasicSingleProducerEnforcer;
 import com.netflix.hollow.api.producer.enforcer.SingleProducerEnforcer;
 import com.netflix.hollow.api.producer.fs.HollowFilesystemBlobStager;
@@ -376,6 +377,7 @@ public class HollowProducer {
         if(!singleProducerEnforcer.isPrimary()) {
             // TODO: minimum time spacing between cycles
             log.log(Level.INFO, "cycle not executed -- not primary");
+            listeners.fireCycleSkipped(CycleSkipReason.NOT_PRIMARY_PRODUCER);
             return lastSucessfulCycle;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducerListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducerListener.java
@@ -17,18 +17,19 @@
  */
 package com.netflix.hollow.api.producer;
 
-import static com.netflix.hollow.api.producer.HollowProducerListener.Status.FAIL;
-import static com.netflix.hollow.api.producer.HollowProducerListener.Status.SUCCESS;
-
 import com.netflix.hollow.api.producer.HollowProducer.ReadState;
 import com.netflix.hollow.api.producer.HollowProducer.WriteState;
+
 import java.util.EventListener;
 import java.util.concurrent.TimeUnit;
 
+import static com.netflix.hollow.api.producer.HollowProducerListener.Status.FAIL;
+import static com.netflix.hollow.api.producer.HollowProducerListener.Status.SUCCESS;
+
 /**
- * Beta API subject to change.
- *
- * A class should implement {@code HollowProducerListener}, if it wants to be notified on start/completion of various stages of the {@link HollowProducer}.
+ * A class should implement {@code HollowProducerListener}, if it wants to be notified on
+ * start/completion of various stages of the {@link HollowProducer}.
+ * Subclasses are encouraged to extend {@link NoOpHollowProducerListener}
  *
  * @author Kinesh Satiya {@literal kineshsatiya@gmail.com}.
  */
@@ -37,7 +38,7 @@ public interface HollowProducerListener extends EventListener {
     /**
      * Called after the {@code HollowProducer} has initialized its data model.
      */
-    public void onProducerInit(long elapsed, TimeUnit unit);
+    void onProducerInit(long elapsed, TimeUnit unit);
 
     /**
      * Called after the {@code HollowProducer} has restored its data state to the indicated version.
@@ -45,7 +46,7 @@ public interface HollowProducerListener extends EventListener {
      *
      * @param restoreVersion Version from which the state for {@code HollowProducer} was restored.
      */
-    public void onProducerRestoreStart(long restoreVersion);
+    void onProducerRestoreStart(long restoreVersion);
 
     /**
      * Called after the {@code HollowProducer} has restored its data state to the indicated version.
@@ -56,7 +57,7 @@ public interface HollowProducerListener extends EventListener {
      * @param elapsed duration of the restore in {@code unit} units
      * @param unit units of the {@code elapsed} duration
      */
-    public void onProducerRestoreComplete(RestoreStatus status, long elapsed, TimeUnit unit);
+    void onProducerRestoreComplete(RestoreStatus status, long elapsed, TimeUnit unit);
 
     /**
      * Indicates that the next state produced will begin a new delta chain.
@@ -66,14 +67,14 @@ public interface HollowProducerListener extends EventListener {
      *
      * @param version the version of the state that will become the first of a new delta chain
      */
-    public void onNewDeltaChain(long version);
+    void onNewDeltaChain(long version);
 
     /**
      * Called when the {@code HollowProducer} has begun a new cycle.
      *
      * @param version Version produced by the {@code HollowProducer} for new cycle about to start.
      */
-    public void onCycleStart(long version);
+    void onCycleStart(long version);
 
     /**
      * Called after {@code HollowProducer} has completed a cycle normally or abnormally. A {@code SUCCESS} status indicates that the
@@ -85,21 +86,21 @@ public interface HollowProducerListener extends EventListener {
      * @param elapsed duration of the cycle in {@code unit} units
      * @param unit units of the {@code elapsed} duration
      */
-    public void onCycleComplete(ProducerStatus status, long elapsed, TimeUnit unit);
+    void onCycleComplete(ProducerStatus status, long elapsed, TimeUnit unit);
 
     /**
      * Called after the new state has been populated if the {@code HollowProducer} detects that no data has changed, thus no snapshot nor delta should be produced.<p>
      *
      * @param version Current version of the cycle.
      */
-    public void onNoDeltaAvailable(long version);
+    void onNoDeltaAvailable(long version);
 
     /**
      * Called before starting to execute the task to populate data into Hollow.
      *
-     * @param version
+     * @param version Current version of the cycle
      */
-    public void onPopulateStart(long version);
+    void onPopulateStart(long version);
 
     /**
      * Called once populating task stage has finished successfully or failed. Use {@code ProducerStatus#getStatus()} to get status of the task.
@@ -108,14 +109,14 @@ public interface HollowProducerListener extends EventListener {
      * @param elapsed Time taken to populate hollow.
      * @param unit unit of {@code elapsed} duration.
      */
-    public void onPopulateComplete(ProducerStatus status, long elapsed, TimeUnit unit);
+    void onPopulateComplete(ProducerStatus status, long elapsed, TimeUnit unit);
 
     /**
      * Called when the {@code HollowProducer} has begun publishing the {@code HollowBlob}s produced this cycle.
      *
      * @param version Version to be published.
      */
-    public void onPublishStart(long version);
+    void onPublishStart(long version);
 
     /**
      * Called after the publish stage finishes normally or abnormally. A {@code SUCCESS} status indicates that
@@ -126,7 +127,7 @@ public interface HollowProducerListener extends EventListener {
      * @param elapsed duration of the publish stage in {@code unit} units
      * @param unit units of the {@code elapsed} duration
      */
-    public void onPublishComplete(ProducerStatus status, long elapsed, TimeUnit unit);
+    void onPublishComplete(ProducerStatus status, long elapsed, TimeUnit unit);
 
     /**
      * Called once a blob has been published successfully or failed to published. Use {@link PublishStatus#getBlob()} to get more details on blob type and size.
@@ -136,14 +137,14 @@ public interface HollowProducerListener extends EventListener {
      * @param elapsed       time taken to publish the blob
      * @param unit          unit of elapsed.
      */
-    public void onArtifactPublish(PublishStatus publishStatus, long elapsed, TimeUnit unit);
+    void onArtifactPublish(PublishStatus publishStatus, long elapsed, TimeUnit unit);
 
     /**
      * Called when the {@code HollowProducer} has begun checking the integrity of the {@code HollowBlob}s produced this cycle.
      *
      * @param version Version to be checked
      */
-    public void onIntegrityCheckStart(long version);
+    void onIntegrityCheckStart(long version);
 
     /**
      * Called after the integrity check stage finishes normally or abnormally. A {@code SUCCESS} status indicates that
@@ -154,14 +155,14 @@ public interface HollowProducerListener extends EventListener {
      * @param elapsed duration of the integrity check stage in {@code unit} units
      * @param unit units of the {@code elapsed} duration
      */
-    public void onIntegrityCheckComplete(ProducerStatus status, long elapsed, TimeUnit unit);
+    void onIntegrityCheckComplete(ProducerStatus status, long elapsed, TimeUnit unit);
 
     /**
      * Called when the {@code HollowProducer} has begun validating the new data state produced this cycle.
      *
      * @param version Version to be validated
      */
-    public void onValidationStart(long version);
+    void onValidationStart(long version);
 
     /**
      * Called after the validation stage finishes normally or abnormally. A {@code SUCCESS} status indicates that
@@ -172,14 +173,14 @@ public interface HollowProducerListener extends EventListener {
      * @param elapsed duration of the validation stage in {@code unit} units
      * @param unit units of the {@code elapsed} duration
      */
-    public void onValidationComplete(ProducerStatus status, long elapsed, TimeUnit unit);
+    void onValidationComplete(ProducerStatus status, long elapsed, TimeUnit unit);
 
     /**
      * Called when the {@code HollowProducer} has begun announcing the {@code HollowBlob} published this cycle.
      *
      * @param version of {@code HollowBlob} that will be announced.
      */
-    public void onAnnouncementStart(long version);
+    void onAnnouncementStart(long version);
 
     /**
      * Called after the announcement stage finishes normally or abnormally. A {@code SUCCESS} status indicates
@@ -190,7 +191,7 @@ public interface HollowProducerListener extends EventListener {
      * @param elapsed duration of the announcement stage in {@code unit} units
      * @param unit units of the {@code elapsed} duration
      */
-    public void onAnnouncementComplete(ProducerStatus status, long elapsed, TimeUnit unit);
+    void onAnnouncementComplete(ProducerStatus status, long elapsed, TimeUnit unit);
 
     /**
      * This class represents information on details when {@link HollowProducer} has finished executing a particular stage.
@@ -198,7 +199,7 @@ public interface HollowProducerListener extends EventListener {
      *
      * @author Kinesh Satiya {@literal kineshsatiya@gmail.com}
      */
-    public class ProducerStatus {
+    class ProducerStatus {
 
         private final long version;
         private final Status status;
@@ -405,7 +406,7 @@ public interface HollowProducerListener extends EventListener {
         }
     }
 
-    public class PublishStatus {
+    class PublishStatus {
         private final Status status;
         private final HollowProducer.Blob blob;
         private final Throwable throwable;
@@ -481,7 +482,7 @@ public interface HollowProducerListener extends EventListener {
 
     }
 
-    public enum Status {
+    enum Status {
         SUCCESS, FAIL, SKIP
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducerListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducerListener.java
@@ -29,7 +29,7 @@ import static com.netflix.hollow.api.producer.HollowProducerListener.Status.SUCC
 /**
  * A class should implement {@code HollowProducerListener}, if it wants to be notified on
  * start/completion of various stages of the {@link HollowProducer}.
- * Subclasses are encouraged to extend {@link NoOpHollowProducerListener}
+ * Subclasses are encouraged to extend {@link BaseHollowProducerListener}
  *
  * @author Kinesh Satiya {@literal kineshsatiya@gmail.com}.
  */

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducerListenerV2.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducerListenerV2.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+/**
+ * An extension of {@link HollowProducerListener} to allow adding new methods without
+ * breaking backwards compatability.
+ * Subclasses should extend {@link BaseHollowProducerListener} to avoid having to override
+ * every method in this interface.
+ * TODO(hollow3): Collapse this into HollowProducerListener.
+ */
+public interface HollowProducerListenerV2 extends HollowProducerListener {
+    enum CycleSkipReason {
+        NOT_PRIMARY_PRODUCER;
+    }
+
+    /**
+     * Called when a cycle is skipped.
+     */
+    void onCycleSkip(CycleSkipReason reason);
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import com.netflix.hollow.api.producer.HollowProducerListener.ProducerStatus;
 import com.netflix.hollow.api.producer.HollowProducerListener.PublishStatus;
 import com.netflix.hollow.api.producer.HollowProducerListener.RestoreStatus;
+import com.netflix.hollow.api.producer.HollowProducerListenerV2.CycleSkipReason;
 import com.netflix.hollow.api.producer.validation.AllValidationStatus;
 import com.netflix.hollow.api.producer.validation.AllValidationStatus.AllValidationStatusBuilder;
 import com.netflix.hollow.api.producer.validation.HollowValidationListener;
@@ -69,6 +70,16 @@ final class ListenerSupport {
 
     void fireNewDeltaChain(long version) {
         for(final HollowProducerListener l : listeners) l.onNewDeltaChain(version);
+    }
+
+    ProducerStatus.Builder fireCycleSkipped(CycleSkipReason reason) {
+        ProducerStatus.Builder psb = new ProducerStatus.Builder();
+        for (final HollowProducerListener l : listeners) {
+            if (l instanceof HollowProducerListenerV2) {
+                ((HollowProducerListenerV2) l).onCycleSkip(reason);
+            }
+        }
+        return psb;
     }
 
     ProducerStatus.Builder fireCycleStart(long version) {

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerListenerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerListenerTest.java
@@ -1,0 +1,61 @@
+package com.netflix.hollow.api.producer;
+
+import com.netflix.hollow.api.producer.enforcer.SingleProducerEnforcer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests to verify that HollowProducerListener objects provided to HollowProducers
+ * are invoked at the right times.
+ */
+public class HollowProducerListenerTest {
+    private HollowProducer producer;
+
+    @Mock
+    private HollowProducerListener listener;
+    @Mock
+    private HollowProducerListenerV2 listenerV2;
+    @Mock
+    private SingleProducerEnforcer singleProducerEnforcer;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        this.producer = new HollowProducer.Builder()
+            .withListeners(listener, listenerV2)
+            .withSingleProducerEnforcer(singleProducerEnforcer).build();
+    }
+
+    @Test
+    public void testCycleSkip() {
+        Mockito.when(singleProducerEnforcer.isPrimary()).thenReturn(false);
+        this.producer.runCycle(null);
+        Mockito.verify(listenerV2).onCycleSkip(
+                HollowProducerListenerV2.CycleSkipReason.NOT_PRIMARY_PRODUCER);
+        Mockito.verify(listener, Mockito.never()).onCycleStart(
+                ArgumentMatchers.anyLong());
+        Mockito.verify(listenerV2, Mockito.never()).onCycleStart(
+                ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    public void testCycleStartEnd() {
+        Mockito.when(singleProducerEnforcer.isPrimary()).thenReturn(true);
+        this.producer.runCycle(Mockito.mock(HollowProducer.Populator.class));
+        Mockito.verify(listener).onCycleStart(ArgumentMatchers.anyLong());
+        Mockito.verify(listenerV2).onCycleStart(ArgumentMatchers.anyLong());
+
+        Mockito.verify(listener).onCycleComplete(
+                Mockito.any(HollowProducerListener.ProducerStatus.class),
+                ArgumentMatchers.anyLong(), Mockito.any(TimeUnit.class));
+        Mockito.verify(listenerV2).onCycleComplete(
+                Mockito.any(HollowProducerListener.ProducerStatus.class),
+                ArgumentMatchers.anyLong(), Mockito.any(TimeUnit.class));
+    }
+}


### PR DESCRIPTION
HollowProducerListener cleanup and documentation update
    
    - remove unnecessary scope modifiers - everything in an
      interface is public by default
    - add missing param javadoc
    - document that implementing classes should extend
      BaseHollowProducerListener

Add v2 producer listener and use it to fire "cycle skipped" event
    
    - instead of breaking library users' compilation, create a
      subinterface of HollowProducerListener to add a new
      listener method
    - create a no-op version of our new HollowProducerListenerV2
      that users of our library should utilize to allow adding
      producer listener hooks without us breaking their
      compilation
    - when calling producer listener hooks, call a new hook when
      a cycle is skipped
    - add mockito as a testCompile dependency, and add unit
      tests for our new functionality