### PR TITLE
Upgrade commons dependencies

### DIFF
--- a/hollow-jsonadapter/build.gradle
+++ b/hollow-jsonadapter/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compile 'com.fasterxml.jackson.core:jackson-core:2.4.3'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.4.3'
-    compile 'commons-io:commons-io:2.4'
+    compile 'commons-io:commons-io:2.6'
     compile 'commons-lang:commons-lang:latest.release'
 
     testCompile 'junit:junit:4.11'

--- a/hollow-ui-tools/build.gradle
+++ b/hollow-ui-tools/build.gradle
@@ -10,8 +10,8 @@ sourceSets {
 dependencies {
     compile project(':hollow')
     compile 'org.apache.velocity:velocity:1.7'
-    compile 'commons-codec:commons-codec:1.8'
-    compile 'commons-io:commons-io:2.3'
+    compile 'commons-codec:commons-codec:1.11'
+    compile 'commons-io:commons-io:2.6'
     compile 'com.google.code.gson:gson:2.8.0'
 
     compileOnly 'org.eclipse.jetty:jetty-server:9.4.3.v20170317'


### PR DESCRIPTION
Fix issue #368 by upgrading `commons-io` and `commons-codec` dependencies to the latest versions (2.8 i 1.11 respectively).