### PR TITLE
Initialize consumer to empty read state if no announcements #140

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/HollowConstants.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/HollowConstants.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api;
+
+/**
+ * An interface to gather various sentinel constants used across hollow.
+ */
+public interface HollowConstants {
+    /**
+     * A version of VERSION_LATEST signifies "latest version".
+     */
+    long VERSION_LATEST = Long.MAX_VALUE;
+
+    /**
+     * A version of VERSION_NONE signifies "no version".
+     */
+    long VERSION_NONE = Long.MIN_VALUE;
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowAnnouncementWatcher.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowAnnouncementWatcher.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.api.client;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
@@ -150,7 +151,7 @@ public abstract class HollowAnnouncementWatcher {
 
     public static class DefaultWatcher extends HollowAnnouncementWatcher {
 
-        private long latestVersion = Long.MAX_VALUE;
+        private long latestVersion = HollowConstants.VERSION_LATEST;
 
         public DefaultWatcher() {
             super();

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowBlob.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowBlob.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.api.client;
 
+import com.netflix.hollow.api.HollowConstants;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -26,7 +27,7 @@ import java.io.InputStream;
  * <dl>
  *      <dt>The "from" version</dt>
  *      <dd>The unique identifier of the state to which a delta transition should be applied.  If
- *          this is a snapshot, then this value is Long.MIN_VALUE</dd>
+ *          this is a snapshot, then this value is HollowConstants.VERSION_NONE.</dd>
  *          
  *      <dt>The "to" version</dt>
  *      <dd>The unique identifier of the state at which a dataset will arrive after this blob is applied.</dd>
@@ -48,7 +49,7 @@ public abstract class HollowBlob {
      * Instantiate a snapshot to a specified data state version.
      */
     public HollowBlob(long toVersion) {
-        this(Long.MIN_VALUE, toVersion);
+        this(HollowConstants.VERSION_NONE, toVersion);
     }
 
     /**
@@ -71,7 +72,7 @@ public abstract class HollowBlob {
     public abstract InputStream getInputStream() throws IOException;
 
     public boolean isSnapshot() {
-        return fromVersion == Long.MIN_VALUE;
+        return fromVersion == HollowConstants.VERSION_NONE;
     }
 
     public boolean isReverseDelta() {

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.api.client;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.metrics.HollowConsumerMetrics;
@@ -26,11 +27,13 @@ import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.filter.HollowFilterConfig;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * A class comprising much of the internal state of a {@link HollowConsumer}.  Not intended for external consumption.
  */
 public class HollowClientUpdater {
+    private static final Logger LOG = Logger.getLogger(HollowClientUpdater.class.getName());
 
     private final HollowUpdatePlanner planner;
     private HollowDataHolder hollowDataHolder;
@@ -71,29 +74,40 @@ public class HollowClientUpdater {
         this.metricsCollector = metricsCollector;
     }
 
+    /**
+     * Updates the state to the provided version. Returns true if the update was successful.
+     */
     public synchronized boolean updateTo(long version) throws Throwable {
-        if(version == getCurrentVersionId())
-            return true;
+        if (version == getCurrentVersionId()) {
+            if (version == HollowConstants.VERSION_NONE && hollowDataHolder == null) {
+                LOG.info("No versions to update to, initializing to empty state");
+                // attempting to refresh, but no available versions - initialize to empty state
+                hollowDataHolder = newHollowDataHolder();
+                forceDoubleSnapshotNextUpdate(); // intentionally ignore doubleSnapshotConfig
+                return true;
+            } else { // already up to date
+                return true;
+            }
+        }
 
         long beforeVersion = getCurrentVersionId();
 
-        for(HollowConsumer.RefreshListener listener : refreshListeners)
+        for (HollowConsumer.RefreshListener listener : refreshListeners)
             listener.refreshStarted(beforeVersion, version);
 
         try {
             HollowUpdatePlan updatePlan = planUpdate(version);
 
-            if(updatePlan.destinationVersion() == Long.MIN_VALUE && version != Long.MAX_VALUE)
+            if (updatePlan.destinationVersion() == HollowConstants.VERSION_NONE
+                    && version != HollowConstants.VERSION_LATEST)
                 throw new Exception("Could not create an update plan for version " + version);
 
-            if(updatePlan.destinationVersion(version) == getCurrentVersionId())
+            if (updatePlan.destinationVersion(version) == getCurrentVersionId())
                 return true;
 
-            if(updatePlan.isSnapshotPlan()) {
-                if(hollowDataHolder == null || doubleSnapshotConfig.allowDoubleSnapshot()) {
-                    HollowReadStateEngine newStateEngine = newStateEngine();
-                    HollowDataHolder newHollowDataHolder = new HollowDataHolder(newStateEngine, apiFactory, failedTransitionTracker, staleReferenceDetector, refreshListeners, objectLongevityConfig);
-                    newHollowDataHolder.setFilter(filter);
+            if (updatePlan.isSnapshotPlan()) {
+                if (hollowDataHolder == null || doubleSnapshotConfig.allowDoubleSnapshot()) {
+                    HollowDataHolder newHollowDataHolder = newHollowDataHolder();
                     newHollowDataHolder.update(updatePlan);
                     hollowDataHolder = newHollowDataHolder;
                     forceDoubleSnapshot = false;
@@ -129,9 +143,8 @@ public class HollowClientUpdater {
     }
 
     public long getCurrentVersionId() {
-        if(hollowDataHolder != null)
-            return hollowDataHolder.getCurrentVersion();
-        return Long.MIN_VALUE;
+        return hollowDataHolder != null ? hollowDataHolder.getCurrentVersion()
+            : HollowConstants.VERSION_NONE;
     }
 
     public void forceDoubleSnapshotNextUpdate() {
@@ -144,8 +157,18 @@ public class HollowClientUpdater {
         return planner.planUpdate(hollowDataHolder.getCurrentVersion(), version, doubleSnapshotConfig.allowDoubleSnapshot());
     }
 
-    private boolean shouldCreateSnapshotPlan() {
-        return hollowDataHolder == null || (forceDoubleSnapshot && doubleSnapshotConfig.allowDoubleSnapshot());
+    /**
+     * Whether or not a snapshot plan should be created. Visible for testing.
+     */
+    boolean shouldCreateSnapshotPlan() {
+        return hollowDataHolder == null || getCurrentVersionId() == HollowConstants.VERSION_NONE
+            ||  (forceDoubleSnapshot && doubleSnapshotConfig.allowDoubleSnapshot());
+    }
+
+    private HollowDataHolder newHollowDataHolder() {
+        return new HollowDataHolder(newStateEngine(), apiFactory,
+                failedTransitionTracker, staleReferenceDetector, refreshListeners,
+                objectLongevityConfig).setFilter(filter);
     }
 
     private HollowReadStateEngine newStateEngine() {

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowDataHolder.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowDataHolder.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.api.client;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.consumer.HollowConsumer.TransitionAwareRefreshListener;
 import com.netflix.hollow.api.custom.HollowAPI;
@@ -51,7 +52,7 @@ public class HollowDataHolder {
 
     private WeakReference<HollowHistoricalStateDataAccess> priorHistoricalDataAccess;
 
-    private long currentVersion = Long.MIN_VALUE;
+    private long currentVersion = HollowConstants.VERSION_NONE;
 
     public HollowDataHolder(HollowReadStateEngine stateEngine, 
                             HollowAPIFactory apiFactory, 
@@ -80,8 +81,9 @@ public class HollowDataHolder {
         return currentVersion;
     }
 
-    public void setFilter(HollowFilterConfig filter) {
+    public HollowDataHolder setFilter(HollowFilterConfig filter) {
         this.filter = filter;
+        return this;
     }
 
     public void update(HollowUpdatePlan updatePlan) throws Throwable {

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlan.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlan.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.api.client;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,17 +63,12 @@ public class HollowUpdatePlan implements Iterable<HollowConsumer.Blob> {
 
     public long destinationVersion(long currentVersion) {
         long dest = destinationVersion();
-        if(dest == Long.MIN_VALUE)
-            return currentVersion;
-        return dest;
+        return dest == HollowConstants.VERSION_NONE ? currentVersion : dest;
     }
 
     public long destinationVersion() {
-        if(transitions.isEmpty())
-            return Long.MIN_VALUE;
-
-        HollowConsumer.Blob lastTransition = transitions.get(transitions.size() - 1);
-        return lastTransition.getToVersion();
+        return transitions.isEmpty() ? HollowConstants.VERSION_NONE
+            : transitions.get(transitions.size() - 1).getToVersion();
     }
 
     public int numTransitions() {

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlanner.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlanner.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.api.client;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 
 /**
@@ -58,13 +59,13 @@ public class HollowUpdatePlanner {
      * @param desiredVersion - The version to which the hollow state engine should be updated once the resultant steps are applied.
      */
     public HollowUpdatePlan planInitializingUpdate(long desiredVersion) throws Exception {
-        return planUpdate(Long.MIN_VALUE, desiredVersion, true);
+        return planUpdate(HollowConstants.VERSION_NONE, desiredVersion, true);
     }
 
     /**
      * Returns the sequence of steps necessary to bring a hollow state engine up to date.
      *
-     * @param currentVersion - The current version of the hollow state engine, or Long.MIN_VALUE if not yet initialized
+     * @param currentVersion - The current version of the hollow state engine, or HollowConstants.VERSION_NONE if not yet initialized
      * @param desiredVersion - The version to which the hollow state engine should be updated once the resultant steps are applied.
      * @param allowSnapshot  - Allow a snapshot plan to be created if the destination version is not reachable
      */
@@ -72,7 +73,7 @@ public class HollowUpdatePlanner {
         if(desiredVersion == currentVersion)
             return HollowUpdatePlan.DO_NOTHING;
 
-        if(currentVersion == Long.MIN_VALUE)
+        if (currentVersion == HollowConstants.VERSION_NONE)
             return snapshotPlan(desiredVersion);
 
         HollowUpdatePlan deltaPlan = deltaPlan(currentVersion, desiredVersion, doubleSnapshotConfig.maxDeltasBeforeDoubleSnapshot());
@@ -130,9 +131,9 @@ public class HollowUpdatePlanner {
         long achievedVersion = currentVersion;
         int transitionCounter = 0;
 
-        while(currentVersion > desiredVersion && transitionCounter < maxDeltas) {
+        while (currentVersion > desiredVersion && transitionCounter < maxDeltas) {
             currentVersion = includeNextReverseDelta(plan, currentVersion);
-            if(currentVersion > Long.MIN_VALUE)
+            if (currentVersion != HollowConstants.VERSION_NONE)
                 achievedVersion = currentVersion;
             transitionCounter++;
         }
@@ -154,7 +155,7 @@ public class HollowUpdatePlanner {
             return transition.getToVersion();
         }
 
-        return Long.MAX_VALUE;
+        return HollowConstants.VERSION_LATEST;
     }
 
     private long includeNextReverseDelta(HollowUpdatePlan plan, long currentVersion) {
@@ -164,7 +165,7 @@ public class HollowUpdatePlanner {
             return transition.getToVersion();
         }
 
-        return Long.MIN_VALUE;
+        return HollowConstants.VERSION_NONE;
     }
 
     private long includeNearestSnapshot(HollowUpdatePlan plan, long desiredVersion) {
@@ -174,7 +175,7 @@ public class HollowUpdatePlanner {
             return transition.getToVersion();
         }
 
-        return Long.MAX_VALUE;
+        return HollowConstants.VERSION_LATEST;
     }
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.api.consumer;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.client.FailedTransitionTracker;
 import com.netflix.hollow.api.client.HollowAPIFactory;
 import com.netflix.hollow.api.client.HollowClientUpdater;
@@ -347,7 +348,7 @@ public class HollowConsumer {
      * <dl>
      * <dt>The "from" version</dt>
      * <dd>The unique identifier of the state to which a delta transition should be applied.  If
-     * this is a snapshot, then this value is Long.MIN_VALUE</dd>
+     * this is a snapshot, then this value is HollowConstants.VERSION_NONE.</dd>
      * <p>
      * <dt>The "to" version</dt>
      * <dd>The unique identifier of the state at which a dataset will arrive after this blob is applied.</dd>
@@ -365,7 +366,7 @@ public class HollowConsumer {
          * Instantiate a snapshot to a specified data state version.
          */
         public Blob(long toVersion) {
-            this(Long.MIN_VALUE, toVersion);
+            this(HollowConstants.VERSION_NONE, toVersion);
         }
 
         /**
@@ -388,7 +389,7 @@ public class HollowConsumer {
         public abstract InputStream getInputStream() throws IOException;
 
         public boolean isSnapshot() {
-            return fromVersion == Long.MIN_VALUE;
+            return fromVersion == HollowConstants.VERSION_NONE;
         }
 
         public boolean isReverseDelta() {
@@ -418,7 +419,7 @@ public class HollowConsumer {
      */
     public static interface AnnouncementWatcher {
 
-        public static final long NO_ANNOUNCEMENT_AVAILABLE = Long.MIN_VALUE;
+        public static final long NO_ANNOUNCEMENT_AVAILABLE = HollowConstants.VERSION_NONE;
 
         /**
          * Return the latest announced version.

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemBlobRetriever.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemBlobRetriever.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.api.consumer.fs;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -82,7 +83,7 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
         if(Files.exists(exactPath))
             return new FilesystemBlob(exactPath, desiredVersion);
         
-        long maxVersionBeforeDesired = Long.MIN_VALUE;
+        long maxVersionBeforeDesired = HollowConstants.VERSION_NONE;
         String maxVersionBeforeDesiredFilename = null;
 
         try(DirectoryStream<Path> directoryStream = Files.newDirectoryStream(blobStorePath)) {
@@ -101,7 +102,7 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
         }
 
         HollowConsumer.Blob filesystemBlob = null;
-        if(maxVersionBeforeDesired > Long.MIN_VALUE)
+        if (maxVersionBeforeDesired != HollowConstants.VERSION_NONE)
             filesystemBlob = new FilesystemBlob(blobStorePath.resolve(maxVersionBeforeDesiredFilename), maxVersionBeforeDesired);
 
         if(fallbackBlobRetriever != null) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -20,6 +20,7 @@ package com.netflix.hollow.api.producer;
 import static com.netflix.hollow.api.consumer.HollowConsumer.AnnouncementWatcher.NO_ANNOUNCEMENT_AVAILABLE;
 import static java.lang.System.currentTimeMillis;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.metrics.HollowMetricsCollector;
 import com.netflix.hollow.api.metrics.HollowProducerMetrics;
@@ -307,7 +308,7 @@ public class HollowProducer {
 
         try {
             listeners.fireProducerRestoreStart(versionDesired);
-            if(versionDesired != Long.MIN_VALUE) {
+            if (versionDesired != HollowConstants.VERSION_NONE) {
 
                 HollowConsumer client = HollowConsumer.withBlobRetriever(blobRetriever).build();
                 client.triggerRefreshTo(versionDesired);
@@ -328,7 +329,7 @@ public class HollowProducer {
                 }
             }
         } catch(Throwable th) {
-            status = RestoreStatus.fail(versionDesired, readState != null ? readState.getVersion() : Long.MIN_VALUE, th);
+            status = RestoreStatus.fail(versionDesired, readState != null ? readState.getVersion() : HollowConstants.VERSION_NONE, th);
             throw th;
         } finally {
             listeners.fireProducerRestoreComplete(status, currentTimeMillis() - start);

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducerListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducerListener.java
@@ -20,6 +20,7 @@ package com.netflix.hollow.api.producer;
 import static com.netflix.hollow.api.producer.HollowProducerListener.Status.FAIL;
 import static com.netflix.hollow.api.producer.HollowProducerListener.Status.SUCCESS;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.producer.HollowProducer.ReadState;
 import com.netflix.hollow.api.producer.HollowProducer.WriteState;
 import java.util.EventListener;
@@ -215,7 +216,7 @@ public interface HollowProducerListener extends EventListener {
         }
 
         static ProducerStatus unknownFailure() {
-            return new ProducerStatus(Status.FAIL, Long.MIN_VALUE, null, null);
+            return new ProducerStatus(Status.FAIL, HollowConstants.VERSION_NONE, null, null);
         }
 
         static ProducerStatus fail(long version) {
@@ -277,7 +278,7 @@ public interface HollowProducerListener extends EventListener {
             private final long start;
             private long end;
 
-            private long version = Long.MIN_VALUE;
+            private long version = HollowConstants.VERSION_NONE;
             private Status status = FAIL;
             private Throwable cause = null;
             private ReadState readState = null;
@@ -347,7 +348,7 @@ public interface HollowProducerListener extends EventListener {
         }
 
         static RestoreStatus unknownFailure() {
-            return new RestoreStatus(Status.FAIL, Long.MIN_VALUE, Long.MIN_VALUE, null);
+            return new RestoreStatus(Status.FAIL, HollowConstants.VERSION_NONE, HollowConstants.VERSION_NONE, null);
         }
 
         static RestoreStatus fail(long versionDesired, long versionReached, Throwable cause) {
@@ -365,7 +366,7 @@ public interface HollowProducerListener extends EventListener {
          * The version desired to restore to when calling
          * {@link HollowProducer#restore(long, com.netflix.hollow.api.consumer.HollowConsumer.BlobRetriever)}
          *
-         * @return the latest announced version or {@code Long.MIN_VALUE} if latest announced version couldn't be
+         * @return the latest announced version or {@code HollowConstants.VERSION_NONE} if latest announced version couldn't be
          * retrieved
          */
         public long getDesiredVersion() {
@@ -375,10 +376,10 @@ public interface HollowProducerListener extends EventListener {
         /**
          * The version reached when restoring.
          * When {@link HollowProducer#restore(long, com.netflix.hollow.api.consumer.HollowConsumer.BlobRetriever)}
-         * succeeds then {@code versionDesired == versionReached} is always true. Can be {@code Long.MIN_VALUE}
+         * succeeds then {@code versionDesired == versionReached} is always true. Can be {@code HollowConstants.VERSION_NONE}
          * indicating restore failed to reach any state, or the version of an intermediate state reached.
          *
-         * @return the version restored to when successful, otherwise {@code Long.MIN_VALUE} if no version was
+         * @return the version restored to when successful, otherwise {@code HollowConstants.VERSION_NONE} if no version was
          * reached or the version of an intermediate state reached before restore completed unsuccessfully.
          */
         public long getVersionReached() {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ReadStateHelper.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ReadStateHelper.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.api.producer;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.producer.HollowProducer.ReadState;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 
@@ -99,6 +100,6 @@ final class ReadStateHelper {
     }
 
     long pendingVersion() {
-        return pending != null ? pending.getVersion() : Long.MIN_VALUE;
+        return pending != null ? pending.getVersion() : HollowConstants.VERSION_NONE;
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowFilesystemBlobStager.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowFilesystemBlobStager.java
@@ -21,6 +21,7 @@ import static com.netflix.hollow.api.producer.HollowProducer.Blob.Type.DELTA;
 import static com.netflix.hollow.api.producer.HollowProducer.Blob.Type.REVERSE_DELTA;
 import static com.netflix.hollow.api.producer.HollowProducer.Blob.Type.SNAPSHOT;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.api.producer.HollowProducer.Blob;
 import com.netflix.hollow.api.producer.HollowProducer.BlobCompressor;
@@ -84,7 +85,7 @@ public class HollowFilesystemBlobStager implements BlobStager {
 
     @Override
     public HollowProducer.Blob openSnapshot(long version) {
-        return new FilesystemBlob(Long.MIN_VALUE, version, SNAPSHOT, stagingPath, compressor);
+        return new FilesystemBlob(HollowConstants.VERSION_NONE, version, SNAPSHOT, stagingPath, compressor);
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowInMemoryBlobStager.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/fs/HollowInMemoryBlobStager.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.api.producer.fs;
 
+import com.netflix.hollow.api.HollowConstants;
 import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.api.producer.HollowProducer.Blob;
 import com.netflix.hollow.core.write.HollowBlobWriter;
@@ -29,7 +30,7 @@ public class HollowInMemoryBlobStager implements HollowProducer.BlobStager {
 
     @Override
     public Blob openSnapshot(long version) {
-        return new InMemoryBlob(Long.MIN_VALUE, version, Blob.Type.SNAPSHOT);
+        return new InMemoryBlob(HollowConstants.VERSION_NONE, version, Blob.Type.SNAPSHOT);
     }
 
     @Override

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.client;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.hollow.api.HollowConstants;
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HollowClientUpdaterTest {
+    private HollowConsumer.DoubleSnapshotConfig mockDoubleSnapshotConfig;
+
+    private HollowClientUpdater hollowClientUpdater;
+
+    @Before
+    public void setUp() {
+        mockDoubleSnapshotConfig = mock(HollowConsumer.DoubleSnapshotConfig.class);
+
+        hollowClientUpdater = new HollowClientUpdater(null, null, null, mockDoubleSnapshotConfig,
+                null, null, null, null, null);
+    }
+
+    @Test
+    public void testUpdateTo_noVersions() throws Throwable {
+        when(mockDoubleSnapshotConfig.allowDoubleSnapshot()).thenReturn(false);
+
+        assertTrue(hollowClientUpdater.updateTo(HollowConstants.VERSION_NONE));
+        HollowReadStateEngine readStateEngine = hollowClientUpdater.getStateEngine();
+        assertTrue("Should have no types", readStateEngine.getAllTypes().isEmpty());
+        assertTrue("Should create snapshot plan next, even if double snapshot config disallows it",
+                hollowClientUpdater.shouldCreateSnapshotPlan());
+        assertTrue(hollowClientUpdater.updateTo(HollowConstants.VERSION_NONE));
+        assertTrue("Should still have no types", readStateEngine.getAllTypes().isEmpty());
+    }
+}


### PR DESCRIPTION
If the AnnouncementWatcher has no published versions when
a HollowConsumer refreshes, initialize it to an empty read
state. Ensure that the next refresh forces a snapshot,
even if we are configured to disallow snapshots.
While we're here, also start the process of consolidating
sentinel values.