### PR TITLE
Expose HollowHashIndex properties

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -203,6 +203,22 @@ public class HollowHashIndex implements HollowTypeStateListener {
        reindexHashIndex();
     }
 
+    public HollowReadStateEngine getStateEngine() {
+        return stateEngine;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getSelectField() {
+        return selectField;
+    }
+
+    public String[] getMatchFields() {
+        return matchFields;
+    }
+
     protected static class HollowHashIndexState {
 
         final FixedLengthElementArray selectHashArray;

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
@@ -243,6 +243,20 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
         // an iterator doesn't update itself if it was retrieved prior to an update being applied
         assertIteratorContainsAll(preUpdateIterator, 4, 5);
     }
+    
+    @Test
+    public void testGettingPropertiesValues() throws Exception {
+        mapper.add(new TypeInlinedString(null));
+        mapper.add(new TypeInlinedString("onez:"));
+        mapper.add(new TypeInlinedString(null));
+
+        roundTripSnapshot();
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeInlinedString", "", "data");
+        Assert.assertEquals(index.getMatchFields().length, 1);
+        Assert.assertEquals(index.getMatchFields()[0], "data");
+        Assert.assertEquals(index.getType(), "TypeInlinedString");
+        Assert.assertEquals(index.getSelectField(), "");
+    }
 
     private void assertIteratorContainsAll(HollowOrdinalIterator iter, int... expectedOrdinals) {
         Set<Integer> ordinalSet = new HashSet<Integer>();


### PR DESCRIPTION
Hi @toolbear,

We have a use case where we want to create hash indexes dynamically. Being able to explore a `HashIndex` in terms of its properties could help us to understand more how to generate endpoints that our users can hit