### PR TITLE
Introduce and throw IncompatibleSchemaException

### DIFF
--- a/hollow-test/src/main/java/com/netflix/hollow/test/HollowReadStateEngineBuilder.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/HollowReadStateEngineBuilder.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.test;
 
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;

--- a/hollow/src/main/java/com/netflix/hollow/api/error/HollowException.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/error/HollowException.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.error;
+
+/**
+ * A generic exception thrown by hollow. In most cases, a subclass of this exception is thrown.
+ */
+public class HollowException extends RuntimeException {
+    public HollowException(String message) {
+        super(message);
+    }
+
+    public HollowException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public HollowException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/error/IncompatibleSchemaException.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/error/IncompatibleSchemaException.java
@@ -1,0 +1,54 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.error;
+
+/**
+ * An exception thrown when trying to compare two versions of an object with incompatible schema.
+ */
+public class IncompatibleSchemaException extends HollowException {
+    private final String typeName;
+    private final String fieldName;
+    private final String fieldType;
+    private final String otherType;
+
+    public IncompatibleSchemaException(String typeName, String fieldName, String fieldType,
+            String otherType) {
+        super("No common schema exists for " + typeName + ": field " + fieldName
+                + " has unmatched types: " + fieldType + " vs " + otherType);
+        this.typeName = typeName;
+        this.fieldName = fieldName;
+        this.fieldType = fieldType;
+        this.otherType = otherType;
+    }
+
+    public String getTypeName() {
+        return this.typeName;
+    }
+
+    public String getFieldName() {
+        return this.fieldName;
+    }
+
+    public String getFieldType() {
+        return this.fieldType;
+    }
+
+    public String getOtherType() {
+        return this.otherType;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalCyclePopulator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalCyclePopulator.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.api.producer;
 
 import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
@@ -1,21 +1,20 @@
 /*
-*
-*  Copyright 2017 Netflix, Inc.
-*
-*     Licensed under the Apache License, Version 2.0 (the "License");
-*     you may not use this file except in compliance with the License.
-*     You may obtain a copy of the License at
-*
-*         http://www.apache.org/licenses/LICENSE-2.0
-*
-*     Unless required by applicable law or agreed to in writing, software
-*     distributed under the License is distributed on an "AS IS" BASIS,
-*     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*     See the License for the specific language governing permissions and
-*     limitations under the License.
-*
-*/
-
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.core.index;
 
 import static com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
@@ -1,21 +1,21 @@
-package com.netflix.hollow.core.index;
 /*
-*
-*  Copyright 2017 Netflix, Inc.
-*
-*     Licensed under the Apache License, Version 2.0 (the "License");
-*     you may not use this file except in compliance with the License.
-*     You may obtain a copy of the License at
-*
-*         http://www.apache.org/licenses/LICENSE-2.0
-*
-*     Unless required by applicable law or agreed to in writing, software
-*     distributed under the License is distributed on an "AS IS" BASIS,
-*     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*     See the License for the specific language governing permissions and
-*     limitations under the License.
-*
-*/
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.index;
 
 import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
 import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowSparseIntegerSet.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowSparseIntegerSet.java
@@ -1,20 +1,20 @@
 /*
-*
-*  Copyright 2017 Netflix, Inc.
-*
-*     Licensed under the Apache License, Version 2.0 (the "License");
-*     you may not use this file except in compliance with the License.
-*     You may obtain a copy of the License at
-*
-*         http://www.apache.org/licenses/LICENSE-2.0
-*
-*     Unless required by applicable law or agreed to in writing, software
-*     distributed under the License is distributed on an "AS IS" BASIS,
-*     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*     See the License for the specific language governing permissions and
-*     limitations under the License.
-*
-*/
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.core.index;
 
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowObjectSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowObjectSchema.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.core.schema;
 
+import com.netflix.hollow.api.error.IncompatibleSchemaException;
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
@@ -159,12 +160,17 @@ public class HollowObjectSchema extends HollowSchema {
         PrimaryKey primaryKey = isNullableObjectEquals(this.primaryKey, otherSchema.getPrimaryKey()) ? this.primaryKey : null;
         HollowObjectSchema commonSchema = new HollowObjectSchema(getName(), commonFields, primaryKey);
 
-        for(int i=0;i<fieldNames.length;i++) {
+        for (int i = 0; i < fieldNames.length; i++) {
             int otherFieldIndex = otherSchema.getPosition(fieldNames[i]);
-            if(otherFieldIndex != -1) {
-                if(fieldTypes[i] != otherSchema.getFieldType(otherFieldIndex)
+             if (otherFieldIndex != -1) {
+                if (fieldTypes[i] != otherSchema.getFieldType(otherFieldIndex)
                         || !referencedTypesEqual(referencedTypes[i], otherSchema.getReferencedType(otherFieldIndex))) {
-                    throw new IllegalArgumentException("No common schema exists for " + getName() + ": field " + fieldNames[i] + " has unmatched types");
+                    String fieldType = fieldTypes[i] == FieldType.REFERENCE ? referencedTypes[i]
+                        : fieldTypes[i].toString().toLowerCase();
+                    String otherFieldType = otherSchema.getFieldType(otherFieldIndex) == FieldType.REFERENCE
+                        ? otherSchema.getReferencedType(otherFieldIndex)
+                        : otherSchema.getFieldType(otherFieldIndex).toString().toLowerCase();
+                    throw new IncompatibleSchemaException(getName(), fieldNames[i], fieldType, otherFieldType);
                 }
 
                 commonSchema.addField(fieldNames[i], fieldTypes[i], referencedTypes[i]);

--- a/hollow/src/main/java/com/netflix/hollow/core/type/accessor/LongDataAccessor.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/type/accessor/LongDataAccessor.java
@@ -1,4 +1,3 @@
-
 /*
  *
  *  Copyright 2017 Netflix, Inc.

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/RecordPrimaryKey.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/RecordPrimaryKey.java
@@ -1,20 +1,20 @@
 /*
-*
-*  Copyright 2017 Netflix, Inc.
-*
-*     Licensed under the Apache License, Version 2.0 (the "License");
-*     you may not use this file except in compliance with the License.
-*     You may obtain a copy of the License at
-*
-*         http://www.apache.org/licenses/LICENSE-2.0
-*
-*     Unless required by applicable law or agreed to in writing, software
-*     distributed under the License is distributed on an "AS IS" BASIS,
-*     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*     See the License for the specific language governing permissions and
-*     limitations under the License.
-*
-*/
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.core.write.objectmapper;
 
 import java.util.Arrays;

--- a/hollow/src/test/java/com/netflix/hollow/core/schema/HollowObjectSchemaTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/schema/HollowObjectSchemaTest.java
@@ -17,13 +17,13 @@
  */
 package com.netflix.hollow.core.schema;
 
+import com.netflix.hollow.api.error.IncompatibleSchemaException;
 import com.netflix.hollow.core.read.filter.HollowFilterConfig;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class HollowObjectSchemaTest {
-
     @Test
     public void findsCommonSchemas() {
         HollowObjectSchema s1 = new HollowObjectSchema("Test", 2, "F2");
@@ -52,6 +52,21 @@ public class HollowObjectSchemaTest {
             Assert.assertNotEquals(s1.getPrimaryKey(), s3.getPrimaryKey());
             Assert.assertNotEquals(s1.getPrimaryKey(), c3.getPrimaryKey());
             Assert.assertNull(c3.getPrimaryKey());
+        }
+    }
+
+    @Test
+    public void findCommonSchema_incompatible() {
+        try {
+            HollowObjectSchema s1 = new HollowObjectSchema("Test", 2, "F1");
+            s1.addField("F1", FieldType.INT);
+            HollowObjectSchema s2 = new HollowObjectSchema("Test", 2, "F1");
+            s2.addField("F1", FieldType.STRING);
+            s1.findCommonSchema(s2);
+            Assert.fail("Expected IncompatibleSchemaException");
+        } catch (IncompatibleSchemaException e) {
+            Assert.assertEquals("Test", e.getTypeName());
+            Assert.assertEquals("F1", e.getFieldName());
         }
     }
 


### PR DESCRIPTION
As part of this, introduce the generic HollowException. The
idea is over time we add subclasses of HollowException for
different "expected" errors that can occur.