### PR TITLE
Preserve encoding for compact Strings

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -401,7 +401,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
                 case STRING:
                     fieldObject = unsafe.getObject(obj, fieldOffset);
                     if(fieldObject != null)
-                        rec.setString(fieldName, getStringFromField(fieldObject));
+                        rec.setString(fieldName, getStringFromField(obj, fieldObject));
                     break;
                 case BYTES:
                     fieldObject = unsafe.getObject(obj, fieldOffset);
@@ -510,7 +510,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
                 return Float.valueOf(f);
             case STRING:
                 fieldObject = unsafe.getObject(obj, fieldOffset);
-                return fieldObject == null ? null : getStringFromField(fieldObject);
+                return fieldObject == null ? null : getStringFromField(obj, fieldObject);
             case BYTES:
                 fieldObject = unsafe.getObject(obj, fieldOffset);
                 return fieldObject == null ? null : (byte[])fieldObject;
@@ -542,12 +542,13 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             }
         }
 
-        private String getStringFromField(Object fieldObject) {
-            if (fieldObject instanceof char[])
+        private String getStringFromField(Object obj, Object fieldObject) {
+            if (obj instanceof String) {
+                return (String) obj;
+            } else if (fieldObject instanceof char[]) {
                 return new String((char[]) fieldObject);
-            if (fieldObject instanceof byte[])
-                return new String((byte[]) fieldObject);
-            throw new IllegalArgumentException("Expected char[] or byte[] value container for STRING.");
+            }
+            throw new IllegalArgumentException("Expected char[] or String value container for STRING.");
         }
     }
     

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapperCompressedStringTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapperCompressedStringTest.java
@@ -1,0 +1,76 @@
+package com.netflix.hollow.core.write.objectmapper;
+
+import static org.junit.Assert.assertEquals;
+
+import com.netflix.hollow.core.AbstractStateEngineTest;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Checks String encoding handling in presence of JDK9 compressed String feature
+ */
+public class HollowObjectTypeMapperCompressedStringTest extends AbstractStateEngineTest {
+
+    @Test
+    public void referencedStringUtfHandling() throws IOException {
+        final String stringValue = "龍爭虎鬥";// "Enter The Dragon"
+
+        String readValue = roundTripReferenceStringValue(stringValue);
+        assertEquals(stringValue, readValue);
+    }
+
+    @Test
+    public void referenceStringLatin1Handling() throws IOException {
+        final String stringValue = "abc";
+        String readValue = roundTripReferenceStringValue(stringValue);
+        assertEquals(stringValue, readValue);
+    }
+
+    @Test
+    public void inlinedStringUtfHandling() throws IOException {
+        final String stringValue = "龍爭虎鬥";// "Enter The Dragon"
+
+        String readValue = roundTripInlinedStringValue(stringValue);
+        assertEquals(stringValue, readValue);
+    }
+
+    @Test
+    public void inlinedStringLatin1Handling() throws IOException {
+        final String stringValue = "abc";
+        String readValue = roundTripInlinedStringValue(stringValue);
+        assertEquals(stringValue, readValue);
+    }
+
+    private String roundTripReferenceStringValue(String value) throws IOException {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+
+        mapper.add(new TypeA(value, 1, null, null));
+
+        roundTripSnapshot();
+
+        HollowObjectTypeDataAccess typeDataAccess = (HollowObjectTypeDataAccess) readStateEngine.getTypeDataAccess("TypeA");
+        int stringFieldIndex = typeDataAccess.getSchema().getPosition("a1");
+        int stringValueOrdinal = typeDataAccess.readOrdinal(0, stringFieldIndex);
+
+        HollowObjectTypeDataAccess stringDataAccess = (HollowObjectTypeDataAccess) readStateEngine.getTypeDataAccess("String");
+        int stringValueField = stringDataAccess.getSchema().getPosition("value");
+        return stringDataAccess.readString(stringValueOrdinal, stringValueField);
+    }
+
+    private String roundTripInlinedStringValue(String value) throws IOException {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+
+        mapper.add(new TypeD(value));
+
+        roundTripSnapshot();
+
+        HollowObjectTypeDataAccess typeDataAccess = (HollowObjectTypeDataAccess) readStateEngine.getTypeDataAccess("TypeD");
+        int stringFieldIndex = typeDataAccess.getSchema().getPosition("inlinedString");
+        return typeDataAccess.readString(0, stringFieldIndex);
+    }
+
+    @Override
+    protected void initializeTypeStates() {
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/TypeD.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/TypeD.java
@@ -1,0 +1,13 @@
+package com.netflix.hollow.core.write.objectmapper;
+
+public class TypeD {
+    @HollowInline private final String inlinedString;
+
+    public TypeD(String inlinedString) {
+        this.inlinedString = inlinedString;
+    }
+
+    public String getInlinedString() {
+        return inlinedString;
+    }
+}


### PR DESCRIPTION
Extension of compact String handling from PR #221 to handle variable encodings possible (UTF16 and LATIN1). 

Please note that solution differs from original code (#221 and before it) in control flow when object passed to mapper in copy method is an instance of String - there is no copy created (getStringFromField method) but original String is returned.
If there is a specific reason that forces us to create such a copy then we could do  `new String((String) obj)`