### PR TITLE
Override default for 'sourceCompatibility' from 'nebula.netflixoss', update latest stable version to '3.0.1'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Binaries are available from Maven Central and jcenter.
 
 |GroupID/Org|ArtifactID/Name|Latest Stable Version|
 |-----------|---------------|---------------------|
-|com.netflix.hollow|hollow|2.16.4|
+|com.netflix.hollow|hollow|3.0.1|
 
 In a Maven `.pom` file:
 
@@ -29,14 +29,14 @@ In a Maven `.pom` file:
         <dependency>
                 <groupId>com.netflix.hollow</groupId>
                 <artifactId>hollow</artifactId>
-                <version>2.16.4</version>
+                <version>3.0.1</version>
         </dependency>
         ...
 
 In a Gradle `build.gradle` file:
 
         ...
-        compile 'com.netflix.hollow:hollow:2.16.4'
+        compile 'com.netflix.hollow:hollow:3.0.1'
         ...
         
 ## Get Support

--- a/build.gradle
+++ b/build.gradle
@@ -6,17 +6,12 @@ plugins {
   id 'nebula.netflixoss' version '5.0.0'
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 subprojects {
   apply plugin: 'nebula.netflixoss'
   apply plugin: 'checkstyle'
 
-  tasks.withType(JavaCompile) {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
 
   group = 'com.netflix.hollow'
   checkstyle {


### PR DESCRIPTION
I've moved setting of values for `sourceCompatibility` and `targetCompatibility` to subprojects section to override the default setting from `nebula.netflixoss` plugin. Without it, after checking out project failed to build with following error:

```
A problem occurred configuring project ':hollow'.
> Could not locate a compatible JDK for target compatibility 1.7. Change the source/target compatibility, set a JDK_17 environment variable with the location, or install to one of the default search locations
```

I've also noticed that latest stable version hasn't been updated for quite some time so I'd like to change that. 
