### PR TITLE
Fix JDK8 support in subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,10 @@ subprojects {
   apply plugin: 'nebula.netflixoss'
   apply plugin: 'checkstyle'
 
-  sourceCompatibility = 1.8
-  targetCompatibility = 1.8
+  tasks.withType(JavaCompile) {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+  }
 
   group = 'com.netflix.hollow'
   checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ subprojects {
   apply plugin: 'checkstyle'
 
   tasks.withType(JavaCompile) {
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
   }
 
   group = 'com.netflix.hollow'


### PR DESCRIPTION
Looks like https://github.com/Netflix/hollow/blob/master/hollow/build.gradle#L1 overrides the `sourceCompatibility` from 1.8 to 1.7.

