### PR TITLE
Add Java 8 javadoc tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,13 @@ subprojects {
     targetCompatibility = 1.8
   }
 
+  tasks.withType(Javadoc) {
+    options.tags(
+        'apiNote:a:API Note:',
+        'implSpec:a:Implementation Requirements:',
+        'implNote:a:Implementation Note:')
+  }
+
   group = 'com.netflix.hollow'
   checkstyle {
     configFile = file("$rootProject.projectDir/config/checkstyle/checkstyle.xml")


### PR DESCRIPTION
A previous commit caused a build failure due to unrecognized JavaDoc tags that are utilized in Java 8. Unfortunately for the javadoc tooling in Java 8 these tags need to be added explicitly.