### PR TITLE
Replace Throwable.printStackTrace with SEVERE log

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowAnnouncementWatcher.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowAnnouncementWatcher.java
@@ -23,6 +23,8 @@ import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Implementations of this class are responsible for two things:
@@ -39,7 +41,7 @@ import java.util.concurrent.ThreadFactory;
  */
 @Deprecated
 public abstract class HollowAnnouncementWatcher {
-
+    private static final Logger log = Logger.getLogger(HollowAnnouncementWatcher.class.getName());
     private final ExecutorService refreshExecutor;
 
     /**
@@ -133,7 +135,7 @@ public abstract class HollowAnnouncementWatcher {
                         Thread.sleep(delay);
                     client.triggerRefresh();
                 } catch(Throwable th) {
-                    th.printStackTrace();
+                    log.log(Level.SEVERE, "Async refresh failed", th);
                 }
             }
         });

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -125,11 +125,11 @@ public class HollowClientUpdater {
             return getCurrentVersionId() == version;
         } catch(Throwable th) {
             forceDoubleSnapshotNextUpdate();
-            for(HollowConsumer.RefreshListener refreshListener : refreshListeners)
-                refreshListener.refreshFailed(beforeVersion, getCurrentVersionId(), version, th);
             metrics.updateRefreshFailed();
             if(metricsCollector != null)
                 metricsCollector.collect(metrics);
+            for(HollowConsumer.RefreshListener refreshListener : refreshListeners)
+                refreshListener.refreshFailed(beforeVersion, getCurrentVersionId(), version, th);
             throw th;
         }
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -32,6 +32,7 @@ import com.netflix.hollow.core.read.filter.HollowFilterConfig;
 import com.netflix.hollow.core.util.DefaultHashCodeFinder;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.tools.history.HollowHistory;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,6 +44,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 
 /**
@@ -107,6 +110,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * </dl>
  */
 public class HollowConsumer {
+    private static final Logger log = Logger.getLogger(HollowConsumer.class.getName());
 
     protected final AnnouncementWatcher announcementWatcher;
     protected final HollowClientUpdater updater;
@@ -210,7 +214,7 @@ public class HollowConsumer {
                         Thread.sleep(delay);
                     triggerRefresh();
                 } catch (Throwable th) {
-                    th.printStackTrace();
+                    log.log(Level.SEVERE, "Async refresh failed", th);
                 }
             }
         });

--- a/hollow/src/main/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProvider.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProvider.java
@@ -28,13 +28,15 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A HollowObjectCacheProvider caches and returns Object representations (presumably {@link HollowRecord}s) of 
  * records of a specific type. 
  */
 public class HollowObjectCacheProvider<T> extends HollowObjectProvider<T> implements HollowTypeStateListener {
-
+    private static final Logger log = Logger.getLogger(HollowObjectCacheProvider.class.getName());
     private final List<T> cachedItems;
 
     private HollowFactory<T> factory;
@@ -104,7 +106,7 @@ public class HollowObjectCacheProvider<T> extends HollowObjectProvider<T> implem
         try {
             return factory.newCachedHollowObject(typeDataAccess, typeAPI, ordinal);
         } catch(Throwable th) {
-            th.printStackTrace();
+            log.log(Level.SEVERE, "Cached object instantiation failed", th);
             return null;
         }
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
@@ -18,11 +18,14 @@
 package com.netflix.hollow.core.memory;
 
 import java.lang.reflect.Field;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import sun.misc.Unsafe;
 
 @SuppressWarnings("restriction")
 public class HollowUnsafeHandle {
-
+    private static final Logger log = Logger.getLogger(HollowUnsafeHandle.class.getName());
     private static Unsafe unsafe;
 
     static {
@@ -32,7 +35,7 @@ public class HollowUnsafeHandle {
             theUnsafe.setAccessible(true);
             unsafe = (Unsafe) theUnsafe.get(null);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.log(Level.SEVERE, "Unsafe access failed", e);
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowTypeDiff.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowTypeDiff.java
@@ -32,11 +32,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Obtained via a {@link HollowDiff}, this is a report of the differences in a specific type between two data states.
  */
 public class HollowTypeDiff {
+    private static final Logger log = Logger.getLogger(HollowTypeDiff.class.getName());
     private final HollowDiff rootDiff;
     private final HollowObjectTypeReadState from;
     private final HollowObjectTypeReadState to;
@@ -212,7 +215,7 @@ public class HollowTypeDiff {
 
                         results[threadId] = rootNode.getFieldDiffs();
                     } catch(Exception e) {
-                        e.printStackTrace();
+                        log.log(Level.SEVERE, "Diffs calculation failed", e);
                     }
                 }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistoricalStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistoricalStateCreator.java
@@ -52,13 +52,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Used to create a historical {@link HollowDataAccess}, even in the absence of a {@link HollowHistory}.
  *
  */
 public class HollowHistoricalStateCreator {
-
+    private static final Logger log = Logger.getLogger(HollowHistoricalStateCreator.class.getName());
     private final HollowHistory totalHistory;
 
     public HollowHistoricalStateCreator() {
@@ -316,7 +318,7 @@ public class HollowHistoricalStateCreator {
             HollowBlobReader reader = new HollowBlobReader(removedRecordCopies);
             reader.readSnapshot(new ByteArrayInputStream(baos.toByteArray()));
         } catch(Exception e) {
-            e.printStackTrace();
+            log.log(Level.SEVERE, "State engine round trip failed", e);
         }
         return removedRecordCopies;
     }

--- a/hollow/src/main/java/com/netflix/hollow/tools/traverse/TransitiveSetTraverser.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/traverse/TransitiveSetTraverser.java
@@ -38,6 +38,8 @@ import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The TransitiveSetTraverser can be used to find children and parent references for a selected set of records.  
@@ -72,6 +74,7 @@ import java.util.Map;
  *
  */
 public class TransitiveSetTraverser {
+    private static final Logger log = Logger.getLogger(TransitiveSetTraverser.class.getName());
 
     /**
      * Augment the given selection by adding the references, and the <i>transitive</i> references, of our selection.
@@ -189,7 +192,7 @@ public class TransitiveSetTraverser {
                     elementOrdinal = iter.next();
                 }
             } catch(Exception e) {
-                e.printStackTrace();
+                log.log(Level.SEVERE, "Add transitive matches failed", e);
             }
 
             ordinal = matchingOrdinals.nextSetBit(ordinal + 1);


### PR DESCRIPTION
In order to improve integration with logging frameworks, printStackTrace() calls are replaced with logging.
Reason for this change is that we loose information in logs about for example OutOfMemory exceptions because they are caught and printed to output.

There is one more change in HollowClientUpdater related to this: to update failure metric before calling RefreshListeners. Otherwise in case something goes wrong inside listener metric will not be updated.