### PR TITLE
HollowPrefixIndex bugfix - multiple elements

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
@@ -61,6 +61,7 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
      *                        The fields in the path could reference another Object, List, Set or a Map.
      *                        The fields should be separated by ".".
      */
+    @SuppressWarnings("WeakerAccess")
     public HollowPrefixIndex(HollowReadStateEngine readStateEngine, String type, String fieldPath) {
 
         if (readStateEngine == null) throw new IllegalArgumentException("Read state engine cannot be null");
@@ -117,11 +118,8 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
         BitSet ordinals = readStateEngine.getTypeState(type).getPopulatedOrdinals();
         int ordinal = ordinals.nextSetBit(0);
         while (ordinal != -1) {
-            String[] keys = getKeys(ordinal);
-            if (keys != null) {
-                for (String key : keys) {
-                    tst.insert(key, ordinal);
-                }
+            for (String key : getKeys(ordinal)) {
+                tst.insert(key, ordinal);
             }
             ordinal = ordinals.nextSetBit(ordinal + 1);
         }
@@ -135,11 +133,8 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
     /**
      * This method estimates the total number of nodes that will required to create the index.
      * Override this method if lower/higher estimate is needed compared to the default implementation.
-     *
-     * @param totalWords
-     * @param averageWordLen
-     * @return
      */
+    @SuppressWarnings("WeakerAccess")
     protected long estimateNumNodes(long totalWords, long averageWordLen) {
         return totalWords * averageWordLen;
     }
@@ -179,6 +174,7 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
      * @param prefix findKeysWithPrefix prefix.
      * @return An instance of HollowOrdinalIterator to iterate over ordinals that match the given findKeysWithPrefix.
      */
+    @SuppressWarnings("WeakerAccess")
     public HollowOrdinalIterator findKeysWithPrefix(String prefix) {
         TST current = this.prefixIndex;
         HollowOrdinalIterator it;
@@ -191,7 +187,6 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
     /**
      * Check if the given exists in the index.
      *
-     * @param key
      * @return boolean value indicating if the key exists in the index.
      */
     public boolean contains(String key) {
@@ -209,6 +204,7 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
      * Remember to call detachFromDeltaUpdates to stop the delta changes.
      * NOTE: Each delta updates creates a new prefix index and swaps the new with current.
      */
+    @SuppressWarnings("WeakerAccess")
     public void listenForDeltaUpdates() {
         readStateEngine.getTypeState(type).addListener(this);
     }
@@ -216,6 +212,7 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
     /**
      * Stop delta updates for this index.
      */
+    @SuppressWarnings("WeakerAccess")
     public void detachFromDeltaUpdates() {
         readStateEngine.getTypeState(type).removeListener(this);
     }
@@ -264,8 +261,6 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
         private FixedLengthElementArray nodes;
         private FixedLengthElementArray ordinalSet;
         private long indexTracker;
-
-        private long size;
 
         /**
          * Create new prefix index. Represents a ternary search tree.
@@ -331,9 +326,7 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
         }
 
         private boolean isLeafNode(long nodeIndex) {
-            if (nodes.getElementValue((nodeIndex * bitsPerNode) + isLeafNodeFlagOffset, 1) == 1)
-                return true;
-            return false;
+            return nodes.getElementValue((nodeIndex * bitsPerNode) + isLeafNodeFlagOffset, 1) == 1;
         }
 
         private void addOrdinal(long nodeIndex, long ordinal) {
@@ -347,15 +340,8 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
             return (int) ordinalSet.getElementValue(ordinalIndex, bitsPerOrdinal);
         }
 
-        private long size() {
-            return size;
-        }
-
         /**
          * Insert into ternary search tree for the given key and ordinal.
-         *
-         * @param key
-         * @param ordinal
          */
         private void insert(String key, int ordinal) {
             if (key == null) throw new IllegalArgumentException("Null key cannot be indexed");
@@ -394,13 +380,11 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
                 }
             }
             addOrdinal(currentNodeIndex, ordinal);
-            size++;
         }
 
         /**
          * This functions checks if the given key exists in the trie.
          *
-         * @param key
          * @return index of the node that findNodeWithKey the last character of the key, if not found then returns -1.
          */
         private long findNodeWithKey(String key) {
@@ -431,15 +415,11 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
 
         private boolean contains(String key) {
             long nodeIndex = findNodeWithKey(key);
-            if (nodeIndex >= 0 && isLeafNode(nodeIndex)) return true;
-            return false;
+            return nodeIndex >= 0 && isLeafNode(nodeIndex);
         }
 
         /**
          * Find all the ordinals that match the given prefix.
-         *
-         * @param prefix
-         * @return
          */
         private HollowOrdinalIterator findKeysWithPrefix(String prefix) {
             if (prefix == null) throw new IllegalArgumentException("Cannot findKeysWithPrefix null prefix");
@@ -472,8 +452,7 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
                 }
             }
 
-            HollowOrdinalIterator iterator = new HollowOrdinalIterator() {
-
+            return new HollowOrdinalIterator() {
                 private Iterator<Integer> it = ordinals.iterator();
 
                 @Override
@@ -482,8 +461,6 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
                     return NO_MORE_ORDINALS;
                 }
             };
-
-            return iterator;
         }
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthMultipleOccurrenceElementArray.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthMultipleOccurrenceElementArray.java
@@ -1,0 +1,166 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.memory.encoding;
+
+import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.LongStream;
+
+/**
+ * This class stores multiple instances of a fixed bit width element in a list of nodes. For
+ * example, it can store multiple 6 bit elements at different indices of the list of nodes.
+ *
+ * Under the hood, it uses a {@link FixedLengthElementArray} in order to implement compact storage
+ * that allows inserting multiple instances of the fixed length elements. It maintains at least
+ * enough space to hold up to the max number of occurrences of each element. This means that if
+ * there are 8 elements at one node index, it will contain enough space to store at least 8 elements
+ * at each index.
+ *
+ * Running out of space at any index triggers a relatively expensive resize operation, where we
+ * create storage of a multiple (currently 1.5x) of the previous storage and copy items over, but
+ * this can be alleviated by passing in a better guess for max elements per node.
+ * Note that this class is currently designed to be used for a relatively small number for
+ * bitsPerElement - it will not work for bitsPerElement greater than 60.
+ */
+public class FixedLengthMultipleOccurrenceElementArray {
+    private static final double RESIZE_MULTIPLE = 1.5;
+    private static final long NO_ELEMENT = 0L;
+
+    private final ArraySegmentRecycler memoryRecycler;
+    private final FixedLengthElementArray nodesWithOrdinalZero;
+    private final int bitsPerElement;
+    private final long elementMask;
+    private final long numNodes;
+
+    private volatile FixedLengthElementArray storage;
+    private volatile int maxElementsPerNode;
+
+    public FixedLengthMultipleOccurrenceElementArray(ArraySegmentRecycler memoryRecycler,
+            long numNodes, int bitsPerElement, int maxElementsPerNodeEstimate) {
+        nodesWithOrdinalZero = new FixedLengthElementArray(memoryRecycler, numNodes);
+        storage = new FixedLengthElementArray(
+                memoryRecycler, numNodes * bitsPerElement * maxElementsPerNodeEstimate);
+        this.memoryRecycler = memoryRecycler;
+        this.bitsPerElement = bitsPerElement;
+        this.elementMask = (1L << bitsPerElement) - 1;
+        this.numNodes = numNodes;
+        this.maxElementsPerNode = maxElementsPerNodeEstimate;
+    }
+
+    /**
+     * This method adds an element at nodeIndex. Note that this does not check for duplicates; if
+     * the element already exists, another instance of it will be added.
+     * This method is not thread-safe - you cannot call this method concurrently with itself or with
+     * {@link #getElements}.
+     */
+    public void addElement(long nodeIndex, long element) {
+        if (element > elementMask) {
+            throw new IllegalArgumentException("Element " + element + " does not fit in "
+                    + bitsPerElement + " bits");
+        }
+        if (nodeIndex >= numNodes) {
+            throw new IllegalArgumentException("Provided nodeIndex  " + nodeIndex
+                    + " greater then numNodes " + numNodes);
+        }
+        if (element == NO_ELEMENT) {
+            // we use 0 to indicate an "empty" element, so we have to store ordinal zero here
+            nodesWithOrdinalZero.setElementValue(nodeIndex, 1, 1);
+            return;
+        }
+        long bucketStart = nodeIndex * maxElementsPerNode * bitsPerElement;
+        long currentIndex;
+        int offset = 0;
+        do {
+            currentIndex = bucketStart + offset * bitsPerElement;
+            offset++;
+        } while (storage.getElementValue(currentIndex, bitsPerElement, elementMask) != NO_ELEMENT
+                && offset < maxElementsPerNode);
+        if (storage.getElementValue(currentIndex, bitsPerElement, elementMask) != NO_ELEMENT) {
+            // we're full at this index - resize, then figure out the new current index
+            resizeStorage();
+            currentIndex = nodeIndex * maxElementsPerNode * bitsPerElement + offset * bitsPerElement;
+        }
+        /* we're adding to the first empty spot from the beginning of the bucket - this is
+         * preferable to adding at the end because we want our getElements method to be fast, and
+         * it's okay for addElement to be comparatively slow */
+        storage.setElementValue(currentIndex, bitsPerElement, element);
+    }
+
+    /**
+     * Return a list of elements at the specified node index. The returned list may contain
+     * duplicates.
+     * This method not thread-safe - the caller must ensure that no one calls {@link #addElement}
+     * concurrently with this method, but calling this method concurrently with itself is safe.
+     */
+    public List<Long> getElements(long nodeIndex) {
+        long bucketStart = nodeIndex * maxElementsPerNode * bitsPerElement;
+        List<Long> ret = new ArrayList<>();
+        if (nodesWithOrdinalZero.getElementValue(nodeIndex, 1, 1) != NO_ELEMENT) {
+            // 0 indicates an "empty" element, so we fetch ordinal zeros from nodesWithOrdinalZero
+            ret.add(NO_ELEMENT);
+        }
+        for (int offset = 0; offset < maxElementsPerNode; offset++) {
+            long element = storage.getElementValue(bucketStart + offset * bitsPerElement,
+                    bitsPerElement, elementMask);
+            if (element == NO_ELEMENT) {
+                break; // we have exhausted the elements at this index
+            }
+            ret.add(element);
+        }
+        return ret;
+    }
+
+    /**
+     * A destructor function - call to free up the underlying memory.
+     */
+    public void destroy() {
+        storage.destroy(memoryRecycler);
+    }
+
+    /**
+     * Resize the underlying storage to a multiple of what it currently is. This method is not
+     * thread-safe.
+     */
+    private void resizeStorage() {
+        int currentElementsPerNode = maxElementsPerNode;
+        int newElementsPerNode = (int) (currentElementsPerNode * RESIZE_MULTIPLE);
+        if (newElementsPerNode <= currentElementsPerNode) {
+            throw new IllegalStateException("cannot resize fixed length array from "
+                    + currentElementsPerNode + " to " + newElementsPerNode);
+        }
+        FixedLengthElementArray newStorage = new FixedLengthElementArray(memoryRecycler,
+                numNodes * bitsPerElement * newElementsPerNode);
+        LongStream.range(0, numNodes).forEach(nodeIndex -> {
+            long currentBucketStart = nodeIndex * currentElementsPerNode * bitsPerElement;
+            long newBucketStart = nodeIndex * newElementsPerNode * bitsPerElement;
+            for (int offset = 0; offset < currentElementsPerNode; offset++) {
+                long element = storage.getElementValue(currentBucketStart + offset * bitsPerElement,
+                        bitsPerElement, elementMask);
+                if (element == NO_ELEMENT) {
+                    break; // we have exhausted the elements at this index
+                }
+                newStorage.setElementValue(
+                        newBucketStart + offset * bitsPerElement, bitsPerElement, element);
+            }
+        });
+        storage.destroy(memoryRecycler);
+        storage = newStorage;
+        maxElementsPerNode = newElementsPerNode;
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrefixIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrefixIndexTest.java
@@ -26,11 +26,13 @@ import com.netflix.hollow.core.write.objectmapper.HollowInline;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -182,6 +184,18 @@ public class HollowPrefixIndexTest {
         HollowPrefixIndex prefixIndex = new HollowPrefixIndex(readStateEngine, "MovieActorReference", "actors.element");
         Set<Integer> ordinals = toSet(prefixIndex.findKeysWithPrefix("kea"));
         Assert.assertTrue(ordinals.size() == 1);
+    }
+
+    @Test
+    public void testMovieActorReference_duplicatesInList() throws Exception {
+        List<Actor> actors = Collections.singletonList(new Actor("Keanu Reeves"));
+        int numMovies = 10;
+        IntStream.range(0, numMovies).mapToObj(index ->
+                new MovieActorReference(index, 1999 + index, "The Matrix " + index, actors))
+            .forEach(objectMapper::add);
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+        HollowPrefixIndex prefixIndex = new HollowPrefixIndex(readStateEngine, "MovieActorReference", "actors.element");
+        Assert.assertEquals(numMovies, toSet(prefixIndex.findKeysWithPrefix("kea")).size());
     }
 
     @Test

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/encoding/FixedLengthMultipleOccurrenceElementArrayTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/encoding/FixedLengthMultipleOccurrenceElementArrayTest.java
@@ -1,0 +1,81 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.memory.encoding;
+
+import static org.junit.Assert.assertEquals;
+
+import com.netflix.hollow.core.memory.pool.WastefulRecycler;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FixedLengthMultipleOccurrenceElementArrayTest {
+    private FixedLengthMultipleOccurrenceElementArray array;
+
+    @Before
+    public void setUp() {
+        array = new FixedLengthMultipleOccurrenceElementArray(
+                WastefulRecycler.SMALL_ARRAY_RECYCLER, 10000L, 5, 4);
+    }
+
+    @Test
+    public void testAddAndGet_returnsMultipleNoZero() {
+        List<Long> elements = LongStream.range(1, 4).boxed().collect(Collectors.toList());
+        elements.forEach(v -> array.addElement(0, v));
+        assertEquals(elements, array.getElements(0));
+    }
+
+    @Test
+    public void testAddAndGet_returnsMultipleWithZero() {
+        List<Long> elements = LongStream.range(0, 3).boxed().collect(Collectors.toList());
+        elements.forEach(v -> array.addElement(0, v));
+        assertEquals(elements, array.getElements(0));
+    }
+
+    @Test
+    public void testAddAndGet_resizes() {
+        List<Long> elements = LongStream.range(1, 4).boxed().collect(Collectors.toList());
+        elements.forEach(v -> array.addElement(0, v));
+        assertEquals(elements, array.getElements(0));
+    }
+
+    @Test
+    public void testAddAndGet_multipleNodes() {
+        List<Long> values0 = LongStream.range(0, 4).boxed().collect(Collectors.toList());
+        List<Long> values1 = LongStream.range(2, 15).boxed().collect(Collectors.toList());
+        List<Long> values2 = LongStream.range(1, 2).boxed().collect(Collectors.toList());
+        values0.forEach(v -> array.addElement(0, v));
+        values1.forEach(v -> array.addElement(1, v));
+        values2.forEach(v -> array.addElement(2, v));
+        assertEquals(values0, array.getElements(0));
+        assertEquals(values1, array.getElements(1));
+        assertEquals(values2, array.getElements(2));
+    }
+
+    @Test
+    public void testLargeNumberOfNodes() {
+        LongStream.range(0, 10000).forEach(nodeIndex -> {
+            List<Long> elements = LongStream.range(0, 31).boxed().collect(Collectors.toList());
+            elements.forEach(ordinal -> array.addElement(nodeIndex, ordinal));
+            assertEquals("nodeIndex " + nodeIndex + " should have correct elements", elements,
+                    array.getElements(nodeIndex));
+        });
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/util/FixedLengthElementArrayTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/util/FixedLengthElementArrayTest.java
@@ -46,6 +46,13 @@ public class FixedLengthElementArrayTest {
     }
 
     @Test
+    public void testGetEmpty() {
+        FixedLengthElementArray arr = new FixedLengthElementArray(
+                WastefulRecycler.SMALL_ARRAY_RECYCLER, 17000);
+        Assert.assertEquals(0, arr.getElementValue(0, 4));
+    }
+
+    @Test
     public void testSetAndGetLargeValues() {
         long testValue = 1913684435138312210L;
         int numBitsPerElement = 61;


### PR DESCRIPTION
* Implement a FixedLengthMultipleOccurrenceElementArray to allow storing multiple elements at a single node. Use this in the HollowPrefixIndex to allow storing multiple elements per node.
* Minor cleanup - get rid of IJ warnings in HollowPrefixIndex

Would be a good idea to review these commit by commit - the first commit is just cleanup. Or if it's easier, I can merge the first commit directly into master for ease of review.