### PR TITLE
Add index and hash JMH benchmarks

### DIFF
--- a/hollow/build.gradle
+++ b/hollow/build.gradle
@@ -1,10 +1,25 @@
+buildscript {
+    repositories {
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
+    }
+    dependencies {
+        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.7'
+    }
+}
+
 apply plugin: 'java'
- 
+apply plugin: 'me.champeau.gradle.jmh'
+
 dependencies {
     testCompile project(":hollow-test")
     testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-core:2.15.0'
     testCompile 'com.google.code.findbugs:findbugs:3.0.1'
+
+    jmh 'org.openjdk.jmh:jmh-core:1.21'
+    jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.21'
 }
 
 // quiet warnings about sun.misc.Unsafe

--- a/hollow/src/jmh/java/com/netflix/hollow/core/index/AbstractHollowIndexBenchmark.java
+++ b/hollow/src/jmh/java/com/netflix/hollow/core/index/AbstractHollowIndexBenchmark.java
@@ -1,0 +1,137 @@
+package com.netflix.hollow.core.index;
+
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.LogManager;
+
+/**
+ * Abstract benchmark class for Hollow indexes. Uses integer keys to avoid mixing in the overhead of individual hash functions.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+public abstract class AbstractHollowIndexBenchmark<T> {
+    private HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+    private HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+    private ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    protected HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+    protected T index;
+    protected String[] matchFields;
+
+    @Param({"1", "10000", "100000", "1000000", "10000000", "100000000"})
+    public int size;
+
+    @Param({"1", "2", "3", "5", "8"})
+    public int querySize;
+
+    @Param({"false", "true"})
+    public boolean nested;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        LogManager.getLogManager().reset();
+
+        for (int i = 0; i < size; i++) {
+            // Make field values unique for a given object, otherwise index build performance worsens significantly
+            int key = getKey(8 * i);
+            mapper.add(new IntType(key, new NestedIntType(key)));
+        }
+
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        matchFields = new String[querySize];
+        for (int i = 0; i < querySize; i++) {
+            int fieldNum = i + 1;
+            String fieldName = "field" + fieldNum;
+            matchFields[i] = nested ? "nested." + fieldName : fieldName;
+        }
+
+        index = createIndex();
+    }
+
+    protected Object[] nextKeys() {
+        int key = getKey(random.nextInt(size));
+        Integer[] keys = new Integer[querySize];
+        for (int i = 0; i < querySize; i++) {
+            keys[i] = key + i;
+        }
+        return keys;
+    }
+
+    protected Object[] missingKeys() {
+        Integer[] keys = new Integer[querySize];
+        for (int i = 0; i < querySize; i++) {
+            keys[i] = -1;
+        }
+        return keys;
+    }
+
+    protected abstract T createIndex();
+
+    protected int cardinality() {
+        return 1;
+    }
+
+    protected int getKey(int key) {
+        int cardinality = cardinality();
+        return key - key % cardinality;
+    }
+
+    protected static class IntType {
+        private int field1;
+        private int field2;
+        private int field3;
+        private int field4;
+        private int field5;
+        private int field6;
+        private int field7;
+        private int field8;
+        private NestedIntType nested;
+
+        public IntType(int i, NestedIntType nested) {
+            this.field1 = i;
+            this.field2 = i + 1;
+            this.field3 = i + 2;
+            this.field4 = i + 3;
+            this.field5 = i + 4;
+            this.field6 = i + 5;
+            this.field7 = i + 6;
+            this.field8 = i + 7;
+            this.nested = nested;
+        }
+    }
+
+    private static class NestedIntType {
+        private int field1;
+        private int field2;
+        private int field3;
+        private int field4;
+        private int field5;
+        private int field6;
+        private int field7;
+        private int field8;
+
+        public NestedIntType(int i) {
+            this.field1 = i;
+            this.field2 = i + 1;
+            this.field3 = i + 2;
+            this.field4 = i + 3;
+            this.field5 = i + 4;
+            this.field6 = i + 5;
+            this.field7 = i + 6;
+            this.field8 = i + 7;
+        }
+    }
+}

--- a/hollow/src/jmh/java/com/netflix/hollow/core/index/AbstractHollowIndexBenchmark.java
+++ b/hollow/src/jmh/java/com/netflix/hollow/core/index/AbstractHollowIndexBenchmark.java
@@ -4,6 +4,9 @@ import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.util.StateEngineRoundTripper;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.LogManager;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
@@ -11,10 +14,6 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-
-import java.io.IOException;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.logging.LogManager;
 
 /**
  * Abstract benchmark class for Hollow indexes. Uses integer keys to avoid mixing in the overhead of individual hash functions.

--- a/hollow/src/jmh/java/com/netflix/hollow/core/index/HollowHashIndexBenchmark.java
+++ b/hollow/src/jmh/java/com/netflix/hollow/core/index/HollowHashIndexBenchmark.java
@@ -1,0 +1,53 @@
+package com.netflix.hollow.core.index;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.concurrent.TimeUnit;
+
+public class HollowHashIndexBenchmark extends AbstractHollowIndexBenchmark<HollowHashIndex> {
+    @Param({"1", "1000", "10000", "100000"})
+    public int cardinality;
+
+    @Override
+    protected int cardinality() {
+        return cardinality;
+    }
+
+    @Override
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public HollowHashIndex createIndex() {
+        return new HollowHashIndex(readStateEngine, IntType.class.getSimpleName(), "", matchFields);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public HollowHashIndexResult findMatches() {
+        return index.findMatches(nextKeys());
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public HollowHashIndexResult findMatchesMissing() {
+        return index.findMatches(missingKeys());
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(HollowHashIndexBenchmark.class.getSimpleName())
+                .warmupIterations(5)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(1)
+                .measurementTime(TimeValue.seconds(3))
+                .forks(1)
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/hollow/src/jmh/java/com/netflix/hollow/core/index/HollowHashIndexBenchmark.java
+++ b/hollow/src/jmh/java/com/netflix/hollow/core/index/HollowHashIndexBenchmark.java
@@ -1,5 +1,6 @@
 package com.netflix.hollow.core.index;
 
+import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
@@ -8,8 +9,6 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
-
-import java.util.concurrent.TimeUnit;
 
 public class HollowHashIndexBenchmark extends AbstractHollowIndexBenchmark<HollowHashIndex> {
     @Param({"1", "1000", "10000", "100000"})

--- a/hollow/src/jmh/java/com/netflix/hollow/core/index/key/HollowPrimaryKeyIndexBenchmark.java
+++ b/hollow/src/jmh/java/com/netflix/hollow/core/index/key/HollowPrimaryKeyIndexBenchmark.java
@@ -1,0 +1,46 @@
+package com.netflix.hollow.core.index.key;
+
+import com.netflix.hollow.core.index.AbstractHollowIndexBenchmark;
+import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.concurrent.TimeUnit;
+
+public class HollowPrimaryKeyIndexBenchmark extends AbstractHollowIndexBenchmark<HollowPrimaryKeyIndex> {
+    @Override
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public HollowPrimaryKeyIndex createIndex() {
+        return new HollowPrimaryKeyIndex(readStateEngine, IntType.class.getSimpleName(), matchFields);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public int getMatchingOrdinal() {
+        return index.getMatchingOrdinal(nextKeys());
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public int getMatchingOrdinalMissing() {
+        return index.getMatchingOrdinal(missingKeys());
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(HollowPrimaryKeyIndexBenchmark.class.getSimpleName())
+                .warmupIterations(5)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(1)
+                .measurementTime(TimeValue.seconds(3))
+                .forks(1)
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/hollow/src/jmh/java/com/netflix/hollow/core/index/key/HollowPrimaryKeyIndexBenchmark.java
+++ b/hollow/src/jmh/java/com/netflix/hollow/core/index/key/HollowPrimaryKeyIndexBenchmark.java
@@ -2,6 +2,7 @@ package com.netflix.hollow.core.index.key;
 
 import com.netflix.hollow.core.index.AbstractHollowIndexBenchmark;
 import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
+import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.runner.Runner;
@@ -9,8 +10,6 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
-
-import java.util.concurrent.TimeUnit;
 
 public class HollowPrimaryKeyIndexBenchmark {
     public static class BuildHollowPrimaryKeyIndexBenchmark extends AbstractHollowPrimaryKeyIndexBenchmark {

--- a/hollow/src/jmh/java/com/netflix/hollow/core/index/key/HollowPrimaryKeyIndexBenchmark.java
+++ b/hollow/src/jmh/java/com/netflix/hollow/core/index/key/HollowPrimaryKeyIndexBenchmark.java
@@ -2,7 +2,6 @@ package com.netflix.hollow.core.index.key;
 
 import com.netflix.hollow.core.index.AbstractHollowIndexBenchmark;
 import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
-import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.runner.Runner;
@@ -11,24 +10,41 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
-public class HollowPrimaryKeyIndexBenchmark extends AbstractHollowIndexBenchmark<HollowPrimaryKeyIndex> {
-    @Override
-    @Benchmark
-    @OutputTimeUnit(TimeUnit.SECONDS)
-    public HollowPrimaryKeyIndex createIndex() {
-        return new HollowPrimaryKeyIndex(readStateEngine, IntType.class.getSimpleName(), matchFields);
+import java.util.concurrent.TimeUnit;
+
+public class HollowPrimaryKeyIndexBenchmark {
+    public static class BuildHollowPrimaryKeyIndexBenchmark extends AbstractHollowPrimaryKeyIndexBenchmark {
+        @Override
+        protected boolean shouldCreateIndexes() {
+            return false;
+        }
+
+        @Benchmark
+        @OutputTimeUnit(TimeUnit.SECONDS)
+        public HollowPrimaryKeyIndex buildIndex() {
+            return createIndex();
+        }
     }
 
-    @Benchmark
-    @OutputTimeUnit(TimeUnit.NANOSECONDS)
-    public int getMatchingOrdinal() {
-        return index.getMatchingOrdinal(nextKeys());
+    public static class LoadHollowPrimaryKeyIndexBenchmark extends AbstractHollowPrimaryKeyIndexBenchmark {
+        @Benchmark
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public int getMatchingOrdinal() {
+            return nextIndex().getMatchingOrdinal(nextKeys());
+        }
+
+        @Benchmark
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public int getMatchingOrdinalMissing() {
+            return nextIndex().getMatchingOrdinal(missingKeys());
+        }
     }
 
-    @Benchmark
-    @OutputTimeUnit(TimeUnit.NANOSECONDS)
-    public int getMatchingOrdinalMissing() {
-        return index.getMatchingOrdinal(missingKeys());
+    public static class AbstractHollowPrimaryKeyIndexBenchmark extends AbstractHollowIndexBenchmark<HollowPrimaryKeyIndex> {
+        @Override
+        public HollowPrimaryKeyIndex createIndex() {
+            return new HollowPrimaryKeyIndex(readStateEngine, IntType.class.getSimpleName(), matchFields);
+        }
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/hollow/src/jmh/java/com/netflix/hollow/core/index/key/HollowPrimaryKeyIndexBenchmark.java
+++ b/hollow/src/jmh/java/com/netflix/hollow/core/index/key/HollowPrimaryKeyIndexBenchmark.java
@@ -2,6 +2,7 @@ package com.netflix.hollow.core.index.key;
 
 import com.netflix.hollow.core.index.AbstractHollowIndexBenchmark;
 import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
+import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.runner.Runner;
@@ -9,8 +10,6 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
-
-import java.util.concurrent.TimeUnit;
 
 public class HollowPrimaryKeyIndexBenchmark extends AbstractHollowIndexBenchmark<HollowPrimaryKeyIndex> {
     @Override

--- a/hollow/src/jmh/java/com/netflix/hollow/core/memory/encoding/HashCodesBenchmark.java
+++ b/hollow/src/jmh/java/com/netflix/hollow/core/memory/encoding/HashCodesBenchmark.java
@@ -1,0 +1,84 @@
+package com.netflix.hollow.core.memory.encoding;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class HashCodesBenchmark {
+    private ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    @Param({"1", "2", "3", "5", "10", "100", "1000"})
+    int length;
+
+    byte[] charData;
+    byte[] multibyteCharData;
+    int intKey;
+    long longKey;
+    String stringKey;
+    String multibyteStringKey;
+
+    @Setup
+    public void setup() {
+        charData = new byte[length];
+        multibyteCharData = new byte[length];
+        for (int i = 0; i < length; i++) {
+            charData[i] = (byte) random.nextInt(0x80);
+            multibyteCharData[i] = (byte) random.nextInt(Character.MAX_VALUE);
+        }
+        stringKey = new String(charData);
+        multibyteStringKey = new String(multibyteCharData);
+    }
+
+    @Benchmark
+    public int hashInt() {
+        return HashCodes.hashInt(intKey);
+    }
+
+    @Benchmark
+    public int hashLong() {
+        return HashCodes.hashLong(longKey);
+    }
+
+    @Benchmark
+    public int hashString() {
+        return HashCodes.hashCode(stringKey);
+    }
+
+    @Benchmark
+    public int hashStringMultibyte() {
+        return HashCodes.hashCode(multibyteStringKey);
+    }
+
+    @Benchmark
+    public int hashBytes() {
+        return HashCodes.hashCode(charData);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(HashCodesBenchmark.class.getSimpleName())
+                .warmupIterations(5)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(1)
+                .measurementTime(TimeValue.seconds(3))
+                .forks(1)
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/hollow/src/jmh/java/com/netflix/hollow/core/memory/encoding/HashCodesBenchmark.java
+++ b/hollow/src/jmh/java/com/netflix/hollow/core/memory/encoding/HashCodesBenchmark.java
@@ -1,5 +1,7 @@
 package com.netflix.hollow.core.memory.encoding;
 
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -13,9 +15,6 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
-
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)


### PR DESCRIPTION
I needed to make some decisions about how to best model/index data for a performance sensitive use case and rather than go through trial and error in the actual implementation I figured I'd add some benchmarks here instead.

The full suite has a lot of permutations, so would several hours to run, so I cherry picked a couple of configurations that gives a meaningful comparison. Would appreciate some feedback on the methodology to make sure the results are correct.

Our use case would currently have ~65 million objects, with cardinality ranging from 1 to 100 thousand - the main questions I was trying to answer here were:

- Nested or non-nested objects for index fields
- Compound or non-compound keys
- Should we seek to reduce cardinality by adding separate collection holder type and group them in the consumer, or is `HashIndex` creation/load performance good enough in the consumer

# HashIndex

`cardinality` refers to the number of matches (i.e. number of objects with identical fields).

```
Benchmark                                    (cardinality)  (nested)  (querySize)   (size)  Mode  Cnt    Score   Error  Units
HollowHashIndexBenchmark.createIndex                     1     false            1  1000000  avgt         0.470           s/op
HollowHashIndexBenchmark.createIndex                     1     false            4  1000000  avgt         0.511           s/op
HollowHashIndexBenchmark.createIndex                     1      true            1  1000000  avgt         0.472           s/op
HollowHashIndexBenchmark.createIndex                     1      true            4  1000000  avgt         0.555           s/op
HollowHashIndexBenchmark.findMatches                     1     false            1  1000000  avgt       369.577          ns/op
HollowHashIndexBenchmark.findMatches                     1     false            4  1000000  avgt       407.978          ns/op
HollowHashIndexBenchmark.findMatches                     1      true            1  1000000  avgt       620.034          ns/op
HollowHashIndexBenchmark.findMatches                     1      true            4  1000000  avgt       642.681          ns/op
HollowHashIndexBenchmark.findMatchesMissing              1     false            1  1000000  avgt        46.252          ns/op
HollowHashIndexBenchmark.findMatchesMissing              1     false            4  1000000  avgt        35.563          ns/op
HollowHashIndexBenchmark.findMatchesMissing              1      true            1  1000000  avgt        64.633          ns/op
HollowHashIndexBenchmark.findMatchesMissing              1      true            4  1000000  avgt        35.785          ns/op
```

Performance improves as cardinality increases:
```
Benchmark                                    (cardinality)  (nested)  (querySize)   (size)  Mode  Cnt    Score   Error  Units
HollowHashIndexBenchmark.createIndex                  1000     false            1  1000000  avgt         0.001           s/op
HollowHashIndexBenchmark.createIndex                  1000     false            4  1000000  avgt         0.002           s/op
HollowHashIndexBenchmark.createIndex                  1000      true            1  1000000  avgt         0.001           s/op
HollowHashIndexBenchmark.createIndex                  1000      true            4  1000000  avgt         0.002           s/op
HollowHashIndexBenchmark.findMatches                  1000     false            1  1000000  avgt        65.274          ns/op
HollowHashIndexBenchmark.findMatches                  1000     false            4  1000000  avgt       133.855          ns/op
HollowHashIndexBenchmark.findMatches                  1000      true            1  1000000  avgt        77.624          ns/op
HollowHashIndexBenchmark.findMatches                  1000      true            4  1000000  avgt       221.643          ns/op
HollowHashIndexBenchmark.findMatchesMissing           1000     false            1  1000000  avgt        22.621          ns/op
HollowHashIndexBenchmark.findMatchesMissing           1000     false            4  1000000  avgt        34.524          ns/op
HollowHashIndexBenchmark.findMatchesMissing           1000      true            1  1000000  avgt        22.642          ns/op
HollowHashIndexBenchmark.findMatchesMissing           1000      true            4  1000000  avgt        34.178          ns/op
```

# PrimaryKeyIndex

```
Benchmark                                                 (nested)  (querySize)   (size)  Mode  Cnt    Score   Error  Units
HollowPrimaryKeyIndexBenchmark.createIndex                   false            1  1000000  avgt         0.063           s/op
HollowPrimaryKeyIndexBenchmark.createIndex                   false            4  1000000  avgt         0.095           s/op
HollowPrimaryKeyIndexBenchmark.createIndex                    true            1  1000000  avgt         0.116           s/op
HollowPrimaryKeyIndexBenchmark.createIndex                    true            4  1000000  avgt         0.189           s/op
HollowPrimaryKeyIndexBenchmark.getMatchingOrdinal            false            1  1000000  avgt       305.982          ns/op
HollowPrimaryKeyIndexBenchmark.getMatchingOrdinal            false            4  1000000  avgt       333.696          ns/op
HollowPrimaryKeyIndexBenchmark.getMatchingOrdinal             true            1  1000000  avgt       563.586          ns/op
HollowPrimaryKeyIndexBenchmark.getMatchingOrdinal             true            4  1000000  avgt       595.999          ns/op
HollowPrimaryKeyIndexBenchmark.getMatchingOrdinalMissing     false            1  1000000  avgt        40.421          ns/op
HollowPrimaryKeyIndexBenchmark.getMatchingOrdinalMissing     false            4  1000000  avgt        36.977          ns/op
HollowPrimaryKeyIndexBenchmark.getMatchingOrdinalMissing      true            1  1000000  avgt        73.481          ns/op
HollowPrimaryKeyIndexBenchmark.getMatchingOrdinalMissing      true            4  1000000  avgt        41.947          ns/op
```

# HashCodes

I went with int keys in the benchmarks, to avoid the hash function being a significant contributor. Added some benchmarks to look at the hash functions separately. You might want to look at the `String` variant of `hashCode`, there's some weirdness about multibyte Strings and has worst performance than hashing a byte array of the same length:
```
Benchmark                                (length)  (multibyte)  Mode  Cnt     Score     Error  Units
Benchmark                               (length)  Mode  Cnt     Score   Error  Units
HashCodesBenchmark.hashBytes                   1  avgt          7.247          ns/op
HashCodesBenchmark.hashBytes                   2  avgt          7.857          ns/op
HashCodesBenchmark.hashBytes                   3  avgt          7.871          ns/op
HashCodesBenchmark.hashBytes                   5  avgt          8.933          ns/op
HashCodesBenchmark.hashBytes                  10  avgt         12.028          ns/op
HashCodesBenchmark.hashBytes                 100  avgt         56.531          ns/op
HashCodesBenchmark.hashBytes                1000  avgt        524.596          ns/op
HashCodesBenchmark.hashInt                     1  avgt          2.630          ns/op
HashCodesBenchmark.hashInt                     2  avgt          2.671          ns/op
HashCodesBenchmark.hashInt                     3  avgt          2.656          ns/op
HashCodesBenchmark.hashInt                     5  avgt          2.656          ns/op
HashCodesBenchmark.hashInt                    10  avgt          2.638          ns/op
HashCodesBenchmark.hashInt                   100  avgt          2.633          ns/op
HashCodesBenchmark.hashInt                  1000  avgt          2.628          ns/op
HashCodesBenchmark.hashLong                    1  avgt          2.705          ns/op
HashCodesBenchmark.hashLong                    2  avgt          2.701          ns/op
HashCodesBenchmark.hashLong                    3  avgt          2.715          ns/op
HashCodesBenchmark.hashLong                    5  avgt          2.731          ns/op
HashCodesBenchmark.hashLong                   10  avgt          2.737          ns/op
HashCodesBenchmark.hashLong                  100  avgt          2.715          ns/op
HashCodesBenchmark.hashLong                 1000  avgt          2.736          ns/op
HashCodesBenchmark.hashString                  1  avgt          9.322          ns/op
HashCodesBenchmark.hashString                  2  avgt         10.185          ns/op
HashCodesBenchmark.hashString                  3  avgt         10.487          ns/op
HashCodesBenchmark.hashString                  5  avgt         13.324          ns/op
HashCodesBenchmark.hashString                 10  avgt         18.794          ns/op
HashCodesBenchmark.hashString                100  avgt         98.877          ns/op
HashCodesBenchmark.hashString               1000  avgt        868.692          ns/op
HashCodesBenchmark.hashStringMultibyte         1  avgt         24.457          ns/op
HashCodesBenchmark.hashStringMultibyte         2  avgt         26.278          ns/op
HashCodesBenchmark.hashStringMultibyte         3  avgt         30.154          ns/op
HashCodesBenchmark.hashStringMultibyte         5  avgt         31.497          ns/op
HashCodesBenchmark.hashStringMultibyte        10  avgt         43.098          ns/op
HashCodesBenchmark.hashStringMultibyte       100  avgt        286.791          ns/op
HashCodesBenchmark.hashStringMultibyte      1000  avgt       2789.318          ns/op
```
