### PR TITLE
Better NPE reported. Fix for issue #253.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
@@ -26,10 +26,12 @@ import com.netflix.hollow.core.write.HollowWriteRecord;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 public class HollowListTypeMapper extends HollowTypeMapper {
+
+    private static final String NULL_ELEMENT_MESSAGE =
+            "Null element contained in instance of a List with schema \"%s\". Lists cannot contain null elements";
 
     private final HollowListSchema schema;
     private final HollowListTypeWriteState writeState;
@@ -69,7 +71,9 @@ public class HollowListTypeMapper extends HollowTypeMapper {
         if(ignoreListOrdering) {
             IntList ordinalList = getIntList();
             for(Object o : l) {
-                Objects.requireNonNull(o, "Null element. Lists cannot contain null elements");
+                if(o == null) {
+                    throw new NullPointerException(String.format(NULL_ELEMENT_MESSAGE, schema));
+                }
                 int ordinal = elementMapper.write(o);
                 ordinalList.add(ordinal);
             }
@@ -78,7 +82,9 @@ public class HollowListTypeMapper extends HollowTypeMapper {
                 rec.addElement(ordinalList.get(i));
         } else {
             for(Object o : l) {
-                Objects.requireNonNull(o, "Null element. Lists cannot contain null elements");
+                if (o == null) {
+                    throw new NullPointerException(String.format(NULL_ELEMENT_MESSAGE, schema));
+                }
                 int ordinal = elementMapper.write(o);
                 rec.addElement(ordinal);
             }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
@@ -26,6 +26,7 @@ import com.netflix.hollow.core.write.HollowWriteRecord;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class HollowListTypeMapper extends HollowTypeMapper {
@@ -68,6 +69,7 @@ public class HollowListTypeMapper extends HollowTypeMapper {
         if(ignoreListOrdering) {
             IntList ordinalList = getIntList();
             for(Object o : l) {
+                Objects.requireNonNull(o, "Null element. Lists cannot contain null elements");
                 int ordinal = elementMapper.write(o);
                 ordinalList.add(ordinal);
             }
@@ -76,6 +78,7 @@ public class HollowListTypeMapper extends HollowTypeMapper {
                 rec.addElement(ordinalList.get(i));
         } else {
             for(Object o : l) {
+                Objects.requireNonNull(o, "Null element. Lists cannot contain null elements");
                 int ordinal = elementMapper.write(o);
                 rec.addElement(ordinal);
             }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -27,6 +27,7 @@ import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class HollowMapTypeMapper extends HollowTypeMapper {
@@ -72,9 +73,11 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
 
         HollowMapWriteRecord rec = (HollowMapWriteRecord)writeRecord();
         for(Map.Entry<?, ?>entry : m.entrySet()) {
-            int keyOrdinal = keyMapper.write(entry.getKey());
-            int valueOrdinal = valueMapper.write(entry.getValue());
-            int hashCode = hashCodeFinder.hashCode(keyMapper.getTypeName(), keyOrdinal, entry.getKey());
+            Object key = Objects.requireNonNull(entry.getKey(), "Null key. Maps cannot contain null keys or values");
+            Object value = Objects.requireNonNull(entry.getValue(), "Null value. Maps cannot contain null keys or values");
+            int keyOrdinal = keyMapper.write(key);
+            int valueOrdinal = valueMapper.write(value);
+            int hashCode = hashCodeFinder.hashCode(keyMapper.getTypeName(), keyOrdinal, key);
 
             rec.addEntry(keyOrdinal, valueOrdinal, hashCode);
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -26,6 +26,7 @@ import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Objects;
 import java.util.Set;
 
 public class HollowSetTypeMapper extends HollowTypeMapper {
@@ -69,6 +70,7 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
 
         HollowSetWriteRecord rec = (HollowSetWriteRecord)writeRecord();
         for(Object o : s) {
+            Objects.requireNonNull(o, "Null element. Sets cannot contain null elements");
             int ordinal = elementMapper.write(o);
             int hashCode = hashCodeFinder.hashCode(elementMapper.getTypeName(), ordinal, o);
             rec.addElement(ordinal, hashCode);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -26,10 +26,12 @@ import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Objects;
 import java.util.Set;
 
 public class HollowSetTypeMapper extends HollowTypeMapper {
+
+    private static final String NULL_ELEMENT_MESSAGE =
+            "Null element contained in instance of a Set with schema \"%s\". Sets cannot contain null elements";
 
     private final HollowSetSchema schema;
     private final HollowSetTypeWriteState writeState;
@@ -70,7 +72,9 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
 
         HollowSetWriteRecord rec = (HollowSetWriteRecord)writeRecord();
         for(Object o : s) {
-            Objects.requireNonNull(o, "Null element. Sets cannot contain null elements");
+            if(o == null) {
+                throw new NullPointerException(String.format(NULL_ELEMENT_MESSAGE, schema));
+            }
             int ordinal = elementMapper.write(o);
             int hashCode = hashCodeFinder.hashCode(elementMapper.getTypeName(), ordinal, o);
             rec.addElement(ordinal, hashCode);

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperTest.java
@@ -67,8 +67,9 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
             mapper.add(new TypeWithList("a", null, "c"));
             Assert.fail("NullPointerException not thrown from List containing null elements");
         } catch (NullPointerException e) {
-            Assert.assertNotNull(e.getMessage());
-            Assert.assertTrue(e.getMessage().contains("Lists"));
+            String m = e.getMessage();
+            Assert.assertNotNull(m);
+            Assert.assertTrue(m.contains("Lists"));
         }
 
         // Sets cannot contain null elements
@@ -76,8 +77,9 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
             mapper.add(new TypeWithSet("a", null, "c"));
             Assert.fail("NullPointerException not thrown from Set containing null elements");
         } catch (NullPointerException e) {
-            Assert.assertNotNull(e.getMessage());
-            Assert.assertTrue(e.getMessage().contains("Sets"));
+            String m = e.getMessage();
+            Assert.assertNotNull(m);
+            Assert.assertTrue(m.contains("Sets"));
         }
 
         // Maps cannot contain null keys
@@ -85,8 +87,10 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
             mapper.add(new TypeWithMap("a", "a", null, "b", "c", "c"));
             Assert.fail("NullPointerException not thrown from Map containing null keys");
         } catch (NullPointerException e) {
-            Assert.assertNotNull(e.getMessage());
-            Assert.assertTrue(e.getMessage().contains("Maps"));
+            String m = e.getMessage();
+            Assert.assertNotNull(m);
+            Assert.assertTrue(m.contains("Maps"));
+            Assert.assertTrue(m.contains("key"));
         }
 
         // Maps cannot contain null values
@@ -94,8 +98,10 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
             mapper.add(new TypeWithMap("a", "a", "b", null, "c", "c"));
             Assert.fail("NullPointerException not thrown from Map containing null values");
         } catch (NullPointerException e) {
-            Assert.assertNotNull(e.getMessage());
-            Assert.assertTrue(e.getMessage().contains("Maps"));
+            String m = e.getMessage();
+            Assert.assertNotNull(m);
+            Assert.assertTrue(m.contains("Maps"));
+            Assert.assertTrue(m.contains("value"));
         }
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -55,6 +56,47 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
 
         //System.out.println("---------------------------------");
         //System.out.println(new HollowRecordJsonStringifier(false, true).stringify(readStateEngine, "TypeA", 1));
+    }
+
+    @Test
+    public void testNullElements() {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+
+        // Lists cannot contain null elements
+        try {
+            mapper.add(new TypeWithList("a", null, "c"));
+            Assert.fail("NullPointerException not thrown from List containing null elements");
+        } catch (NullPointerException e) {
+            Assert.assertNotNull(e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("Lists"));
+        }
+
+        // Sets cannot contain null elements
+        try {
+            mapper.add(new TypeWithSet("a", null, "c"));
+            Assert.fail("NullPointerException not thrown from Set containing null elements");
+        } catch (NullPointerException e) {
+            Assert.assertNotNull(e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("Sets"));
+        }
+
+        // Maps cannot contain null keys
+        try {
+            mapper.add(new TypeWithMap("a", "a", null, "b", "c", "c"));
+            Assert.fail("NullPointerException not thrown from Map containing null keys");
+        } catch (NullPointerException e) {
+            Assert.assertNotNull(e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("Maps"));
+        }
+
+        // Maps cannot contain null values
+        try {
+            mapper.add(new TypeWithMap("a", "a", "b", null, "c", "c"));
+            Assert.fail("NullPointerException not thrown from Map containing null values");
+        } catch (NullPointerException e) {
+            Assert.assertNotNull(e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("Maps"));
+        }
     }
 
     @Test
@@ -312,7 +354,7 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
     }
 
     @SuppressWarnings("unused")
-    private static enum TestEnum {
+    private enum TestEnum {
         ONE(1),
         TWO(2),
         THREE(3);
@@ -397,7 +439,6 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
         }
     }
 
-
     @SuppressWarnings("unused")
     private static class TestClassImplementingInterface implements TestInterface {
         int val1;
@@ -409,6 +450,33 @@ public class HollowObjectMapperTest extends AbstractStateEngineTest {
         @Override
         public int test() {
             return 0;
+        }
+    }
+
+    static class TypeWithSet {
+        Set<String> c;
+
+        TypeWithSet(String... c) {
+            this.c = new HashSet<>(Arrays.asList(c));
+        }
+    }
+
+    static class TypeWithList {
+        List<String> c;
+
+        TypeWithList(String... c) {
+            this.c = new ArrayList<>(Arrays.asList(c));
+        }
+    }
+
+    static class TypeWithMap {
+        Map<String, String> m;
+
+        TypeWithMap(String... kv) {
+            m = new HashMap<>();
+            for (int i = 0; i < kv.length; i += 2) {
+                m.put(kv[i], kv[i + 1]);
+            }
         }
     }
 }


### PR DESCRIPTION
Throw explicit NPEs for null values in collections and maps (null values
are not supported)