### PR TITLE
Concurrent addition/removal of consumer refresh listeners.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowDataHolder.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowDataHolder.java
@@ -31,12 +31,11 @@ import com.netflix.hollow.tools.history.HollowHistoricalStateDataAccess;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
-import java.util.List;
 
 /**
  * A class comprising much of the internal state of a {@link HollowConsumer}.  Not intended for external consumption.
  */
-public class HollowDataHolder {
+class HollowDataHolder {
 
     private final HollowReadStateEngine stateEngine;
     private final HollowAPIFactory apiFactory;
@@ -44,7 +43,6 @@ public class HollowDataHolder {
     private final FailedTransitionTracker failedTransitionTracker;
     private final StaleHollowReferenceDetector staleReferenceDetector;
     private final HollowConsumer.ObjectLongevityConfig objLongevityConfig;
-    private final List<HollowConsumer.RefreshListener> refreshListeners;
 
     private HollowFilterConfig filter;
 
@@ -54,53 +52,51 @@ public class HollowDataHolder {
 
     private long currentVersion = HollowConstants.VERSION_NONE;
 
-    public HollowDataHolder(HollowReadStateEngine stateEngine, 
+    HollowDataHolder(HollowReadStateEngine stateEngine,
                             HollowAPIFactory apiFactory, 
                             FailedTransitionTracker failedTransitionTracker, 
                             StaleHollowReferenceDetector staleReferenceDetector, 
-                            List<HollowConsumer.RefreshListener> refreshListeners, 
                             HollowConsumer.ObjectLongevityConfig objLongevityConfig) {
         this.stateEngine = stateEngine;
         this.apiFactory = apiFactory;
         this.reader = new HollowBlobReader(stateEngine);
         this.failedTransitionTracker = failedTransitionTracker;
         this.staleReferenceDetector = staleReferenceDetector;
-        this.refreshListeners = refreshListeners;
         this.objLongevityConfig = objLongevityConfig;
     }
 
-    public HollowReadStateEngine getStateEngine() {
+    HollowReadStateEngine getStateEngine() {
         return stateEngine;
     }
 
-    public HollowAPI getAPI() {
+    HollowAPI getAPI() {
         return currentAPI;
     }
 
-    public long getCurrentVersion() {
+    long getCurrentVersion() {
         return currentVersion;
     }
 
-    public HollowDataHolder setFilter(HollowFilterConfig filter) {
+    HollowDataHolder setFilter(HollowFilterConfig filter) {
         this.filter = filter;
         return this;
     }
 
-    public void update(HollowUpdatePlan updatePlan) throws Throwable {
+    void update(HollowUpdatePlan updatePlan, HollowConsumer.RefreshListener[] refreshListeners) throws Throwable {
         if(failedTransitionTracker.anyTransitionWasFailed(updatePlan))
             throw new RuntimeException("Update plan contains known failing transition!");
 
         if(updatePlan.isSnapshotPlan())
-            applySnapshotPlan(updatePlan);
+            applySnapshotPlan(updatePlan, refreshListeners);
         else
-            applyDeltaOnlyPlan(updatePlan);
+            applyDeltaOnlyPlan(updatePlan, refreshListeners);
     }
 
-    private void applySnapshotPlan(HollowUpdatePlan updatePlan) throws Throwable {
-        applySnapshotTransition(updatePlan.getSnapshotTransition());
+    private void applySnapshotPlan(HollowUpdatePlan updatePlan, HollowConsumer.RefreshListener[] refreshListeners) throws Throwable {
+        applySnapshotTransition(updatePlan.getSnapshotTransition(), refreshListeners);
             
         for(HollowConsumer.Blob blob : updatePlan.getDeltaTransitions()) {
-            applyDeltaTransition(blob, true);
+            applyDeltaTransition(blob, true, refreshListeners);
         }
 
         try {
@@ -112,9 +108,9 @@ public class HollowDataHolder {
         }
     }
 
-    private void applySnapshotTransition(HollowConsumer.Blob snapshotBlob) throws Throwable {
+    private void applySnapshotTransition(HollowConsumer.Blob snapshotBlob, HollowConsumer.RefreshListener[] refreshListeners) throws Throwable {
         try(InputStream is = snapshotBlob.getInputStream()) {
-            applyStateEngineTransition(is, snapshotBlob);
+            applyStateEngineTransition(is, snapshotBlob, refreshListeners);
             initializeAPI();
             
             for(HollowConsumer.RefreshListener refreshListener : refreshListeners) {
@@ -139,15 +135,15 @@ public class HollowDataHolder {
         staleReferenceDetector.newAPIHandle(currentAPI);
     }
 
-    private void applyDeltaOnlyPlan(HollowUpdatePlan updatePlan) throws Throwable {
+    private void applyDeltaOnlyPlan(HollowUpdatePlan updatePlan, HollowConsumer.RefreshListener[] refreshListeners) throws Throwable {
         for(HollowConsumer.Blob blob : updatePlan) {
-            applyDeltaTransition(blob, false);
+            applyDeltaTransition(blob, false, refreshListeners);
         }
     }
 
-    private void applyDeltaTransition(HollowConsumer.Blob blob, boolean isSnapshotPlan) throws Throwable {
+    private void applyDeltaTransition(HollowConsumer.Blob blob, boolean isSnapshotPlan, HollowConsumer.RefreshListener[] refreshListeners) throws Throwable {
         try(InputStream is = blob.getInputStream()) {
-            applyStateEngineTransition(is, blob);
+            applyStateEngineTransition(is, blob, refreshListeners);
 
             if(objLongevityConfig.enableLongLivedObjectSupport()) {
                 HollowDataAccess previousDataAccess = currentAPI.getDataAccess();
@@ -194,7 +190,7 @@ public class HollowDataHolder {
         priorHistoricalDataAccess = new WeakReference<HollowHistoricalStateDataAccess>(nextPriorState);
     }
 
-    private void applyStateEngineTransition(InputStream is, HollowConsumer.Blob transition) throws IOException {
+    private void applyStateEngineTransition(InputStream is, HollowConsumer.Blob transition, HollowConsumer.RefreshListener[] refreshListeners) throws IOException {
         if(transition.isSnapshot()) {
             if(filter == null)
                 reader.readSnapshot(is);

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -325,33 +325,29 @@ public class HollowConsumer {
     }
 
     /**
-     * Add a {@link RefreshListener} to this consumer.
-     *
-     * @implNote this implementation will first acquire the {@link #getRefreshLock() refresh lock} before adding
-     * the new refresh listener. This ensures the listener will receive events for a complete cycle.
+     * Adds a {@link RefreshListener} to this consumer.
+     * <p>
+     * If the listener was previously added to this consumer, as determined by reference equality or {@code Object}
+     * equality, then this method does nothing.
+     * <p>
+     * If a listener is added, concurrently, during the occurrence of a refresh then the listener will not receive
+     * events until the next refresh.  The listener may also be removed concurrently.
      */
     public void addRefreshListener(RefreshListener listener) {
-        getRefreshLock().lock();
-        try {
-            updater.addRefreshListener(listener);
-        } finally {
-            getRefreshLock().unlock();
-        }
+        updater.addRefreshListener(listener);
     }
 
     /**
-     * Remove a {@link RefreshListener} from this consumer.
-     *
-     * @implNote this implementation will first acquire the {@link #getRefreshLock() refresh lock} before removing
-     * the refresh listener. This ensures the listener will receive events for a complete cycle.
+     * Removes a {@link RefreshListener} from this consumer.
+     * <p>
+     * If the listener was not previously added to this consumer, as determined by reference equality or {@code Object}
+     * equality, then this method does nothing.
+     * <p>
+     * If a listener is removed, concurrently, during  the occurrence of a refresh then the listener will receive all
+     * events for that refresh but not receive events for subsequent any refreshes.
      */
     public void removeRefreshListener(RefreshListener listener) {
-        getRefreshLock().lock();
-        try {
-            updater.removeRefreshListener(listener);
-        } finally {
-            getRefreshLock().unlock();
-        }
+        updater.removeRefreshListener(listener);
     }
 
     /**

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowRefreshListenerTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowRefreshListenerTests.java
@@ -209,7 +209,7 @@ public class HollowRefreshListenerTests {
         final List<GenericHollowObject> deltaOrdinal0Objects = new ArrayList<GenericHollowObject>();
         final List<GenericHollowObject> deltaOrdinal1Objects = new ArrayList<GenericHollowObject>();
 
-        AbstractRefreshListener longevityListener = new AbstractRefreshListener() {
+        HollowConsumer.RefreshListener longevityListener = new AbstractRefreshListener() {
             public void snapshotApplied(HollowAPI api, HollowReadStateEngine stateEngine, long version) throws Exception {
                 snapshotOrdinal0Objects.add(new GenericHollowObject(api.getDataAccess(), "Integer", 0));
             }
@@ -230,7 +230,107 @@ public class HollowRefreshListenerTests {
         Assert.assertEquals(4, deltaOrdinal1Objects.get(2).getInt("value"));
         Assert.assertEquals(5, deltaOrdinal0Objects.get(3).getInt("value"));
     }
-    
+
+    @Test
+    public void testAddListenerDuringRefresh() {
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .build();
+
+        class SecondRefreshListener extends AbstractRefreshListener {
+            int refreshStarted;
+            int refreshSuccessful;
+            @Override public void refreshStarted(long currentVersion, long requestedVersion) {
+                refreshStarted++;
+            }
+
+            @Override public void refreshSuccessful(long beforeVersion, long afterVersion, long requestedVersion) {
+                refreshSuccessful++;
+            }
+        };
+
+        class FirstRefreshListener extends SecondRefreshListener {
+            SecondRefreshListener srl = new SecondRefreshListener();
+
+            @Override public void refreshStarted(long currentVersion, long requestedVersion) {
+                super.refreshStarted(currentVersion, requestedVersion);
+                // Add the second listener concurrently during a refresh
+                consumer.addRefreshListener(srl);
+            }
+        };
+
+        FirstRefreshListener frl = new FirstRefreshListener();
+        consumer.addRefreshListener(frl);
+
+        long v1 = runCycle(producer, 1);
+        consumer.triggerRefreshTo(v1+1);
+
+        Assert.assertEquals(1, frl.refreshStarted);
+        Assert.assertEquals(1, frl.refreshSuccessful);
+        Assert.assertEquals(0, frl.srl.refreshStarted);
+        Assert.assertEquals(0, frl.srl.refreshSuccessful);
+
+        long v2 = runCycle(producer, 2);
+        consumer.triggerRefreshTo(v2+1);
+
+        Assert.assertEquals(2, frl.refreshStarted);
+        Assert.assertEquals(2, frl.refreshSuccessful);
+        Assert.assertEquals(1, frl.srl.refreshStarted);
+        Assert.assertEquals(1, frl.srl.refreshSuccessful);
+    }
+
+    @Test
+    public void testRemoveListenerDuringRefresh() {
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .build();
+
+        class SecondRefreshListener extends AbstractRefreshListener {
+            int refreshStarted;
+            int refreshSuccessful;
+            @Override public void refreshStarted(long currentVersion, long requestedVersion) {
+                refreshStarted++;
+            }
+
+            @Override public void refreshSuccessful(long beforeVersion, long afterVersion, long requestedVersion) {
+                refreshSuccessful++;
+            }
+        };
+
+        class FirstRefreshListener extends SecondRefreshListener {
+            SecondRefreshListener srl;
+
+            FirstRefreshListener(SecondRefreshListener srl) {
+                this.srl = srl;
+            }
+
+            @Override public void refreshStarted(long currentVersion, long requestedVersion) {
+                super.refreshStarted(currentVersion, requestedVersion);
+                // Remove the second listener concurrently during a refresh
+                consumer.removeRefreshListener(srl);
+            }
+        };
+
+        SecondRefreshListener srl = new SecondRefreshListener();
+        FirstRefreshListener frl = new FirstRefreshListener(srl);
+        consumer.addRefreshListener(frl);
+        consumer.addRefreshListener(srl);
+
+        long v1 = runCycle(producer, 1);
+        consumer.triggerRefreshTo(v1+1);
+
+        Assert.assertEquals(1, frl.refreshStarted);
+        Assert.assertEquals(1, frl.refreshSuccessful);
+        Assert.assertEquals(1, frl.srl.refreshStarted);
+        Assert.assertEquals(1, frl.srl.refreshSuccessful);
+
+        long v2 = runCycle(producer, 2);
+        consumer.triggerRefreshTo(v2+1);
+
+        Assert.assertEquals(2, frl.refreshStarted);
+        Assert.assertEquals(2, frl.refreshSuccessful);
+        Assert.assertEquals(1, frl.srl.refreshStarted);
+        Assert.assertEquals(1, frl.srl.refreshSuccessful);
+    }
+
     private long runCycle(HollowProducer producer, final int cycleNumber) {
         return producer.runCycle(new Populator() {
             public void populate(WriteState state) throws Exception {


### PR DESCRIPTION
- Remove the use of the refresh lock when adding or removing
refresh listeners.  Instead listeners are stored in a de-duped
CopyOnWriteArrayList and a snapshot (an array) is obtained
at the start of the refresh that is iterated over.  Changes
(additions/removals) will not take effect until the next
refresh.

- Changed HollowDataHolder to be package private as it is not
part of the public API.