### PR TITLE
Fix for ArrayOutOfBoundException in HasfIndex (#159)

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -60,7 +60,7 @@ public class HollowHashIndex implements HollowTypeStateListener {
         this.typeState = (HollowObjectTypeReadState) stateEngine.getTypeState(type);
         this.selectField = selectField;
         this.matchFields = matchFields;
-        
+
         reindexHashIndex();
     }
 
@@ -160,8 +160,6 @@ public class HollowHashIndex implements HollowTypeStateListener {
 
                 HollowObjectTypeReadState objectAccess = (HollowObjectTypeReadState)readState;
                 int fieldIdx = fieldPath[fieldPath.length-1];
-                if(hashOrdinal == -1 && query[i] == null)
-                    continue;
                 if(!HollowReadFieldUtils.fieldValueEquals(objectAccess, hashOrdinal, fieldIdx, query[i]))
                     return false;
             }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
@@ -144,6 +144,9 @@ class HollowObjectTypeReadStateShard {
     }
 
     public Boolean readBoolean(int ordinal, int fieldIndex) {
+        if (ordinal < 0)
+            return null;
+
         HollowObjectTypeDataElements currentData;
         long value;
 
@@ -167,6 +170,9 @@ class HollowObjectTypeReadStateShard {
     }
 
     public byte[] readBytes(int ordinal, int fieldIndex) {
+        if (ordinal < 0)
+            return null;
+
         HollowObjectTypeDataElements currentData;
         byte[] result;
 
@@ -200,6 +206,9 @@ class HollowObjectTypeReadStateShard {
     }
 
     public String readString(int ordinal, int fieldIndex) {
+        if (ordinal < 0)
+            return null;
+
         HollowObjectTypeDataElements currentData;
         String result;
 
@@ -231,6 +240,9 @@ class HollowObjectTypeReadStateShard {
     }
 
     public boolean isStringFieldEqual(int ordinal, int fieldIndex, String testValue) {
+        if (ordinal < 0)
+            return testValue == null;
+
         HollowObjectTypeDataElements currentData;
         boolean result;
 

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
@@ -19,6 +19,7 @@ package com.netflix.hollow.core.index;
 
 import com.netflix.hollow.core.AbstractStateEngineTest;
 import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+import com.netflix.hollow.core.write.objectmapper.HollowInline;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -29,11 +30,15 @@ import org.junit.Test;
 
 
 public class HollowHashIndexTest extends AbstractStateEngineTest {
+    private HollowObjectMapper mapper;
+
+    @Override
+    protected void initializeTypeStates() {
+        mapper = new HollowObjectMapper(writeStateEngine);
+    }
 
     @Test
     public void testBasicHashIndexFunctionality() throws Exception {
-        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
-
         mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
         mapper.add(new TypeA(1, 1.1d, new TypeB("1")));
         mapper.add(new TypeA(2, 2.2d, new TypeB("two"), new TypeB("twenty"), new TypeB("two hundred")));
@@ -43,7 +48,7 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
 
         roundTripSnapshot();
 
-        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "a1", new String[] {"a1", "ab.element.b1.value"});
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "a1", new String[]{"a1", "ab.element.b1.value"});
 
         Assert.assertNull("An entry that doesn't have any matches has a null iterator", index.findMatches(0, "notfound"));
         assertIteratorContainsAll(index.findMatches(1, "one").iterator(), 0);
@@ -54,42 +59,94 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
         assertIteratorContainsAll(index.findMatches(3, "three").iterator(), 3);
         assertIteratorContainsAll(index.findMatches(3, "thirty").iterator(), 3);
         assertIteratorContainsAll(index.findMatches(3, "three hundred").iterator(), 3);
-        assertIteratorContainsAll(index.findMatches(4, "four").iterator(), 4,5);
+        assertIteratorContainsAll(index.findMatches(4, "four").iterator(), 4, 5);
         assertIteratorContainsAll(index.findMatches(4, "forty").iterator(), 5);
-        
+
     }
 
     @Test
-    public void testIndexingNullFieldValues() throws Exception {
-        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
-
-        mapper.add(new TypeB("one"));
+    public void testIndexingStringTypeFieldWithNullValues() throws Exception {
         mapper.add(new TypeB(null));
+        mapper.add(new TypeB("onez:"));
 
         roundTripSnapshot();
-
         HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeB", "", "b1.value");
 
-        assertIteratorContainsAll(index.findMatches("one").iterator(), 0);
+        Assert.assertNull(index.findMatches("one:"));
+        assertIteratorContainsAll(index.findMatches("onez:").iterator(), 1);
+    }
 
-        try {
-            index.findMatches(new Object[] { null });
-            Assert.fail("exception expected");
-        } catch(IllegalArgumentException ex) {
-            Assert.assertEquals("querying by null unsupported; i=0", ex.getMessage());
-        }
+    @Test
+    public void testIndexingStringTypeFieldsWithNullValues() throws Exception {
+        mapper.add(new TypeC(null, "onez:"));
+        mapper.add(new TypeC("onez:", "onez:"));
+        mapper.add(new TypeC(null, null));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeC", "", "b1.value", "b2.value");
+
+        Assert.assertNull(index.findMatches("one"));
+        Assert.assertNull(index.findMatches("one", "onez:"));
+        assertIteratorContainsAll(index.findMatches("onez:", "onez:").iterator(), 1);
+    }
+
+    @Test
+    public void testIndexingStringTypeFieldsWithNullValuesInDifferentOrder() throws Exception {
+        mapper.add(new TypeC(null, null));
+        mapper.add(new TypeC(null, "onez:"));
+        mapper.add(new TypeC("onez:", "onez:"));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeC", "", "b1.value", "b2.value");
+
+        Assert.assertNull(index.findMatches("one"));
+        Assert.assertNull(index.findMatches("one", "onez:"));
+        assertIteratorContainsAll(index.findMatches("onez:", "onez:").iterator(), 2);
+    }
+
+    @Test
+    public void testIndexingBooleanTypeFieldWithNullValues() throws Exception {
+        mapper.add(new TypeD(null, null));
+        mapper.add(new TypeD(true, "onez:"));
+        mapper.add(new TypeD(false, null));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeD", "", "b1.value");
+
+        assertIteratorContainsAll(index.findMatches(Boolean.FALSE).iterator(), 2);
+        assertIteratorContainsAll(index.findMatches(Boolean.TRUE).iterator(), 1);
+    }
+
+    @Test
+    public void testIndexingInlinedStringTypeFieldWithNullValues() throws Exception {
+        mapper.add(new TypeE(null));
+        mapper.add(new TypeE("onez:"));
+        mapper.add(new TypeE(null));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeE", "", "b1");
+
+        Assert.assertNull(index.findMatches("one:"));
+        assertIteratorContainsAll(index.findMatches("onez:").iterator(), 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFindingMatchForNullQueryValue() throws Exception {
+        mapper.add(new TypeB("one:"));
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeB", "", "b1.value");
+        index.findMatches(new Object[]{null});
+        Assert.fail("exception expected");
     }
 
     @Test
     public void testUpdateListener() throws Exception {
-        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
-
         mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
         mapper.add(new TypeA(1, 1.1d, new TypeB("1")));
         mapper.add(new TypeA(2, 2.2d, new TypeB("two"), new TypeB("twenty"), new TypeB("two hundred")));
         mapper.add(new TypeA(3, 3.3d, new TypeB("three"), new TypeB("thirty"), new TypeB("three hundred")));
         mapper.add(new TypeA(4, 4.4d, new TypeB("four")));
-        mapper.add(new TypeA(4, 4.5d, new TypeB("four"), new TypeB("forty")));        
+        mapper.add(new TypeA(4, 4.5d, new TypeB("four"), new TypeB("forty")));
 
         roundTripSnapshot();
 
@@ -98,10 +155,10 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
 
         // spot check initial mapper state
         Assert.assertNull("An entry that doesn't have any matches has a null iterator", index.findMatches(0));
-        assertIteratorContainsAll(index.findMatches(1).iterator(), 1,0);
+        assertIteratorContainsAll(index.findMatches(1).iterator(), 1, 0);
         assertIteratorContainsAll(index.findMatches(2).iterator(), 2);
         assertIteratorContainsAll(index.findMatches(3).iterator(), 3);
-        assertIteratorContainsAll(index.findMatches(4).iterator(), 4,5);
+        assertIteratorContainsAll(index.findMatches(4).iterator(), 4, 5);
 
         HollowOrdinalIterator preUpdateIterator = index.findMatches(4).iterator();
 
@@ -116,16 +173,13 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
         roundTripDelta();
 
         // verify the ordinals we get from the index match our new expected ones.
-        assertIteratorContainsAll(index.findMatches(1).iterator(), 1,0);
+        assertIteratorContainsAll(index.findMatches(1).iterator(), 1, 0);
         Assert.assertNull("A removed entry that doesn't have any matches", index.findMatches(2));
         assertIteratorContainsAll(index.findMatches(3).iterator(), 3);
-        assertIteratorContainsAll(index.findMatches(4).iterator(), 5,6,7);
+        assertIteratorContainsAll(index.findMatches(4).iterator(), 5, 6, 7);
 
         // an iterator doesn't update itself if it was retrieved prior to an update being applied
-        assertIteratorContainsAll(preUpdateIterator, 4,5);
-
-
-
+        assertIteratorContainsAll(preUpdateIterator, 4, 5);
     }
 
     private void assertIteratorContainsAll(HollowOrdinalIterator iter, int... expectedOrdinals) {
@@ -136,7 +190,7 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
             ordinal = iter.next();
         }
 
-        for (int ord: expectedOrdinals) {
+        for (int ord : expectedOrdinals) {
             Assert.assertTrue(ordinalSet.contains(ord));
         }
         Assert.assertTrue(ordinalSet.size() == expectedOrdinals.length);
@@ -171,7 +225,35 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
         }
     }
 
-    @Override
-    protected void initializeTypeStates() { }
+    @SuppressWarnings("unused")
+    private static class TypeC {
+        private final String b1;
+        private final String b2;
 
+        public TypeC(String b1, String b2) {
+            this.b1 = b1;
+            this.b2 = b2;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeD {
+        private final Boolean b1;
+        private final String b2;
+
+        public TypeD(Boolean b1, String b2) {
+            this.b1 = b1;
+            this.b2 = b2;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeE {
+        @HollowInline
+        private final String b1;
+
+        public TypeE(String b1) {
+            this.b1 = b1;
+        }
+    }
 }


### PR DESCRIPTION
Fix for issue: #159 

Removed obsolete block:
`if(hashOrdinal == -1 && query[i] == null)
continue;`

Added prechecks to HollowObjectTypeReadStateShard.java in case of indexing objects.
Added tests (might be run without changes in order to determine the problem).