### PR TITLE
Add possibility to deprecate API

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
@@ -35,6 +35,7 @@ import com.netflix.hollow.api.objects.HollowObject;
 import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.write.objectmapper.DeprecatedApi;
 import com.netflix.hollow.tools.stringifier.HollowRecordStringifier;
 import java.util.Set;
 
@@ -117,6 +118,9 @@ public class HollowObjectJavaGenerator extends HollowConsumerJavaFileGenerator {
 
     private void appendAccessors(StringBuilder classBuilder) {
         for(int i=0;i<schema.numFields();i++) {
+
+            classBuilder.append(generateFieldAccessorDeprecatedApiAnnotation(schema.getDeprecatedApiAnnotation(i)));
+
             switch(schema.getFieldType(i)) {
                 case BOOLEAN:
                     classBuilder.append(generateBooleanFieldAccessor(i));
@@ -146,6 +150,17 @@ public class HollowObjectJavaGenerator extends HollowConsumerJavaFileGenerator {
 
             classBuilder.append("\n\n");
         }
+    }
+
+    private static String generateFieldAccessorDeprecatedApiAnnotation(DeprecatedApi deprecatedApiAnnotation) {
+        StringBuilder builder = new StringBuilder();
+        if (deprecatedApiAnnotation != null) {
+            builder.append("    /**\n")
+                    .append("    * " + deprecatedApiAnnotation.value() + "\n")
+                    .append("    */\n")
+                    .append("    @Deprecated\n");
+        }
+        return builder.toString();
     }
 
     private String generateByteArrayFieldAccessor(int fieldNum) {

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
@@ -154,11 +154,17 @@ public class HollowObjectJavaGenerator extends HollowConsumerJavaFileGenerator {
 
     private static String generateFieldAccessorDeprecatedApiAnnotation(DeprecatedApi deprecatedApiAnnotation) {
         StringBuilder builder = new StringBuilder();
+
         if (deprecatedApiAnnotation != null) {
-            builder.append("    /**\n")
-                    .append("    * " + deprecatedApiAnnotation.value() + "\n")
-                    .append("    */\n")
-                    .append("    @Deprecated\n");
+            String annotationValue = deprecatedApiAnnotation.value();
+
+            if (!annotationValue.isEmpty()) {
+                builder.append("    /**\n")
+                        .append("     * @deprecated ").append(annotationValue).append("\n")
+                        .append("     */\n");
+            }
+
+            builder.append("    @Deprecated\n");
         }
         return builder.toString();
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowObjectSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowObjectSchema.java
@@ -23,6 +23,7 @@ import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.read.filter.HollowFilterConfig;
 import com.netflix.hollow.core.read.filter.HollowFilterConfig.ObjectFilterConfig;
+import com.netflix.hollow.core.write.objectmapper.DeprecatedApi;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -43,6 +44,7 @@ public class HollowObjectSchema extends HollowSchema {
     private final String fieldNames[];
     private final FieldType fieldTypes[];
     protected final String referencedTypes[];
+    private final DeprecatedApi deprecatedFields[];
     private final HollowTypeReadState referencedFieldTypeStates[];  /// populated during deserialization
     private final PrimaryKey primaryKey;
 
@@ -59,6 +61,7 @@ public class HollowObjectSchema extends HollowSchema {
         this.fieldNames = new String[numFields];
         this.fieldTypes = new FieldType[numFields];
         this.referencedTypes = new String[numFields];
+        this.deprecatedFields = new DeprecatedApi[numFields];
         this.referencedFieldTypeStates = new HollowTypeReadState[numFields];
         this.primaryKey = primaryKey;
     }
@@ -76,17 +79,25 @@ public class HollowObjectSchema extends HollowSchema {
     }
 
     public int addField(String fieldName, FieldType fieldType, String referencedType) {
-        return addField(fieldName, fieldType, referencedType, null);
+        return addField(fieldName, fieldType, referencedType, null, null);
     }
 
-    public int addField(String fieldName, FieldType fieldType, String referencedType, HollowTypeReadState referencedTypeState) {
+    public int addField(String fieldName, FieldType fieldType, DeprecatedApi deprecatedApiAnnotation) {
+        return addField(fieldName, fieldType, null, deprecatedApiAnnotation);
+    }
+
+    public int addField(String fieldName, FieldType fieldType, String referencedType, DeprecatedApi deprecatedApiAnnotation) {
+        return addField(fieldName, fieldType, referencedType, deprecatedApiAnnotation, null);
+    }
+
+    public int addField(String fieldName, FieldType fieldType, String referencedType, DeprecatedApi deprecatedApiAnnotation, HollowTypeReadState referencedTypeState) {
         if(fieldType == FieldType.REFERENCE && referencedType == null)
             throw new RuntimeException("When adding a REFERENCE field to a schema, the referenced type must be provided.  Check type: " + getName() + " field: " + fieldName);
 
         fieldNames[size] = fieldName;
         fieldTypes[size] = fieldType;
         referencedTypes[size] = referencedType;
-
+        deprecatedFields[size] = deprecatedApiAnnotation;
         nameFieldIndexLookup.put(fieldName, Integer.valueOf(size));
 
         size++;
@@ -134,6 +145,10 @@ public class HollowObjectSchema extends HollowSchema {
 
     public String getReferencedType(int fieldPosition) {
         return referencedTypes[fieldPosition];
+    }
+
+    public DeprecatedApi getDeprecatedApiAnnotation(int fieldPosition) {
+        return deprecatedFields[fieldPosition];
     }
 
     public void setReferencedTypeState(int fieldPosition, HollowTypeReadState state) {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/DeprecatedApi.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/DeprecatedApi.java
@@ -6,6 +6,46 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+
+/**
+ * This annotation is meant to be used on data model fields to point
+ * deprecation and discourage to use them.
+ *
+ * <p>An annotated field with {@code @DeprecatedApi} will be transformed during
+ * Consumer API Generation into snippets consisting of JavaDoc information,
+ * if any exists, and {@link java.lang.Deprecated} annotation on accessor method.
+ *
+ * <p>Example:
+ *
+ * <p>The following data model snippet:
+ *
+ * <pre>
+ *  {@literal @DeprecatedApi}("Use {{@literal @link} #getNewValue()} instead.")
+ *  private final long value;
+ *
+ *  private final long newValue;
+ *
+ *  {@literal @DeprecatedApi}
+ *  private final String name;
+ * </pre>
+ *
+ * <p>will be transformed into:
+ *
+ * <pre>
+ *  /**
+ *   * @deprecated Use {{@literal @link} #getNewValue()} instead.
+ *   * /
+ *  {@literal @Deprecated}
+ *  public final long getValue(){...}
+ *
+ *  public final long getNewValue(){...}
+ *
+ *  {@literal @Deprecated}
+ *  public final String getName(){...}
+ * </pre>
+ *
+ * @see java.lang.Deprecated
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(FIELD)
 public @interface DeprecatedApi {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/DeprecatedApi.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/DeprecatedApi.java
@@ -1,0 +1,15 @@
+package com.netflix.hollow.core.write.objectmapper;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({FIELD, METHOD})
+public @interface DeprecatedApi {
+    String value() default "Empty Javadoc";
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/DeprecatedApi.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/DeprecatedApi.java
@@ -1,15 +1,13 @@
 package com.netflix.hollow.core.write.objectmapper;
 
 import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 @Retention(RetentionPolicy.RUNTIME)
-@Target({FIELD, METHOD})
+@Target(FIELD)
 public @interface DeprecatedApi {
-    String value() default "Empty Javadoc";
+    String value() default "";
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -104,9 +104,9 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
 
         for(MappedField field : mappedFields) {
             if(field.getFieldType() == MappedFieldType.REFERENCE) {
-                schema.addField(field.getFieldName(), field.getFieldType().getSchemaFieldType(), field.getReferencedTypeName());
+                schema.addField(field.getFieldName(), field.getFieldType().getSchemaFieldType(), field.getReferencedTypeName(), field.getDeprecatedApiAnnotation());
             } else {
-                schema.addField(field.getFieldName(), field.getFieldType().getSchemaFieldType());
+                schema.addField(field.getFieldName(), field.getFieldType().getSchemaFieldType(), field.getDeprecatedApiAnnotation());
             }
         }
 
@@ -256,6 +256,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
         private final HollowHashKey hashKeyAnnotation;
         private final HollowShardLargeType numShardsAnnotation;
         private final boolean isInlinedField;
+        private final DeprecatedApi deprecatedApiAnnotation;
 
         private MappedField(Field f) {
             this(f, new HashSet<Type>());
@@ -270,7 +271,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             this.hashKeyAnnotation = f.getAnnotation(HollowHashKey.class);
             this.numShardsAnnotation = f.getAnnotation(HollowShardLargeType.class);
             this.isInlinedField = f.isAnnotationPresent(HollowInline.class);
-            
+            this.deprecatedApiAnnotation = f.getAnnotation(DeprecatedApi.class);
 
             HollowTypeMapper subTypeMapper = null;
             
@@ -349,6 +350,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             this.fieldType = specialField;
             this.subTypeMapper = null;
             this.isInlinedField = false;
+            this.deprecatedApiAnnotation = null;
         }
 
         public String getFieldName() {
@@ -357,6 +359,10 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
 
         public MappedFieldType getFieldType() {
             return fieldType;
+        }
+
+        public DeprecatedApi getDeprecatedApiAnnotation() {
+            return deprecatedApiAnnotation;
         }
 
         public String getReferencedTypeName() {

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowDataAccessorAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowDataAccessorAPIGeneratorTest.java
@@ -45,7 +45,10 @@ public class HollowDataAccessorAPIGeneratorTest extends AbstractHollowAPIGenerat
     static class Movie {
         int id;
 
-        @DeprecatedApi("@deprecated use {@link #getNewName} instead")
+        @DeprecatedApi
+        int age;
+
+        @DeprecatedApi("Use {@link #getNewName} instead")
         String name;
 
         String newName;

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowDataAccessorAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowDataAccessorAPIGeneratorTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.hollow.api.codegen;
 
+import com.netflix.hollow.core.write.objectmapper.DeprecatedApi;
 import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 import java.io.IOException;
 import org.junit.Before;
@@ -44,6 +45,9 @@ public class HollowDataAccessorAPIGeneratorTest extends AbstractHollowAPIGenerat
     static class Movie {
         int id;
 
+        @DeprecatedApi("@deprecated use {@link #getNewName} instead")
         String name;
+
+        String newName;
     }
 }


### PR DESCRIPTION
As the created API changes in a lifetime, I would like to be able to `@Deprecate` accessor methods. This PR gives that opportunity. 

Example:
```
@DeprecatedApi("@deprecated Use {@link #getPrePaddingTimeRef} instead")
private final long prePaddingTime;
```

Model annotated field transformed into:

```
/**
* @deprecated Use {@link #getPrePaddingTimeRef} instead.
*/
@Deprecated
public long getPrePaddingTime() {
    return delegate().getPrePaddingTime(ordinal);
}
```
