### PR TITLE
Fix codegen bug where we tried to import collections from root package

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
@@ -59,14 +59,11 @@ import java.util.Set;
 public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator {
     public static final String SUB_PACKAGE_NAME = "";
 
-    private final HollowDataset dataset;
     private final boolean parameterizeClassNames;
 
     public HollowAPIClassJavaGenerator(String packageName, String apiClassname, HollowDataset dataset, boolean parameterizeClassNames, CodeGeneratorConfig config) {
-        super(packageName, SUB_PACKAGE_NAME, config);
-
+        super(packageName, SUB_PACKAGE_NAME, dataset, config);
         this.className = apiClassname;
-        this.dataset = dataset;
         this.parameterizeClassNames = parameterizeClassNames;
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIFactoryJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIFactoryJavaGenerator.java
@@ -20,6 +20,7 @@ package com.netflix.hollow.api.codegen;
 import com.netflix.hollow.api.client.HollowAPIFactory;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.objects.provider.HollowFactory;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
 import java.util.Collections;
 import java.util.Set;
@@ -35,8 +36,9 @@ public class HollowAPIFactoryJavaGenerator extends HollowConsumerJavaFileGenerat
 
     private final String apiClassname;
 
-    public HollowAPIFactoryJavaGenerator(String packageName, String apiClassname, CodeGeneratorConfig config) {
-        super(packageName, SUB_PACKAGE_NAME, config);
+    public HollowAPIFactoryJavaGenerator(String packageName, String apiClassname, HollowDataset dataset,
+            CodeGeneratorConfig config) {
+        super(packageName, SUB_PACKAGE_NAME, dataset, config);
         this.apiClassname = apiClassname;
         this.className = apiClassname + "Factory";
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowCodeGenerationUtils.java
@@ -26,6 +26,7 @@ import com.netflix.hollow.api.objects.delegate.HollowMapLookupDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowSetCachedDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowSetDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowSetLookupDelegate;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowListSchema;
 import com.netflix.hollow.core.schema.HollowMapSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
@@ -393,5 +394,9 @@ public class HollowCodeGenerationUtils {
             primitiveTypes.add(type);
         }
         return primitiveTypes;
+    }
+
+    public static boolean isCollectionType(String schemaName, HollowDataset dataset) {
+        return dataset.getSchema(schemaName).getSchemaType() != HollowSchema.SchemaType.OBJECT;
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/api/HollowDataAccessorGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/api/HollowDataAccessorGenerator.java
@@ -23,6 +23,7 @@ import com.netflix.hollow.api.codegen.HollowConsumerJavaFileGenerator;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.consumer.data.AbstractHollowDataAccessor;
 import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
@@ -41,15 +42,16 @@ public class HollowDataAccessorGenerator extends HollowConsumerJavaFileGenerator
     protected final String type;
     protected final HollowObjectSchema schema;
 
-    public HollowDataAccessorGenerator(String packageName, String apiclassName, HollowObjectSchema schema, CodeGeneratorConfig config) {
-        super(packageName, SUB_PACKAGE_NAME, config);
-        this.className = getclassName(schema);
+    public HollowDataAccessorGenerator(String packageName, String apiclassName, HollowObjectSchema schema,
+            HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, SUB_PACKAGE_NAME, dataset, config);
+        this.className = getClassName(schema);
         this.apiclassName = apiclassName;
         this.type =  hollowImplClassname(schema.getName());
         this.schema = schema;
     }
 
-    protected String getclassName(HollowObjectSchema schema) {
+    protected String getClassName(HollowObjectSchema schema) {
         return schema.getName() + "DataAccessor";
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/api/HollowTypeAPIGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/api/HollowTypeAPIGenerator.java
@@ -19,6 +19,7 @@ import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.typeAPICl
 
 import com.netflix.hollow.api.codegen.CodeGeneratorConfig;
 import com.netflix.hollow.api.codegen.HollowConsumerJavaFileGenerator;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowSchema;
 
 public abstract class HollowTypeAPIGenerator extends HollowConsumerJavaFileGenerator {
@@ -26,8 +27,9 @@ public abstract class HollowTypeAPIGenerator extends HollowConsumerJavaFileGener
 
     protected final String apiClassname;
 
-    public HollowTypeAPIGenerator(String stateEngineClassname, String packageName, HollowSchema schema, CodeGeneratorConfig config) {
-        super(packageName, SUB_PACKAGE_NAME, config);
+    public HollowTypeAPIGenerator(String stateEngineClassname, String packageName, HollowSchema schema,
+            HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, SUB_PACKAGE_NAME, dataset, config);
         this.apiClassname = stateEngineClassname;
         this.className = typeAPIClassname(schema.getName());
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/api/TypeAPIListJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/api/TypeAPIListJavaGenerator.java
@@ -25,6 +25,7 @@ import com.netflix.hollow.api.codegen.HollowAPIGenerator;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.custom.HollowListTypeAPI;
 import com.netflix.hollow.api.objects.delegate.HollowListLookupDelegate;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.read.dataaccess.HollowListTypeDataAccess;
 import com.netflix.hollow.core.schema.HollowListSchema;
 
@@ -39,8 +40,9 @@ import com.netflix.hollow.core.schema.HollowListSchema;
 public class TypeAPIListJavaGenerator extends HollowTypeAPIGenerator {
     private final HollowListSchema schema;
 
-    public TypeAPIListJavaGenerator(String apiClassname, String packageName, HollowListSchema schema, CodeGeneratorConfig config) {
-        super(apiClassname, packageName, schema, config);
+    public TypeAPIListJavaGenerator(String apiClassname, String packageName, HollowListSchema schema,
+            HollowDataset dataset, CodeGeneratorConfig config) {
+        super(apiClassname, packageName, schema, dataset, config);
         this.schema = schema;
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/api/TypeAPIMapJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/api/TypeAPIMapJavaGenerator.java
@@ -25,6 +25,7 @@ import com.netflix.hollow.api.codegen.HollowAPIGenerator;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.custom.HollowMapTypeAPI;
 import com.netflix.hollow.api.objects.delegate.HollowMapLookupDelegate;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.read.dataaccess.HollowMapTypeDataAccess;
 import com.netflix.hollow.core.schema.HollowMapSchema;
 
@@ -39,8 +40,9 @@ import com.netflix.hollow.core.schema.HollowMapSchema;
 public class TypeAPIMapJavaGenerator extends HollowTypeAPIGenerator {
     private final HollowMapSchema schema;
 
-    public TypeAPIMapJavaGenerator(String apiClassname, String packageName, HollowMapSchema schema, CodeGeneratorConfig config) {
-        super(apiClassname, packageName, schema, config);
+    public TypeAPIMapJavaGenerator(String apiClassname, String packageName, HollowMapSchema schema,
+            HollowDataset dataset, CodeGeneratorConfig config) {
+        super(apiClassname, packageName, schema, dataset, config);
         this.schema = schema;
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/api/TypeAPIObjectJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/api/TypeAPIObjectJavaGenerator.java
@@ -26,6 +26,7 @@ import com.netflix.hollow.api.codegen.CodeGeneratorConfig;
 import com.netflix.hollow.api.codegen.HollowAPIGenerator;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.custom.HollowObjectTypeAPI;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.write.HollowObjectWriteRecord;
@@ -52,8 +53,9 @@ public class TypeAPIObjectJavaGenerator extends HollowTypeAPIGenerator {
         }
     });
 
-    public TypeAPIObjectJavaGenerator(String apiClassname, String packageName, HollowObjectSchema schema,CodeGeneratorConfig config) {
-        super(apiClassname, packageName, schema, config);
+    public TypeAPIObjectJavaGenerator(String apiClassname, String packageName, HollowObjectSchema schema,
+            HollowDataset dataset, CodeGeneratorConfig config) {
+        super(apiClassname, packageName, schema, dataset, config);
         this.objectSchema = schema;
 
         this.importClasses.add(HollowObjectTypeAPI.class);

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/api/TypeAPISetJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/api/TypeAPISetJavaGenerator.java
@@ -25,6 +25,7 @@ import com.netflix.hollow.api.codegen.HollowAPIGenerator;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.custom.HollowSetTypeAPI;
 import com.netflix.hollow.api.objects.delegate.HollowSetLookupDelegate;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.read.dataaccess.HollowSetTypeDataAccess;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 
@@ -39,8 +40,9 @@ import com.netflix.hollow.core.schema.HollowSetSchema;
 public class TypeAPISetJavaGenerator extends HollowTypeAPIGenerator {
     private final HollowSetSchema schema;
 
-    public TypeAPISetJavaGenerator(String apiClassname, String packageName, HollowSetSchema schema,CodeGeneratorConfig config) {
-        super(apiClassname, packageName, schema, config);
+    public TypeAPISetJavaGenerator(String apiClassname, String packageName, HollowSetSchema schema,
+            HollowDataset dataset, CodeGeneratorConfig config) {
+        super(apiClassname, packageName, schema, dataset, config);
         this.schema = schema;
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateCachedImplGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateCachedImplGenerator.java
@@ -32,6 +32,7 @@ import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.custom.HollowTypeAPI;
 import com.netflix.hollow.api.objects.delegate.HollowCachedDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowObjectAbstractDelegate;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
@@ -40,12 +41,12 @@ import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
  * This class contains template logic for generating a {@link HollowAPI} implementation.  Not intended for external consumption.
  *
  * @see HollowAPIGenerator
- *
  */
 public class HollowObjectDelegateCachedImplGenerator extends HollowObjectDelegateGenerator {
 
-    public HollowObjectDelegateCachedImplGenerator(String packageName, HollowObjectSchema schema, HollowErgonomicAPIShortcuts ergonomicShortcuts,CodeGeneratorConfig config) {
-        super(packageName, schema, ergonomicShortcuts, config);
+    public HollowObjectDelegateCachedImplGenerator(String packageName, HollowObjectSchema schema,
+            HollowErgonomicAPIShortcuts ergonomicShortcuts, HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, schema, ergonomicShortcuts, dataset, config);
         this.className = delegateCachedImplName(schema.getName());
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateGenerator.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.api.codegen.delegate;
 import com.netflix.hollow.api.codegen.CodeGeneratorConfig;
 import com.netflix.hollow.api.codegen.HollowConsumerJavaFileGenerator;
 import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 
 public abstract class HollowObjectDelegateGenerator extends HollowConsumerJavaFileGenerator {
@@ -26,8 +27,9 @@ public abstract class HollowObjectDelegateGenerator extends HollowConsumerJavaFi
     protected final HollowObjectSchema schema;
     protected final HollowErgonomicAPIShortcuts ergonomicShortcuts;
 
-    public HollowObjectDelegateGenerator(String packageName, HollowObjectSchema schema, HollowErgonomicAPIShortcuts ergonomicShortcuts, CodeGeneratorConfig config) {
-        super(packageName, SUB_PACKAGE_NAME, config);
+    public HollowObjectDelegateGenerator(String packageName, HollowObjectSchema schema,
+            HollowErgonomicAPIShortcuts ergonomicShortcuts, HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, SUB_PACKAGE_NAME, dataset, config);
         this.schema = schema;
         this.ergonomicShortcuts = ergonomicShortcuts;
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateInterfaceGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateInterfaceGenerator.java
@@ -29,18 +29,19 @@ import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts;
 import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts.Shortcut;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.objects.delegate.HollowObjectDelegate;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 
 /**
  * This class contains template logic for generating a {@link HollowAPI} implementation.  Not intended for external consumption.
  *
  * @see HollowAPIGenerator
- *
  */
 public class HollowObjectDelegateInterfaceGenerator extends HollowObjectDelegateGenerator {
 
-    public HollowObjectDelegateInterfaceGenerator(String packageName, HollowObjectSchema schema, HollowErgonomicAPIShortcuts ergonomicShortcuts, CodeGeneratorConfig config) {
-        super(packageName, schema, ergonomicShortcuts, config);
+    public HollowObjectDelegateInterfaceGenerator(String packageName, HollowObjectSchema schema,
+            HollowErgonomicAPIShortcuts ergonomicShortcuts, HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, schema, ergonomicShortcuts, dataset, config);
         this.className = delegateInterfaceName(schema.getName());
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateLookupImplGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateLookupImplGenerator.java
@@ -29,6 +29,7 @@ import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts;
 import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts.Shortcut;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.objects.delegate.HollowObjectAbstractDelegate;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 
@@ -36,12 +37,12 @@ import com.netflix.hollow.core.schema.HollowObjectSchema;
  * This class contains template logic for generating a {@link HollowAPI} implementation.  Not intended for external consumption.
  *
  * @see HollowAPIGenerator
- *
  */
 public class HollowObjectDelegateLookupImplGenerator extends HollowObjectDelegateGenerator {
 
-    public HollowObjectDelegateLookupImplGenerator(String packageName, HollowObjectSchema schema, HollowErgonomicAPIShortcuts ergonomicShortcuts, CodeGeneratorConfig config) {
-        super(packageName, schema, ergonomicShortcuts, config);
+    public HollowObjectDelegateLookupImplGenerator(String packageName, HollowObjectSchema schema,
+            HollowErgonomicAPIShortcuts ergonomicShortcuts, HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, schema, ergonomicShortcuts, dataset, config);
         this.className = delegateLookupImplName(schema.getName());
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowHashIndexGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowHashIndexGenerator.java
@@ -44,7 +44,7 @@ public class HollowHashIndexGenerator extends HollowIndexGenerator {
     private final boolean isListenToDataRefreah;
 
     public HollowHashIndexGenerator(String packageName, String apiClassname, HollowDataset dataset, CodeGeneratorConfig config) {
-        super(packageName, apiClassname, config);
+        super(packageName, apiClassname, dataset, config);
         this.className = apiClassname + "HashIndex";
         this.dataset = dataset;
         this.isListenToDataRefreah = config.isListenToDataRefresh();

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowIndexGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowIndexGenerator.java
@@ -17,14 +17,16 @@ package com.netflix.hollow.api.codegen.indexes;
 
 import com.netflix.hollow.api.codegen.CodeGeneratorConfig;
 import com.netflix.hollow.api.codegen.HollowConsumerJavaFileGenerator;
+import com.netflix.hollow.core.HollowDataset;
 
 public abstract class HollowIndexGenerator extends HollowConsumerJavaFileGenerator {
     public static final String SUB_PACKAGE_NAME = "index";
 
     protected final String apiClassname;
 
-    public HollowIndexGenerator(String packageName, String apiClassname, CodeGeneratorConfig config) {
-        super(packageName, SUB_PACKAGE_NAME, config);
+    public HollowIndexGenerator(String packageName, String apiClassname, HollowDataset dataset,
+            CodeGeneratorConfig config) {
+        super(packageName, SUB_PACKAGE_NAME, dataset, config);
         this.apiClassname = apiClassname;
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowPrimaryKeyIndexGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowPrimaryKeyIndexGenerator.java
@@ -34,12 +34,10 @@ import java.util.List;
  * @see HollowAPIGenerator
  */
 public class HollowPrimaryKeyIndexGenerator extends HollowUniqueKeyIndexGenerator {
-    protected final HollowDataset dataset;
     protected final PrimaryKey pk;
 
     public HollowPrimaryKeyIndexGenerator(HollowDataset dataset, String packageName, String apiClassname, HollowObjectSchema schema, CodeGeneratorConfig config) {
-        super(packageName, apiClassname, schema, config);
-        this.dataset = dataset;
+        super(packageName, apiClassname, schema, dataset, config);
         this.pk = schema.getPrimaryKey();
         isGenSimpleConstructor = true;
         isParameterizedConstructorPublic = false;

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowUniqueKeyIndexGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowUniqueKeyIndexGenerator.java
@@ -22,6 +22,7 @@ import com.netflix.hollow.api.codegen.HollowAPIGenerator;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.consumer.index.AbstractHollowUniqueKeyIndex;
 import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
 import java.util.Arrays;
@@ -40,8 +41,9 @@ public class HollowUniqueKeyIndexGenerator extends HollowIndexGenerator {
     protected boolean isParameterizedConstructorPublic = true;
     protected boolean isAutoListenToDataRefresh = false;
 
-    public HollowUniqueKeyIndexGenerator(String packageName, String apiClassname, HollowObjectSchema schema, CodeGeneratorConfig config) {
-        super(packageName, apiClassname, config);
+    public HollowUniqueKeyIndexGenerator(String packageName, String apiClassname, HollowObjectSchema schema,
+            HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, apiClassname, dataset, config);
 
         this.type = schema.getName();
         this.className = getClassName(schema);

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/LegacyHollowPrimaryKeyIndexGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/LegacyHollowPrimaryKeyIndexGenerator.java
@@ -20,6 +20,7 @@ package com.netflix.hollow.api.codegen.indexes;
 import com.netflix.hollow.api.codegen.CodeGeneratorConfig;
 import com.netflix.hollow.api.codegen.HollowAPIGenerator;
 import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 
 /**
@@ -30,8 +31,9 @@ import com.netflix.hollow.core.schema.HollowObjectSchema;
  */
 public class LegacyHollowPrimaryKeyIndexGenerator extends HollowUniqueKeyIndexGenerator {
 
-    public LegacyHollowPrimaryKeyIndexGenerator(String packageName, String apiClassname, HollowObjectSchema schema, CodeGeneratorConfig config) {
-        super(packageName, apiClassname, schema, config);
+    public LegacyHollowPrimaryKeyIndexGenerator(String packageName, String apiClassname, HollowObjectSchema schema,
+            HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, apiClassname, schema, dataset, config);
 
         isGenSimpleConstructor = true;
         isParameterizedConstructorPublic = true;

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowCollectionsGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowCollectionsGenerator.java
@@ -17,6 +17,7 @@ package com.netflix.hollow.api.codegen.objects;
 
 import com.netflix.hollow.api.codegen.CodeGeneratorConfig;
 import com.netflix.hollow.api.codegen.HollowConsumerJavaFileGenerator;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowSchema;
 
 public abstract class HollowCollectionsGenerator extends HollowConsumerJavaFileGenerator {
@@ -24,8 +25,9 @@ public abstract class HollowCollectionsGenerator extends HollowConsumerJavaFileG
 
     protected final String apiClassname;
 
-    public HollowCollectionsGenerator(String packageName, String apiClassname, HollowSchema schema, CodeGeneratorConfig config) {
-        super(packageName, SUB_PACKAGE_NAME, config);
+    public HollowCollectionsGenerator(String packageName, String apiClassname, HollowSchema schema,
+            HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, SUB_PACKAGE_NAME, dataset, config);
 
         this.apiClassname = apiClassname;
         this.className = hollowImplClassname(schema.getName());

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowFactoryJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowFactoryJavaGenerator.java
@@ -30,6 +30,7 @@ import com.netflix.hollow.api.objects.delegate.HollowListCachedDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowMapCachedDelegate;
 import com.netflix.hollow.api.objects.delegate.HollowSetCachedDelegate;
 import com.netflix.hollow.api.objects.provider.HollowFactory;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
 import com.netflix.hollow.core.schema.HollowListSchema;
 import com.netflix.hollow.core.schema.HollowMapSchema;
@@ -41,7 +42,6 @@ import java.util.Arrays;
  * This class contains template logic for generating a {@link HollowAPI} implementation.  Not intended for external consumption.
  *
  * @see HollowAPIGenerator
- *
  */
 public class HollowFactoryJavaGenerator extends HollowConsumerJavaFileGenerator {
     public static final String SUB_PACKAGE_NAME = "core";
@@ -49,9 +49,9 @@ public class HollowFactoryJavaGenerator extends HollowConsumerJavaFileGenerator 
     private final String objectClassName;
     private final HollowSchema schema;
 
-    public HollowFactoryJavaGenerator(String packageName, HollowSchema schema, CodeGeneratorConfig config) {
-        super(packageName, SUB_PACKAGE_NAME, config);
-
+    public HollowFactoryJavaGenerator(String packageName, HollowSchema schema, HollowDataset dataset,
+            CodeGeneratorConfig config) {
+        super(packageName, SUB_PACKAGE_NAME, dataset, config);
         this.objectClassName = hollowImplClassname(schema.getName());
         this.className = hollowFactoryClassname(schema.getName());
         this.schema = schema;

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowListJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowListJavaGenerator.java
@@ -25,6 +25,7 @@ import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.objects.HollowList;
 import com.netflix.hollow.api.objects.delegate.HollowListDelegate;
 import com.netflix.hollow.api.objects.generic.GenericHollowRecordHelper;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowListSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
 import java.util.Arrays;
@@ -42,8 +43,9 @@ public class HollowListJavaGenerator extends HollowCollectionsGenerator {
     private final String elementClassName;
     private final boolean parameterize;
 
-    public HollowListJavaGenerator(String packageName, String apiClassname, HollowListSchema schema, Set<String> parameterizedTypes, boolean parameterizeClassNames,CodeGeneratorConfig config) {
-        super(packageName, apiClassname, schema, config);
+    public HollowListJavaGenerator(String packageName, String apiClassname, HollowListSchema schema, Set<String>
+            parameterizedTypes, boolean parameterizeClassNames, HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, apiClassname, schema, dataset, config);
 
         this.schema = schema;
         this.elementClassName = hollowImplClassname(schema.getElementType());

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowMapJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowMapJavaGenerator.java
@@ -38,23 +38,20 @@ import java.util.Set;
  * This class contains template logic for generating a {@link HollowAPI} implementation.  Not intended for external consumption.
  *
  * @see HollowAPIGenerator
- *
  */
 public class HollowMapJavaGenerator extends HollowCollectionsGenerator {
-
     private final HollowMapSchema schema;
-    private final HollowDataset dataset;
     private final String keyClassName;
     private final String valueClassName;
 
     private final boolean parameterizeKey;
     private final boolean parameterizeValue;
 
-    public HollowMapJavaGenerator(String packageName, String apiClassname, HollowMapSchema schema, HollowDataset dataset, Set<String> parameterizedTypes, boolean parameterizeClassNames, CodeGeneratorConfig config) {
-        super(packageName, apiClassname, schema, config);
-
+    public HollowMapJavaGenerator(String packageName, String apiClassname, HollowMapSchema schema,
+            HollowDataset dataset, Set<String> parameterizedTypes, boolean parameterizeClassNames,
+            CodeGeneratorConfig config) {
+        super(packageName, apiClassname, schema, dataset, config);
         this.schema = schema;
-        this.dataset = dataset;
         this.keyClassName = hollowImplClassname(schema.getKeyType());
         this.valueClassName = hollowImplClassname(schema.getValueType());
         this.parameterizeKey = parameterizeClassNames || parameterizedTypes.contains(schema.getKeyType());

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
@@ -32,6 +32,7 @@ import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts;
 import com.netflix.hollow.api.codegen.HollowErgonomicAPIShortcuts.Shortcut;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import com.netflix.hollow.tools.stringifier.HollowRecordStringifier;
@@ -41,7 +42,6 @@ import java.util.Set;
  * This class contains template logic for generating a {@link HollowAPI} implementation.  Not intended for external consumption.
  *
  * @see HollowAPIGenerator
- *
  */
 public class HollowObjectJavaGenerator extends HollowConsumerJavaFileGenerator {
     public static final String SUB_PACKAGE_NAME = "";
@@ -55,8 +55,10 @@ public class HollowObjectJavaGenerator extends HollowConsumerJavaFileGenerator {
     private final boolean useBooleanFieldErgonomics;
     private final boolean restrictApiToFieldType;
 
-    public HollowObjectJavaGenerator(String packageName, String apiClassname, HollowObjectSchema schema, Set<String> parameterizedTypes, boolean parameterizeClassNames, HollowErgonomicAPIShortcuts ergonomicShortcuts, CodeGeneratorConfig config) {
-        super(packageName, computeSubPackageName(schema), config);
+    public HollowObjectJavaGenerator(String packageName, String apiClassname, HollowObjectSchema schema, Set<String>
+            parameterizedTypes, boolean parameterizeClassNames, HollowErgonomicAPIShortcuts ergonomicShortcuts,
+            HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, computeSubPackageName(schema), dataset, config);
 
         this.apiClassname = apiClassname;
         this.schema = schema;

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowSetJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowSetJavaGenerator.java
@@ -25,6 +25,7 @@ import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.objects.HollowSet;
 import com.netflix.hollow.api.objects.delegate.HollowSetDelegate;
 import com.netflix.hollow.api.objects.generic.GenericHollowRecordHelper;
+import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 import java.util.Arrays;
@@ -42,8 +43,9 @@ public class HollowSetJavaGenerator extends HollowCollectionsGenerator {
     private final String elementClassName;
     private final boolean parameterize;
 
-    public HollowSetJavaGenerator(String packageName, String apiClassname, HollowSetSchema schema, Set<String> parameterizedTypes, boolean parameterizeClassNames, CodeGeneratorConfig config) {
-        super(packageName, apiClassname, schema, config);
+    public HollowSetJavaGenerator(String packageName, String apiClassname, HollowSetSchema schema, Set<String>
+            parameterizedTypes, boolean parameterizeClassNames, HollowDataset dataset, CodeGeneratorConfig config) {
+        super(packageName, apiClassname, schema, dataset, config);
 
         this.schema = schema;
         this.elementClassName = hollowImplClassname(schema.getElementType());


### PR DESCRIPTION
Most of the changes here are just so that we can get the
HollowDataset into the HollowConsumerJavaFileGenerator, so
we can pass it to HollowCodeGenerationUtils to figure out if
a schemaName is a Collection type.