### PR TITLE
Add main functions to HollowAPIGenerator and HollowPOJOGenerator

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/ArgumentParser.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/ArgumentParser.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.netflix.hollow.api.codegen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ArgumentParser<T extends Enum> {
+    public class ParsedArgument {
+        private final T key;
+        private final String value;
+
+        public ParsedArgument(T key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public T getKey() {
+            return key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+    private static final Pattern COMMAND_LINE_ARG_PATTERN = Pattern.compile("--(\\w+)=([\\w,./]+)");
+
+    private final List<ParsedArgument> parsedArguments = new ArrayList<>();
+
+    public ArgumentParser(Class<T> validArguments, String[] args) {
+        for (String arg : args) {
+            Matcher matcher = COMMAND_LINE_ARG_PATTERN.matcher(arg);
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException("Invalid argument " + arg);
+            }
+            String argK = matcher.group(1);
+            String argV = matcher.group(2);
+            try {
+                T key = (T) Enum.valueOf(validArguments, argK);
+                parsedArguments.add(new ParsedArgument(key, argV));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid argument " + arg);
+            }
+        }
+    }
+
+    public List<ParsedArgument> getParsedArguments() {
+        return this.parsedArguments;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaParser.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaParser.java
@@ -19,6 +19,7 @@ package com.netflix.hollow.core.schema;
 
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.StreamTokenizer;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -33,17 +34,17 @@ import java.util.logging.Logger;
 public class HollowSchemaParser {
 
     private static final Logger log = Logger.getLogger(HollowSchemaParser.class.getName());
-    /**
-     * Parse a collection of {@link HollowSchema}s from the provided String. 
-     */
-    public static List<HollowSchema> parseCollectionOfSchemas(String schemas) throws IOException {
-        StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(schemas));
-        configureTokenizer(tokenizer);
 
+    /**
+     * Parse a collection of {@link HollowSchema}s from the provided Reader.
+     */
+    public static List<HollowSchema> parseCollectionOfSchemas(Reader reader) throws IOException {
+        StreamTokenizer tokenizer = new StreamTokenizer(reader);
+        configureTokenizer(tokenizer);
         List<HollowSchema> schemaList = new ArrayList<HollowSchema>();
 
         HollowSchema schema = parseSchema(tokenizer);
-        while(schema != null) {
+        while (schema != null) {
             schemaList.add(schema);
             schema = parseSchema(tokenizer);
         }
@@ -52,7 +53,14 @@ public class HollowSchemaParser {
     }
 
     /**
-     * Parse a single {@link HollowSchema} from the provided String. 
+     * Parse a collection of {@link HollowSchema}s from the provided String.
+     */
+    public static List<HollowSchema> parseCollectionOfSchemas(String schemas) throws IOException {
+        return parseCollectionOfSchemas(new StringReader(schemas));
+    }
+
+    /**
+     * Parse a single {@link HollowSchema} from the provided String.
      */
     public static HollowSchema parseSchema(String schema) throws IOException {
         StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(schema));

--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
@@ -24,6 +24,7 @@ import com.netflix.hollow.core.schema.HollowListSchema;
 import com.netflix.hollow.core.schema.HollowMapSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchemaParser;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 import com.netflix.hollow.core.write.HollowListTypeWriteState;
 import com.netflix.hollow.core.write.HollowMapTypeWriteState;
@@ -33,6 +34,10 @@ import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.copy.HollowRecordCopier;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.BitSet;
 import java.util.Collection;
 
@@ -51,6 +56,24 @@ public class HollowWriteStateCreator {
         populateStateEngineWithTypeWriteStates(stateEngine, schemas);
 
         return stateEngine;
+    }
+
+    /**
+     * Reads a schema file into the provided HollowWriteStateEngine. The schema file must be on the classpath.
+     */
+    public static void readSchemaFileIntoWriteState(String schemaFilePath, HollowWriteStateEngine engine)
+            throws IOException {
+        InputStream input = null;
+        try {
+            input = HollowWriteStateCreator.class.getResourceAsStream(schemaFilePath);
+            Collection<HollowSchema> schemas =
+                HollowSchemaParser.parseCollectionOfSchemas(new BufferedReader(new InputStreamReader(input)));
+            populateStateEngineWithTypeWriteStates(engine, schemas);
+        } finally {
+            if (input != null) {
+                input.close();
+            }
+        }
     }
 
     /**
@@ -162,5 +185,4 @@ public class HollowWriteStateCreator {
         writeEngine.overrideNextStateRandomizedTag(readEngine.getCurrentRandomizedTag());
         writeEngine.prepareForWrite();
     }
-
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/ArgumentParserTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/ArgumentParserTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.netflix.hollow.api.codegen;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+public class ArgumentParserTest {
+    enum Commands {
+        orderCoffee,
+        drinkCoffee,
+        writeArgumentParserClass;
+    };
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_missingDash() {
+        new ArgumentParser<Commands>(Commands.class, new String[]{"-orderCoffee=f"});
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void test_missingValue() {
+        new ArgumentParser<Commands>(Commands.class, new String[]{"--orderCoffee"});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_missingArgument() {
+        new ArgumentParser<Commands>(Commands.class, new String[]{"--compileOnFirstTry=f"});
+    }
+
+    @Test
+    public void test_noCommands() {
+        assertEquals(Arrays.asList(), new ArgumentParser<Commands>(Commands.class, new String[] {}).getParsedArguments());
+    }
+
+    @Test
+    public void test_validCommands() {
+        assertEquals(3, new ArgumentParser<Commands>(Commands.class, new String[] {
+            "--orderCoffee=first", "--drinkCoffee=next", "--writeArgumentParserClass=yay"}).getParsedArguments().size());
+        assertParsedArgument("--orderCoffee=fi.rst", Commands.orderCoffee, "fi.rst");
+        assertParsedArgument("--drinkCoffee=ne/xt", Commands.drinkCoffee, "ne/xt");
+        assertParsedArgument("--writeArgumentParserClass=complete", Commands.writeArgumentParserClass, "complete");
+
+    }
+
+    private void assertParsedArgument(String commandLineArg, Commands key, String value) {
+        ArgumentParser<Commands>.ParsedArgument parsed = new ArgumentParser<>(Commands.class, new String[] {
+            commandLineArg}).getParsedArguments().get(0);
+        assertEquals(key, parsed.getKey());
+        assertEquals(value, parsed.getValue());
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/schema/HollowSchemaParserTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/schema/HollowSchemaParserTest.java
@@ -19,7 +19,10 @@ package com.netflix.hollow.core.schema;
 
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
@@ -211,4 +214,20 @@ public class HollowSchemaParserTest {
         Assert.assertEquals(4, schemas.size());
     }
 
+    @Test
+    public void testParseCollectionOfSchemas_reader() throws Exception {
+        InputStream input = null;
+        try {
+            input = getClass().getResourceAsStream("/schema1.txt");
+            List<HollowSchema> schemas =
+                    HollowSchemaParser.parseCollectionOfSchemas(new BufferedReader(new InputStreamReader(input)));
+            Assert.assertEquals("Should have two schemas", 2, schemas.size());
+            Assert.assertEquals("Should have Minion schema", "Minion", schemas.get(0).getName());
+            Assert.assertEquals("Should have String schema", "String", schemas.get(1).getName());
+        } finally {
+            if (input != null) {
+                input.close();
+            }
+        }
+    }
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/util/HollowWriteStateCreatorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/util/HollowWriteStateCreatorTest.java
@@ -150,6 +150,14 @@ public class HollowWriteStateCreatorTest {
             Assert.fail();
         } catch(Exception expected) { }
     }
+
+    @Test
+    public void testReadSchemaFileIntoWriteState() throws Exception {
+        HollowWriteStateEngine engine = new HollowWriteStateEngine();
+        Assert.assertEquals("Should have no type states", 0, engine.getOrderedTypeStates().size());
+        HollowWriteStateCreator.readSchemaFileIntoWriteState("/schema1.txt", engine);
+        Assert.assertEquals("Should now have types", 2, engine.getOrderedTypeStates().size());
+    }
     
     @SuppressWarnings("unused")
     @HollowTypeName(name="Integer")

--- a/hollow/src/test/resources/schema1.txt
+++ b/hollow/src/test/resources/schema1.txt
@@ -1,0 +1,8 @@
+Minion @PrimaryKey(minionId) {
+    long minionId;
+    String name;
+}
+
+String {
+    string value;
+}


### PR DESCRIPTION
This allows calling these generators as part of a build
process, as JavaExec tasks.