### PR TITLE
Correctly split to extract the field values of a primary key

### DIFF
--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
@@ -240,7 +240,9 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
     }
 
     private Object[] parseKey(PrimaryKey primaryKey, String keyString) {
-        String fields[] = keyString.split(":");
+        // Split by the number of fields of the primary key
+        // This ensures correct extraction of an empty value for the last field
+        String fields[] = keyString.split(":", primaryKey.numFields());
         
         Object key[] = new Object[fields.length];
         


### PR DESCRIPTION
The explorer UI would fail with an index out of bounds exception due to extracting too few values from the primary key string if the last field is of type String and the value is empty.  