### PR TITLE
make HollowProducer's writeEngine and objectMapper methods public

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -343,11 +343,11 @@ public class HollowProducer {
         return new HollowObjectMapper(writeEngine);
     }
 
-    protected HollowWriteStateEngine getWriteEngine() {
+    public HollowWriteStateEngine getWriteEngine() {
         return objectMapper.getStateEngine();
     }
-    
-    protected HollowObjectMapper getObjectMapper() {
+
+    public HollowObjectMapper getObjectMapper() {
         return objectMapper;
     }
 


### PR DESCRIPTION
https://hollow.how/diving-deeper/ says that:

```
A HollowReadStateEngine can be obtained from a HollowConsumer via the method getStateEngine().
A HollowWriteStateEngine can be obtained from a HollowProducer via the method getWriteEngine().
```

However, `HollowProducer` doesn't expose `getWriteEngine` to consumers.