### PR TITLE
Protecting against NPE when getStateEngine() is called

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -185,7 +185,10 @@ public class HollowClientUpdater {
     }
 
     public HollowReadStateEngine getStateEngine() {
-        return hollowDataHolder.getStateEngine();
+        if(hollowDataHolder != null) {
+            return hollowDataHolder.getStateEngine();
+        }
+        return null;
     }
 
     public HollowAPI getAPI() {


### PR DESCRIPTION
Returning null instead of NPE when calling getStateEngine()