### PR TITLE
Added support of compact Strings.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -290,6 +290,8 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
                 fieldType = MappedFieldType.FLOAT;
             } else if(type == double.class) {
                 fieldType = MappedFieldType.DOUBLE;
+            } else if (type == byte[].class && clazz == String.class) {
+                fieldType = MappedFieldType.STRING;
             } else if(type == byte[].class) {
                 fieldType = MappedFieldType.BYTES;
             } else if(type == char[].class) {
@@ -399,7 +401,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
                 case STRING:
                     fieldObject = unsafe.getObject(obj, fieldOffset);
                     if(fieldObject != null)
-                        rec.setString(fieldName, new String((char[])fieldObject));
+                        rec.setString(fieldName, getStringFromField(fieldObject));
                     break;
                 case BYTES:
                     fieldObject = unsafe.getObject(obj, fieldOffset);
@@ -469,7 +471,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
                     break;
             }
         }
-        
+
         public Object retrieveFieldValue(Object obj, int[] fieldPathIdx, int idx) {
             Object fieldObject;
 
@@ -508,7 +510,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
                 return Float.valueOf(f);
             case STRING:
                 fieldObject = unsafe.getObject(obj, fieldOffset);
-                return fieldObject == null ? null : new String((char[])fieldObject);
+                return fieldObject == null ? null : getStringFromField(fieldObject);
             case BYTES:
                 fieldObject = unsafe.getObject(obj, fieldOffset);
                 return fieldObject == null ? null : (byte[])fieldObject;
@@ -538,6 +540,14 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             default:
                 throw new IllegalArgumentException("Cannot extract POJO primary key from a " + fieldType + " mapped field type");
             }
+        }
+
+        private String getStringFromField(Object fieldObject) {
+            if (fieldObject instanceof char[])
+                return new String((char[]) fieldObject);
+            if (fieldObject instanceof byte[])
+                return new String((byte[]) fieldObject);
+            throw new IllegalArgumentException("Expected char[] or byte[] value container for STRING.");
         }
     }
     


### PR DESCRIPTION
Java 9 brought the concept of compact Strings that was originally introduced by Java 6 (-XX:+UseCompressedStrings). From Java 9 byte array is used internally in String to store the value by default.

We are migrating our project to Java 9 and found only this issue for now. Solution supports both possible types char[] and byte[] as a storage for String value. So there will not be any issues with backward compatibility.