### PR TITLE
Allow creating HollowConsumers for testing purposes

### DIFF
--- a/hollow-test/src/main/java/com/netflix/hollow/test/HollowWriteStateEngineBuilder.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/HollowWriteStateEngineBuilder.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.test;
+
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * This class allows constructing HollowWriteStateEngine instances for testing purposes.
+ * You cannot add to a HollowWriteStateEngineBuilder after calling build, however you may build
+ * multiple HollowWriteStateEngine objects with the same builder.
+ */
+public class HollowWriteStateEngineBuilder {
+    private final HollowWriteStateEngine writeEngine;
+    private final HollowObjectMapper objectMapper;
+
+    private boolean built;
+
+    /**
+     * Create a HollowWriteStateEngineBuilder with an empty initial type state. Adding objects will
+     * add their types, if not already present.
+     */
+    public HollowWriteStateEngineBuilder() {
+        this(Collections.emptyList());
+    }
+
+    /**
+     * Create a HollowWriteStateEngineBuilder, initializing it with a type state containing the
+     * provided types. Adding objects will add their types, if not already present.
+     */
+    public HollowWriteStateEngineBuilder(Collection<Class<?>> types) {
+        writeEngine = new HollowWriteStateEngine();
+        objectMapper = new HollowObjectMapper(writeEngine);
+        for (Class<?> type : types) {
+            objectMapper.initializeTypeState(type);
+        }
+    }
+
+    /**
+     * Add an object that will be in our built HollowWriteStateEngine. You cannot add any more
+     * objects after calling build().
+     */
+    public HollowWriteStateEngineBuilder add(Object... objects) {
+        if (built) {
+            throw new IllegalArgumentException("Cannot add after building Hollow state engine");
+        }
+        Arrays.stream(objects).forEach(objectMapper::add);
+        return this;
+    }
+
+    /**
+     * Build a HollowWriteStateEngine. You cannot add() any more objects after calling this.
+     */
+    public HollowWriteStateEngine build() {
+        built = true;
+        return writeEngine;
+    }
+}

--- a/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestAnnouncementWatcher.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestAnnouncementWatcher.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.test.consumer;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.HollowConsumer.AnnouncementWatcher;
+
+/**
+ * A simple implementation of an AnnouncementWatcher which allows setting the latest version.
+ */
+public class TestAnnouncementWatcher implements AnnouncementWatcher {
+    private long latestVersion = NO_ANNOUNCEMENT_AVAILABLE;
+
+    @Override
+    public long getLatestVersion() {
+        return latestVersion;
+    }
+
+    public TestAnnouncementWatcher setLatestVersion(long latestVersion) {
+        this.latestVersion = latestVersion;
+        return this;
+    }
+
+    @Override
+    public void subscribeToUpdates(HollowConsumer consumer) {
+        // no-op
+    }
+}

--- a/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestBlob.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestBlob.java
@@ -15,23 +15,31 @@
  *     limitations under the License.
  *
  */
-package com.netflix.hollow.api.consumer;
+package com.netflix.hollow.test.consumer;
 
 import com.netflix.hollow.api.consumer.HollowConsumer.Blob;
 import java.io.IOException;
 import java.io.InputStream;
 
-class FakeBlob extends Blob {
+public class TestBlob extends Blob {
+    private final InputStream inputStream;
 
-    public FakeBlob(long toVersion) {
+    public TestBlob(long toVersion) {
         super(toVersion);
+        this.inputStream = null;
     }
 
-    public FakeBlob(long fromVersion, long toVersion) {
+    public TestBlob(long toVersion, InputStream inputStream) {
+        super(toVersion);
+        this.inputStream = inputStream;
+    }
+
+    public TestBlob(long fromVersion, long toVersion) {
         super(fromVersion, toVersion);
+        this.inputStream = null;
     }
 
     public InputStream getInputStream() throws IOException {
-        return null;
+        return inputStream;
     }
 }

--- a/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestBlobRetriever.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestBlobRetriever.java
@@ -15,24 +15,21 @@
  *     limitations under the License.
  *
  */
-package com.netflix.hollow.api.consumer;
+package com.netflix.hollow.test.consumer;
 
 import com.netflix.hollow.api.consumer.HollowConsumer.Blob;
 import com.netflix.hollow.api.consumer.HollowConsumer.BlobRetriever;
 import java.util.HashMap;
 import java.util.Map;
 
-public class FakeBlobRetriever implements BlobRetriever {
-
-    private final Map<Long, Blob> snapshots;
-    private final Map<Long, Blob> deltas;
-    private final Map<Long, Blob> reverseDeltas;
-
-    public FakeBlobRetriever() {
-        this.snapshots = new HashMap<Long, Blob>();
-        this.deltas = new HashMap<Long, Blob>();
-        this.reverseDeltas = new HashMap<Long, Blob>();
-    }
+/**
+ * A simple implementation of a BlobRetriever which allows adding blobs and holds them all in
+ * memory.
+ */
+public class TestBlobRetriever implements BlobRetriever {
+    private final Map<Long, Blob> snapshots = new HashMap<>();
+    private final Map<Long, Blob> deltas = new HashMap<>();
+    private final Map<Long, Blob> reverseDeltas = new HashMap<>();
 
     @Override
     public Blob retrieveSnapshotBlob(long desiredVersion) {

--- a/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestHollowConsumer.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestHollowConsumer.java
@@ -1,0 +1,107 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.test.consumer;
+
+import com.netflix.hollow.api.client.HollowAPIFactory;
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.metrics.HollowConsumerMetrics;
+import com.netflix.hollow.api.metrics.HollowMetricsCollector;
+import com.netflix.hollow.core.read.filter.HollowFilterConfig;
+import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
+import com.netflix.hollow.core.write.HollowBlobWriter;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+/**
+ * This class allows constructing HollowConsumer objects for use in unit and integration tests.
+ * This uses an in-memory blob store, which means that all state is kept in memory, and so this is
+ * not suited for use in normal application usage, just in tests.
+ *
+ * Example usage:
+ *
+ * // your data state will be represented by a state engine
+ * HollowWriteStateEngine stateEngine = new HollowWriteStateEngineBuilder()
+ *     .add("somedata")
+ *     .add(new MyDataModelType("somestuff", 2))
+ *     .build();
+ * // we will add the snapshot with a version, and make the announcementWatcher see this version
+ * long latestVersion = 1L;
+ * TestHollowConsumer consumer = new TestHollowConsumer.Builder()
+ *        .withAnnouncementWatcher(new TestAnnouncementWatcher().setLatestVersion(latestVersion))
+ *        .withBlobRetriever(new TestBlobRetriever())
+ *        .withGeneratedAPIClass(MyApiClass.class)
+ *        .build();
+ * consumer.addSnapshot(latestVersion, stateEngine);
+ * consumer.triggerRefresh();
+ *
+ * If you wish to use triggerRefreshTo instead of triggerRefresh, do not provide an
+ * AnnouncementWatcher.
+ */
+public class TestHollowConsumer extends HollowConsumer {
+    private final BlobRetriever blobRetriever;
+
+    protected TestHollowConsumer(BlobRetriever blobRetriever,
+            AnnouncementWatcher announcementWatcher,
+            List<RefreshListener> updateListeners,
+            HollowAPIFactory apiFactory,
+            HollowFilterConfig dataFilter,
+            ObjectLongevityConfig objectLongevityConfig,
+            ObjectLongevityDetector objectLongevityDetector,
+            DoubleSnapshotConfig doubleSnapshotConfig,
+            HollowObjectHashCodeFinder hashCodeFinder,
+            Executor refreshExecutor,
+            HollowMetricsCollector<HollowConsumerMetrics> metricsCollector) {
+        super(blobRetriever, announcementWatcher, updateListeners, apiFactory, dataFilter, objectLongevityConfig,
+                objectLongevityDetector, doubleSnapshotConfig, hashCodeFinder, refreshExecutor, metricsCollector);
+        this.blobRetriever = blobRetriever;
+    }
+
+    public TestHollowConsumer addSnapshot(long version, HollowWriteStateEngine stateEngine) throws IOException {
+        if (blobRetriever instanceof TestBlobRetriever) {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            new HollowBlobWriter(stateEngine).writeSnapshot(outputStream);
+            ((TestBlobRetriever) blobRetriever).addSnapshot(version, new TestBlob(version,
+                    new ByteArrayInputStream(outputStream.toByteArray())));
+        } else {
+            throw new IllegalStateException("Cannot add snapshot if not using TestBlobRetriever");
+        }
+        return this;
+    }
+
+    public static class Builder extends HollowConsumer.Builder<Builder> {
+        @Override
+        public TestHollowConsumer build() {
+            checkArguments();
+            return new TestHollowConsumer(blobRetriever,
+                    announcementWatcher,
+                    refreshListeners,
+                    apiFactory,
+                    filterConfig,
+                    objectLongevityConfig,
+                    objectLongevityDetector,
+                    doubleSnapshotConfig,
+                    hashCodeFinder,
+                    refreshExecutor,
+                    metricsCollector);
+        }
+    }
+}

--- a/hollow-test/src/test/java/com/netflix/hollow/test/HollowReadStateEngineBuilderTest.java
+++ b/hollow-test/src/test/java/com/netflix/hollow/test/HollowReadStateEngineBuilderTest.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.test;
 
 import static org.junit.Assert.assertEquals;

--- a/hollow-test/src/test/java/com/netflix/hollow/test/consumer/TestHollowConsumerTest.java
+++ b/hollow-test/src/test/java/com/netflix/hollow/test/consumer/TestHollowConsumerTest.java
@@ -1,0 +1,102 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.test.consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.netflix.hollow.api.consumer.HollowConsumer.AnnouncementWatcher;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.test.HollowWriteStateEngineBuilder;
+import java.util.Arrays;
+import java.util.HashSet;
+import org.junit.Test;
+
+public class TestHollowConsumerTest {
+    @Test
+    public void testAddSnapshot_version() throws Exception {
+        long latestVersion = 1L;
+        TestHollowConsumer consumer = new TestHollowConsumer.Builder()
+            .withAnnouncementWatcher(new TestAnnouncementWatcher().setLatestVersion(latestVersion))
+            .withBlobRetriever(new TestBlobRetriever())
+            .build();
+        consumer.addSnapshot(latestVersion, new HollowWriteStateEngineBuilder().build());
+        assertEquals("Should be no version", AnnouncementWatcher.NO_ANNOUNCEMENT_AVAILABLE, consumer.getCurrentVersionId());
+        consumer.triggerRefresh();
+        assertEquals("Should be at latest version", latestVersion, consumer.getCurrentVersionId());
+    }
+
+    @Test
+    public void testAddSnapshot_data() throws Exception {
+        long latestVersion = 1L;
+        TestHollowConsumer consumer = new TestHollowConsumer.Builder()
+            .withAnnouncementWatcher(new TestAnnouncementWatcher().setLatestVersion(1L))
+            .withBlobRetriever(new TestBlobRetriever())
+            .build();
+        consumer.addSnapshot(latestVersion,
+                new HollowWriteStateEngineBuilder().add("foo").add(2).build());
+        consumer.triggerRefresh();
+        HollowDataAccess data = consumer.getAPI().getDataAccess();
+        assertEquals("Should have string and int",
+                new HashSet<>(Arrays.asList("String", "Integer")), data.getAllTypes());
+        assertEquals("foo",
+                new GenericHollowObject(data, "String", 0).getString("value"));
+        assertEquals(2,
+                new GenericHollowObject(data, "Integer", 0).getInt("value"));
+    }
+
+    @Test
+    public void testAddSnapshot_triggerRefreshTo() throws Exception {
+        long version = 2;
+        TestHollowConsumer consumer = new TestHollowConsumer.Builder()
+            .withBlobRetriever(new TestBlobRetriever())
+            .build();
+        consumer.addSnapshot(version, new HollowWriteStateEngineBuilder().build());
+        try {
+            consumer.triggerRefreshTo(version - 1);
+            fail("Should have failed to create an update plan");
+        } catch (RuntimeException e) { // we should make this a specific exception
+        }
+        consumer.triggerRefreshTo(version); // should succeed
+    }
+
+    @Test
+    public void testAddSnapshot_afterUpdate() throws Exception {
+        long version1 = 1L;
+        long version2 = 2L;
+        TestAnnouncementWatcher announcementWatcher =
+            new TestAnnouncementWatcher().setLatestVersion(version1);
+        TestHollowConsumer consumer = new TestHollowConsumer.Builder()
+            .withAnnouncementWatcher(announcementWatcher)
+            .withBlobRetriever(new TestBlobRetriever())
+            .build();
+        consumer.addSnapshot(version1, new HollowWriteStateEngineBuilder().build());
+        consumer.triggerRefresh();
+        assertEquals(version1, consumer.getCurrentVersionId());
+
+        consumer.addSnapshot(version2, new HollowWriteStateEngineBuilder().build());
+        consumer.triggerRefresh();
+        assertEquals("We haven't told announcementWatcher about version2 yet", version1,
+                consumer.getCurrentVersionId());
+
+        announcementWatcher.setLatestVersion(version2);
+        consumer.triggerRefresh();
+        assertEquals(version2, consumer.getCurrentVersionId());
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/error/SchemaNotFoundException.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/error/SchemaNotFoundException.java
@@ -40,7 +40,7 @@ public class SchemaNotFoundException extends HollowException {
         return this.availableTypes;
     }
 
-    private static final String getMessageSuffix(Collection<String> availableTypes) {
+    private static String getMessageSuffix(Collection<String> availableTypes) {
         if (availableTypes.isEmpty()) {
             return "empty type state, make sure your namespace has published versions";
         } else {

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowUpdatePlanTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowUpdatePlanTest.java
@@ -18,6 +18,7 @@
 package com.netflix.hollow.api.consumer;
 
 import com.netflix.hollow.api.client.HollowUpdatePlan;
+import com.netflix.hollow.test.consumer.TestBlob;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,11 +27,11 @@ public class HollowUpdatePlanTest {
     @Test
     public void testIsSnapshot() {
         HollowUpdatePlan plan = new HollowUpdatePlan();
-        plan.add(new FakeBlob(1));
+        plan.add(new TestBlob(1));
 
         Assert.assertTrue(plan.isSnapshotPlan());
 
-        plan.add(new FakeBlob(1, 2));
+        plan.add(new TestBlob(1, 2));
 
         Assert.assertTrue(plan.isSnapshotPlan());
 
@@ -38,40 +39,40 @@ public class HollowUpdatePlanTest {
 
         Assert.assertFalse(plan.isSnapshotPlan());
 
-        plan.add(new FakeBlob(1, 2));
+        plan.add(new TestBlob(1, 2));
 
         Assert.assertFalse(plan.isSnapshotPlan());
     }
 
     @Test
     public void testGetSnapshotTransition() {
-        FakeBlob snapshotTransition = new FakeBlob(1);
+        TestBlob snapshotTransition = new TestBlob(1);
 
         HollowUpdatePlan plan = new HollowUpdatePlan();
         plan.add(snapshotTransition);
 
         Assert.assertSame(snapshotTransition, plan.getSnapshotTransition());
 
-        plan.add(new FakeBlob(1, 2));
+        plan.add(new TestBlob(1, 2));
 
         Assert.assertSame(snapshotTransition, plan.getSnapshotTransition());
     }
 
     @Test
     public void testGetDeltaTransitionsForSnapshotPlan() {
-        FakeBlob snapshotTransition = new FakeBlob(1);
+        TestBlob snapshotTransition = new TestBlob(1);
 
         HollowUpdatePlan plan = new HollowUpdatePlan();
         plan.add(snapshotTransition);
 
         Assert.assertTrue(plan.getDeltaTransitions().isEmpty());
 
-        FakeBlob delta1 = new FakeBlob(1, 2);
+        TestBlob delta1 = new TestBlob(1, 2);
         plan.add(delta1);
 
         Assert.assertEquals(1, plan.getDeltaTransitions().size());
 
-        FakeBlob delta2 = new FakeBlob(2, 3);
+        TestBlob delta2 = new TestBlob(2, 3);
         plan.add(delta2);
 
         Assert.assertEquals(2, plan.getDeltaTransitions().size());
@@ -86,12 +87,12 @@ public class HollowUpdatePlanTest {
 
         Assert.assertTrue(plan.getDeltaTransitions().isEmpty());
 
-        FakeBlob delta1 = new FakeBlob(1, 2);
+        TestBlob delta1 = new TestBlob(1, 2);
         plan.add(delta1);
 
         Assert.assertEquals(1, plan.getDeltaTransitions().size());
 
-        FakeBlob delta2 = new FakeBlob(2, 3);
+        TestBlob delta2 = new TestBlob(2, 3);
         plan.add(delta2);
 
         Assert.assertEquals(2, plan.getDeltaTransitions().size());

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowUpdatePlannerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowUpdatePlannerTest.java
@@ -20,18 +20,20 @@ package com.netflix.hollow.api.consumer;
 import com.netflix.hollow.api.client.HollowUpdatePlan;
 import com.netflix.hollow.api.client.HollowUpdatePlanner;
 import com.netflix.hollow.api.consumer.HollowConsumer.Blob;
+import com.netflix.hollow.test.consumer.TestBlob;
+import com.netflix.hollow.test.consumer.TestBlobRetriever;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class HollowUpdatePlannerTest {
 
-    FakeBlobRetriever mockTransitionCreator;
+    TestBlobRetriever mockTransitionCreator;
     HollowUpdatePlanner planner;
 
     @Before
     public void setUp() {
-        mockTransitionCreator = new FakeBlobRetriever();
+        mockTransitionCreator = new TestBlobRetriever();
         planner = new HollowUpdatePlanner(mockTransitionCreator, new HollowConsumer.DoubleSnapshotConfig() {
             @Override
             public int maxDeltasBeforeDoubleSnapshot() {
@@ -268,19 +270,19 @@ public class HollowUpdatePlannerTest {
 
 
     private void addMockSnapshot(long desiredVersion, long actualVersion) {
-        Blob result = new FakeBlob(Long.MIN_VALUE, actualVersion);
+        Blob result = new TestBlob(Long.MIN_VALUE, actualVersion);
 
         mockTransitionCreator.addSnapshot(desiredVersion, result);
     }
 
     private void addMockDelta(long fromVersion, long toVersion) {
-        Blob result = new FakeBlob(fromVersion, toVersion);
+        Blob result = new TestBlob(fromVersion, toVersion);
 
         mockTransitionCreator.addDelta(fromVersion, result);
     }
 
     private void addMockReverseDelta(long fromVersion, long toVersion) {
-        Blob result = new FakeBlob(fromVersion, toVersion);
+        Blob result = new TestBlob(fromVersion, toVersion);
 
         mockTransitionCreator.addReverseDelta(fromVersion, result);
     }


### PR DESCRIPTION
Add TestHollowConsumer, TestBlobRetriever, and
TestAnnouncementWatcher to facilitate creating
HollowConsumer objects for use in unit tests.
Generally speaking, a TestHollowConsumer is constructed
with a TestAnnouncementWatcher and TestBlobRetriever, and
can be manipulated load a snapshot as represented by a
HollowWriteStateEngine. Support for loading deltas will come
later.
As part of this effort, refactor
HollowReadStateEngineBuilder to extract a
HollowWriteStateEngineBuilder.