### PR TITLE
Exceptions thrown by HollowProducerListeners should be caught and logged

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
@@ -41,8 +41,8 @@ import java.util.logging.Logger;
  */
 final class ListenerSupport {
 
-    private final Logger log = Logger.getLogger(ListenerSupport.class.getName());
-
+    private static final Logger LOG = Logger.getLogger(ListenerSupport.class.getName());
+    
     private final Set<HollowProducerListener> listeners;
     private final Set<HollowValidationListener> validationListeners;
     private final Set<IncrementalCycleListener> incrementalCycleListeners;
@@ -78,7 +78,7 @@ final class ListenerSupport {
             try {
                 l.onProducerInit(elapsedMillis, MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -88,7 +88,7 @@ final class ListenerSupport {
             try {
                 l.onProducerRestoreStart(version);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -98,7 +98,7 @@ final class ListenerSupport {
             try {
                 l.onProducerRestoreComplete(status, elapsedMillis, MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -108,7 +108,7 @@ final class ListenerSupport {
             try {
                 l.onNewDeltaChain(version);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -120,7 +120,7 @@ final class ListenerSupport {
                 try {
                     ((HollowProducerListenerV2) l).onCycleSkip(reason);
                 } catch(Throwable t) {
-                    log.warning("Error executing listener" + t);
+                    LOG.warning("Error executing listener" + t);
                 }
             }
         }
@@ -133,7 +133,7 @@ final class ListenerSupport {
             try {
                 l.onCycleStart(version);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
         return psb;
@@ -145,7 +145,7 @@ final class ListenerSupport {
             try {
                 l.onCycleComplete(st, psb.elapsed(), MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -155,7 +155,7 @@ final class ListenerSupport {
             try {
                 l.onNoDeltaAvailable(psb.version());
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -166,7 +166,7 @@ final class ListenerSupport {
             try {
                 l.onPopulateStart(version);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
         return builder;
@@ -178,7 +178,7 @@ final class ListenerSupport {
             try {
                 l.onPopulateComplete(st, builder.elapsed(), MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -189,7 +189,7 @@ final class ListenerSupport {
             try {
                 l.onPublishStart(version);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
         return psb;
@@ -201,7 +201,7 @@ final class ListenerSupport {
             try {
                 l.onPublishComplete(status, builder.elapsed(), MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -212,7 +212,7 @@ final class ListenerSupport {
             try {
                 l.onArtifactPublish(status, builder.elapsed(), MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -223,7 +223,7 @@ final class ListenerSupport {
             try {
                 l.onIntegrityCheckStart(psb.version());
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
         return psb;
@@ -235,7 +235,7 @@ final class ListenerSupport {
             try {
                 l.onIntegrityCheckComplete(st, psb.elapsed(), MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -249,7 +249,7 @@ final class ListenerSupport {
                 l.onValidationStart(version);
                 firedListeners.add(l);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
 
         }
@@ -259,7 +259,7 @@ final class ListenerSupport {
                     vl.onValidationStart(version);
                 }
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
         return psb;
@@ -271,7 +271,7 @@ final class ListenerSupport {
             try {
                 l.onValidationComplete(st, psb.elapsed(), MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
         
@@ -280,7 +280,7 @@ final class ListenerSupport {
             try {
                 vl.onValidationComplete(valStatus, psb.elapsed(), MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -291,7 +291,7 @@ final class ListenerSupport {
             try {
                 l.onAnnouncementStart(psb.version());
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
         return psb;
@@ -303,7 +303,7 @@ final class ListenerSupport {
             try {
                 l.onAnnouncementComplete(st, psb.elapsed(), MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -314,7 +314,7 @@ final class ListenerSupport {
             try {
                 l.onCycleComplete(icsb.build(), icsb.elapsed(), MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }
@@ -325,7 +325,7 @@ final class ListenerSupport {
             try {
                 l.onCycleFail(icsb.build(), icsb.elapsed(), MILLISECONDS);
             } catch(Throwable t) {
-                log.warning("Error executing listener" + t);
+                LOG.warning("Error executing listener" + t);
             }
         }
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
@@ -28,10 +28,10 @@ import com.netflix.hollow.api.producer.validation.AllValidationStatus;
 import com.netflix.hollow.api.producer.validation.AllValidationStatus.AllValidationStatusBuilder;
 import com.netflix.hollow.api.producer.validation.HollowValidationListener;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.logging.Logger;
 
 /**
  * Beta API subject to change.
@@ -39,6 +39,9 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * @author Tim Taylor {@literal<tim@toolbear.io>}
  */
 final class ListenerSupport {
+
+    private final Logger log = Logger.getLogger(ListenerSupport.class.getName());
+
     private final Set<HollowProducerListener> listeners;
     private final Set<HollowValidationListener> validationListeners;
     private final Set<IncrementalCycleListener> incrementalCycleListeners;
@@ -70,26 +73,54 @@ final class ListenerSupport {
     }
 
     void fireProducerInit(long elapsedMillis) {
-        for(final HollowProducerListener l : listeners) l.onProducerInit(elapsedMillis, MILLISECONDS);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onProducerInit(elapsedMillis, MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireProducerRestoreStart failed | " + e);
+            }
+        }
     }
 
     void fireProducerRestoreStart(long version) {
-        for(final HollowProducerListener l : listeners) l.onProducerRestoreStart(version);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onProducerRestoreStart(version);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireProducerRestoreStart failed | " + e);
+            }
+        }
     }
 
     void fireProducerRestoreComplete(RestoreStatus status, long elapsedMillis) {
-        for(final HollowProducerListener l : listeners) l.onProducerRestoreComplete(status, elapsedMillis, MILLISECONDS);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onProducerRestoreComplete(status, elapsedMillis, MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireProducerRestoreComplete failed | " + e);
+            }
+        }
     }
 
     void fireNewDeltaChain(long version) {
-        for(final HollowProducerListener l : listeners) l.onNewDeltaChain(version);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onNewDeltaChain(version);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireNewDeltaChain failed | " + e);
+            }
+        }
     }
 
     ProducerStatus.Builder fireCycleSkipped(CycleSkipReason reason) {
         ProducerStatus.Builder psb = new ProducerStatus.Builder();
         for (final HollowProducerListener l : listeners) {
             if (l instanceof HollowProducerListenerV2) {
-                ((HollowProducerListenerV2) l).onCycleSkip(reason);
+                try {
+                    ((HollowProducerListenerV2) l).onCycleSkip(reason);
+                } catch(RuntimeException e) {
+                    log.warning("Execution of " + l.getClass().getName() + "  during fireCycleSkipped failed | " + e);
+                }
             }
         }
         return psb;
@@ -97,55 +128,115 @@ final class ListenerSupport {
 
     ProducerStatus.Builder fireCycleStart(long version) {
         ProducerStatus.Builder psb = new ProducerStatus.Builder().version(version);
-        for(final HollowProducerListener l : listeners) l.onCycleStart(version);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onCycleStart(version);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireCycleStart failed | " + e);
+            }
+        }
         return psb;
     }
 
     void fireCycleComplete(ProducerStatus.Builder psb) {
         ProducerStatus st = psb.build();
-        for(final HollowProducerListener l : listeners) l.onCycleComplete(st, psb.elapsed(), MILLISECONDS);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onCycleComplete(st, psb.elapsed(), MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireCycleComplete failed | " + e);
+            }
+        }
     }
 
     void fireNoDelta(ProducerStatus.Builder psb) {
-        for(final HollowProducerListener l : listeners) l.onNoDeltaAvailable(psb.version());
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onNoDeltaAvailable(psb.version());
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireNoDelta failed | " + e);
+            }
+        }
     }
 
     ProducerStatus.Builder firePopulateStart(long version) {
         ProducerStatus.Builder builder = new ProducerStatus.Builder().version(version);
-        for (final HollowProducerListener l : listeners) l.onPopulateStart(version);
+        for (final HollowProducerListener l : listeners) {
+            try {
+                l.onPopulateStart(version);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during firePopulateStart failed | " + e);
+            }
+        }
         return builder;
     }
 
     void firePopulateComplete(ProducerStatus.Builder builder) {
         ProducerStatus st = builder.build();
-        for (final HollowProducerListener l : listeners) l.onPopulateComplete(st, builder.elapsed(), MILLISECONDS);
+        for (final HollowProducerListener l : listeners) {
+            try {
+                l.onPopulateComplete(st, builder.elapsed(), MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during firePopulateComplete failed | " + e);
+            }
+        }
     }
 
     ProducerStatus.Builder firePublishStart(long version) {
         ProducerStatus.Builder psb = new ProducerStatus.Builder().version(version);
-        for(final HollowProducerListener l : listeners) l.onPublishStart(version);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onPublishStart(version);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during firePublishStart failed | " + e);
+            }
+        }
         return psb;
     }
 
     void firePublishComplete(ProducerStatus.Builder builder) {
         ProducerStatus status = builder.build();
-        for(final HollowProducerListener l : listeners) l.onPublishComplete(status, builder.elapsed(), MILLISECONDS);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onPublishComplete(status, builder.elapsed(), MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during firePublishComplete failed | " + e);
+            }
+        }
     }
 
     void fireArtifactPublish(PublishStatus.Builder builder) {
         PublishStatus status = builder.build();
-        for(final HollowProducerListener l : listeners) l.onArtifactPublish(status, builder.elapsed(), MILLISECONDS);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onArtifactPublish(status, builder.elapsed(), MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireArtifactPublish failed | " + e);
+            }
+        }
     }
 
     ProducerStatus.Builder fireIntegrityCheckStart(HollowProducer.ReadState readState) {
         ProducerStatus.Builder psb = new ProducerStatus.Builder().version(readState);
-        for(final HollowProducerListener l : listeners) l.onIntegrityCheckStart(psb.version());
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onIntegrityCheckStart(psb.version());
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireIntegrityCheckStart failed | " + e);
+            }
+        }
         return psb;
     }
 
     void fireIntegrityCheckComplete(ProducerStatus.Builder psb) {
         ProducerStatus st = psb.build();
-        for(final HollowProducerListener l : listeners) l.onIntegrityCheckComplete(st, psb.elapsed(), MILLISECONDS);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onIntegrityCheckComplete(st, psb.elapsed(), MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireIntegrityCheckComplete failed | " + e);
+            }
+        }
     }
 
     ProducerStatus.Builder fireValidationStart(HollowProducer.ReadState readState) {
@@ -153,12 +244,21 @@ final class ListenerSupport {
         long version = readState.getVersion();
         Set<Object> firedListeners = new HashSet<>();
         for (final HollowProducerListener l : listeners) {
-            l.onValidationStart(version);
-            firedListeners.add(l);
+            try {
+                l.onValidationStart(version);
+                firedListeners.add(l);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireValidationStart failed | " + e);
+            }
+
         }
         for (final HollowValidationListener vl: validationListeners){
-            if (!firedListeners.contains(vl)) {
-                vl.onValidationStart(version);
+            try {
+                if (!firedListeners.contains(vl)) {
+                    vl.onValidationStart(version);
+                }
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + vl.getClass().getName() + "  during fireValidationStart failed | " + e);
             }
         }
         return psb;
@@ -166,32 +266,67 @@ final class ListenerSupport {
 
     void fireValidationComplete(ProducerStatus.Builder psb, AllValidationStatusBuilder valStatusBuilder) {
         ProducerStatus st = psb.build();
-        for(final HollowProducerListener l : listeners) l.onValidationComplete(st, psb.elapsed(), MILLISECONDS);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onValidationComplete(st, psb.elapsed(), MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireValidationComplete failed | " + e);
+            }
+        }
         
         AllValidationStatus valStatus = valStatusBuilder.build();
-        for(final HollowValidationListener vl : validationListeners) vl.onValidationComplete(valStatus, psb.elapsed(), MILLISECONDS);
+        for(final HollowValidationListener vl : validationListeners) {
+            try {
+                vl.onValidationComplete(valStatus, psb.elapsed(), MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + vl.getClass().getName() + "  during fireValidationComplete failed | " + e);
+            }
+        }
     }
 
     ProducerStatus.Builder fireAnnouncementStart(HollowProducer.ReadState readState) {
         ProducerStatus.Builder psb = new ProducerStatus.Builder().version(readState);
-        for(final HollowProducerListener l : listeners) l.onAnnouncementStart(psb.version());
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onAnnouncementStart(psb.version());
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireAnnouncementStart failed | " + e);
+            }
+        }
         return psb;
     }
 
     void fireAnnouncementComplete(ProducerStatus.Builder psb) {
         ProducerStatus st = psb.build();
-        for(final HollowProducerListener l : listeners) l.onAnnouncementComplete(st, psb.elapsed(), MILLISECONDS);
+        for(final HollowProducerListener l : listeners) {
+            try {
+                l.onAnnouncementComplete(st, psb.elapsed(), MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireAnnouncementComplete failed | " + e);
+            }
+        }
     }
 
     void fireIncrementalCycleComplete(long version, long recordsAddedOrModified, long recordsRemoved, Map<String, Object> cycleMetadata) {
         IncrementalCycleStatus.Builder icsb = new IncrementalCycleStatus.Builder().success(version, recordsAddedOrModified, recordsRemoved, cycleMetadata);
-        for(final IncrementalCycleListener l : incrementalCycleListeners)
-            l.onCycleComplete(icsb.build(), icsb.elapsed(), MILLISECONDS);
+        for(final IncrementalCycleListener l : incrementalCycleListeners) {
+            try {
+                l.onCycleComplete(icsb.build(), icsb.elapsed(), MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireIncrementalCycleComplete failed | " + e);
+            }
+        }
     }
 
     void fireIncrementalCycleFail(Throwable cause, long recordsAddedOrModified, long recordsRemoved, Map<String, Object> cycleMetadata) {
         IncrementalCycleStatus.Builder icsb = new IncrementalCycleStatus.Builder().fail(cause, recordsAddedOrModified, recordsRemoved, cycleMetadata);
-        for(final IncrementalCycleListener l : incrementalCycleListeners)
-            l.onCycleFail(icsb.build(), icsb.elapsed(), MILLISECONDS);
+        for(final IncrementalCycleListener l : incrementalCycleListeners) {
+            try {
+                l.onCycleFail(icsb.build(), icsb.elapsed(), MILLISECONDS);
+            } catch(RuntimeException e) {
+                log.warning("Execution of " + l.getClass().getName() + "  during fireIncrementalCycleFail failed | " + e);
+            }
+        }
     }
+
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
@@ -28,8 +28,9 @@ import com.netflix.hollow.api.producer.validation.AllValidationStatus;
 import com.netflix.hollow.api.producer.validation.AllValidationStatus.AllValidationStatusBuilder;
 import com.netflix.hollow.api.producer.validation.HollowValidationListener;
 
-import java.util.*;
-import java.util.concurrent.Callable;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.logging.Logger;
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
@@ -77,8 +77,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onProducerInit(elapsedMillis, MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireProducerRestoreStart failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -87,8 +87,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onProducerRestoreStart(version);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireProducerRestoreStart failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -97,8 +97,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onProducerRestoreComplete(status, elapsedMillis, MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireProducerRestoreComplete failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -107,8 +107,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onNewDeltaChain(version);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireNewDeltaChain failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -119,8 +119,8 @@ final class ListenerSupport {
             if (l instanceof HollowProducerListenerV2) {
                 try {
                     ((HollowProducerListenerV2) l).onCycleSkip(reason);
-                } catch(RuntimeException e) {
-                    log.warning("Execution of " + l.getClass().getName() + "  during fireCycleSkipped failed | " + e);
+                } catch(Throwable t) {
+                    log.warning("Error executing listener" + t);
                 }
             }
         }
@@ -132,8 +132,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onCycleStart(version);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireCycleStart failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
         return psb;
@@ -144,8 +144,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onCycleComplete(st, psb.elapsed(), MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireCycleComplete failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -154,8 +154,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onNoDeltaAvailable(psb.version());
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireNoDelta failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -165,8 +165,8 @@ final class ListenerSupport {
         for (final HollowProducerListener l : listeners) {
             try {
                 l.onPopulateStart(version);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during firePopulateStart failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
         return builder;
@@ -177,8 +177,8 @@ final class ListenerSupport {
         for (final HollowProducerListener l : listeners) {
             try {
                 l.onPopulateComplete(st, builder.elapsed(), MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during firePopulateComplete failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -188,8 +188,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onPublishStart(version);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during firePublishStart failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
         return psb;
@@ -200,8 +200,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onPublishComplete(status, builder.elapsed(), MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during firePublishComplete failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -211,8 +211,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onArtifactPublish(status, builder.elapsed(), MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireArtifactPublish failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -222,8 +222,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onIntegrityCheckStart(psb.version());
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireIntegrityCheckStart failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
         return psb;
@@ -234,8 +234,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onIntegrityCheckComplete(st, psb.elapsed(), MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireIntegrityCheckComplete failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -248,8 +248,8 @@ final class ListenerSupport {
             try {
                 l.onValidationStart(version);
                 firedListeners.add(l);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireValidationStart failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
 
         }
@@ -258,8 +258,8 @@ final class ListenerSupport {
                 if (!firedListeners.contains(vl)) {
                     vl.onValidationStart(version);
                 }
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + vl.getClass().getName() + "  during fireValidationStart failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
         return psb;
@@ -270,8 +270,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onValidationComplete(st, psb.elapsed(), MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireValidationComplete failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
         
@@ -279,8 +279,8 @@ final class ListenerSupport {
         for(final HollowValidationListener vl : validationListeners) {
             try {
                 vl.onValidationComplete(valStatus, psb.elapsed(), MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + vl.getClass().getName() + "  during fireValidationComplete failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -290,8 +290,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onAnnouncementStart(psb.version());
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireAnnouncementStart failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
         return psb;
@@ -302,8 +302,8 @@ final class ListenerSupport {
         for(final HollowProducerListener l : listeners) {
             try {
                 l.onAnnouncementComplete(st, psb.elapsed(), MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireAnnouncementComplete failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -313,8 +313,8 @@ final class ListenerSupport {
         for(final IncrementalCycleListener l : incrementalCycleListeners) {
             try {
                 l.onCycleComplete(icsb.build(), icsb.elapsed(), MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireIncrementalCycleComplete failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }
@@ -324,8 +324,8 @@ final class ListenerSupport {
         for(final IncrementalCycleListener l : incrementalCycleListeners) {
             try {
                 l.onCycleFail(icsb.build(), icsb.elapsed(), MILLISECONDS);
-            } catch(RuntimeException e) {
-                log.warning("Execution of " + l.getClass().getName() + "  during fireIncrementalCycleFail failed | " + e);
+            } catch(Throwable t) {
+                log.warning("Error executing listener" + t);
             }
         }
     }

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/ListenerSupportTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/ListenerSupportTest.java
@@ -24,6 +24,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 public class ListenerSupportTest {
     interface ProducerAndValidationListener
             extends HollowProducerListenerV2, HollowValidationListener {
@@ -57,5 +59,98 @@ public class ListenerSupportTest {
         Mockito.verify(listener).onValidationStart(version);
         Mockito.verify(validationListener).onValidationStart(version);
         Mockito.verify(producerAndValidationListener).onValidationStart(version);
+    }
+
+    @Test
+    public void testFireValidationStartDontStopWhenOneFails() {
+        long version = 31337;
+        HollowProducer.ReadState readState = Mockito.mock(HollowProducer.ReadState.class);
+        Mockito.when(readState.getVersion()).thenReturn(version);
+        Mockito.doThrow(RuntimeException.class).when(validationListener).onValidationStart(version);
+        listenerSupport.fireValidationStart(readState);
+        Mockito.verify(listener).onValidationStart(version);
+        Mockito.verify(producerAndValidationListener).onValidationStart(version);
+    }
+
+    @Test
+    public void fireProducerInitDontStopWhenOneFails() {
+        long version = 31337;
+        HollowProducer.ReadState readState = Mockito.mock(HollowProducer.ReadState.class);
+        Mockito.when(readState.getVersion()).thenReturn(version);
+        Mockito.doThrow(RuntimeException.class).when(listener).onProducerInit(1L, MILLISECONDS);
+        listenerSupport.fireProducerInit(1L);
+        Mockito.verify(listener).onProducerInit(1L, MILLISECONDS);
+    }
+
+    @Test
+    public void fireProducerRestoreStartDontStopWhenOneFails() {
+        long version = 31337;
+        HollowProducer.ReadState readState = Mockito.mock(HollowProducer.ReadState.class);
+        Mockito.when(readState.getVersion()).thenReturn(version);
+        Mockito.doThrow(RuntimeException.class).when(listener).onProducerRestoreStart(version);
+        listenerSupport.fireProducerRestoreComplete(null, 1L);
+        Mockito.verify(listener).onProducerRestoreComplete(null, 1L, MILLISECONDS);
+    }
+
+    @Test
+    public void fireNewDeltaChainDontStopWhenOneFails() {
+        long version = 31337;
+        HollowProducer.ReadState readState = Mockito.mock(HollowProducer.ReadState.class);
+        Mockito.when(readState.getVersion()).thenReturn(version);
+        Mockito.doThrow(RuntimeException.class).when(listener).onNewDeltaChain(version);
+        listenerSupport.fireNewDeltaChain(version);
+        Mockito.verify(listener).onNewDeltaChain(version);
+
+    }
+
+    @Test
+    public void fireCycleStartDontStopWhenOneFails() {
+        long version = 31337;
+        HollowProducer.ReadState readState = Mockito.mock(HollowProducer.ReadState.class);
+        Mockito.when(readState.getVersion()).thenReturn(version);
+        Mockito.doThrow(RuntimeException.class).when(listener).onCycleStart(version);
+        listenerSupport.fireCycleStart(version);
+        Mockito.verify(listener).onCycleStart(version);
+    }
+
+    @Test
+    public void firePopulateStartDontStopWhenOneFails() {
+        long version = 31337;
+        HollowProducer.ReadState readState = Mockito.mock(HollowProducer.ReadState.class);
+        Mockito.when(readState.getVersion()).thenReturn(version);
+        Mockito.doThrow(RuntimeException.class).when(listener).onPopulateStart(version);
+        listenerSupport.firePopulateStart(version);
+        Mockito.verify(listener).onPopulateStart(version);
+    }
+
+    @Test
+    public void firePublishStartDontStopWhenOneFails() {
+        long version = 31337;
+        HollowProducer.ReadState readState = Mockito.mock(HollowProducer.ReadState.class);
+        Mockito.when(readState.getVersion()).thenReturn(version);
+        Mockito.doThrow(RuntimeException.class).when(listener).onPublishStart(version);
+        listenerSupport.firePublishStart(version);
+        Mockito.verify(listener).onPublishStart(version);
+    }
+
+    @Test
+    public void fireIntegrityCheckStartDontStopWhenOneFails() {
+        long version = 31337;
+        HollowProducer.ReadState readState = Mockito.mock(HollowProducer.ReadState.class);
+        Mockito.when(readState.getVersion()).thenReturn(version);
+        Mockito.doThrow(RuntimeException.class).when(listener).onIntegrityCheckStart(version);
+        listenerSupport.fireIntegrityCheckStart(readState);
+        Mockito.verify(listener).onIntegrityCheckStart(version);
+    }
+
+
+    @Test
+    public void fireAnnouncementStartDontStopWhenOneFails() {
+        long version = 31337;
+        HollowProducer.ReadState readState = Mockito.mock(HollowProducer.ReadState.class);
+        Mockito.when(readState.getVersion()).thenReturn(version);
+        Mockito.doThrow(RuntimeException.class).when(listener).onAnnouncementStart(version);
+        listenerSupport.fireAnnouncementStart(readState);
+        Mockito.verify(listener).onAnnouncementStart(version);
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/ListenerSupportTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/ListenerSupportTest.java
@@ -17,14 +17,14 @@
  */
 package com.netflix.hollow.api.producer;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import com.netflix.hollow.api.producer.validation.HollowValidationListener;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class ListenerSupportTest {
     interface ProducerAndValidationListener


### PR DESCRIPTION
This is a simple implementation for https://github.com/Netflix/hollow/issues/209

I think it could be better with Java 8+ and functions... at least to abstract the error handling logic.

thoughts @toolbear @akhaku 