### PR TITLE
Throw useful exception in primary key init if no type

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowUniqueKeyIndexGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowUniqueKeyIndexGenerator.java
@@ -88,7 +88,7 @@ public class HollowUniqueKeyIndexGenerator extends HollowIndexGenerator {
         builder.append("    }\n\n");
 
         builder.append("    public " + className + "(HollowConsumer consumer, boolean isListenToDataRefresh) {\n");
-        builder.append("        this(consumer, isListenToDataRefresh, ((HollowObjectSchema)consumer.getStateEngine().getSchema(\"" + type + "\")).getPrimaryKey().getFieldPaths());\n");
+        builder.append("        this(consumer, isListenToDataRefresh, ((HollowObjectSchema)consumer.getStateEngine().getNonNullSchema(\"" + type + "\")).getPrimaryKey().getFieldPaths());\n");
         builder.append("    }\n\n");
 
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/error/SchemaNotFoundException.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/error/SchemaNotFoundException.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.error;
+
+import java.util.Collection;
+
+/**
+ * An exception thrown when trying to use a schema that does not exist.
+ */
+public class SchemaNotFoundException extends HollowException {
+    private final String typeName;
+    private final Collection<String> availableTypes;
+
+    public SchemaNotFoundException(String typeName, Collection<String> availableTypes) {
+        super("Could not find schema for " + typeName + " - available schemas: " + availableTypes);
+        this.typeName = typeName;
+        this.availableTypes = availableTypes;
+    }
+
+    public String getTypeName() {
+        return this.typeName;
+    }
+
+    public Collection<String> getAvailableTypes() {
+        return this.availableTypes;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/HollowDataset.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowDataset.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.core;
 
+import com.netflix.hollow.api.error.SchemaNotFoundException;
 import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
 import com.netflix.hollow.core.schema.HollowSchema;
 import java.util.List;
@@ -38,5 +39,10 @@ public interface HollowDataset {
      * @return the schema for the specified type in this dataset.
      */
     HollowSchema getSchema(String typeName);
+
+    /**
+     * Like {@link #getSchema}, but throws a {@link SchemaNotFoundException} if the schema is not found.
+     */
+    HollowSchema getNonNullSchema(String typeName) throws SchemaNotFoundException;
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.core;
 
+import com.netflix.hollow.api.error.SchemaNotFoundException;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
@@ -41,11 +42,14 @@ public interface HollowStateEngine extends HollowDataset {
 
     @Override
     List<HollowSchema> getSchemas();
-    
+
     @Override
     HollowSchema getSchema(String typeName);
-    
+
+    @Override
+    HollowSchema getNonNullSchema(String typeName) throws SchemaNotFoundException;
+
     Map<String, String> getHeaderTags();
-    
+
     String getHeaderTag(String name);
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/dataaccess/disabled/HollowDisabledDataAccess.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/dataaccess/disabled/HollowDisabledDataAccess.java
@@ -74,6 +74,11 @@ public class HollowDisabledDataAccess implements HollowDataAccess {
     }
 
     @Override
+    public HollowSchema getNonNullSchema(String name) {
+        throw new IllegalStateException("Data Access is Disabled");
+    }
+
+    @Override
     public void resetSampling() { }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/read/dataaccess/proxy/HollowProxyDataAccess.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/dataaccess/proxy/HollowProxyDataAccess.java
@@ -132,6 +132,11 @@ public class HollowProxyDataAccess implements HollowDataAccess {
     }
 
     @Override
+    public HollowSchema getNonNullSchema(String name) {
+        return currentDataAccess.getNonNullSchema(name);
+    }
+
+    @Override
     public void resetSampling() {
         currentDataAccess.resetSampling();
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.core.read.engine;
 
+import com.netflix.hollow.api.error.SchemaNotFoundException;
 import com.netflix.hollow.core.HollowStateEngine;
 import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.core.memory.pool.RecyclingRecycler;
@@ -198,6 +199,15 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
     public HollowSchema getSchema(String type) {
         HollowTypeReadState typeState = getTypeState(type);
         return typeState == null ? null : typeState.getSchema();
+    }
+
+    @Override
+    public HollowSchema getNonNullSchema(String type) {
+        HollowSchema schema = getSchema(type);
+        if (schema == null) {
+            throw new SchemaNotFoundException(type, getAllTypes());
+        }
+        return schema;
     }
 
     protected void afterInitialization() { }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.hollow.core.write;
 
+import com.netflix.hollow.api.error.SchemaNotFoundException;
 import com.netflix.hollow.core.HollowStateEngine;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
@@ -327,6 +328,19 @@ public class HollowWriteStateEngine implements HollowStateEngine {
     @Override
     public HollowSchema getSchema(String schemaName) {
         return hollowSchemas.get(schemaName);
+    }
+
+    @Override
+    public HollowSchema getNonNullSchema(String schemaName) {
+        HollowSchema schema = getSchema(schemaName);
+        if (schema == null) {
+            List<String> schemas = new ArrayList<>();
+            for (HollowSchema s : getSchemas()) {
+                schemas.add(s.getName());
+            }
+            throw new SchemaNotFoundException(schemaName, schemas);
+        }
+        return schema;
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistoricalStateDataAccess.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistoricalStateDataAccess.java
@@ -18,6 +18,7 @@
 package com.netflix.hollow.tools.history;
 
 import com.netflix.hollow.api.client.StackTraceRecorder;
+import com.netflix.hollow.api.error.SchemaNotFoundException;
 import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
 import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
@@ -206,4 +207,12 @@ public class HollowHistoricalStateDataAccess implements HollowDataAccess {
         return getTypeDataAccess(name).getSchema();
     }
 
+    @Override
+    public HollowSchema getNonNullSchema(String name) {
+        HollowSchema schema = getSchema(name);
+        if (schema == null) {
+            throw new SchemaNotFoundException(name, getAllTypes());
+        }
+        return schema;
+    }
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowPrimaryKeyAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowPrimaryKeyAPIGeneratorTest.java
@@ -16,7 +16,6 @@
 package com.netflix.hollow.api.codegen;
 
 import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
-import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,7 +23,7 @@ public class HollowPrimaryKeyAPIGeneratorTest extends AbstractHollowAPIGenerator
 
     @Override
     @Before
-    public void setup() throws IOException {
+    public void setup() {
     }
 
     @Override


### PR DESCRIPTION
Instead of failing with an NPE, throw a descriptive
exception when constructing a primary key for a missing
type.
Note that if you call ReadStateEngine.getSchema(typeName)
yourself, you will continue to get back null. This new
exception is only thrown when creating a unique key, in
order to have callers not have to catch a
NullPointerException.