### PR TITLE
Add destinationPath to HollowAPIGenerator builder - fixes #183

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIGenerator.java
@@ -399,7 +399,7 @@ public class HollowAPIGenerator {
     public static class Builder extends AbstractHollowAPIGeneratorBuilder<Builder, HollowAPIGenerator> {
         @Override
         protected HollowAPIGenerator  instantiateGenerator() {
-            return new HollowAPIGenerator(apiClassname, packageName, dataset, parameterizedTypes, parameterizeAllClassnames, useErgonomicShortcuts);
+            return new HollowAPIGenerator(apiClassname, packageName, dataset, parameterizedTypes, parameterizeAllClassnames, useErgonomicShortcuts, destinationPath);
         }
 
         @Override

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -3,6 +3,7 @@ package com.netflix.hollow.api.codegen;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
@@ -52,6 +53,8 @@ public class HollowAPIGeneratorTest {
         } catch (IOException e) {
             throw new RuntimeException("Could not write files to: " + clazzFolder);
         }
+
+        Assert.assertTrue(clazzFiles.list().length > 0);
     }
 
     @SuppressWarnings("unused")

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -1,0 +1,65 @@
+package com.netflix.hollow.api.codegen;
+
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class HollowAPIGeneratorTest {
+
+    private static String tmpFolder = System.getProperty("java.io.tmpdir");
+    private static String clazzFolder = String.format("%s/classes", tmpFolder);
+
+    @AfterClass
+    public static void cleanup() throws IOException {
+        Path directory = Paths.get(clazzFolder);
+        Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    @Test
+    public void generatesFileUsingDestinationPath()  {
+        HollowWriteStateEngine stateEngine  = new HollowWriteStateEngine();
+        HollowObjectMapper objectMapper = new HollowObjectMapper(stateEngine);
+        objectMapper.initializeTypeState(MyClass.class);
+        File clazzFiles = new File(clazzFolder);
+
+        HollowAPIGenerator hollowAPIGenerator = new HollowAPIGenerator.Builder()
+                .withAPIClassname("API")
+                .withPackageName("com.netflix.hollow.example.api.generated")
+                .withDataModel(stateEngine)
+                .withDestination(clazzFiles.toPath())
+                .build();
+
+        try {
+            hollowAPIGenerator.generateSourceFiles();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not write files to: " + clazzFolder);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class MyClass {
+        int id;
+
+        public MyClass(int id) {
+            this.id = id;
+        }
+    }
+}


### PR DESCRIPTION
`destinationPath` was missing in `instantiateGenerator`. Quick fix and added a test for it.

Related to https://github.com/Netflix/hollow/issues/183