### PR TITLE
Unify field paths parsing.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/FieldPath.java
@@ -47,7 +47,7 @@ import java.util.List;
  * <p>
  * This class has a convenience method to find values following the field path and given a start field position.
  */
-public class FieldPath {
+class FieldPath {
 
     private final String fieldPath;
     private final HollowDataAccess hollowDataAccess;
@@ -67,7 +67,7 @@ public class FieldPath {
      * @param type             parent type of the field path
      * @param fieldPath        "." separated fields
      */
-    public FieldPath(HollowDataAccess hollowDataAccess, String type, String fieldPath) {
+    FieldPath(HollowDataAccess hollowDataAccess, String type, String fieldPath) {
         this(hollowDataAccess, type, fieldPath, true);
     }
 
@@ -80,7 +80,7 @@ public class FieldPath {
      * @param fieldPath        "." separated fields
      * @param autoExpand       if the field path should be auto-expand collections and references with one field.
      */
-    public FieldPath(HollowDataAccess hollowDataAccess, String type, String fieldPath, boolean autoExpand) {
+    FieldPath(HollowDataAccess hollowDataAccess, String type, String fieldPath, boolean autoExpand) {
         this.fieldPath = fieldPath;
         this.hollowDataAccess = hollowDataAccess;
         this.type = type;
@@ -89,101 +89,45 @@ public class FieldPath {
     }
 
     private void initialize() {
-        String[] fieldParts = fieldPath.split("\\.");
+        FieldPaths.FieldPath<FieldPaths.FieldSegment> path =
+                FieldPaths.createFieldPathForPrefixIndex(hollowDataAccess, type, fieldPath, autoExpand);
+
         List<String> fields = new ArrayList<>();
         List<Integer> fieldPositions = new ArrayList<>();
         List<FieldType> fieldTypes = new ArrayList<>();
 
-        // traverse through the field path to save field position and types.
-        String refType = type;
         String lastRefType = type;
-        int i = 0;
-        while (i < fieldParts.length || refType != null) {
+        for (FieldPaths.FieldSegment segment : path.getSegments()) {
+            fields.add(segment.getName());
 
-            HollowSchema schema = hollowDataAccess.getSchema(refType);
-            if (schema == null)
-                throw new IllegalArgumentException("Schema not found for the type : " + refType);
-            SchemaType schemaType = hollowDataAccess.getSchema(refType).getSchemaType();
+            if (segment.getEnclosingSchema().getSchemaType() == SchemaType.OBJECT) {
+                assert segment instanceof FieldPaths.ObjectFieldSegment;
+                FieldPaths.ObjectFieldSegment oSegment = (FieldPaths.ObjectFieldSegment) segment;
 
-            String fieldName = null;
-            int fieldPosition = 0;
-            FieldType fieldType = FieldType.REFERENCE;
-
-            if (schemaType.equals(SchemaType.OBJECT)) {
-
-                HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
-
-                // find field position, field name and field type
-                if (i >= fieldParts.length) {
-                    if (!autoExpand || objectSchema.numFields() != 1)
-                        throw new IllegalArgumentException("Incomplete field path at type :" + refType + ". Please enter the field names in type to complete the path.");
-                    fieldPosition = 0;
-                } else {
-                    fieldPosition = objectSchema.getPosition(fieldParts[i]);
-                    if (fieldPosition < 0)
-                        throw new IllegalArgumentException("Could not find a valid field position for the field :" + fieldParts[i] + " in type :" + refType);
-                    i++; // increment index for field part for next iteration.
-                }
-
-                fieldName = objectSchema.getFieldName(fieldPosition);
-                fieldType = objectSchema.getFieldType(fieldPosition);
-
-                // check field type.
-                if (fieldType.equals(FieldType.REFERENCE)) {
-                    refType = objectSchema.getReferencedType(fieldName);
-                } else if (i >= fieldParts.length) {
-                    // reached the end of field path
-                    lastRefType = refType;
-                    refType = null;
-                } else {
-                    // if not end of the field path and found a value type, then throw the exception.
-                    throw new IllegalArgumentException("Field path should contain references and should lead to a field primitive field type");
-                }
-
-            } else if (schemaType.equals(SchemaType.LIST) || schemaType.equals(SchemaType.SET)) {
-
-                if (autoExpand && (i >= fieldParts.length || (i < fieldParts.length && !fieldParts[i].equals("element")))) {
-                    fieldName = "element";
-                } else {
-                    fieldName = fieldParts[i];
-                    i++; // increment index for field part for next iteration.
-                }
-                // update ref type to element type.
-                refType = ((HollowCollectionSchema) schema).getElementType();
-
-            } else if (schemaType.equals(SchemaType.MAP)) {
-
-                if ((i >= fieldParts.length) || (!fieldParts[i].equals("value") && !fieldParts[i].equals("key")))
-                    throw new IllegalArgumentException("When using Map in field path, please specify key or value. Cannot auto-expand on Map type field");
-
-                // update field name and increment i to move to next field
-                fieldName = fieldParts[i];
-                i++;
-
-                // update ref type depending on key or value in field path for map.
-                if (fieldName.equals("value")) {
-                    refType = ((HollowMapSchema) schema).getValueType();
-                } else refType = ((HollowMapSchema) schema).getKeyType();
+                fieldPositions.add(oSegment.getIndex());
+                fieldTypes.add(oSegment.getType());
+            } else {
+                fieldPositions.add(0);
+                fieldTypes.add(FieldType.REFERENCE);
             }
 
-            // update lists
-            fields.add(fieldName);
-            fieldPositions.add(fieldPosition);
-            fieldTypes.add(fieldType);
+            String refType = segment.getTypeName();
+            if (refType != null) {
+                lastRefType = refType;
+            }
         }
 
-        this.fields = fields.toArray(new String[fields.size()]);
-        this.fieldPositions = new int[fieldPositions.size()];
-        for (i = 0; i < fieldPositions.size(); i++) this.fieldPositions[i] = fieldPositions.get(i);
-        this.fieldTypes = fieldTypes.toArray(new FieldType[fieldTypes.size()]);
+        this.fields = fields.toArray(new String[0]);
+        this.fieldPositions = fieldPositions.stream().mapToInt(i -> i).toArray();
+        this.fieldTypes = fieldTypes.toArray(new FieldType[0]);
         this.lastRefTypeInPath = lastRefType;
     }
 
-    public String getLastRefTypeInPath() {
+    String getLastRefTypeInPath() {
         return lastRefTypeInPath;
     }
 
-    public FieldType getLastFieldType() {
+    FieldType getLastFieldType() {
         return fieldTypes[this.fields.length - 1];
     }
 
@@ -193,7 +137,7 @@ public class FieldPath {
      * @param ordinal ordinal record for the given type in field path
      * @return Array of values found at the field path for the given ordinal record in the type.
      */
-    public Object[] findValues(int ordinal) {
+    Object[] findValues(int ordinal) {
         return getAllValues(ordinal, type, 0);
     }
 
@@ -203,7 +147,7 @@ public class FieldPath {
      * @param ordinal the ordinal used to find a value
      * @return A value found at the field path for the given ordinal record in the type.
      */
-    public Object findValue(int ordinal) {
+    Object findValue(int ordinal) {
         return getValue(ordinal, type, 0);
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/index/FieldPaths.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/FieldPaths.java
@@ -1,0 +1,456 @@
+package com.netflix.hollow.core.index;
+
+import static java.util.stream.Collectors.joining;
+
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.index.key.PrimaryKey;
+import com.netflix.hollow.core.schema.HollowCollectionSchema;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Functionality for processing field paths.
+ */
+public final class FieldPaths {
+
+    /**
+     * Creates an object-based field path given a data set and the field path in symbolic form conforming to paths
+     * associated with a primary key.
+     *
+     * @param dataset the data set
+     * @param type the type name from which to bind the field path
+     * @param path the symbolic field path
+     * @return the field path
+     * @throws IllegalArgumentException if the symbolic field path is ill-formed and cannot be bound
+     */
+    public static FieldPath<ObjectFieldSegment> createFieldPathForPrimaryKey(
+            HollowDataset dataset, String type, String path) {
+        boolean autoExpand = !path.endsWith("!");
+        path = autoExpand ? path : path.substring(0, path.length() - 1);
+
+        FieldPath<FieldSegment> fp = createFieldPath(dataset, type, path, autoExpand, false, false);
+
+        // Erasure trick to avoid copying when it is known the list only contains
+        // instances of ObjectFieldSegment
+        assert fp.segments.stream().allMatch(o -> o instanceof ObjectFieldSegment);
+        @SuppressWarnings( {"unchecked", "raw"})
+        FieldPath<ObjectFieldSegment> result = (FieldPath<ObjectFieldSegment>) (FieldPath) fp;
+        return result;
+    }
+
+    /**
+     * Creates a field path given a data set and the field path in symbolic form conforming to paths
+     * associated with a hash index.
+     *
+     * @param dataset the data set
+     * @param type the type name from which to bind the field path
+     * @param path the symbolic field path
+     * @return the field path
+     * @throws IllegalArgumentException if the symbolic field path is ill-formed and cannot be bound
+     */
+    public static FieldPath<FieldSegment> createFieldPathForHashIndex(HollowDataset dataset, String type, String path) {
+        return createFieldPath(dataset, type, path, false, false, true);
+    }
+
+    /**
+     * Creates a field path given a data set and the field path in symbolic form conforming to paths
+     * associated with a prefix index.
+     *
+     * @param dataset the data set
+     * @param type the type name from which to bind the field path
+     * @param path the symbolic field path
+     * @param autoExpand {@code true} if the field path should be expanded (if needed) to a full path referencing
+     * an object field whose type is a non-reference type, otherwise the field path is not expanded and must be
+     * a full path
+     * @return the field path
+     * @throws IllegalArgumentException if the symbolic field path is ill-formed and cannot be bound
+     */
+    public static FieldPath<FieldSegment> createFieldPathForPrefixIndex(
+            HollowDataset dataset, String type, String path, boolean autoExpand) {
+        // If autoExpand is false then requireFullPath must be true
+        boolean requireFullPath = !autoExpand;
+        return createFieldPath(dataset, type, path, autoExpand, requireFullPath, true);
+    }
+
+    /**
+     * Creates a field path given a data set and the field path in symbolic form.
+     *
+     * @param dataset the data set
+     * @param type the type name from which to bind the field path
+     * @param path the symbolic field path
+     * @param autoExpand {@code true} if the field path should be expanded (if needed) to a full path referencing
+     * an object field whose type is a non-reference type, otherwise the field path is not expanded
+     * @param requireFullPath {@code true} if a full path is required when {@code autoExpand} is {@code false}.
+     * Ignored if {@code autoExpand} is {@code true}.
+     * @param traverseSequences {@code true} if lists, sets and maps are traversed, otherwise an
+     * {@code IllegalArgumentException} will be thrown
+     * @return the field path
+     * @throws IllegalArgumentException if the symbolic field path is ill-formed and cannot be bound
+     */
+    static FieldPath<FieldSegment> createFieldPath(
+            HollowDataset dataset, String type, String path,
+            boolean autoExpand, boolean requireFullPath, boolean traverseSequences) {
+        Objects.requireNonNull(dataset);
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(path);
+
+        String[] segments = path.isEmpty() ? new String[0] : path.split("\\.");
+        List<FieldSegment> fieldSegments = new ArrayList<>();
+
+        String segmentType = type;
+        for (int i = 0; i < segments.length; i++) {
+            HollowSchema schema = dataset.getSchema(segmentType);
+            // @@@ Can this only occur for anything other than the root `type`?
+            if (schema == null) {
+                throw new FieldPathException(FieldPathException.ErrorKind.NOT_BINDABLE, dataset, type, segments,
+                        fieldSegments, null, i);
+            }
+
+            String segment = segments[i];
+            HollowSchema.SchemaType schemaType = schema.getSchemaType();
+            if (schemaType == HollowSchema.SchemaType.OBJECT) {
+                HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
+
+                int index = objectSchema.getPosition(segment);
+                if (index == -1) {
+                    throw new FieldPathException(FieldPathException.ErrorKind.NOT_FOUND, dataset, type, segments,
+                            fieldSegments, schema, i);
+                }
+
+                segmentType = objectSchema.getReferencedType(index);
+                fieldSegments.add(new ObjectFieldSegment(objectSchema, segment, segmentType, index));
+            } else if (traverseSequences && (schemaType == HollowSchema.SchemaType.SET
+                    || schemaType == HollowSchema.SchemaType.LIST)) {
+                HollowCollectionSchema collectionSchema = (HollowCollectionSchema) schema;
+
+                if (!segment.equals("element")) {
+                    throw new FieldPathException(FieldPathException.ErrorKind.NOT_FOUND, dataset, type, segments,
+                            fieldSegments, schema, i);
+                }
+
+                segmentType = collectionSchema.getElementType();
+                fieldSegments.add(new FieldSegment(collectionSchema, segment, segmentType));
+            } else if (traverseSequences && schemaType == HollowSchema.SchemaType.MAP) {
+                HollowMapSchema mapSchema = (HollowMapSchema) schema;
+
+                if (segment.equals("key")) {
+                    segmentType = mapSchema.getKeyType();
+                } else if (segment.equals("value")) {
+                    segmentType = mapSchema.getValueType();
+                } else {
+                    throw new FieldPathException(FieldPathException.ErrorKind.NOT_FOUND, dataset, type, segments,
+                            fieldSegments, schema, i);
+                }
+
+                fieldSegments.add(new FieldSegment(mapSchema, segment, segmentType));
+            } else if (!traverseSequences) {
+                throw new FieldPathException(FieldPathException.ErrorKind.NOT_TRAVERSABLE, dataset, type, segments,
+                        fieldSegments, schema, i);
+            }
+
+            if (i < segments.length - 1 && segmentType == null) {
+                throw new FieldPathException(FieldPathException.ErrorKind.NOT_TRAVERSABLE, dataset, type, segments,
+                        fieldSegments, schema, i);
+            }
+        }
+
+        if (autoExpand) {
+            while (segmentType != null) {
+                HollowSchema schema = dataset.getSchema(segmentType);
+
+                if (schema.getSchemaType() == HollowSchema.SchemaType.OBJECT) {
+                    HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
+
+                    if (objectSchema.numFields() == 1) {
+                        segmentType = objectSchema.getReferencedType(0);
+
+                        fieldSegments.add(
+                                new ObjectFieldSegment(objectSchema, objectSchema.getFieldName(0), segmentType,
+                                        0));
+                    } else if (objectSchema.getPrimaryKey() != null && objectSchema.getPrimaryKey().numFields() == 1) {
+                        PrimaryKey key = objectSchema.getPrimaryKey();
+
+                        FieldPath<ObjectFieldSegment> expandedFieldSegments;
+                        try {
+                            expandedFieldSegments =
+                                    createFieldPathForPrimaryKey(dataset, key.getType(), key.getFieldPaths()[0]);
+                        } catch (FieldPathException cause) {
+                            FieldPathException e = new FieldPathException(FieldPathException.ErrorKind.NOT_EXPANDABLE,
+                                    dataset, type, segments,
+                                    fieldSegments, objectSchema);
+                            e.initCause(cause);
+                            throw e;
+                        }
+
+                        fieldSegments.addAll(expandedFieldSegments.segments);
+                        break;
+                    } else {
+                        throw new FieldPathException(FieldPathException.ErrorKind.NOT_EXPANDABLE, dataset, type,
+                                segments,
+                                fieldSegments, objectSchema);
+                    }
+                } else {
+                    throw new FieldPathException(FieldPathException.ErrorKind.NOT_EXPANDABLE, dataset, type, segments,
+                            fieldSegments, schema);
+                }
+            }
+        } else if (requireFullPath && segmentType != null) {
+            throw new FieldPathException(FieldPathException.ErrorKind.NOT_FULL, dataset, type, segments,
+                    fieldSegments);
+        }
+
+        return new FieldPath<>(type, fieldSegments);
+    }
+
+    /**
+     * An exception contain structured information when a field path cannot be bound.
+     */
+    static final class FieldPathException extends IllegalArgumentException {
+        enum ErrorKind {
+            NOT_BINDABLE,
+            NOT_FOUND,
+            NOT_FULL,
+            NOT_TRAVERSABLE,
+            NOT_EXPANDABLE,
+            ;
+        }
+
+        final ErrorKind error;
+        final String rootType;
+        final String[] segments;
+
+        // Prior paths
+        final List<FieldSegment> fieldSegments;
+
+        // Partial state
+        final HollowSchema enclosingSchema;
+        final int segmentIndex;
+
+        FieldPathException(
+                ErrorKind error, HollowDataset dataset, String rootType, String[] segments,
+                List<FieldSegment> fieldSegments) {
+            this(error, dataset, rootType, segments, fieldSegments, null, segments.length);
+        }
+
+        FieldPathException(
+                ErrorKind error, HollowDataset dataset, String rootType, String[] segments,
+                List<FieldSegment> fieldSegments, HollowSchema enclosingSchema) {
+            this(error, dataset, rootType, segments, fieldSegments, enclosingSchema, segments.length);
+        }
+
+        FieldPathException(
+                ErrorKind error, HollowDataset dataset, String rootType, String[] segments,
+                List<FieldSegment> fieldSegments, HollowSchema enclosingSchema, int segmentIndex) {
+            super(message(error, dataset, rootType, segments, fieldSegments, enclosingSchema, segmentIndex));
+
+            this.error = error;
+            this.rootType = rootType;
+            this.segments = segments;
+            this.fieldSegments = Collections.unmodifiableList(fieldSegments);
+            this.enclosingSchema = enclosingSchema;
+            this.segmentIndex = segmentIndex;
+        }
+
+        static String message(
+                ErrorKind error, HollowDataset dataset, String rootType, String[] segments,
+                List<FieldSegment> fieldSegments, HollowSchema enclosingSchema, int segmentIndex) {
+            switch (error) {
+                case NOT_BINDABLE:
+                    return String.format("Field path \"%s\" cannot be bound to data set %s. " +
+                                    "A schema of type named \"%s\" cannot be found for the last segment of the path prefix \"%s\".",
+                            toPathString(segments), dataset,
+                            getLastTypeName(rootType, fieldSegments), toPathString(segments, segmentIndex + 1));
+                case NOT_FOUND:
+                    return String.format("Field path \"%s\" not found in data set %s. " +
+                                    "A schema of type named \"%s\" does not contain a field for the last segment of the path prefix \"%s\".",
+                            toPathString(segments), dataset,
+                            enclosingSchema.getName(), toPathString(segments, segmentIndex + 1));
+                case NOT_TRAVERSABLE: {
+                    if (enclosingSchema.getSchemaType() != HollowSchema.SchemaType.OBJECT) {
+                        return String.format("Field path \"%s\" is not traversable in data set %s. " +
+                                        "A non-object schema of type named \"%s\" and of schema type %s cannot be traversed for the last segment of the path prefix \"%s\".",
+                                toPathString(segments), dataset,
+                                enclosingSchema.getName(), enclosingSchema.getSchemaType(),
+                                toPathString(segments, segmentIndex + 1));
+                    } else {
+                        return String.format("Field path \"%s\" is not traversable in data set %s. " +
+                                        "An object schema of type named \"%s\" cannot be traversed for the last segment of the path prefix \"%s\". "
+                                        +
+                                        "The last segment of the path prefix refers to a value (non-reference) field.",
+                                toPathString(segments), dataset,
+                                enclosingSchema.getName(),
+                                toPathString(segments, segmentIndex + 1));
+                    }
+                }
+                case NOT_FULL:
+                    return String.format("Field path \"%s\" is not a full path in data set %s. " +
+                                    "The last segment of the path is not a value (non-reference) field and refers to a reference field whose schema is of type named \"%s\"",
+                            toPathString(segments), dataset,
+                            fieldSegments.get(fieldSegments.size() - 1).getTypeName());
+                case NOT_EXPANDABLE: {
+                    if (enclosingSchema.getSchemaType() == HollowSchema.SchemaType.OBJECT) {
+                        HollowObjectSchema objectSchema = (HollowObjectSchema) enclosingSchema;
+                        if (objectSchema.numFields() != 1 || objectSchema.getPrimaryKey() == null
+                                || objectSchema.getPrimaryKey().numFields() != 1) {
+                            return String.format("Field path \"%s\" is not expandable in data set %s. " +
+                                            "An object schema of type named \"%s\" cannot be traversed for the last segment of the partially expanded path \"%s\". "
+                                            +
+                                            "The schema contains more than one field, or has no primary key, or has a primary key with more than one field path.",
+                                    toPathString(segments), dataset,
+                                    enclosingSchema.getName(),
+                                    toPathString(fieldSegments));
+                        }
+                    }
+                    return String.format("Field path \"%s\" is not expandable in data set %s. " +
+                                    "A non-object schema of type named \"%s\" and of schema type %s cannot be traversed for the last segment of the partially expanded path \"%s\".",
+                            toPathString(segments), dataset,
+                            enclosingSchema.getName(), enclosingSchema.getSchemaType(),
+                            toPathString(fieldSegments));
+                }
+                default:
+                    throw new InternalError("Cannot reach here");
+            }
+        }
+
+        static String getLastTypeName(String rootType, List<FieldSegment> fieldSegments) {
+            return fieldSegments.isEmpty()
+                    ? rootType
+                    : fieldSegments.get(fieldSegments.size() - 1).typeName;
+        }
+
+        static String toPathString(List<FieldSegment> segments) {
+            return segments.stream().map(FieldSegment::getName).collect(joining("."));
+        }
+
+        static String toPathString(String[] segments) {
+            return toPathString(segments, segments.length);
+        }
+
+        static String toPathString(String[] segments, int l) {
+            return Arrays.stream(segments).limit(l).collect(joining("."));
+        }
+    }
+
+    /**
+     * A structured representation field path containing field segments.
+     *
+     * @param <T> the field segment type
+     */
+    public final static class FieldPath<T extends FieldSegment> {
+        //        HollowDataset hd;
+        final String rootType;
+        final List<T> segments;
+
+        FieldPath(String rootType, List<T> segments) {
+            this.rootType = rootType;
+            this.segments = Collections.unmodifiableList(segments);
+        }
+
+        /**
+         * Returns the root type from which this field path is bound.
+         *
+         * @return the root type
+         */
+        public String getRootType() {
+            return rootType;
+        }
+
+        /**
+         * Returns the field segments.
+         *
+         * @return the field segments.  The returned list is unmodifiable.
+         */
+        public List<T> getSegments() {
+            return segments;
+        }
+    }
+
+    /**
+     * A structured representation of field segment.
+     */
+    public static class FieldSegment {
+        final HollowSchema enclosingSchema;
+        final String name;
+        final String typeName;
+
+        FieldSegment(HollowSchema enclosingSchema, String name, String typeName) {
+            this.name = name;
+            this.typeName = typeName;
+            this.enclosingSchema = enclosingSchema;
+        }
+
+        /**
+         * Returns the enclosing schema that declares a field corresponding to this segment.
+         *
+         * @return the enclosing schema
+         */
+        public HollowSchema getEnclosingSchema() {
+            return enclosingSchema;
+        }
+
+        /**
+         * Returns the segment name.
+         *
+         * @return the segment name
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Returns the schema type name associated with this segment.
+         *
+         * @return the schema type name.
+         */
+        public String getTypeName() {
+            return typeName;
+        }
+    }
+
+    /**
+     * A structured representation of field segment corresponding to a field in an object schema.
+     */
+    public final static class ObjectFieldSegment extends FieldSegment {
+        final int index;
+        final HollowObjectSchema.FieldType type;
+
+        ObjectFieldSegment(
+                HollowObjectSchema enclosingSchema, String name, String typeName,
+                int index) {
+            super(enclosingSchema, name, typeName);
+            this.index = index;
+            this.type = enclosingSchema.getFieldType(index);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public HollowObjectSchema getEnclosingSchema() {
+            return (HollowObjectSchema) super.getEnclosingSchema();
+        }
+
+        /**
+         * The field index in the enclosing object schema.
+         *
+         * @return the field index
+         */
+        public int getIndex() {
+            return index;
+        }
+
+        /**
+         * The field type of the field in the enclosing object schema.
+         *
+         * @return the field type
+         */
+        public HollowObjectSchema.FieldType getType() {
+            return type;
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPreindexer.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPreindexer.java
@@ -17,18 +17,19 @@
  */
 package com.netflix.hollow.core.index;
 
+import static java.util.stream.Collectors.joining;
+
 import com.netflix.hollow.core.index.traversal.HollowIndexerValueTraverser;
-import com.netflix.hollow.core.read.dataaccess.HollowCollectionTypeDataAccess;
-import com.netflix.hollow.core.read.dataaccess.HollowMapTypeDataAccess;
-import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.schema.HollowCollectionSchema;
 import com.netflix.hollow.core.schema.HollowMapSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSchema;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class HollowPreindexer {
@@ -65,70 +66,74 @@ public class HollowPreindexer {
         numMatchTraverserFields = baseFieldToIndexMap.size();
         selectFieldSpec = getHollowHashIndexField(typeState, selectField, baseFieldToIndexMap, false);
 
-        String baseFields[] = new String[baseFieldToIndexMap.size()];
+        String[] baseFields = new String[baseFieldToIndexMap.size()];
 
         for(Map.Entry<String, Integer> entry : baseFieldToIndexMap.entrySet()) {
-            baseFields[entry.getValue().intValue()] = entry.getKey();
+            baseFields[entry.getValue()] = entry.getKey();
         }
 
         traverser = new HollowIndexerValueTraverser(stateEngine, type, baseFields);
     }
-    
-    private HollowHashIndexField getHollowHashIndexField(HollowTypeReadState originalTypeState, String selectField, Map<String, Integer> baseFieldToIndexMap, boolean truncate) {
-        String fieldPaths[] = "".equals(selectField) ? new String[0] : selectField.split("\\.");
-        int fieldPathIndexes[] = new int[fieldPaths.length];
 
-        int baseFieldPathIdx = 0;
-        int fieldPathIdx = 0;
+    private HollowHashIndexField getHollowHashIndexField(HollowTypeReadState originalTypeState, String selectField,
+            Map<String, Integer> baseFieldToIndexMap, boolean truncate) {
+        FieldPaths.FieldPath<FieldPaths.FieldSegment> path = FieldPaths.createFieldPathForHashIndex(
+                stateEngine, type, selectField);
 
         HollowTypeReadState typeState = originalTypeState;
         HollowTypeReadState baseTypeState = originalTypeState;
 
+        int baseFieldPathIdx = 0;
+
+        List<FieldPaths.FieldSegment> segments = path.getSegments();
+        int fieldPathIndexes[] = new int[segments.size()];
         FieldType fieldType = FieldType.REFERENCE;
 
-        for(int i=0;i<fieldPaths.length;i++) {
+        for (int i = 0; i < segments.size(); i++) {
+            FieldPaths.FieldSegment segment = segments.get(i);
 
-            if(typeState instanceof HollowObjectTypeDataAccess) {
-                HollowObjectSchema schema = ((HollowObjectTypeDataAccess)typeState).getSchema();
-                fieldPathIndexes[fieldPathIdx] = schema.getPosition(fieldPaths[fieldPathIdx]);
-                typeState = schema.getReferencedTypeState(fieldPathIndexes[fieldPathIdx]);
-                fieldType = schema.getFieldType(fieldPathIndexes[fieldPathIdx]);
+            HollowSchema schema = segment.enclosingSchema;
+            switch (schema.getSchemaType()) {
+                case OBJECT:
+                    FieldPaths.ObjectFieldSegment objectSegment = (FieldPaths.ObjectFieldSegment) segment;
+                    fieldType = objectSegment.getType();
+                    fieldPathIndexes[i] = objectSegment.getIndex();
 
-                if(!truncate)
-                    baseFieldPathIdx = fieldPathIdx + 1;
+                    HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
+                    typeState = objectSchema.getReferencedTypeState(objectSegment.getIndex());
 
-            } else if(typeState instanceof HollowCollectionTypeDataAccess) {
-                HollowCollectionSchema schema = ((HollowCollectionTypeDataAccess)typeState).getSchema();
-                typeState = schema.getElementTypeState();
-                baseTypeState = typeState;
-                baseFieldPathIdx = fieldPathIdx+1;
-                fieldType = FieldType.REFERENCE;
-            } else {
-                HollowMapSchema schema = ((HollowMapTypeDataAccess)typeState).getSchema();
-                boolean isKey = "key".equals(fieldPaths[fieldPathIdx]);
-                typeState = isKey ? schema.getKeyTypeState() : schema.getValueTypeState();
-                baseTypeState = typeState;
-                baseFieldPathIdx = fieldPathIdx+1;
-                fieldType = FieldType.REFERENCE;
+                    if(!truncate)
+                        baseFieldPathIdx = i + 1;
+                    break;
+                case SET:
+                case LIST:
+                    fieldType = FieldType.REFERENCE;
+
+                    HollowCollectionSchema collectionSchema = (HollowCollectionSchema) schema;
+                    baseTypeState = typeState = collectionSchema.getElementTypeState();
+
+                    baseFieldPathIdx = i + 1;
+                    break;
+                case MAP:
+                    fieldType = FieldType.REFERENCE;
+
+                    HollowMapSchema mapSchema = (HollowMapSchema) schema;
+                    boolean isKey = "key".equals(segment.getName());
+                    baseTypeState = typeState = isKey ? mapSchema.getKeyTypeState() : mapSchema.getValueTypeState();
+
+                    baseFieldPathIdx = i + 1;
+                    break;
             }
-
-            fieldPathIdx++;
         }
 
-        StringBuilder basePathBuilder = new StringBuilder();
-        for(int i=0;i<baseFieldPathIdx;i++) {
-            if(i > 0)
-                basePathBuilder.append('.');
-            basePathBuilder.append(fieldPaths[i]);
-        }
-        String basePath = basePathBuilder.toString();
-        Integer basePathIdx = baseFieldToIndexMap.get(basePath);
-        if(basePathIdx == null) {
-            basePathIdx = Integer.valueOf(baseFieldToIndexMap.size());
-            baseFieldToIndexMap.put(basePath, basePathIdx);
-        }
+        String basePath = segments.stream().limit(baseFieldPathIdx)
+                .map(FieldPaths.FieldSegment::getName)
+                .collect(joining("."));
+        int basePathIdx = baseFieldToIndexMap.computeIfAbsent(basePath, k -> baseFieldToIndexMap.size());
 
-        return new HollowHashIndexField(basePathIdx.intValue(), Arrays.copyOfRange(fieldPathIndexes, baseFieldPathIdx, fieldPathIndexes.length), baseTypeState, fieldType);
+        return new HollowHashIndexField(basePathIdx,
+                Arrays.copyOfRange(fieldPathIndexes, baseFieldPathIdx, fieldPathIndexes.length),
+                baseTypeState, fieldType);
     }
 
     public HollowTypeReadState getTypeState() {

--- a/hollow/src/main/java/com/netflix/hollow/core/index/key/PrimaryKey.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/key/PrimaryKey.java
@@ -18,10 +18,9 @@
 package com.netflix.hollow.core.index.key;
 
 import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.index.FieldPaths;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
-import com.netflix.hollow.core.schema.HollowSchema;
-import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
 import java.util.Arrays;
 
 /**
@@ -45,10 +44,12 @@ public class PrimaryKey {
      * its child record referenced by the field <i>country</i>, and finally the country's field <i>id</i>.
      */
     public PrimaryKey(String type, String... fieldPaths) {
-        if (fieldPaths == null || fieldPaths.length == 0) throw new IllegalArgumentException("fieldPaths can't not be null or empty");
+        if (fieldPaths == null || fieldPaths.length == 0) {
+            throw new IllegalArgumentException("fieldPaths can't not be null or empty");
+        }
 
         this.type = type;
-        this.fieldPaths = fieldPaths;
+        this.fieldPaths = fieldPaths.clone();
     }
 
     public String getType() {
@@ -149,73 +150,9 @@ public class PrimaryKey {
      * @return the field path index
      */
     public static int[] getFieldPathIndex(HollowDataset dataset, String type, String fieldPath) {
-        boolean isReferenceFieldPath = fieldPath.endsWith("!");
-
-        return getFieldPathIndex(dataset, type, (isReferenceFieldPath ? fieldPath.substring(0, fieldPath.length() - 1) : fieldPath), !isReferenceFieldPath);
-    }
-
-    private static int[] getFieldPathIndex(HollowDataset dataset, String type, String fieldPath, boolean isAutoExpand) {
-        String paths[] = fieldPath.split("\\.");
-        int pathIndexes[] = new int[paths.length];
-
-        String refType = type;
-
-        for(int i=0;i<paths.length;i++) {
-            HollowSchema schema = dataset.getSchema(refType);
-
-            if(schema == null)
-                throw new IllegalArgumentException("Invalid field path declaration for type " + type + ": " + fieldPath +".  The type " + refType + " is unavailable.");
-
-            if(schema.getSchemaType() != SchemaType.OBJECT)
-                throw new IllegalArgumentException("Invalid field path declaration for type " + type + ": " + fieldPath + ".  " +
-                        "Field paths may only traverse through OBJECT types, but this declaration passes through a " + schema.getSchemaType().toString() + " type (" + refType + ").");
-
-
-            HollowObjectSchema objectSchema = (HollowObjectSchema)dataset.getSchema(refType);
-            pathIndexes[i] = objectSchema.getPosition(paths[i]);
-
-            if(pathIndexes[i] == -1)
-                throw new IllegalArgumentException("Invalid field path declaration for type " + type + ": " + fieldPath + ".  " +
-                        "At element " + i + ", the field " + paths[i] + " was not found in type " + refType + ".");
-
-            refType = objectSchema.getReferencedType(pathIndexes[i]);
-
-            if(i < paths.length - 1 && refType == null)
-                throw new IllegalArgumentException("Invalid field path declaration for type " + type + ": " + fieldPath + ".  " +
-                        "No available traversal after element " + i + ": " + paths[i] + ".");
-
-
-        }
-
-        if (isAutoExpand) {
-            while(refType != null) {
-                HollowSchema schema = dataset.getSchema(refType);
-
-                if(schema.getSchemaType() == SchemaType.OBJECT) {
-                    HollowObjectSchema objectSchema = (HollowObjectSchema)schema;
-
-                    if(objectSchema.numFields() == 1) {
-                        pathIndexes = Arrays.copyOf(pathIndexes, pathIndexes.length + 1);
-                        pathIndexes[pathIndexes.length - 1] = 0;
-                        refType = ((HollowObjectSchema)schema).getReferencedType(0);
-                        continue;
-                    }
-
-                    if(objectSchema.getPrimaryKey() != null && objectSchema.getPrimaryKey().numFields() == 1) {
-                        int[] trailingFieldPathIndex = objectSchema.getPrimaryKey().getFieldPathIndex(dataset, 0);
-                        int priorLength = pathIndexes.length;
-                        pathIndexes = Arrays.copyOf(pathIndexes, pathIndexes.length + trailingFieldPathIndex.length);
-                        System.arraycopy(trailingFieldPathIndex, 0, pathIndexes, priorLength, trailingFieldPathIndex.length);
-                        return pathIndexes;
-                    }
-                }
-
-                throw new IllegalArgumentException("Invalid field path declaration for type " + type + ": " + fieldPath + ".  This path ends in a REFERENCE field which is not auto-traversable.  " +
-                        "If this is intended to actually indicate a REFERENCE field, specify the field path as \"" + fieldPath + "!\".");
-            }
-        }
-
-        return pathIndexes;
+        return FieldPaths.createFieldPathForPrimaryKey(dataset, type, fieldPath).getSegments().stream()
+                .mapToInt(FieldPaths.ObjectFieldSegment::getIndex)
+                .toArray();
     }
 
     @Override

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrefixIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrefixIndexTest.java
@@ -170,7 +170,7 @@ public class HollowPrefixIndexTest {
         MovieSetReference movieSetReference = new MovieSetReference(1, 1999, "The Matrix", new HashSet<String>(Arrays.asList("Keanu Reeves", "Laurence Fishburne", "Carrie-Anne Moss")));
         objectMapper.add(movieSetReference);
         StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
-        HollowPrefixIndex prefixIndex = new HollowPrefixIndex(readStateEngine, "MovieSetReference", "actors.value");
+        HollowPrefixIndex prefixIndex = new HollowPrefixIndex(readStateEngine, "MovieSetReference", "actors.element");
         Set<Integer> ordinals = toSet(prefixIndex.findKeysWithPrefix("kea"));
         Assert.assertTrue(ordinals.size() == 1);
     }

--- a/hollow/src/test/java/com/netflix/hollow/core/index/PrimaryKeyTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/PrimaryKeyTest.java
@@ -66,46 +66,58 @@ public class PrimaryKeyTest {
         try {
             PrimaryKey invalidFieldDefinition = new PrimaryKey("TypeWithTraversablePrimaryKey", "subType.nofield");
             invalidFieldDefinition.getFieldPathIndex(writeEngine, 0);
-        } catch(IllegalArgumentException expected) {
-            Assert.assertEquals("Invalid field path declaration for type TypeWithTraversablePrimaryKey: subType.nofield.  " +
-                                "At element 1, the field nofield was not found in type SubTypeWithTraversablePrimaryKey.",
-                                expected.getMessage());
+            Assert.fail("IllegalArgumentException expected");
+        } catch (FieldPaths.FieldPathException expected) {
+            Assert.assertEquals(FieldPaths.FieldPathException.ErrorKind.NOT_FOUND, expected.error);
+            Assert.assertEquals(1, expected.fieldSegments.size());
+            Assert.assertEquals(1, expected.segmentIndex);
+            Assert.assertEquals("SubTypeWithTraversablePrimaryKey", expected.enclosingSchema.getName());
         }
         
         try {
             PrimaryKey invalidFieldDefinition = new PrimaryKey("TypeWithTraversablePrimaryKey", "subType.id.value.alldone");
             invalidFieldDefinition.getFieldPathIndex(writeEngine, 0);
-        } catch(IllegalArgumentException expected) {
-            Assert.assertEquals("Invalid field path declaration for type TypeWithTraversablePrimaryKey: subType.id.value.alldone.  " +
-                                "No available traversal after element 2: value.",
-                                expected.getMessage());
+            Assert.fail("IllegalArgumentException expected");
+        } catch (FieldPaths.FieldPathException expected) {
+            Assert.assertEquals(FieldPaths.FieldPathException.ErrorKind.NOT_TRAVERSABLE, expected.error);
+            Assert.assertEquals(3, expected.fieldSegments.size());
+            Assert.assertEquals(2, expected.segmentIndex);
+            Assert.assertEquals("value", expected.fieldSegments.get(2).getName());
+            Assert.assertEquals("String", expected.enclosingSchema.getName());
         }
         
         try {
             PrimaryKey invalidFieldDefinition = new PrimaryKey("TypeWithTraversablePrimaryKey", "subType2");
             invalidFieldDefinition.getFieldPathIndex(writeEngine, 0);
-        } catch(IllegalArgumentException expected) {
-            Assert.assertEquals("Invalid field path declaration for type TypeWithTraversablePrimaryKey: subType2.  " +
-                                "This path ends in a REFERENCE field which is not auto-traversable.  " +
-                                "If this is intended to actually indicate a REFERENCE field, specify the field path as \"subType2!\".",
-                                expected.getMessage());
+            Assert.fail("IllegalArgumentException expected");
+        } catch (FieldPaths.FieldPathException expected) {
+            Assert.assertEquals(FieldPaths.FieldPathException.ErrorKind.NOT_EXPANDABLE, expected.error);
+            Assert.assertEquals(1, expected.fieldSegments.size());
+            Assert.assertEquals("subType2", expected.fieldSegments.get(0).getName());
+            Assert.assertEquals("SubTypeWithNonTraversablePrimaryKey", expected.enclosingSchema.getName());
         }
         
         try {
             PrimaryKey invalidFieldDefinition = new PrimaryKey("TypeWithTraversablePrimaryKey", "strList.element.value");
             invalidFieldDefinition.getFieldPathIndex(writeEngine, 0);
-        } catch(IllegalArgumentException expected) {
-            Assert.assertEquals("Invalid field path declaration for type TypeWithTraversablePrimaryKey: strList.element.value.  " +
-                                "Field paths may only traverse through OBJECT types, but this declaration passes through a LIST type (ListOfString).",
-                                expected.getMessage());
+            Assert.fail("IllegalArgumentException expected");
+        } catch (FieldPaths.FieldPathException expected) {
+            Assert.assertEquals(FieldPaths.FieldPathException.ErrorKind.NOT_TRAVERSABLE, expected.error);
+            Assert.assertEquals(1, expected.fieldSegments.size());
+            Assert.assertEquals(1, expected.segmentIndex);
+            Assert.assertEquals("element", expected.segments[expected.segmentIndex]);
+            Assert.assertEquals("ListOfString", expected.enclosingSchema.getName());
         }
         
         try {
             PrimaryKey invalidFieldDefinition = new PrimaryKey("UnknownType", "id");
             invalidFieldDefinition.getFieldPathIndex(writeEngine, 0);
-        } catch(IllegalArgumentException expected) {
-            Assert.assertEquals("Invalid field path declaration for type UnknownType: id.  The type UnknownType is unavailable.",
-                                expected.getMessage());
+            Assert.fail("IllegalArgumentException expected");
+        } catch (FieldPaths.FieldPathException expected) {
+            Assert.assertEquals(FieldPaths.FieldPathException.ErrorKind.NOT_BINDABLE, expected.error);
+            Assert.assertEquals(0, expected.fieldSegments.size());
+            Assert.assertEquals(0, expected.segmentIndex);
+            Assert.assertEquals("UnknownType", expected.rootType);
         }
     }
     


### PR DESCRIPTION
Fields paths are predominantly utilized in three places:
1.  For primary key indexes;
2. Hash key indexes; and
3. Prefix indexes.

Each have subtly different semantics.  The processing of field paths and error reporting in each case has been unified without changing the semantics (with one exception, for case 3 auto-traversing collections is now disallowed).  New functionality has been added to process a field path into a structured form that can be reasoned about in those three cases but also for future cases such as a higher level type safe API for index querying (to follow soon), or perhaps by an IDE highlighting errors in field path declarations in, say, a hollow schema language.

Existing tests are currently relied upon.  Documentation on `com.netflix.hollow.core.index.FieldPaths` needs to be expanded later on to specify the field path semantics, formally specifying what is presented in the `hollow.how` documentation.

`com.netflix.hollow.core.index.FieldPath` has been made package private.  It was only used by `HollowPrefixIndex` and has semantics that are not applicable to the other cases.  It provides additional useful functionality, value extraction, that can be separated out from structured field paths.