### PR TITLE
Exporting refresh metrics via listeners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,16 @@ buildscript {
   repositories { jcenter() }
 }
 
+plugins {
+  id 'nebula.netflixoss' version '6.0.3'
+}
+
 subprojects {
+  apply plugin: 'nebula.netflixoss'
   apply plugin: 'checkstyle'
+
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
 
   tasks.withType(JavaCompile) {
     sourceCompatibility = 1.8
@@ -18,7 +26,6 @@ subprojects {
   }
 
   group = 'com.netflix.hollow'
-
   checkstyle {
     configFile = file("$rootProject.projectDir/config/checkstyle/checkstyle.xml")
   }

--- a/build.gradle
+++ b/build.gradle
@@ -2,16 +2,8 @@ buildscript {
   repositories { jcenter() }
 }
 
-plugins {
-  id 'nebula.netflixoss' version '6.0.3'
-}
-
 subprojects {
-  apply plugin: 'nebula.netflixoss'
   apply plugin: 'checkstyle'
-
-  sourceCompatibility = 1.8
-  targetCompatibility = 1.8
 
   tasks.withType(JavaCompile) {
     sourceCompatibility = 1.8
@@ -26,6 +18,7 @@ subprojects {
   }
 
   group = 'com.netflix.hollow'
+
   checkstyle {
     configFile = file("$rootProject.projectDir/config/checkstyle/checkstyle.xml")
   }

--- a/hollow/build.gradle
+++ b/hollow/build.gradle
@@ -1,10 +1,12 @@
 apply plugin: 'java'
- 
+
 dependencies {
     testCompile project(":hollow-test")
     testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-core:2.15.0'
     testCompile 'com.google.code.findbugs:findbugs:3.0.1'
+
+    // compileOnly 'org.projectlombok:lombok:1.16.12' // TODO: get team's buy-in for using Lombok
 }
 
 // quiet warnings about sun.misc.Unsafe

--- a/hollow/build.gradle
+++ b/hollow/build.gradle
@@ -5,8 +5,6 @@ dependencies {
     testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-core:2.15.0'
     testCompile 'com.google.code.findbugs:findbugs:3.0.1'
-
-    // compileOnly 'org.projectlombok:lombok:1.16.12' // TODO: get team's buy-in for using Lombok
 }
 
 // quiet warnings about sun.misc.Unsafe

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -110,14 +110,19 @@ public class HollowClientUpdater {
 
         long beforeVersion = getCurrentVersionId();
 
-        for (HollowConsumer.RefreshListener listener : localListeners)
+        for (HollowConsumer.RefreshListener listener : localListeners) {
             listener.refreshStarted(beforeVersion, version);
+        }
 
         try {
             HollowUpdatePlan updatePlan = shouldCreateSnapshotPlan()
                 ? planner.planInitializingUpdate(version)
                 : planner.planUpdate(hollowDataHolderVolatile.getCurrentVersion(), version,
                         doubleSnapshotConfig.allowDoubleSnapshot());
+
+            for (HollowConsumer.RefreshListener listener : localListeners)
+                if (listener instanceof HollowConsumer.TransitionAwareRefreshListener)
+                    ((HollowConsumer.TransitionAwareRefreshListener)listener).transitionsPlanned(beforeVersion, version, updatePlan.isSnapshotPlan(), updatePlan.getTransitionSequence());
 
             if (updatePlan.destinationVersion() == HollowConstants.VERSION_NONE
                     && version != HollowConstants.VERSION_LATEST)

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -110,9 +110,8 @@ public class HollowClientUpdater {
 
         long beforeVersion = getCurrentVersionId();
 
-        for (HollowConsumer.RefreshListener listener : localListeners) {
+        for (HollowConsumer.RefreshListener listener : localListeners)
             listener.refreshStarted(beforeVersion, version);
-        }
 
         try {
             HollowUpdatePlan updatePlan = shouldCreateSnapshotPlan()

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlan.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlan.java
@@ -17,6 +17,8 @@
  */
 package com.netflix.hollow.api.client;
 
+import static java.util.stream.Collectors.toList;
+
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.core.HollowConstants;
 import java.util.ArrayList;
@@ -59,6 +61,16 @@ public class HollowUpdatePlan implements Iterable<HollowConsumer.Blob> {
 
     public HollowConsumer.Blob getTransition(int index) {
         return transitions.get(index);
+    }
+
+    public List<HollowConsumer.Blob> getTransitions() {
+        return transitions;
+    }
+
+    public List<HollowConsumer.Blob.BlobType> getTransitionSequence() {
+        return transitions.stream()
+                .map(t -> t.getBlobType())
+                .collect(toList());
     }
 
     public long destinationVersion(long currentVersion) {

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -777,13 +777,14 @@ public class HollowConsumer {
          * Called after refresh started and update plan has been initialized, but before the update plan starts executing.
          * It is called only once per update plan (and thus only once per consumer refresh). Exposes details of the
          * update plan.
+         * @implSpec The default implementation provided does nothing.
          *
          * @param beforeVersion The version when refresh started
-         * @param requestedVersion The intended version at the end of the refresh
+         * @param desiredVersion The version that the consumer refresh tries update to, even though it might not be attainable eg. HollowConstants.VERSION_LATEST
          * @param isSnapshotPlan Indicates whether the refresh involves a snapshot transition
          * @param transitionSequence List of transitions comprising the refresh
          */
-        void transitionsPlanned(long beforeVersion, long requestedVersion, boolean isSnapshotPlan, List<HollowConsumer.Blob.BlobType> transitionSequence);
+        default void transitionsPlanned(long beforeVersion, long desiredVersion, boolean isSnapshotPlan, List<HollowConsumer.Blob.BlobType> transitionSequence) {}
     }
 
     public static class AbstractRefreshListener implements TransitionAwareRefreshListener {
@@ -793,7 +794,7 @@ public class HollowConsumer {
         }
 
         @Override
-        public void transitionsPlanned(long beforeVersion, long requestedVersion, boolean isSnapshotPlan, List<HollowConsumer.Blob.BlobType> transitionSequence) {
+        public void transitionsPlanned(long beforeVersion, long desiredVersion, boolean isSnapshotPlan, List<HollowConsumer.Blob.BlobType> transitionSequence) {
             // no-op
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/AbstractRefreshMetricsListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/AbstractRefreshMetricsListener.java
@@ -1,0 +1,178 @@
+package com.netflix.hollow.api.consumer.metrics;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+public class AbstractRefreshMetricsListener extends HollowConsumer.AbstractRefreshListener  {
+
+    private long consecutiveSuccesses;
+    private long consecutiveFailures;
+
+    private Instant lastRefreshInstant;
+    private Instant refreshStart;
+
+    private ConsumerRefreshStatus refreshStatus;                    // success or failure
+    private ConsumerRefreshTransitionType refreshTransitionType;    // snapshot or delta transition
+    private ConsumerRefreshLoadType refreshLoadType;                // "init" indicates first successful load on consumer, "subsequent" indicates subsequent load during refresh
+
+    private long refreshLoadCount;
+
+    // Encapsulate the refresh metrics so that more metrics/properties can be added in future wihtout breaking existing clients.
+    public static class ConsumerRefreshMetrics {
+        private long refreshDurationMillis;
+        private ConsumerRefreshStatus refreshStatus;
+        private ConsumerRefreshTransitionType refreshTransitionType;
+        private ConsumerRefreshLoadType refreshLoadType;
+
+        public ConsumerRefreshMetrics(long refreshDurationMillis, ConsumerRefreshStatus refreshStatus, ConsumerRefreshTransitionType refreshTransitionType, ConsumerRefreshLoadType refreshLoadType) {
+            this.refreshDurationMillis = refreshDurationMillis;
+            this.refreshStatus = Objects.requireNonNull(refreshStatus);
+            this.refreshTransitionType = refreshTransitionType;   // Transition type can be unknown for some failed snapshot or delta transition
+            this.refreshLoadType = Objects.requireNonNull(refreshLoadType);
+        }
+
+        public long getRefreshDurationMillis() {
+            return refreshDurationMillis;
+        }
+        public ConsumerRefreshStatus getRefreshStatus() {
+            return refreshStatus;
+        }
+        public ConsumerRefreshTransitionType getRefreshTransitionType() {
+            return refreshTransitionType;
+        }
+        public ConsumerRefreshLoadType getRefreshLoadType() {
+            return refreshLoadType;
+        }
+    }
+
+    public enum ConsumerRefreshTransitionType {
+        Snapshot("snapshot"),       // refresh involved snapshot transition
+        Delta("delta");             // refresh applied a delta transition
+
+        final private String type;
+        ConsumerRefreshTransitionType(String type) {
+            this.type = type;
+        }
+    }
+
+    public enum ConsumerRefreshLoadType {
+        Init("init"),               // consumer's first-time initialized with a snapshot
+        Subsequent("subsequent");   // consumer subsequent updated with either delta or snapshot
+
+        final private String type;
+        ConsumerRefreshLoadType(String type) {
+            this.type = type;
+        }
+    }
+
+    public enum ConsumerRefreshStatus {
+        Success("success"),
+        Failure("failure");
+
+        final private String status;
+        ConsumerRefreshStatus(String status) {
+            this.status = status;
+        }
+    }
+
+
+    public AbstractRefreshMetricsListener() {
+        lastRefreshInstant = Instant.now(); // TODO: Is this an acceptable value for the first transition?
+        refreshLoadCount = 0l;
+        consecutiveSuccesses = 0l;
+        consecutiveFailures = 0l;
+        refreshStatus = ConsumerRefreshStatus.Success;  // TODO: Ok to initialize as success for first refresh?
+        refreshLoadType = ConsumerRefreshLoadType.Init;
+        refreshTransitionType = null;
+    }
+
+    @Override
+    public final void refreshStarted(long currentVersion, long requestedVersion) {
+        refreshStart = Instant.now();
+        refreshTransitionType = null;   // Don't assume snapshot or delta transition, since a failed transition might
+                                        // leave the value of this variable in an incorrect state. Hence the value is
+                                        // reset at the start of every refresh.
+
+        // TODO: If this is an init load then we can get visibility into bootstrap time
+        // if (loadType.equals(ConsumerLoadType.Init)) {
+        //
+        // }
+    }
+
+    @Override
+    public final void refreshSuccessful(long beforeVersion, long afterVersion, long requestedVersion) {
+        Instant refreshEnd = Instant.now();
+
+        long refreshDurationMillis = Duration.between(refreshStart, refreshEnd).toMillis();
+        long timeSinceLastSuccessfulRefreshMillis = 0l;
+
+        consecutiveSuccesses ++;
+        consecutiveFailures = 0l;
+        // reset the timer to zero to indicate a refresh happened.
+        lastRefreshInstant = refreshEnd;
+        refreshStatus = ConsumerRefreshStatus.Success;
+
+        reportRefreshStats(new ConsumerRefreshMetrics(refreshDurationMillis, refreshStatus, refreshTransitionType, refreshLoadType));
+        reportTimeSinceLastSuccessfulRefresh(timeSinceLastSuccessfulRefreshMillis);
+        reportConsecutiveSuccesses(consecutiveSuccesses);
+        reportConsecutiveFailures(consecutiveFailures);
+    }
+
+    @Override
+    public final void refreshFailed(long beforeVersion, long afterVersion, long requestedVersion, Throwable failureCause) {
+        Instant refreshEnd = Instant.now();
+
+        long refreshDurationMillis = Duration.between(refreshStart, refreshEnd).toMillis();
+        long timeSinceLastSuccessfulRefreshMillis = Duration.between(lastRefreshInstant, refreshEnd).toMillis();
+
+        consecutiveSuccesses = 0l;
+        consecutiveFailures ++;
+        refreshStatus = ConsumerRefreshStatus.Failure;
+
+        reportRefreshStats(new ConsumerRefreshMetrics(refreshDurationMillis, refreshStatus, refreshTransitionType, refreshLoadType));
+        reportTimeSinceLastSuccessfulRefresh(timeSinceLastSuccessfulRefreshMillis);
+        reportConsecutiveSuccesses(consecutiveSuccesses);
+        reportConsecutiveFailures(consecutiveFailures);
+    }
+
+    @Override
+    public final void blobLoaded(HollowConsumer.Blob transition) {
+        refreshLoadCount ++;
+
+        if (refreshLoadCount > 1) {
+            refreshLoadType = ConsumerRefreshLoadType.Subsequent;
+        }
+    }
+
+    @Override
+    public final void snapshotUpdateOccurred(HollowAPI refreshAPI, HollowReadStateEngine stateEngine, long version) {
+        refreshTransitionType = ConsumerRefreshTransitionType.Snapshot;
+    }
+
+    @Override
+    public final void deltaUpdateOccurred(HollowAPI refreshAPI, HollowReadStateEngine stateEngine, long version) {
+        refreshTransitionType = ConsumerRefreshTransitionType.Delta;
+    }
+
+    @Override
+    public final void snapshotApplied(HollowAPI api, HollowReadStateEngine stateEngine, long version) throws Exception {
+        // no-op
+    }
+
+    @Override
+    public final void deltaApplied(HollowAPI api, HollowReadStateEngine stateEngine, long version) throws Exception {
+        // no-op
+    }
+
+    // Below reporting methods can be overridden by classes for custom metric reporting behavior. This way more metrics
+    // can be added without breaking existing clients.
+    public void reportRefreshStats(ConsumerRefreshMetrics refreshStats) { }
+    public void reportTimeSinceLastSuccessfulRefresh(long timeSinceLastSuccessfulRefreshMillis) { }
+    public void reportConsecutiveSuccesses(long consecutiveSuccesses) { }
+    public void reportConsecutiveFailures(long consecutiveFailures) { }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/AbstractRefreshMetricsListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/AbstractRefreshMetricsListener.java
@@ -63,7 +63,6 @@ public abstract class AbstractRefreshMetricsListener extends AbstractRefreshList
 
         updatePlanDetails.beforeVersion = beforeVersion;
         updatePlanDetails.desiredVersion = desiredVersion;
-        updatePlanDetails.numTransitions = transitionSequence.size();
         updatePlanDetails.transitionSequence = transitionSequence;
         if (isSnapshotPlan) {
             overallRefreshType = BlobType.SNAPSHOT;

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/ConsumerRefreshMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/ConsumerRefreshMetrics.java
@@ -1,6 +1,7 @@
 package com.netflix.hollow.api.consumer.metrics;
 
 import com.netflix.hollow.api.consumer.HollowConsumer.Blob.BlobType;
+import java.util.List;
 import java.util.OptionalLong;
 
 public class ConsumerRefreshMetrics {
@@ -13,6 +14,30 @@ public class ConsumerRefreshMetrics {
     private long consecutiveFailures;
     private OptionalLong refreshSuccessAgeMillisOptional; // time elapsed since the previous successful refresh
     private long refreshEndTimeNano;                // monotonic system time when refresh ended
+
+    /**
+     * A class that contains details of the consumer refresh update plan that may be useful to report as metrics or logs.
+     * These details are computed in {@code AbstractRefreshMetricsListener} during execution of the update plan.
+     */
+    public static class UpdatePlanDetails {
+        long beforeVersion;
+        long desiredVersion;
+        List<BlobType> transitionSequence;
+        int numSuccessfulTransitions;
+
+        public long getBeforeVersion() {
+            return beforeVersion;
+        }
+        public long getDesiredVersion() {
+            return desiredVersion;
+        }
+        public List<BlobType> getTransitionSequence() {
+            return transitionSequence;
+        }
+        public int getNumSuccessfulTransitions() {
+            return numSuccessfulTransitions;
+        }
+    }
 
     public long getDurationMillis() {
         return durationMillis;

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/ConsumerRefreshMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/ConsumerRefreshMetrics.java
@@ -12,6 +12,7 @@ public class ConsumerRefreshMetrics {
     private UpdatePlanDetails updatePlanDetails;    // details about the update plan such as no. and types of transitions and no. of successful transitions
     private long consecutiveFailures;
     private OptionalLong refreshSuccessAgeMillisOptional; // time elapsed since the previous successful refresh
+    private long refreshEndTimeNano;                // monotonic system time when refresh ended
 
     public long getDurationMillis() {
         return durationMillis;
@@ -34,9 +35,12 @@ public class ConsumerRefreshMetrics {
     public OptionalLong getRefreshSuccessAgeMillisOptional() {
         return refreshSuccessAgeMillisOptional;
     }
+    public long getRefreshEndTimeNano() {
+        return refreshEndTimeNano;
+    }
 
     private ConsumerRefreshMetrics(long durationMillis, boolean isRefreshSuccess, boolean isInitialLoad, BlobType overallRefreshType,
-            UpdatePlanDetails updatePlanDetails, long consecutiveFailures, OptionalLong refreshSuccessAgeMillisOptional) {
+            UpdatePlanDetails updatePlanDetails, long consecutiveFailures, OptionalLong refreshSuccessAgeMillisOptional, long refreshEndTimeNano) {
         this.durationMillis = durationMillis;
         this.isRefreshSuccess = isRefreshSuccess;
         this.isInitialLoad = isInitialLoad;
@@ -44,6 +48,7 @@ public class ConsumerRefreshMetrics {
         this.updatePlanDetails = updatePlanDetails;
         this.consecutiveFailures = consecutiveFailures;
         this.refreshSuccessAgeMillisOptional = refreshSuccessAgeMillisOptional;
+        this.refreshEndTimeNano = refreshEndTimeNano;
     }
 
     public static final class Builder {
@@ -54,6 +59,7 @@ public class ConsumerRefreshMetrics {
         private UpdatePlanDetails updatePlanDetails;
         private long consecutiveFailures;
         private OptionalLong refreshSuccessAgeMillisOptional;
+        private long refreshEndTimeNano;
 
         public Builder() {
             refreshSuccessAgeMillisOptional = OptionalLong.empty();
@@ -89,10 +95,14 @@ public class ConsumerRefreshMetrics {
             this.refreshSuccessAgeMillisOptional = OptionalLong.of(refreshSuccessAgeMillis);
             return this;
         }
+        public Builder setRefreshEndTimeNano(long refreshEndTimeNano) {
+            this.refreshEndTimeNano = refreshEndTimeNano;
+            return this;
+        }
 
         public ConsumerRefreshMetrics build() {
             return new ConsumerRefreshMetrics(durationMillis, isRefreshSuccess, isInitialLoad, overallRefreshType,
-                    updatePlanDetails, consecutiveFailures, refreshSuccessAgeMillisOptional);
+                    updatePlanDetails, consecutiveFailures, refreshSuccessAgeMillisOptional, refreshEndTimeNano);
         }
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/ConsumerRefreshMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/ConsumerRefreshMetrics.java
@@ -39,16 +39,15 @@ public class ConsumerRefreshMetrics {
         return refreshEndTimeNano;
     }
 
-    private ConsumerRefreshMetrics(long durationMillis, boolean isRefreshSuccess, boolean isInitialLoad, BlobType overallRefreshType,
-            UpdatePlanDetails updatePlanDetails, long consecutiveFailures, OptionalLong refreshSuccessAgeMillisOptional, long refreshEndTimeNano) {
-        this.durationMillis = durationMillis;
-        this.isRefreshSuccess = isRefreshSuccess;
-        this.isInitialLoad = isInitialLoad;
-        this.overallRefreshType = overallRefreshType;
-        this.updatePlanDetails = updatePlanDetails;
-        this.consecutiveFailures = consecutiveFailures;
-        this.refreshSuccessAgeMillisOptional = refreshSuccessAgeMillisOptional;
-        this.refreshEndTimeNano = refreshEndTimeNano;
+    private ConsumerRefreshMetrics(Builder builder) {
+        this.durationMillis = builder.durationMillis;
+        this.isRefreshSuccess = builder.isRefreshSuccess;
+        this.isInitialLoad = builder.isInitialLoad;
+        this.overallRefreshType = builder.overallRefreshType;
+        this.updatePlanDetails = builder.updatePlanDetails;
+        this.consecutiveFailures = builder.consecutiveFailures;
+        this.refreshSuccessAgeMillisOptional = builder.refreshSuccessAgeMillisOptional;
+        this.refreshEndTimeNano = builder.refreshEndTimeNano;
     }
 
     public static final class Builder {
@@ -77,8 +76,7 @@ public class ConsumerRefreshMetrics {
             this.isInitialLoad = isInitialLoad;
             return this;
         }
-        public Builder setOverallRefreshType(
-                BlobType overallRefreshType) {
+        public Builder setOverallRefreshType(BlobType overallRefreshType) {
             this.overallRefreshType = overallRefreshType;
             return this;
         }
@@ -101,8 +99,7 @@ public class ConsumerRefreshMetrics {
         }
 
         public ConsumerRefreshMetrics build() {
-            return new ConsumerRefreshMetrics(durationMillis, isRefreshSuccess, isInitialLoad, overallRefreshType,
-                    updatePlanDetails, consecutiveFailures, refreshSuccessAgeMillisOptional, refreshEndTimeNano);
+            return new ConsumerRefreshMetrics(this);
         }
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/ConsumerRefreshMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/ConsumerRefreshMetrics.java
@@ -1,7 +1,7 @@
 package com.netflix.hollow.api.consumer.metrics;
 
 import com.netflix.hollow.api.consumer.HollowConsumer.Blob.BlobType;
-import java.util.Optional;
+import java.util.OptionalLong;
 
 public class ConsumerRefreshMetrics {
 
@@ -11,7 +11,7 @@ public class ConsumerRefreshMetrics {
     private BlobType overallRefreshType;            // snapshot, delta, or reverse delta
     private UpdatePlanDetails updatePlanDetails;    // details about the update plan such as no. and types of transitions and no. of successful transitions
     private long consecutiveFailures;
-    private Optional<Long> refreshSuccessAgeMillisOptional; // time elapsed since the previous successful refresh
+    private OptionalLong refreshSuccessAgeMillisOptional; // time elapsed since the previous successful refresh
 
     public long getDurationMillis() {
         return durationMillis;
@@ -31,12 +31,12 @@ public class ConsumerRefreshMetrics {
     public long getConsecutiveFailures() {
         return consecutiveFailures;
     }
-    public Optional<Long> getRefreshSuccessAgeMillisOptional() {
+    public OptionalLong getRefreshSuccessAgeMillisOptional() {
         return refreshSuccessAgeMillisOptional;
     }
 
     private ConsumerRefreshMetrics(long durationMillis, boolean isRefreshSuccess, boolean isInitialLoad, BlobType overallRefreshType,
-            UpdatePlanDetails updatePlanDetails, long consecutiveFailures, Optional<Long> refreshSuccessAgeMillisOptional) {
+            UpdatePlanDetails updatePlanDetails, long consecutiveFailures, OptionalLong refreshSuccessAgeMillisOptional) {
         this.durationMillis = durationMillis;
         this.isRefreshSuccess = isRefreshSuccess;
         this.isInitialLoad = isInitialLoad;
@@ -53,10 +53,10 @@ public class ConsumerRefreshMetrics {
         private BlobType overallRefreshType;
         private UpdatePlanDetails updatePlanDetails;
         private long consecutiveFailures;
-        private Optional<Long> refreshSuccessAgeMillisOptional;
+        private OptionalLong refreshSuccessAgeMillisOptional;
 
         public Builder() {
-            refreshSuccessAgeMillisOptional = Optional.empty();
+            refreshSuccessAgeMillisOptional = OptionalLong.empty();
         }
 
         public Builder setDurationMillis(long durationMillis) {
@@ -86,7 +86,7 @@ public class ConsumerRefreshMetrics {
             return this;
         }
         public Builder setRefreshSuccessAgeMillisOptional(long refreshSuccessAgeMillis) {
-            this.refreshSuccessAgeMillisOptional = Optional.of(refreshSuccessAgeMillis);
+            this.refreshSuccessAgeMillisOptional = OptionalLong.of(refreshSuccessAgeMillis);
             return this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/ConsumerRefreshMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/ConsumerRefreshMetrics.java
@@ -1,0 +1,98 @@
+package com.netflix.hollow.api.consumer.metrics;
+
+import com.netflix.hollow.api.consumer.HollowConsumer.Blob.BlobType;
+import java.util.Optional;
+
+public class ConsumerRefreshMetrics {
+
+    private long durationMillis;
+    private boolean isRefreshSuccess;               // true if refresh was successful, false if refresh failed
+    private boolean isInitialLoad;                  // true if initial load, false if subsequent refresh
+    private BlobType overallRefreshType;            // snapshot, delta, or reverse delta
+    private UpdatePlanDetails updatePlanDetails;    // details about the update plan such as no. and types of transitions and no. of successful transitions
+    private long consecutiveFailures;
+    private Optional<Long> refreshSuccessAgeMillisOptional; // time elapsed since the previous successful refresh
+
+    public long getDurationMillis() {
+        return durationMillis;
+    }
+    public boolean getIsRefreshSuccess() {
+        return isRefreshSuccess;
+    }
+    public boolean getIsInitialLoad() {
+        return isInitialLoad;
+    }
+    public BlobType getOverallRefreshType() {
+        return overallRefreshType;
+    }
+    public UpdatePlanDetails getUpdatePlanDetails() {
+        return updatePlanDetails;
+    }
+    public long getConsecutiveFailures() {
+        return consecutiveFailures;
+    }
+    public Optional<Long> getRefreshSuccessAgeMillisOptional() {
+        return refreshSuccessAgeMillisOptional;
+    }
+
+    private ConsumerRefreshMetrics(long durationMillis, boolean isRefreshSuccess, boolean isInitialLoad, BlobType overallRefreshType,
+            UpdatePlanDetails updatePlanDetails, long consecutiveFailures, Optional<Long> refreshSuccessAgeMillisOptional) {
+        this.durationMillis = durationMillis;
+        this.isRefreshSuccess = isRefreshSuccess;
+        this.isInitialLoad = isInitialLoad;
+        this.overallRefreshType = overallRefreshType;
+        this.updatePlanDetails = updatePlanDetails;
+        this.consecutiveFailures = consecutiveFailures;
+        this.refreshSuccessAgeMillisOptional = refreshSuccessAgeMillisOptional;
+    }
+
+    public static final class Builder {
+        private long durationMillis;
+        private boolean isRefreshSuccess;
+        private boolean isInitialLoad;
+        private BlobType overallRefreshType;
+        private UpdatePlanDetails updatePlanDetails;
+        private long consecutiveFailures;
+        private Optional<Long> refreshSuccessAgeMillisOptional;
+
+        public Builder() {
+            refreshSuccessAgeMillisOptional = Optional.empty();
+        }
+
+        public Builder setDurationMillis(long durationMillis) {
+            this.durationMillis = durationMillis;
+            return this;
+        }
+        public Builder setIsRefreshSuccess(boolean isRefreshSuccess) {
+            this.isRefreshSuccess = isRefreshSuccess;
+            return this;
+        }
+        public Builder setIsInitialLoad(boolean isInitialLoad) {
+            this.isInitialLoad = isInitialLoad;
+            return this;
+        }
+        public Builder setOverallRefreshType(
+                BlobType overallRefreshType) {
+            this.overallRefreshType = overallRefreshType;
+            return this;
+        }
+        public Builder setUpdatePlanDetails(
+                UpdatePlanDetails updatePlanDetails) {
+            this.updatePlanDetails = updatePlanDetails;
+            return this;
+        }
+        public Builder setConsecutiveFailures(long consecutiveFailures) {
+            this.consecutiveFailures = consecutiveFailures;
+            return this;
+        }
+        public Builder setRefreshSuccessAgeMillisOptional(long refreshSuccessAgeMillis) {
+            this.refreshSuccessAgeMillisOptional = Optional.of(refreshSuccessAgeMillis);
+            return this;
+        }
+
+        public ConsumerRefreshMetrics build() {
+            return new ConsumerRefreshMetrics(durationMillis, isRefreshSuccess, isInitialLoad, overallRefreshType,
+                    updatePlanDetails, consecutiveFailures, refreshSuccessAgeMillisOptional);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/RefreshMetricsReporting.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/RefreshMetricsReporting.java
@@ -3,7 +3,7 @@ package com.netflix.hollow.api.consumer.metrics;
 /**
  * An interface to facilitate reporting of Hollow Consumer refresh metrics.
  * <p>
- * At different stages of Hollow Consumer refresh for eg. refresh start or refresh end, the methods in this interface
+ * At different stages of Hollow Consumer refresh for eg. refresh start and refresh end, the methods in this interface
  * are called with computed metrics. Hollow consumers can implement custom metrics reporting behavior by implementing
  * these methods.
  */
@@ -14,6 +14,7 @@ public interface RefreshMetricsReporting {
      * failed refreshes. It allows classes to implement custom metrics reporting behavior.
      *
      * @param refreshMetrics Object containing refresh metrics such as duration, consecutive failures, etc.
+     *
      * @see com.netflix.hollow.api.consumer.metrics.ConsumerRefreshMetrics
      */
     void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics);

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/RefreshMetricsReporting.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/RefreshMetricsReporting.java
@@ -1,0 +1,20 @@
+package com.netflix.hollow.api.consumer.metrics;
+
+/**
+ * An interface to facilitate reporting of Hollow Consumer refresh metrics.
+ * <p>
+ * At different stages of Hollow Consumer refresh for eg. refresh start or refresh end, the methods in this interface
+ * are called with computed metrics. Hollow consumers can implement custom metrics reporting behavior by implementing
+ * these methods.
+ */
+public interface RefreshMetricsReporting {
+
+    /**
+     * Metrics for a refresh (such as duration, status, etc.) are passed to this method at the end of successful and
+     * failed refreshes. It allows classes to implement custom metrics reporting behavior.
+     *
+     * @param refreshMetrics Object containing refresh metrics such as duration, consecutive failures, etc.
+     * @see com.netflix.hollow.api.consumer.metrics.ConsumerRefreshMetrics
+     */
+    void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics);
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/UpdatePlanDetails.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/UpdatePlanDetails.java
@@ -1,0 +1,21 @@
+package com.netflix.hollow.api.consumer.metrics;
+
+import com.netflix.hollow.api.consumer.HollowConsumer.Blob.BlobType;
+import java.util.List;
+
+/**
+ * A class that contains details of the update plan that may be useful to report as metrics or logs. These details are computed
+ * during the execution of the update plan {@code HollowClientUpdater} to {@code TransitionAwareRefreshListener}s.
+ */
+public class UpdatePlanDetails {
+
+    long beforeVersion;
+    long afterVersion;
+    // long announcedVersion; // TODO: what is this? From /Users/sunjeets/workspace/cinder/cinder/cinder-proto-definition/src/main/proto/netflix/cinder/consumer.proto
+    // long version; // TODO: what is this?
+    // boolean isPinned; // TODO:
+    int numTransitions; // how many transitions in this update Plan
+
+    List<BlobType> transitionSequence;
+    int successfulTransitions;
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/UpdatePlanDetails.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/UpdatePlanDetails.java
@@ -5,17 +5,14 @@ import java.util.List;
 
 /**
  * A class that contains details of the update plan that may be useful to report as metrics or logs. These details are computed
- * during the execution of the update plan {@code HollowClientUpdater} to {@code TransitionAwareRefreshListener}s.
+ * during execution of the update plan {@code HollowClientUpdater} to {@code TransitionAwareRefreshListener}s.
  */
 public class UpdatePlanDetails {
 
     long beforeVersion;
-    long afterVersion;
-    // long announcedVersion; // TODO: what is this? From /Users/sunjeets/workspace/cinder/cinder/cinder-proto-definition/src/main/proto/netflix/cinder/consumer.proto
-    // long version; // TODO: what is this?
-    // boolean isPinned; // TODO:
+    long desiredVersion;
     int numTransitions; // how many transitions in this update Plan
 
     List<BlobType> transitionSequence;
-    int successfulTransitions;
+    int numSuccessfulTransitions;
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/UpdatePlanDetails.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/UpdatePlanDetails.java
@@ -4,15 +4,13 @@ import com.netflix.hollow.api.consumer.HollowConsumer.Blob.BlobType;
 import java.util.List;
 
 /**
- * A class that contains details of the update plan that may be useful to report as metrics or logs. These details are computed
- * during execution of the update plan {@code HollowClientUpdater} to {@code TransitionAwareRefreshListener}s.
+ * A class that contains details of the consumer refresh update plan that may be useful to report as metrics or logs.
+ * These details are computed in {@code AbstractRefreshMetricsListener} during execution of the update plan.
  */
 public class UpdatePlanDetails {
 
     long beforeVersion;
     long desiredVersion;
-    int numTransitions; // how many transitions in this update Plan
-
     List<BlobType> transitionSequence;
     int numSuccessfulTransitions;
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowConsumerMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowConsumerMetrics.java
@@ -20,7 +20,7 @@ package com.netflix.hollow.api.metrics;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 
 public class HollowConsumerMetrics extends HollowMetrics {
-    private int refreshFailed;
+    private int refreshFailed;      // TODO: Move these metrics over to com.netflix.hollow.api.consumer.metrics.AbstractRefreshMetricsListener
     private int refreshSucceeded;
 
     /**

--- a/hollow/src/main/java/com/netflix/hollow/core/util/Versions.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/Versions.java
@@ -3,15 +3,9 @@ package com.netflix.hollow.core.util;
 import static com.netflix.hollow.core.HollowConstants.VERSION_LATEST;
 import static com.netflix.hollow.core.HollowConstants.VERSION_NONE;
 
-import java.util.OptionalLong;
-
 public final class Versions {
 
     private Versions() {}
-
-    public static OptionalLong maybeVersion(long version) {
-        return version == VERSION_NONE ? OptionalLong.empty() : OptionalLong.of(version);
-    }
 
     public static String prettyVersion(long version) {
         if (version == VERSION_NONE) {

--- a/hollow/src/main/java/com/netflix/hollow/core/util/Versions.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/Versions.java
@@ -1,0 +1,25 @@
+package com.netflix.hollow.core.util;
+
+import static com.netflix.hollow.core.HollowConstants.VERSION_LATEST;
+import static com.netflix.hollow.core.HollowConstants.VERSION_NONE;
+
+import java.util.Optional;
+
+public final class Versions {
+
+    private Versions() {}
+
+    public static Optional<Long> maybeVersion(long version) {
+        return version == VERSION_NONE ? Optional.empty() : Optional.of(version);
+    }
+
+    public static String prettyVersion(long version) {
+        if (version == VERSION_NONE) {
+            return "none";
+        } else if (version == VERSION_LATEST) {
+            return "latest";
+        } else {
+            return String.valueOf(version);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/util/Versions.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/Versions.java
@@ -5,13 +5,17 @@ import static com.netflix.hollow.core.HollowConstants.VERSION_NONE;
 
 public final class Versions {
 
+    // visible for testing
+    static final String PRETTY_VERSION_NONE = "none";
+    static final String PRETTY_VERSION_LATEST = "latest";
+
     private Versions() {}
 
     public static String prettyVersion(long version) {
         if (version == VERSION_NONE) {
-            return "none";
+            return PRETTY_VERSION_NONE;
         } else if (version == VERSION_LATEST) {
-            return "latest";
+            return PRETTY_VERSION_LATEST;
         } else {
             return String.valueOf(version);
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/util/Versions.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/Versions.java
@@ -3,14 +3,14 @@ package com.netflix.hollow.core.util;
 import static com.netflix.hollow.core.HollowConstants.VERSION_LATEST;
 import static com.netflix.hollow.core.HollowConstants.VERSION_NONE;
 
-import java.util.Optional;
+import java.util.OptionalLong;
 
 public final class Versions {
 
     private Versions() {}
 
-    public static Optional<Long> maybeVersion(long version) {
-        return version == VERSION_NONE ? Optional.empty() : Optional.of(version);
+    public static OptionalLong maybeVersion(long version) {
+        return version == VERSION_NONE ? OptionalLong.empty() : OptionalLong.of(version);
     }
 
     public static String prettyVersion(long version) {

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/metrics/AbstractRefreshMetricsListenerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/metrics/AbstractRefreshMetricsListenerTest.java
@@ -1,0 +1,176 @@
+package com.netflix.hollow.api.consumer.metrics;
+
+import static com.netflix.hollow.core.HollowConstants.VERSION_NONE;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractRefreshMetricsListenerTest {
+
+    private final long TEST_VERSION_LOW = 123l;
+    private final long TEST_VERSION_HIGH = 456l;
+
+    TestRefreshMetricsListener concreteRefreshMetricsListener;
+
+    class TestRefreshMetricsListener extends AbstractRefreshMetricsListener {
+        @Override
+        public void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
+            Assert.assertNotNull(refreshMetrics);
+        }
+    }
+
+    @Before
+    public void setup() {
+        concreteRefreshMetricsListener = new TestRefreshMetricsListener();
+    }
+
+    @Test
+    public void testRefreshStartedWithInitialLoad() {
+        concreteRefreshMetricsListener.refreshStarted(VERSION_NONE, TEST_VERSION_HIGH);
+        ConsumerRefreshMetrics refreshMetrics = concreteRefreshMetricsListener.refreshMetricsBuilder.build();
+        Assert.assertEquals(true, refreshMetrics.getIsInitialLoad());
+        Assert.assertNotNull(refreshMetrics.getUpdatePlanDetails());
+    }
+
+    @Test
+    public void testRefreshStartedWithSubsequentLoad() {
+        concreteRefreshMetricsListener.refreshStarted(TEST_VERSION_LOW, TEST_VERSION_HIGH);
+        ConsumerRefreshMetrics refreshMetrics = concreteRefreshMetricsListener.refreshMetricsBuilder.build();
+        Assert.assertEquals(false, refreshMetrics.getIsInitialLoad());
+        Assert.assertNotNull(refreshMetrics.getUpdatePlanDetails());
+    }
+
+    @Test
+    public void testTransitionsPlannedWithSnapshotUpdatePlan() {
+        List<HollowConsumer.Blob.BlobType> testTransitionSequence = new ArrayList<HollowConsumer.Blob.BlobType>() {{
+            add(HollowConsumer.Blob.BlobType.SNAPSHOT);
+            add(HollowConsumer.Blob.BlobType.DELTA);
+            add(HollowConsumer.Blob.BlobType.DELTA);
+        }};
+        concreteRefreshMetricsListener.refreshStarted(TEST_VERSION_LOW, TEST_VERSION_HIGH);
+        concreteRefreshMetricsListener.transitionsPlanned(TEST_VERSION_LOW, TEST_VERSION_HIGH, true, testTransitionSequence);
+        ConsumerRefreshMetrics refreshMetrics = concreteRefreshMetricsListener.refreshMetricsBuilder.build();
+
+        Assert.assertEquals(HollowConsumer.Blob.BlobType.SNAPSHOT, refreshMetrics.getOverallRefreshType());
+        Assert.assertEquals(TEST_VERSION_HIGH, refreshMetrics.getUpdatePlanDetails().getDesiredVersion());
+        Assert.assertEquals(TEST_VERSION_LOW, refreshMetrics.getUpdatePlanDetails().getBeforeVersion());
+        Assert.assertEquals(testTransitionSequence, refreshMetrics.getUpdatePlanDetails().getTransitionSequence());
+    }
+
+    @Test
+    public void testTransitionsPlannedWithDeltaUpdatePlan() {
+        List<HollowConsumer.Blob.BlobType> testTransitionSequence = new ArrayList<HollowConsumer.Blob.BlobType>() {{
+            add(HollowConsumer.Blob.BlobType.DELTA);
+            add(HollowConsumer.Blob.BlobType.DELTA);
+            add(HollowConsumer.Blob.BlobType.DELTA);
+        }};
+        concreteRefreshMetricsListener.refreshStarted(TEST_VERSION_LOW, TEST_VERSION_HIGH);
+        concreteRefreshMetricsListener.transitionsPlanned(TEST_VERSION_LOW, TEST_VERSION_HIGH, false, testTransitionSequence);
+        ConsumerRefreshMetrics refreshMetrics = concreteRefreshMetricsListener.refreshMetricsBuilder.build();
+
+        Assert.assertEquals(HollowConsumer.Blob.BlobType.DELTA, refreshMetrics.getOverallRefreshType());
+        Assert.assertEquals(TEST_VERSION_HIGH, refreshMetrics.getUpdatePlanDetails().getDesiredVersion());
+        Assert.assertEquals(TEST_VERSION_LOW, refreshMetrics.getUpdatePlanDetails().getBeforeVersion());
+        Assert.assertEquals(testTransitionSequence, refreshMetrics.getUpdatePlanDetails().getTransitionSequence());
+    }
+
+    @Test
+    public void testTransitionsPlannedWithReverseDeltaUpdatePlan() {
+        List<HollowConsumer.Blob.BlobType> testTransitionSequence = new ArrayList<HollowConsumer.Blob.BlobType>() {{
+            add(HollowConsumer.Blob.BlobType.REVERSE_DELTA);
+            add(HollowConsumer.Blob.BlobType.REVERSE_DELTA);
+            add(HollowConsumer.Blob.BlobType.REVERSE_DELTA);
+        }};
+        concreteRefreshMetricsListener.refreshStarted(TEST_VERSION_HIGH, TEST_VERSION_LOW);
+        concreteRefreshMetricsListener.transitionsPlanned(TEST_VERSION_HIGH, TEST_VERSION_LOW, false, testTransitionSequence);
+        ConsumerRefreshMetrics refreshMetrics = concreteRefreshMetricsListener.refreshMetricsBuilder.build();
+
+        Assert.assertEquals(HollowConsumer.Blob.BlobType.REVERSE_DELTA, refreshMetrics.getOverallRefreshType());
+        Assert.assertEquals(TEST_VERSION_LOW, refreshMetrics.getUpdatePlanDetails().getDesiredVersion());
+        Assert.assertEquals(TEST_VERSION_HIGH, refreshMetrics.getUpdatePlanDetails().getBeforeVersion());
+        Assert.assertEquals(testTransitionSequence, refreshMetrics.getUpdatePlanDetails().getTransitionSequence());
+    }
+
+    @Test
+    public void testRefreshSuccess() {
+        class SuccessTestRefreshMetricsListener extends AbstractRefreshMetricsListener {
+            @Override
+            public void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
+                Assert.assertEquals(0l, refreshMetrics.getConsecutiveFailures());
+                Assert.assertEquals(true, refreshMetrics.getIsRefreshSuccess());
+                Assert.assertEquals(0l, refreshMetrics.getRefreshSuccessAgeMillisOptional().getAsLong());
+                Assert.assertNotEquals(0l, refreshMetrics.getRefreshEndTimeNano());
+            }
+        }
+        SuccessTestRefreshMetricsListener successTestRefreshMetricsListener = new SuccessTestRefreshMetricsListener();
+        successTestRefreshMetricsListener.refreshStarted(TEST_VERSION_LOW, TEST_VERSION_HIGH);
+        successTestRefreshMetricsListener.refreshSuccessful(TEST_VERSION_LOW, TEST_VERSION_HIGH, TEST_VERSION_HIGH);
+    }
+
+    @Test
+    public void testRefreshFailure() {
+        class FailureTestRefreshMetricsListener extends AbstractRefreshMetricsListener {
+            @Override
+            public void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
+                Assert.assertNotEquals(0l, refreshMetrics.getConsecutiveFailures());
+                Assert.assertEquals(false, refreshMetrics.getIsRefreshSuccess());
+                Assert.assertNotEquals(Optional.empty(), refreshMetrics.getRefreshSuccessAgeMillisOptional());
+                Assert.assertNotEquals(0l, refreshMetrics.getRefreshEndTimeNano());
+            }
+        }
+        FailureTestRefreshMetricsListener successTestRefreshMetricsListener = new FailureTestRefreshMetricsListener();
+        successTestRefreshMetricsListener.refreshStarted(TEST_VERSION_LOW, TEST_VERSION_HIGH);
+        successTestRefreshMetricsListener.refreshFailed(TEST_VERSION_LOW, TEST_VERSION_HIGH, TEST_VERSION_HIGH, null);
+
+    }
+
+    @Test
+    public void testMetricsWhenMultiTransitionRefreshSucceeds() {
+        class SuccessTestRefreshMetricsListener extends AbstractRefreshMetricsListener {
+            @Override
+            public void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
+                Assert.assertEquals(3, refreshMetrics.getUpdatePlanDetails().getNumSuccessfulTransitions());
+            }
+        }
+        List<HollowConsumer.Blob.BlobType> testTransitionSequence = new ArrayList<HollowConsumer.Blob.BlobType>() {{
+            add(HollowConsumer.Blob.BlobType.SNAPSHOT);
+            add(HollowConsumer.Blob.BlobType.DELTA);
+            add(HollowConsumer.Blob.BlobType.DELTA);
+        }};
+
+        SuccessTestRefreshMetricsListener successTestRefreshMetricsListener = new SuccessTestRefreshMetricsListener();
+        successTestRefreshMetricsListener.refreshStarted(TEST_VERSION_LOW, TEST_VERSION_HIGH);
+        successTestRefreshMetricsListener.transitionsPlanned(TEST_VERSION_LOW, TEST_VERSION_HIGH, true, testTransitionSequence);
+        successTestRefreshMetricsListener.blobLoaded(null);
+        successTestRefreshMetricsListener.blobLoaded(null);
+        successTestRefreshMetricsListener.blobLoaded(null);
+        successTestRefreshMetricsListener.refreshSuccessful(TEST_VERSION_LOW, TEST_VERSION_HIGH, TEST_VERSION_HIGH);
+    }
+
+    @Test
+    public void testMetricsWhenMultiTransitionRefreshFails() {
+        class FailureTestRefreshMetricsListener extends AbstractRefreshMetricsListener {
+            @Override
+            public void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
+                Assert.assertEquals(1, refreshMetrics.getUpdatePlanDetails().getNumSuccessfulTransitions());
+            }
+        }
+        List<HollowConsumer.Blob.BlobType> testTransitionSequence = new ArrayList<HollowConsumer.Blob.BlobType>() {{
+            add(HollowConsumer.Blob.BlobType.SNAPSHOT);
+            add(HollowConsumer.Blob.BlobType.DELTA);
+            add(HollowConsumer.Blob.BlobType.DELTA);
+        }};
+
+        FailureTestRefreshMetricsListener failureTestRefreshMetricsListener = new FailureTestRefreshMetricsListener();
+        failureTestRefreshMetricsListener.refreshStarted(TEST_VERSION_LOW, TEST_VERSION_HIGH);
+        failureTestRefreshMetricsListener.transitionsPlanned(TEST_VERSION_LOW, TEST_VERSION_HIGH, true, testTransitionSequence);
+        failureTestRefreshMetricsListener.blobLoaded(null);
+        failureTestRefreshMetricsListener.refreshFailed(TEST_VERSION_LOW, TEST_VERSION_HIGH, TEST_VERSION_HIGH, null);
+
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/util/VersionsTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/util/VersionsTest.java
@@ -1,0 +1,18 @@
+package com.netflix.hollow.core.util;
+
+import static com.netflix.hollow.core.HollowConstants.VERSION_LATEST;
+import static com.netflix.hollow.core.HollowConstants.VERSION_NONE;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VersionsTest {
+
+    @Test
+    public void testPrettyPrint() {
+        Assert.assertEquals(Versions.PRETTY_VERSION_NONE, Versions.prettyVersion(VERSION_NONE));
+        Assert.assertEquals(Versions.PRETTY_VERSION_LATEST, Versions.prettyVersion(VERSION_LATEST));
+        Assert.assertEquals("123", Versions.prettyVersion(123l));
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
@@ -20,7 +20,6 @@ package com.netflix.hollow.tools.stringifier;
 import static com.netflix.hollow.tools.stringifier.HollowStringifier.INDENT;
 import static com.netflix.hollow.tools.stringifier.HollowStringifier.NEWLINE;
 
-
 import com.netflix.hollow.api.objects.HollowRecord;
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;


### PR DESCRIPTION
Highlights:
- Consumer refresh metrics computed in Hollow, can be attached as a listener.
- Added performance cost to Hollow is trivial if a metrics listener isn't registered (basically "transitionsPlanned" event is called on all listeners but no implementations will be bound).
- Introduced "transitionsPlanned" event that gets triggered after refresh start and once an update plan has been created but before it is executed, to provide early visibility into what is intended.
- Add notion of "overallRefreshType" only for metrics purposes which can be snapshot(1+ snapshots, 0+deltas) , delta(1+deltas) or reversedelta(1+ reversedeltas).
- Distinguish between initial vs. subsequent load type
- Additional details of update plan are now available like how many transitions and sequence of transitions for eg. [snapshot, delta, delta]. Also computes how many transitions were successful at the end of refresh.
- Remove tracking of consecutiveSuccesses metric
- last successful refresh time metric is now optional, which protects against the initial load failure case

Testing:
Unit tests and deployed to a cinderhollowhistoryexplorer in Test env. I was able to test backwards compatibility with existing metrics.