### PR TITLE
IncrementalCyclePopulator will not attempt to remove records from a n…

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalCyclePopulator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalCyclePopulator.java
@@ -38,9 +38,11 @@ public class HollowIncrementalCyclePopulator implements HollowProducer.Populator
     }
 
     private void removeRecords(HollowProducer.WriteState newState) {
-        Map<String, BitSet> recordsToRemove = findTypesWithRemovedRecords(newState.getPriorState());
-        markRecordsToRemove(newState.getPriorState(), recordsToRemove);
-        removeRecordsFromNewState(newState, recordsToRemove);
+        if (newState.getPriorState() != null) {
+            Map<String, BitSet> recordsToRemove = findTypesWithRemovedRecords(newState.getPriorState());
+            markRecordsToRemove(newState.getPriorState(), recordsToRemove);
+            removeRecordsFromNewState(newState, recordsToRemove);
+        }
     }
 
     private Map<String, BitSet> findTypesWithRemovedRecords(HollowProducer.ReadState readState) {


### PR DESCRIPTION
…ull previous state

Allows incremental producer to directly create the first snapshot without relying on a special run of the underlying classic producer
This should also address issue 154 (https://github.com/Netflix/hollow/issues/154)