### PR TITLE
Use transient and long value for __assigned_ordinal

### DIFF
--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -92,7 +92,7 @@ public class Director {
     long id;
     String directorName;
 
-    private final int __assigned_ordinal = HollowConstants.ORDINAL_NONE;
+    private transient final long __assigned_ordinal = HollowConstants.ORDINAL_NONE;
 }
 ```
 


### PR DESCRIPTION
Using an int field for  __assigned_ordinal may result in corrupt data being produced if the cached object is reused over cycles and the underlying ordinal would change. When a long field is used a random value generated per-cycle is stored in the top-32 bits of the field's value on first occurrence, and is checked on subsequent occurrences (see usages ASSIGNED_ORDINAL_CYCLE_MASK).
(Separately, support for int fields should be removed.)  