### PR TITLE
ArrayOutOfBoundException: -1 when searching by Hash Index (#159)

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -160,10 +160,9 @@ public class HollowHashIndex implements HollowTypeStateListener {
 
                 HollowObjectTypeReadState objectAccess = (HollowObjectTypeReadState)readState;
                 int fieldIdx = fieldPath[fieldPath.length-1];
-                if(hashOrdinal == -1 && query[i] == null)
-                    continue;
-                if(!HollowReadFieldUtils.fieldValueEquals(objectAccess, hashOrdinal, fieldIdx, query[i]))
+                if(hashOrdinal == -1 || !HollowReadFieldUtils.fieldValueEquals(objectAccess, hashOrdinal, fieldIdx, query[i])) {
                     return false;
+                }
             }
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -91,7 +91,6 @@ public class HollowHashIndex implements HollowTypeStateListener {
             hashCode ^= HashCodes.hashInt(keyHashCode(query[i], i));
         }
 
-        //System.out.println("QUERY HASH: " + hashCode);
         HollowHashIndexResult result;
         do {
             result = null;
@@ -109,7 +108,7 @@ public class HollowHashIndex implements HollowTypeStateListener {
                 }
 
                 bucket = (bucket + 1) & hashState.getMatchHashMask();
-                hashBucketBit = (long) bucket * hashState.getBitsPerMatchHashEntry();
+                hashBucketBit = bucket * hashState.getBitsPerMatchHashEntry();
                 bucketIsEmpty = hashState.getMatchHashTable().getElementValue(hashBucketBit, hashState.getBitsPerTraverserField()[0]) == 0;
             }
         } while (hashState != hashStateVolatile);
@@ -122,15 +121,15 @@ public class HollowHashIndex implements HollowTypeStateListener {
         case BOOLEAN:
             return HollowReadFieldUtils.booleanHashCode((Boolean)key);
         case DOUBLE:
-            return HollowReadFieldUtils.doubleHashCode(((Double)key).doubleValue());
+            return HollowReadFieldUtils.doubleHashCode((Double) key);
         case FLOAT:
-            return HollowReadFieldUtils.floatHashCode(((Float)key).floatValue());
+            return HollowReadFieldUtils.floatHashCode((Float) key);
         case INT:
-            return HollowReadFieldUtils.intHashCode(((Integer)key).intValue());
+            return HollowReadFieldUtils.intHashCode((Integer) key);
         case LONG:
-            return HollowReadFieldUtils.longHashCode(((Long)key).longValue());
+            return HollowReadFieldUtils.longHashCode((Long) key);
         case REFERENCE:
-            return ((Integer)key).intValue();
+            return (Integer) key;
         case BYTES:
             return HashCodes.hashCode((byte[])key);
         case STRING:
@@ -146,10 +145,10 @@ public class HollowHashIndex implements HollowTypeStateListener {
             int hashOrdinal = (int)matchHashTable.getElementValue(hashBucketBit + hashState.getOffsetPerTraverserField()[field.getBaseIteratorFieldIdx()], hashState.getBitsPerTraverserField()[field.getBaseIteratorFieldIdx()]) - 1;
 
             HollowTypeReadState readState = field.getBaseDataAccess();
-            int fieldPath[] = field.getSchemaFieldPositionPath();
+            int[] fieldPath = field.getSchemaFieldPositionPath();
 
             if(fieldPath.length == 0) {
-                if(hashOrdinal != ((Integer)query[i]).intValue())
+                if(hashOrdinal != (Integer) query[i])
                     return false;
             } else {
                 for(int j=0;j<fieldPath.length - 1;j++) {

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -148,7 +148,7 @@ public class HollowHashIndex implements HollowTypeStateListener {
             int[] fieldPath = field.getSchemaFieldPositionPath();
 
             if(fieldPath.length == 0) {
-                if (query[i].equals(hashOrdinal))
+                if (!query[i].equals(hashOrdinal))
                     return false;
             } else {
                 for(int j=0;j<fieldPath.length - 1;j++) {

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -148,7 +148,7 @@ public class HollowHashIndex implements HollowTypeStateListener {
             int[] fieldPath = field.getSchemaFieldPositionPath();
 
             if(fieldPath.length == 0) {
-                if(hashOrdinal != (Integer) query[i])
+                if (query[i].equals(hashOrdinal))
                     return false;
             } else {
                 for(int j=0;j<fieldPath.length - 1;j++) {

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexBuilder.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexBuilder.java
@@ -367,13 +367,17 @@ public class HollowHashIndexBuilder {
                 if(matchOrdinal != hashOrdinal) {
                     HollowObjectTypeReadState objectAccess = (HollowObjectTypeReadState)readState;
                     int fieldIdx = fieldPath[fieldPath.length-1];
-                    if(!HollowReadFieldUtils.fieldsAreEqual(objectAccess, matchOrdinal, fieldIdx, objectAccess, hashOrdinal, fieldIdx))
+                    if(isAnyFieldNull(matchOrdinal, hashOrdinal) || !HollowReadFieldUtils.fieldsAreEqual(objectAccess, matchOrdinal, fieldIdx, objectAccess, hashOrdinal, fieldIdx))
                         return false;
                 }
             }
         }
 
         return true;
+    }
+
+    private boolean isAnyFieldNull(int matchOrdinal, int hashOrdinal) {
+        return matchOrdinal == -1 || hashOrdinal == -1;
     }
 
     private int getMatchHash(int matchIdx) {

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexBuilder.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexBuilder.java
@@ -69,7 +69,7 @@ public class HollowHashIndexBuilder {
         this.preindexer = new HollowPreindexer(stateEngine, type, selectField, matchFields);
         preindexer.buildFieldSpecifications();
 
-        this.memoryRecycler = WastefulRecycler.DEFAULT_INSTANCE; //stateEngine.getMemoryRecycler();
+        this.memoryRecycler = WastefulRecycler.DEFAULT_INSTANCE;
 
         HollowIndexerValueTraverser traverser = preindexer.getTraverser();
 
@@ -119,9 +119,6 @@ public class HollowHashIndexBuilder {
 
             for(int i=0;i<traverser.getNumMatches();i++) {
                 int matchHash = getMatchHash(i);
-
-                //if((ordinal & 4095) == 0)
-                //    System.out.println("ORDINAL: " + ordinal + " HASH: " + matchHash);
 
                 long bucket = matchHash & intermediateMatchHashMask;
                 long hashBucketBit = bucket * bitsPerIntermediateMatchHashEntry;
@@ -267,7 +264,7 @@ public class HollowHashIndexBuilder {
 
             while(!rehashBucketIsEmpty) {
                 rehashBucket = (rehashBucket + 1) & newMatchHashMask;
-                rehashBucketBit = (long)rehashBucket * newBitsPerMatchHashEntry;
+                rehashBucketBit = rehashBucket * newBitsPerMatchHashEntry;
                 rehashBucketIsEmpty = newMatchHashTable.getElementValue(rehashBucketBit, bitsPerTraverserField[0]) == 0;
             }
 
@@ -351,7 +348,7 @@ public class HollowHashIndexBuilder {
             int hashOrdinal = (int)intermediateMatchHashTable.getElementValue(hashBucketBit + offsetPerTraverserField[field.getBaseIteratorFieldIdx()], bitsPerTraverserField[field.getBaseIteratorFieldIdx()]) - 1;
 
             HollowTypeReadState readState = field.getBaseDataAccess();
-            int fieldPath[] = field.getSchemaFieldPositionPath();
+            int[] fieldPath = field.getSchemaFieldPositionPath();
 
             if(fieldPath.length == 0) {
                 if(matchOrdinal != hashOrdinal)
@@ -387,7 +384,7 @@ public class HollowHashIndexBuilder {
             HollowHashIndexField field = preindexer.getMatchFieldSpecs()[i];
             int ordinal = preindexer.getTraverser().getMatchOrdinal(matchIdx, field.getBaseIteratorFieldIdx());
             HollowTypeReadState readState = field.getBaseDataAccess();
-            int fieldPath[] = field.getSchemaFieldPositionPath();
+            int[] fieldPath = field.getSchemaFieldPositionPath();
 
             if(fieldPath.length == 0) {
                 matchHash ^= HashCodes.hashInt(ordinal);

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
@@ -19,6 +19,7 @@ package com.netflix.hollow.core.index;
 
 import com.netflix.hollow.core.AbstractStateEngineTest;
 import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+import com.netflix.hollow.core.write.objectmapper.HollowInline;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -29,11 +30,15 @@ import org.junit.Test;
 
 
 public class HollowHashIndexTest extends AbstractStateEngineTest {
+    private HollowObjectMapper mapper;
+
+    @Override
+    protected void initializeTypeStates() {
+        mapper = new HollowObjectMapper(writeStateEngine);
+    }
 
     @Test
     public void testBasicHashIndexFunctionality() throws Exception {
-        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
-
         mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
         mapper.add(new TypeA(1, 1.1d, new TypeB("1")));
         mapper.add(new TypeA(2, 2.2d, new TypeB("two"), new TypeB("twenty"), new TypeB("two hundred")));
@@ -43,7 +48,7 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
 
         roundTripSnapshot();
 
-        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "a1", new String[] {"a1", "ab.element.b1.value"});
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "a1", new String[]{"a1", "ab.element.b1.value"});
 
         Assert.assertNull("An entry that doesn't have any matches has a null iterator", index.findMatches(0, "notfound"));
         assertIteratorContainsAll(index.findMatches(1, "one").iterator(), 0);
@@ -54,42 +59,156 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
         assertIteratorContainsAll(index.findMatches(3, "three").iterator(), 3);
         assertIteratorContainsAll(index.findMatches(3, "thirty").iterator(), 3);
         assertIteratorContainsAll(index.findMatches(3, "three hundred").iterator(), 3);
-        assertIteratorContainsAll(index.findMatches(4, "four").iterator(), 4,5);
+        assertIteratorContainsAll(index.findMatches(4, "four").iterator(), 4, 5);
         assertIteratorContainsAll(index.findMatches(4, "forty").iterator(), 5);
-        
+
     }
 
     @Test
-    public void testIndexingNullFieldValues() throws Exception {
-        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
-
-        mapper.add(new TypeB("one"));
+    public void testIndexingStringTypeFieldWithNullValues() throws Exception {
         mapper.add(new TypeB(null));
+        mapper.add(new TypeB("onez:"));
 
         roundTripSnapshot();
-
         HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeB", "", "b1.value");
 
-        assertIteratorContainsAll(index.findMatches("one").iterator(), 0);
+        Assert.assertNull(index.findMatches("one:"));
+        assertIteratorContainsAll(index.findMatches("onez:").iterator(), 1);
+    }
 
-        try {
-            index.findMatches(new Object[] { null });
-            Assert.fail("exception expected");
-        } catch(IllegalArgumentException ex) {
-            Assert.assertEquals("querying by null unsupported; i=0", ex.getMessage());
-        }
+    @Test
+    public void testIndexingBytesTypeFieldWithNullValues() throws Exception {
+        byte[] bytes = {-120,0,0,0};
+        mapper.add(new TypeBytes(null));
+        mapper.add(new TypeBytes(bytes));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeBytes", "", "data");
+
+        byte[] nonExistingBytes = {1};
+        Assert.assertNull(index.findMatches(nonExistingBytes));
+        assertIteratorContainsAll(index.findMatches(bytes).iterator(), 1);
+    }
+
+    @Test
+    public void testIndexingStringTypeFieldsWithNullValues() throws Exception {
+        mapper.add(new TypeTwoStrings(null, "onez:"));
+        mapper.add(new TypeTwoStrings("onez:", "onez:"));
+        mapper.add(new TypeTwoStrings(null, null));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeTwoStrings", "", "b1.value", "b2.value");
+
+        Assert.assertNull(index.findMatches("one"));
+        Assert.assertNull(index.findMatches("one", "onez:"));
+        assertIteratorContainsAll(index.findMatches("onez:", "onez:").iterator(), 1);
+    }
+
+    @Test
+    public void testIndexingStringTypeFieldsWithNullValuesInDifferentOrder() throws Exception {
+        mapper.add(new TypeTwoStrings(null, null));
+        mapper.add(new TypeTwoStrings(null, "onez:"));
+        mapper.add(new TypeTwoStrings("onez:", "onez:"));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeTwoStrings", "", "b1.value", "b2.value");
+
+        Assert.assertNull(index.findMatches("one"));
+        Assert.assertNull(index.findMatches("one", "onez:"));
+        assertIteratorContainsAll(index.findMatches("onez:", "onez:").iterator(), 2);
+    }
+
+    @Test
+    public void testIndexingBooleanTypeFieldWithNullValues() throws Exception {
+        mapper.add(new TypeBoolean(null));
+        mapper.add(new TypeBoolean(true));
+        mapper.add(new TypeBoolean(false));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeBoolean", "", "data.value");
+
+        assertIteratorContainsAll(index.findMatches(Boolean.FALSE).iterator(), 2);
+        assertIteratorContainsAll(index.findMatches(Boolean.TRUE).iterator(), 1);
+    }
+
+    @Test
+    public void testIndexingInlinedStringTypeFieldWithNullValues() throws Exception {
+        mapper.add(new TypeInlinedString(null));
+        mapper.add(new TypeInlinedString("onez:"));
+        mapper.add(new TypeInlinedString(null));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeInlinedString", "", "data");
+
+        Assert.assertNull(index.findMatches("one:"));
+        assertIteratorContainsAll(index.findMatches("onez:").iterator(), 1);
+    }
+
+    @Test
+    public void testIndexingLongTypeFieldWithNullValues() throws Exception {
+        mapper.add(new TypeLong(null));
+        mapper.add(new TypeLong(3L));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeLong", "", "data.value");
+
+        Assert.assertNull(index.findMatches(2L));
+        assertIteratorContainsAll(index.findMatches(3L).iterator(), 1);
+    }
+
+    @Test
+    public void testIndexingDoubleTypeFieldWithNullValues() throws Exception {
+        mapper.add(new TypeDouble(null));
+        mapper.add(new TypeDouble(-8.0));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeDouble", "", "data.value");
+
+        Assert.assertNull(index.findMatches(2.0));
+        assertIteratorContainsAll(index.findMatches(-8.0).iterator(), 1);
+    }
+
+    @Test
+    public void testIndexingIntegerTypeFieldWithNullValues() throws Exception {
+        mapper.add(new TypeInteger(null));
+        mapper.add(new TypeInteger(-1));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeInteger", "", "data.value");
+
+        Assert.assertNull(index.findMatches(2));
+        assertIteratorContainsAll(index.findMatches(-1).iterator(), 1);
+    }
+
+    @Test
+    public void testIndexingFloatTypeFieldWithNullValues() throws Exception {
+        mapper.add(new TypeFloat(null));
+        mapper.add(new TypeFloat(-1.0f));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeFloat", "", "data.value");
+
+        Assert.assertNull(index.findMatches(2.0f));
+        assertIteratorContainsAll(index.findMatches(-1.0f).iterator(), 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFindingMatchForNullQueryValue() throws Exception {
+        mapper.add(new TypeB("one:"));
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeB", "", "b1.value");
+        index.findMatches(new Object[]{null});
+        Assert.fail("exception expected");
     }
 
     @Test
     public void testUpdateListener() throws Exception {
-        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
-
         mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
         mapper.add(new TypeA(1, 1.1d, new TypeB("1")));
         mapper.add(new TypeA(2, 2.2d, new TypeB("two"), new TypeB("twenty"), new TypeB("two hundred")));
         mapper.add(new TypeA(3, 3.3d, new TypeB("three"), new TypeB("thirty"), new TypeB("three hundred")));
         mapper.add(new TypeA(4, 4.4d, new TypeB("four")));
-        mapper.add(new TypeA(4, 4.5d, new TypeB("four"), new TypeB("forty")));        
+        mapper.add(new TypeA(4, 4.5d, new TypeB("four"), new TypeB("forty")));
 
         roundTripSnapshot();
 
@@ -98,10 +217,10 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
 
         // spot check initial mapper state
         Assert.assertNull("An entry that doesn't have any matches has a null iterator", index.findMatches(0));
-        assertIteratorContainsAll(index.findMatches(1).iterator(), 1,0);
+        assertIteratorContainsAll(index.findMatches(1).iterator(), 1, 0);
         assertIteratorContainsAll(index.findMatches(2).iterator(), 2);
         assertIteratorContainsAll(index.findMatches(3).iterator(), 3);
-        assertIteratorContainsAll(index.findMatches(4).iterator(), 4,5);
+        assertIteratorContainsAll(index.findMatches(4).iterator(), 4, 5);
 
         HollowOrdinalIterator preUpdateIterator = index.findMatches(4).iterator();
 
@@ -116,16 +235,13 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
         roundTripDelta();
 
         // verify the ordinals we get from the index match our new expected ones.
-        assertIteratorContainsAll(index.findMatches(1).iterator(), 1,0);
+        assertIteratorContainsAll(index.findMatches(1).iterator(), 1, 0);
         Assert.assertNull("A removed entry that doesn't have any matches", index.findMatches(2));
         assertIteratorContainsAll(index.findMatches(3).iterator(), 3);
-        assertIteratorContainsAll(index.findMatches(4).iterator(), 5,6,7);
+        assertIteratorContainsAll(index.findMatches(4).iterator(), 5, 6, 7);
 
         // an iterator doesn't update itself if it was retrieved prior to an update being applied
-        assertIteratorContainsAll(preUpdateIterator, 4,5);
-
-
-
+        assertIteratorContainsAll(preUpdateIterator, 4, 5);
     }
 
     private void assertIteratorContainsAll(HollowOrdinalIterator iter, int... expectedOrdinals) {
@@ -136,7 +252,7 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
             ordinal = iter.next();
         }
 
-        for (int ord: expectedOrdinals) {
+        for (int ord : expectedOrdinals) {
             Assert.assertTrue(ordinalSet.contains(ord));
         }
         Assert.assertTrue(ordinalSet.size() == expectedOrdinals.length);
@@ -171,7 +287,78 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
         }
     }
 
-    @Override
-    protected void initializeTypeStates() { }
+    @SuppressWarnings("unused")
+    private static class TypeTwoStrings {
+        private final String b1;
+        private final String b2;
 
+        public TypeTwoStrings(String b1, String b2) {
+            this.b1 = b1;
+            this.b2 = b2;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeBoolean {
+        private final Boolean data;
+
+        public TypeBoolean(Boolean data) {
+            this.data = data;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeInlinedString {
+        @HollowInline
+        private final String data;
+
+        public TypeInlinedString(String data) {
+            this.data = data;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeLong {
+        private final Long data;
+
+        public TypeLong(Long data) {
+            this.data = data;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeDouble {
+        private final Double data;
+
+        public TypeDouble(Double data) {
+            this.data = data;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeInteger {
+        private final Integer data;
+
+        public TypeInteger(Integer data) {
+            this.data = data;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeFloat {
+        private final Float data;
+
+        public TypeFloat(Float data) {
+            this.data = data;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TypeBytes {
+        private final byte[] data;
+
+        public TypeBytes(byte[] data) {
+            this.data = data;
+        }
+    }
 }


### PR DESCRIPTION
Add tests with evidence of the issue, add relevant fixes, propose refactoring (in separate commit).

PR created in favor of https://github.com/Netflix/hollow/pull/206
Instead of making changes in HollowObjectTypeReadStateShard moved prechecks to HollowHashIndexBuilder and HollowHashIndex.

I've found many places, which are using magic -1 value :)
Here is the small list:
- com/netflix/hollow/tools/diff/count/HollowDiffObjectCountingNode.java:128
- com/netflix/hollow/tools/diff/count/HollowDiffObjectCountingNode.java:175
- com/netflix/hollow/tools/diff/exact/mapper/DiffEqualityObjectMapper.java:101
- com.netflix.hollow.diffview.HollowObjectDiffViewGenerator#fromOrdinal
- com/netflix/hollow/diffview/effigy/HollowEffigyFactory.java:47
- ...
So this PR should fit the philosophy.