### PR TITLE
Support the removal of the last n historical states

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistory.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistory.java
@@ -135,6 +135,13 @@ public class HollowHistory {
     }
 
     /**
+     * @return the number of historical states
+     */
+    public int getNumberOfHistoricalStates() {
+        return historicalStates.size();
+    }
+
+    /**
      * @param version A version in the past
      * @return The {@link HollowHistoricalState} for the specified version, if it exists.
      */
@@ -343,9 +350,32 @@ public class HollowHistory {
         historicalStateLookupMap.put(historicalState.getVersion(), historicalState);
 
         if(historicalStates.size() > maxHistoricalStatesToKeep) {
+            removeHistoricalStates(1);
+        }
+    }
+
+    /**
+     * Removes the last {@code n} historical states.
+     *
+     * @param n the number of historical states to remove
+     * @throws IllegalArgumentException if the {@code n} is less than {@code 0} or
+     * greater than the {@link #getNumberOfHistoricalStates() number} of historical
+     * states.
+     */
+    public void removeHistoricalStates(int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException(String.format(
+                    "Number of states to remove is negative: %d", n));
+        }
+        if (n > historicalStates.size()) {
+            throw new IllegalArgumentException(String.format(
+                    "Number of states to remove, %d, is greater than the number of states. %d",
+                    n, historicalStates.size()));
+        }
+
+        while (n-- > 0) {
             HollowHistoricalState removedState = historicalStates.remove(historicalStates.size() - 1);
             historicalStateLookupMap.remove(removedState.getVersion());
         }
     }
-
 }

--- a/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryTest.java
@@ -301,6 +301,80 @@ public class HollowHistoryTest extends AbstractStateEngineTest {
         }
     }
 
+    @Test
+    public void testHistoricalStates() throws IOException {
+        addRecord(1, 2, 3);
+
+        roundTripSnapshot();
+
+        HollowHistory history = new HollowHistory(readStateEngine, 1L, 2);
+        Assert.assertEquals(0, history.getNumberOfHistoricalStates());
+
+        {
+            addRecord(1, 2, 3);
+            addRecord(4, 5, 6);
+
+            roundTripDelta();
+            history.deltaOccurred(2L);
+
+            Assert.assertEquals(1, history.getNumberOfHistoricalStates());
+        }
+
+
+        HollowHistoricalState[] historicalStates;
+        {
+            addRecord(1, 2, 3);
+
+            roundTripDelta();
+            history.deltaOccurred(3L);
+
+            Assert.assertEquals(2, history.getNumberOfHistoricalStates());
+            historicalStates = history.getHistoricalStates();
+        }
+
+        {
+            addRecord(1, 2, 3);
+            addRecord(4, 5, 6);
+
+            roundTripDelta();
+            history.deltaOccurred(4L);
+
+            Assert.assertEquals(2, history.getNumberOfHistoricalStates());
+            Assert.assertEquals(historicalStates[0], history.getHistoricalStates()[1]);
+        }
+
+        {
+            history.removeHistoricalStates(1);
+            Assert.assertEquals(1, history.getNumberOfHistoricalStates());
+            historicalStates = history.getHistoricalStates();
+        }
+
+        {
+            addRecord(1, 2, 3);
+
+            roundTripDelta();
+            history.deltaOccurred(5L);
+
+            Assert.assertEquals(2, history.getNumberOfHistoricalStates());
+            Assert.assertEquals(historicalStates[0], history.getHistoricalStates()[1]);
+        }
+
+        {
+            history.removeHistoricalStates(history.getNumberOfHistoricalStates());
+            Assert.assertEquals(0, history.getNumberOfHistoricalStates());
+        }
+
+        {
+            addRecord(1, 2, 3);
+            addRecord(4, 5, 6);
+
+            roundTripDelta();
+            history.deltaOccurred(6L);
+
+            Assert.assertEquals(1, history.getNumberOfHistoricalStates());
+        }
+    }
+
     private void setupKeyIndex(HollowReadStateEngine stateEngine, HollowHistory history) {
         HollowHistoryKeyIndex keyIndex = history.getKeyIndex();
         for (String type : stateEngine.getAllTypes()) {


### PR DESCRIPTION
This is useful for the removal of older historical state in response to memory pressure.