### PR TITLE
Ensure exceptions are reported from async task. Less resource intensive state copying.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistoricalStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistoricalStateCreator.java
@@ -35,6 +35,7 @@ import com.netflix.hollow.core.schema.HollowSchemaSorter;
 import com.netflix.hollow.core.util.HollowWriteStateCreator;
 import com.netflix.hollow.core.util.IntMap;
 import com.netflix.hollow.core.util.IntMap.IntMapEntryIterator;
+import com.netflix.hollow.core.util.SimultaneousExecutor;
 import com.netflix.hollow.core.write.HollowBlobWriter;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
@@ -44,23 +45,24 @@ import com.netflix.hollow.tools.combine.IdentityOrdinalRemapper;
 import com.netflix.hollow.tools.combine.OrdinalRemapper;
 import com.netflix.hollow.tools.diff.exact.DiffEqualOrdinalMap;
 import com.netflix.hollow.tools.diff.exact.DiffEqualityMapping;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Used to create a historical {@link HollowDataAccess}, even in the absence of a {@link HollowHistory}.
  *
  */
 public class HollowHistoricalStateCreator {
-    private static final Logger log = Logger.getLogger(HollowHistoricalStateCreator.class.getName());
+
     private final HollowHistory totalHistory;
 
     public HollowHistoricalStateCreator() {
@@ -309,20 +311,49 @@ public class HollowHistoricalStateCreator {
     }
 
     private static HollowReadStateEngine roundTripStateEngine(HollowWriteStateEngine writeEngine) {
+        HollowBlobWriter writer = new HollowBlobWriter(writeEngine);
         HollowReadStateEngine removedRecordCopies = new HollowReadStateEngine();
+        HollowBlobReader reader = new HollowBlobReader(removedRecordCopies);
 
-        try {
-            HollowBlobWriter writer = new HollowBlobWriter(writeEngine);
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            writer.writeSnapshot(baos);
-            HollowBlobReader reader = new HollowBlobReader(removedRecordCopies);
-            reader.readSnapshot(new ByteArrayInputStream(baos.toByteArray()));
-        } catch(Exception e) {
-            log.log(Level.SEVERE, "State engine round trip failed", e);
+        // Use a pipe to write and read concurrently to avoid writing
+        // to temporary files or allocating memory
+        // @@@ for small states it's more efficient to sequentially write to
+        // and read from a byte array but it is tricky to estimate the size
+        SimultaneousExecutor executor = new SimultaneousExecutor(1);
+        Exception pipeException = null;
+        // Ensure read-side is closed after completion of read
+        try (PipedInputStream in = new PipedInputStream(1 << 15)) {
+            PipedOutputStream out = new PipedOutputStream(in);
+            executor.execute(() -> {
+                // Ensure write-side is closed after completion of write
+                try (Closeable ac = out) {
+                    writer.writeSnapshot(out);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            reader.readSnapshot(in);
+        } catch (Exception e) {
+            pipeException = e;
         }
+
+        // Ensure no underlying writer exception is lost due to broken pipe
+        try {
+            executor.awaitSuccessfulCompletion();
+        } catch (InterruptedException | ExecutionException e) {
+            if (pipeException == null) {
+                throw new RuntimeException(e);
+            }
+
+            pipeException.addSuppressed(e);
+        }
+        if (pipeException != null)
+            throw new RuntimeException(pipeException);
+
         return removedRecordCopies;
     }
-    
+
     private List<HollowSchema> schemasWithoutKeys(List<HollowSchema> schemas) {
         List<HollowSchema> baldSchemas = new ArrayList<HollowSchema>();
         for(HollowSchema prevSchema : schemas)

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryKeyIndex.java
@@ -27,12 +27,13 @@ import com.netflix.hollow.core.write.HollowBlobWriter;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.tools.history.HollowHistory;
 
+import java.io.Closeable;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 public class HollowHistoryKeyIndex {
 
@@ -137,56 +138,87 @@ public class HollowHistoryKeyIndex {
         SimultaneousExecutor executor = new SimultaneousExecutor();
 
         for(final Map.Entry<String, HollowHistoryTypeKeyIndex> entry : typeKeyIndexes.entrySet()) {
-            executor.execute(new Runnable() {
-                public void run() {
-                    HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) latestStateEngine.getTypeState(entry.getKey());
-                    entry.getValue().update(typeState, isDelta);
-                }
+            executor.execute(() -> {
+                HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) latestStateEngine.getTypeState(entry.getKey());
+                entry.getValue().update(typeState, isDelta);
             });
         }
 
-        executor.awaitUninterruptibly();
+        try {
+            executor.awaitSuccessfulCompletion();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private HollowReadStateEngine roundTripStateEngine(boolean isInitialUpdate, boolean isSnapshot) {
-        try {
-            Path tmpFile = Files.createTempFile("roundtrip", "snapshot");
+        HollowBlobWriter writer = new HollowBlobWriter(writeStateEngine);
+        // Use existing readStateEngine on initial update or delta;
+        // otherwise, create new one to properly handle double snapshot
+        HollowReadStateEngine newReadStateEngine = (isInitialUpdate || !isSnapshot)
+                ? readStateEngine : new HollowReadStateEngine();
+        HollowBlobReader reader = new HollowBlobReader(newReadStateEngine);
+
+        // Use a pipe to write and read concurrently to avoid writing
+        // to temporary files or allocating memory
+        // @@@ for small states it's more efficient to sequentially write to
+        // and read from a byte array but it is tricky to estimate the size
+        SimultaneousExecutor executor = new SimultaneousExecutor(1);
+        Exception pipeException = null;
+        // Ensure read-side is closed after completion of read
+        try (PipedInputStream in = new PipedInputStream(1 << 15)) {
+            PipedOutputStream out = new PipedOutputStream(in);
+            executor.execute(() -> {
+                // Ensure write-side is closed after completion of write
+                try (Closeable ac = out) {
+                    if (isInitialUpdate || isSnapshot) {
+                        writer.writeSnapshot(out);
+                    } else {
+                        writer.writeDelta(out);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
             if (isInitialUpdate || isSnapshot) {
-                OutputStream fileOutputStream = Files.newOutputStream(tmpFile);
-                HollowBlobWriter writer = new HollowBlobWriter(writeStateEngine);
-                writer.writeSnapshot(fileOutputStream);
-                // Use existing readStateEngine on initial update; otherwise, create new one to properly handle double snapshot
-                HollowReadStateEngine newReadStateEngine = isInitialUpdate ? readStateEngine : new HollowReadStateEngine();
-                HollowBlobReader reader = new HollowBlobReader(newReadStateEngine);
-                reader.readSnapshot(Files.newInputStream(tmpFile));
-                return newReadStateEngine;
+                reader.readSnapshot(in);
             } else {
-                OutputStream fileOutputStream = Files.newOutputStream(tmpFile);
-                HollowBlobWriter writer = new HollowBlobWriter(writeStateEngine);
-                writer.writeDelta(fileOutputStream);
-                HollowBlobReader reader = new HollowBlobReader(readStateEngine);
-                reader.applyDelta(Files.newInputStream(tmpFile));
-                return readStateEngine;
+                reader.applyDelta(in);
             }
-        } catch(IOException e) {
-            throw new RuntimeException(e);
-        } finally {
-            writeStateEngine.prepareForNextCycle();
+        } catch (Exception e) {
+            pipeException = e;
         }
+
+        // Ensure no underlying writer exception is lost due to broken pipe
+        try {
+            executor.awaitSuccessfulCompletion();
+        } catch (InterruptedException | ExecutionException e) {
+            if (pipeException == null) {
+                throw new RuntimeException(e);
+            }
+
+            pipeException.addSuppressed(e);
+        }
+        if (pipeException != null)
+            throw new RuntimeException(pipeException);
+
+        writeStateEngine.prepareForNextCycle();
+        return newReadStateEngine;
     }
 
     private void rehashKeys() {
         SimultaneousExecutor executor = new SimultaneousExecutor();
 
         for(final Map.Entry<String, HollowHistoryTypeKeyIndex> entry : typeKeyIndexes.entrySet()) {
-            executor.execute(new Runnable() {
-                public void run() {
-                    entry.getValue().hashRecordKeys();
-                }
-            });
+            executor.execute(() -> entry.getValue().hashRecordKeys());
         }
 
-        executor.awaitUninterruptibly();
+        try {
+            executor.awaitSuccessfulCompletion();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -90,7 +90,9 @@ public class HollowHistoryTypeKeyIndex {
 
     public void update(HollowObjectTypeReadState latestTypeState, boolean isDelta) {
         copyExistingKeys();
-        if(isDelta)
+        if (latestTypeState == null) return;
+
+        if (isDelta)
             populateNewCurrentRecordKeys(latestTypeState);
         else
             populateAllCurrentRecordKeys(latestTypeState);
@@ -328,6 +330,8 @@ public class HollowHistoryTypeKeyIndex {
 
     private void copyExistingKeys() {
         HollowTypeWriteState typeState = writeStateEngine.getTypeState(primaryKey.getType());
+        if (typeState == null) return;
+
         typeState.addAllObjectsFromPreviousCycle();
     }
 


### PR DESCRIPTION
Ensure an exception is reported, rather than swallowed, for failure of
a task run asynchronously within an executor.  Swallowing just as likely
moves the reported error to somewhere else, that operates on partially
constructed information, making it hard to track the actual source (even
if logging is performed).
Use a piped input/output stream to convert from a write state to
a read state. This is likely less resource intensive that writing to
a file or memory.