### PR TITLE
Type safe hash indexer.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowHashIndexGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowHashIndexGenerator.java
@@ -66,6 +66,10 @@ public class HollowHashIndexGenerator extends HollowIndexGenerator {
 
         builder.append("\n");
         builder.append("@SuppressWarnings(\"all\")\n");
+        builder.append("@Deprecated\n");
+        builder.append("/**\n");
+        builder.append(" * @deprecated see {@link com.netflix.hollow.api.consumer.index.HashIndex}\n");
+        builder.append(" */\n");
         builder.append("public class " + className + " extends " + AbstractHollowHashIndex.class.getSimpleName() + "<" + apiClassname + "> {\n\n");
 
         builder.append("    public " + className + "(HollowConsumer consumer, String queryType, String selectFieldPath, String... matchFieldPaths) {\n");

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/data/AbstractHollowOrdinalIterable.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/data/AbstractHollowOrdinalIterable.java
@@ -18,6 +18,8 @@ package com.netflix.hollow.api.consumer.data;
 import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
 import java.util.Iterator;
 
+// @@@ AbstractHollowOrdinalIterable is incorrect, it's a one shot iterable that
+//     behaves incorrectly on second and subsequent iterations
 public abstract class AbstractHollowOrdinalIterable<T> implements Iterable<T> {
     private final HollowOrdinalIterator iter;
     private final int firstOrdinal;

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/AbstractHollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/AbstractHollowHashIndex.java
@@ -22,11 +22,11 @@ import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 
 /**
  * Intended for internal use only - used by API code generator
- *,
- * @author dsu
+ * @deprecated see {@link HashIndex}
  */
 // TODO(timt): how to move to `API extends HollowAPI` without binary incompatiblity of access to the `api`
 //             field in generated subclasses, e.g. `find*Matches(...)`
+@Deprecated
 public abstract class AbstractHollowHashIndex<API> {
     protected final HollowConsumer consumer;
     protected final String queryType;

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/FieldPath.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/FieldPath.java
@@ -1,0 +1,25 @@
+package com.netflix.hollow.api.consumer.index;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A field path associated with a field or method declaration whose type or
+ * return type respectively is associated resolution of the field path.
+ *
+ * @see com.netflix.hollow.core.index.FieldPaths
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target( {ElementType.FIELD, ElementType.METHOD}) public @interface FieldPath {
+    /**
+     * @return the field path, if empty then the path is derived from the field or method name.
+     */
+    String value() default "";
+
+    /**
+     * @return the field path order
+     */
+    int order() default 0;
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndex.java
@@ -1,0 +1,158 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.consumer.index;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.objects.HollowRecord;
+import java.util.Objects;
+
+/**
+ * A type safe hash index for indexing non-primary-key data.
+ * <p>
+ * This type of index can map multiple keys to a single matching record,
+ * and/or multiple records to a single key.
+ *
+ * @param <T> the root, select, and result type
+ * @param <Q> the query type
+ */
+public final class HashIndex<T extends HollowRecord, Q> extends HashIndexSelect<T, T, Q> {
+
+    HashIndex(
+            HollowConsumer consumer,
+            Class<T> rootType,
+            boolean listenToDataRefresh,
+            Class<Q> matchedFieldsType) {
+        super(consumer,
+                rootType,
+                listenToDataRefresh,
+                rootType, "",
+                matchedFieldsType);
+    }
+
+    HashIndex(
+            HollowConsumer consumer,
+            Class<T> rootType,
+            boolean listenToDataRefresh,
+            String fieldPath, Class<Q> matchedFieldType) {
+        super(consumer,
+                rootType,
+                listenToDataRefresh,
+                rootType, "",
+                fieldPath, matchedFieldType);
+    }
+
+    /**
+     * Starts the building of a {@link HashIndex}.
+     *
+     * @param consumer the consumer containing instances of the given root type
+     * @param rootType the root type to match and select from
+     * @param <T> the root type
+     */
+    public static <T extends HollowRecord> Builder<T> from(HollowConsumer consumer, Class<T> rootType) {
+        Objects.requireNonNull(consumer);
+        Objects.requireNonNull(rootType);
+        return new Builder<>(consumer, rootType);
+    }
+
+    /**
+     * The builder of a {@link HashIndex} or a {@link HashIndexSelect}.
+     * <p>
+     * The default configuration specifies, unless specified differently by an initiating builder method, that
+     * the hash index listen to {@code HollowConsumer} version updates as if by a call to {@link #listenToDataRefresh}
+     * with a value of {@code true}.
+     *
+     * @param <T> the root type
+     */
+    public static final class Builder<T extends HollowRecord> {
+        final HollowConsumer consumer;
+        final Class<T> rootType;
+        boolean listenToDataRefresh = true;
+
+        Builder(HollowConsumer consumer, Class<T> rootType) {
+            this.consumer = consumer;
+            this.rootType = rootType;
+        }
+
+        /**
+         * Creates a {@link HashIndex} for matching with field paths and types declared by
+         * {@link FieldPath} annotated fields or methods on the given query type.
+         *
+         * @param queryType the query type
+         * @param <Q> the query type
+         * @return a {@code HashIndex}
+         * @throws IllegalArgumentException if the query type declares one or more invalid field paths
+         * or invalid types given resolution of corresponding field paths
+         */
+        public <Q> HashIndex<T, Q> usingBean(Class<Q> queryType) {
+            Objects.requireNonNull(queryType);
+            return new HashIndex<>(consumer, rootType, listenToDataRefresh, queryType);
+        }
+
+        /**
+         * Creates a {@link HashIndex} for matching with a single query field path and type.
+         *
+         * @param queryFieldPath the query field path
+         * @param queryFieldType the query type
+         * @param <Q> the query type
+         * @return a {@code HashIndex}
+         * @throws IllegalArgumentException if the query field path is empty or invalid
+         * @throws IllegalArgumentException if the query field type is invalid given resolution of the
+         * query field path
+         */
+        public <Q> HashIndex<T, Q> usingPath(String queryFieldPath, Class<Q> queryFieldType) {
+            Objects.requireNonNull(queryFieldPath);
+            if (queryFieldPath.isEmpty()) {
+                throw new IllegalArgumentException("queryFieldPath argument is an empty String");
+            }
+            Objects.requireNonNull(queryFieldType);
+            return new HashIndex<>(consumer, rootType, listenToDataRefresh, queryFieldPath, queryFieldType);
+        }
+
+        /**
+         * Configures the hash index to listen to {@code HollowConsumer} version updates.
+         * On an update the index recalculates so updated data will be reflected in the results of a query
+         * (performed after the update).
+         *
+         * @param listen {@code true} if the index listens to {@code HollowConsumer} version updates,
+         * otherwise {@code false} and the index does not listen to {@code HollowConsumer} updates.  The default
+         * value is {@code true}, unless specified differently by the initiating builder method returning this builder.
+         * @return this builder
+         */
+        public Builder<T> listenToDataRefresh(boolean listen) {
+            listenToDataRefresh = listen;
+            return this;
+        }
+
+        /**
+         * Transitions to build a hash index with result selection.
+         *
+         * @param selectFieldPath the select field path
+         * @param selectFieldType the select, and result, field type associated with the
+         * resolved select field path
+         * @param <S> the select type
+         * @return a builder of a {@link HashIndexSelect}
+         */
+        public <S extends HollowRecord> BuilderWithSelect<T, S> selectField(
+                String selectFieldPath, Class<S> selectFieldType) {
+            Objects.requireNonNull(selectFieldPath);
+            Objects.requireNonNull(selectFieldType);
+            return new BuilderWithSelect<>(consumer, rootType, listenToDataRefresh, selectFieldPath,
+                    selectFieldType);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndexSelect.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndexSelect.java
@@ -1,0 +1,647 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.consumer.index;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.api.objects.HollowRecord;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.index.FieldPaths;
+import com.netflix.hollow.core.index.HollowHashIndex;
+import com.netflix.hollow.core.index.HollowHashIndexResult;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * A type safe hash index, with result selection, for indexing non-primary-key data.
+ * <p>
+ * This type of index can map multiple keys to a single matching record,
+ * and/or multiple records to a single key.
+ *
+ * @param <T> the root type
+ * @param <S> the select and result type
+ * @param <Q> the query type
+ */
+public class HashIndexSelect<T extends HollowRecord, S extends HollowRecord, Q> {
+    final HollowConsumer consumer;
+    HollowAPI api;
+    boolean listenToDataRefresh;
+    final SelectFieldPathResultExtractor<S> selectField;
+    final List<MatchFieldPathArgumentExtractor<Q>> matchFields;
+    final String rootTypeName;
+    final String selectFieldPath;
+    final String[] matchFieldPaths;
+    HollowHashIndex hhi;
+    RefreshListener refreshListener;
+
+    HashIndexSelect(
+            HollowConsumer consumer,
+            Class<T> rootType,
+            boolean listenToDataRefresh,
+            SelectFieldPathResultExtractor<S> selectField,
+            List<MatchFieldPathArgumentExtractor<Q>> matchFields) {
+        this.consumer = consumer;
+        this.api = consumer.getAPI();
+        this.selectField = selectField;
+        this.matchFields = matchFields;
+
+        // Validate select field path
+        // @@@ Add method to FieldPath
+        this.selectFieldPath = selectField.fieldPath.getSegments().stream().map(FieldPaths.FieldSegment::getName)
+                .collect(joining("."));
+
+        // Validate match field paths
+        this.matchFieldPaths = matchFields.stream()
+                // @@@ Add method to FieldPath
+                .map(mf -> mf.fieldPath.getSegments().stream().map(FieldPaths.FieldSegment::getName)
+                        .collect(joining(".")))
+                .toArray(String[]::new);
+        this.rootTypeName = rootType.getSimpleName();
+
+        this.hhi = new HollowHashIndex(consumer.getStateEngine(), rootTypeName, selectFieldPath, matchFieldPaths);
+
+        if (listenToDataRefresh) {
+            listenToDataRefresh();
+        }
+    }
+
+    HashIndexSelect(
+            HollowConsumer consumer,
+            Class<T> rootType,
+            boolean listenToDataRefresh,
+            Class<S> selectType, String selectField,
+            Class<Q> matchFieldsType) {
+        this(consumer,
+                rootType,
+                listenToDataRefresh,
+                SelectFieldPathResultExtractor
+                        .from(consumer.getAPI().getClass(), consumer.getStateEngine(), rootType, selectField,
+                                selectType),
+                MatchFieldPathArgumentExtractor
+                        .fromHolderClass(consumer.getStateEngine(), rootType, matchFieldsType));
+    }
+
+    HashIndexSelect(
+            HollowConsumer consumer,
+            Class<T> rootType,
+            boolean listenToDataRefresh,
+            Class<S> selectType, String selectField,
+            String fieldPath, Class<Q> matchFieldType) {
+        this(consumer,
+                rootType,
+                listenToDataRefresh,
+                SelectFieldPathResultExtractor
+                        .from(consumer.getAPI().getClass(), consumer.getStateEngine(), rootType, selectField,
+                                selectType),
+                Collections.singletonList(
+                        MatchFieldPathArgumentExtractor
+                                .fromPathAndType(consumer.getStateEngine(), rootType, fieldPath, matchFieldType)));
+    }
+
+    /**
+     * Listens to {@code HollowConsumer} version updates.
+     * On an update the index recalculates so updated data will be reflected in the results of a query
+     * (performed after the update).
+     */
+    public void listenToDataRefresh() {
+        if (listenToDataRefresh) {
+            return;
+        }
+        listenToDataRefresh = true;
+
+        if (refreshListener == null) {
+            refreshListener = new RefreshListener();
+        }
+
+        hhi.listenForDeltaUpdates();
+        consumer.addRefreshListener(refreshListener);
+    }
+
+    /**
+     * Disables listening to {@code HollowConsumer} version updates.
+     * Updated data will not be reflected in the results of a query.
+     * <p>
+     * This method should be called before the index is discarded to ensure unnecessary recalculation
+     * is not performed and to ensure the index is reclaimed by the garbage collector.
+     */
+    public void detachFromDataRefresh() {
+        if (!listenToDataRefresh) {
+            return;
+        }
+        listenToDataRefresh = false;
+
+        hhi.detachFromDeltaUpdates();
+        consumer.removeRefreshListener(refreshListener);
+    }
+
+    final class RefreshListener implements HollowConsumer.RefreshListener {
+        @Override
+        public void snapshotUpdateOccurred(HollowAPI refreshAPI, HollowReadStateEngine stateEngine, long version) {
+            hhi.detachFromDeltaUpdates();
+            hhi = new HollowHashIndex(consumer.getStateEngine(), rootTypeName, selectFieldPath, matchFieldPaths);
+            hhi.listenForDeltaUpdates();
+            api = refreshAPI;
+        }
+
+        @Override
+        public void deltaUpdateOccurred(HollowAPI refreshAPI, HollowReadStateEngine stateEngine, long version) {
+            api = refreshAPI;
+        }
+
+        @Override public void refreshStarted(long currentVersion, long requestedVersion) {
+        }
+
+        @Override public void blobLoaded(HollowConsumer.Blob transition) {
+        }
+
+        @Override public void refreshSuccessful(long beforeVersion, long afterVersion, long requestedVersion) {
+        }
+
+        @Override public void refreshFailed(
+                long beforeVersion, long afterVersion, long requestedVersion, Throwable failureCause) {
+        }
+    }
+
+    /**
+     * Finds matches for a given query.
+     *
+     * @param query the query
+     * @return a stream of matching records (may be empty if there are no matches)
+     */
+    public Stream<S> findMatches(Q query) {
+        Object[] queryArray = matchFields.stream().map(mf -> mf.extract(query)).toArray();
+
+        HollowHashIndexResult matches = hhi.findMatches(queryArray);
+        if (matches == null) {
+            return Stream.empty();
+        }
+
+        return matches.stream().mapToObj(i -> selectField.extract(api, i));
+    }
+
+    /**
+     * An extractor that extracts an argument value from an instance of a holding type for an associated match field
+     * path, transforming the value if necessary from a {@code HollowRecord} to an ordinal integer value.
+     *
+     * @param <Q> query type
+     */
+    static final class MatchFieldPathArgumentExtractor<Q> {
+        final FieldPaths.FieldPath<FieldPaths.FieldSegment> fieldPath;
+
+        final Function<Q, Object> extractor;
+
+        MatchFieldPathArgumentExtractor(
+                FieldPaths.FieldPath<FieldPaths.FieldSegment> fieldPath, Function<Q, ?> extractor) {
+            this.fieldPath = fieldPath;
+            @SuppressWarnings("unchecked")
+            Function<Q, Object> erasedResultExtractor = (Function<Q, Object>) extractor;
+            this.extractor = erasedResultExtractor;
+        }
+
+        Object extract(Q v) {
+            return extractor.apply(v);
+        }
+
+        static <Q> List<MatchFieldPathArgumentExtractor<Q>> fromHolderClass(
+                HollowDataset dataset, Class<?> rootType, Class<Q> holder) {
+            // @@@ Check for duplicates
+
+            // Query annotated fields
+            Stream<Field> fields = Stream.of(holder.getDeclaredFields())
+                    .filter(f -> f.isAnnotationPresent(FieldPath.class));
+
+            // Query annotated methods (abstract or concrete) that have
+            // a return type and no parameter types
+            Stream<Method> methods = Stream.of(holder.getDeclaredMethods())
+                    .filter(m -> m.isAnnotationPresent(FieldPath.class))
+                    .filter(m -> m.getReturnType() != void.class)
+                    .filter(m -> m.getParameterCount() == 0)
+                    .filter(m -> !m.isSynthetic())
+                    .filter(m -> !Modifier.isNative(m.getModifiers()));
+
+            return Stream.concat(fields, methods)
+                    .sorted(Comparator.comparingInt(f -> f.getDeclaredAnnotation(FieldPath.class).order()))
+                    .map(ae -> {
+                        try {
+                            if (ae instanceof Field) {
+                                return MatchFieldPathArgumentExtractor.<Q>fromField(dataset, rootType, (Field) ae);
+                            } else {
+                                return MatchFieldPathArgumentExtractor.<Q>fromMethod(dataset, rootType, (Method) ae);
+
+                            }
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .collect(toList());
+        }
+
+        static <Q> MatchFieldPathArgumentExtractor<Q> fromField(HollowDataset dataset, Class<?> rootType, Field f)
+                throws IllegalAccessException {
+            f.setAccessible(true);
+            return fromHandle(dataset, rootType, getFieldPath(f), MethodHandles.lookup().unreflectGetter(f));
+        }
+
+        static <Q> MatchFieldPathArgumentExtractor<Q> fromMethod(HollowDataset dataset, Class<?> rootType, Method m)
+                throws IllegalAccessException {
+            if (m.getReturnType() == void.class || m.getParameterCount() > 0) {
+                throw new IllegalArgumentException(String.format(
+                        "A @FieldPath annotated method must have zero parameters and a non-void return type: %s",
+                        m.toGenericString()));
+            }
+            m.setAccessible(true);
+            return fromHandle(dataset, rootType, getFieldPath(m), MethodHandles.lookup().unreflect(m));
+        }
+
+        static <Q> MatchFieldPathArgumentExtractor<Q> fromHandle(
+                HollowDataset dataset, Class<?> rootType, String fieldPath, MethodHandle mh) {
+            return fromFunction(dataset, rootType, fieldPath, mh.type().returnType(), getterGenericExtractor(mh));
+        }
+
+        static <T> MatchFieldPathArgumentExtractor<T> fromPathAndType(
+                HollowDataset dataset, Class<?> rootType, String fieldPath, Class<T> type) {
+            return fromFunction(dataset, rootType, fieldPath, type, Function.identity());
+        }
+
+        static IllegalArgumentException incompatibleMatchType(
+                Class<?> extractorType, String fieldPath,
+                HollowObjectSchema.FieldType schemaFieldType) {
+            return new IllegalArgumentException(
+                    String.format("Match type %s incompatible with field path %s resolving to field of value type %s",
+                            extractorType.getName(), fieldPath, schemaFieldType));
+        }
+
+        static IllegalArgumentException incompatibleMatchType(
+                Class<?> extractorType, String fieldPath, String typeName) {
+            return new IllegalArgumentException(
+                    String.format(
+                            "Match type %s incompatible with field path %s resolving to field of reference type %s",
+                            extractorType.getName(), fieldPath, typeName));
+        }
+
+        static <Q, T> MatchFieldPathArgumentExtractor<Q> fromFunction(
+                HollowDataset dataset, Class<?> rootType, String fieldPath,
+                Class<T> extractorType, Function<Q, T> extractorFunction) {
+            String rootTypeName = rootType.getSimpleName();
+            FieldPaths.FieldPath<FieldPaths.FieldSegment> fp =
+                    FieldPaths.createFieldPathForHashIndex(dataset, rootTypeName, fieldPath);
+
+            // @@@ Method on FieldPath
+            FieldPaths.FieldSegment lastSegment = fp.getSegments().get(fp.getSegments().size() - 1);
+            HollowObjectSchema.FieldType schemaFieldType;
+            if (lastSegment.getEnclosingSchema().getSchemaType() == HollowSchema.SchemaType.OBJECT) {
+                FieldPaths.ObjectFieldSegment os = (FieldPaths.ObjectFieldSegment) lastSegment;
+                schemaFieldType = os.getType();
+            } else {
+                schemaFieldType = HollowObjectSchema.FieldType.REFERENCE;
+            }
+
+            Function<Q, ?> extractor = extractorFunction;
+            switch (schemaFieldType) {
+                case BOOLEAN:
+                    if (extractorType != boolean.class && extractorType != Boolean.class) {
+                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                    }
+                    break;
+                case DOUBLE:
+                    if (extractorType != double.class && extractorType != Double.class) {
+                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                    }
+                    break;
+                case FLOAT:
+                    if (extractorType != float.class && extractorType != Float.class) {
+                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                    }
+                    break;
+                case INT:
+                    if (extractorType == byte.class || extractorType == Byte.class) {
+                        @SuppressWarnings("unchecked")
+                        Function<Q, Byte> f = (Function<Q, Byte>) extractorFunction;
+                        extractor = f.andThen(Byte::intValue);
+                        break;
+                    } else if (extractorType == short.class || extractorType == Short.class) {
+                        @SuppressWarnings("unchecked")
+                        Function<Q, Short> f = (Function<Q, Short>) extractorFunction;
+                        extractor = f.andThen(Short::intValue);
+                        break;
+                    } else if (extractorType == char.class || extractorType == Character.class) {
+                        @SuppressWarnings("unchecked")
+                        Function<Q, Character> f = (Function<Q, Character>) extractorFunction;
+                        extractor = f.andThen(c -> (int) c);
+                    } else if (extractorType != int.class && extractorType != Integer.class) {
+                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                    }
+                    break;
+                case LONG:
+                    if (extractorType != long.class && extractorType != Long.class) {
+                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                    }
+                    break;
+                case REFERENCE: {
+                    // @@@ If extractorType == int.class then consider it an ordinal value
+                    //   and directly use the extractorFunction
+
+                    String typeName = lastSegment.getTypeName();
+
+                    // Manage for String and all box types
+                    if (typeName.equals("String")) {
+                        if (!HollowObject.class.isAssignableFrom(extractorType)) {
+                            throw incompatibleMatchType(extractorType, fieldPath, typeName);
+                        }
+                        // @@@ Check that object schema has single value field of String type such as HString
+                    } else if (!extractorType.getSimpleName().equals(typeName)) {
+                        throw incompatibleMatchType(extractorType, fieldPath, typeName);
+                    } else if (!HollowRecord.class.isAssignableFrom(extractorType)) {
+                        throw incompatibleMatchType(extractorType, fieldPath, typeName);
+                    }
+
+                    @SuppressWarnings("unchecked")
+                    Function<Q, HollowRecord> f = (Function<Q, HollowRecord>) extractorFunction;
+                    extractor = f.andThen(HollowRecord::getOrdinal);
+                    break;
+                }
+                case BYTES:
+                    if (extractorType != byte[].class) {
+                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                    }
+                    break;
+                case STRING:
+                    if (extractorType == char[].class) {
+                        @SuppressWarnings("unchecked")
+                        Function<Q, char[]> f = (Function<Q, char[]>) extractorFunction;
+                        extractor = f.andThen(String::valueOf);
+                        break;
+                    } else if (extractorType != String.class) {
+                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                    }
+                    break;
+            }
+
+            return new MatchFieldPathArgumentExtractor<>(fp, extractor);
+        }
+
+        private static <Q, T> Function<Q, T> getterGenericExtractor(MethodHandle getter) {
+            return h -> {
+                try {
+                    @SuppressWarnings("unchecked")
+                    T t = (T) getter.invoke(h);
+                    return t;
+                } catch (RuntimeException | Error e) {
+                    throw e;
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            };
+        }
+
+        private static String getFieldPath(Field f) {
+            return getFieldPath(f, f);
+        }
+
+        private static String getFieldPath(Method m) {
+            return getFieldPath(m, m);
+        }
+
+        private static String getFieldPath(Member m, AnnotatedElement e) {
+            FieldPath fpa = e.getDeclaredAnnotation(FieldPath.class);
+            if (fpa == null) {
+                return m.getName();
+            }
+
+            String fieldPath = e.getDeclaredAnnotation(FieldPath.class).value();
+            if (fieldPath.isEmpty()) {
+                return m.getName();
+            }
+
+            return fieldPath;
+        }
+    }
+
+    /**
+     * An extractor that extracts a result value for an associated select field path transforming the value if
+     * necessary from an ordinal integer to an instance of a {@code HollowRecord} depending on the result type.
+     *
+     * @param <T> the result type
+     */
+    // The select path will be utilized to choose the nearest reference type to the leaf
+    // i.e. if the last segment refers to a primitive value then the enclosing schema will be used
+    static final class SelectFieldPathResultExtractor<T> {
+        final FieldPaths.FieldPath<FieldPaths.FieldSegment> fieldPath;
+
+        final SelectFieldPathResultExtractor.BiObjectIntFunction<HollowAPI, T> extractor;
+
+        SelectFieldPathResultExtractor(
+                FieldPaths.FieldPath<FieldPaths.FieldSegment> fieldPath,
+                SelectFieldPathResultExtractor.BiObjectIntFunction<HollowAPI, T> extractor) {
+            this.fieldPath = fieldPath;
+            this.extractor = extractor;
+        }
+
+        interface BiObjectIntFunction<T, R> {
+            R apply(T t, int i);
+        }
+
+        T extract(HollowAPI api, int ordinal) {
+            return extractor.apply(api, ordinal);
+        }
+
+        static IllegalArgumentException incompatibleSelectType(
+                Class<?> selectType, String fieldPath, HollowObjectSchema.FieldType schemaFieldType) {
+            return new IllegalArgumentException(
+                    String.format("Select type %s incompatible with field path %s resolving to field of type %s",
+                            selectType.getName(), fieldPath, schemaFieldType));
+        }
+
+        static IllegalArgumentException incompatibleSelectType(Class<?> selectType, String fieldPath, String typeName) {
+            return new IllegalArgumentException(
+                    String.format(
+                            "Select type %s incompatible with field path %s resolving to field of reference type %s",
+                            selectType.getName(), fieldPath, typeName));
+        }
+
+        static <T> SelectFieldPathResultExtractor<T> from(
+                Class<? extends HollowAPI> apiType, HollowDataset dataset, Class<?> rootType, String fieldPath,
+                Class<T> selectType) {
+            String rootTypeName = rootType.getSimpleName();
+            FieldPaths.FieldPath<FieldPaths.FieldSegment> fp =
+                    FieldPaths.createFieldPathForHashIndex(dataset, rootTypeName, fieldPath);
+
+            String typeName;
+            if (!fp.getSegments().isEmpty()) {
+                // @@@ Method on FieldPath
+                FieldPaths.FieldSegment lastSegment = fp.getSegments().get(fp.getSegments().size() - 1);
+                HollowSchema.SchemaType schemaType = lastSegment.getEnclosingSchema().getSchemaType();
+                HollowObjectSchema.FieldType schemaFieldType;
+                if (schemaType == HollowSchema.SchemaType.OBJECT) {
+                    FieldPaths.ObjectFieldSegment os = (FieldPaths.ObjectFieldSegment) lastSegment;
+                    schemaFieldType = os.getType();
+                } else {
+                    schemaFieldType = HollowObjectSchema.FieldType.REFERENCE;
+                }
+                typeName = lastSegment.getTypeName();
+
+                if (schemaFieldType != HollowObjectSchema.FieldType.REFERENCE) {
+                    // The field path must reference a field of a reference type
+                    // This is contrary to the underlying HollowHashIndex which selects
+                    // the enclosing reference type for a field of a value type.
+                    // It is considered better to be consistent and literal with field path
+                    // expressions
+                    throw incompatibleSelectType(selectType, fieldPath, schemaFieldType);
+                } else if (typeName.equals("String")) {
+                    if (!HollowObject.class.isAssignableFrom(selectType)) {
+                        throw incompatibleSelectType(selectType, fieldPath, typeName);
+                    }
+                    // @@@ Check that object schema has single value field of String type such as HString
+                } else if (!selectType.getSimpleName().equals(typeName)) {
+                    if (schemaType != HollowSchema.SchemaType.OBJECT && !GenericHollowObject.class.isAssignableFrom(
+                            selectType)) {
+                        throw incompatibleSelectType(selectType, fieldPath, typeName);
+                    }
+                    // @@@ GenericHollow{List, Set, Map} based on schemaType
+                } else if (!HollowRecord.class.isAssignableFrom(selectType)) {
+                    throw incompatibleSelectType(selectType, fieldPath, typeName);
+                }
+            } else {
+                typeName = rootTypeName;
+            }
+
+            if (GenericHollowObject.class.isAssignableFrom(selectType)) {
+                SelectFieldPathResultExtractor.BiObjectIntFunction<HollowAPI, T> extractor =
+                        (a, o) -> {
+                            @SuppressWarnings("unchecked")
+                            T t = (T) new GenericHollowObject(a.getDataAccess(), typeName, o);
+                            return t;
+                        };
+                return new SelectFieldPathResultExtractor<>(fp, extractor);
+            } else {
+                MethodHandle selectInstantiate;
+                try {
+                    selectInstantiate = MethodHandles.lookup().findVirtual(
+                            apiType,
+                            "get" + selectType.getSimpleName(),
+                            MethodType.methodType(selectType, int.class));
+                } catch (NoSuchMethodException | IllegalAccessException e) {
+                    throw new IllegalArgumentException(
+                            String.format("Select type %s is not associated with API %s",
+                                    selectType.getName(), apiType.getName()),
+                            e);
+                }
+
+                SelectFieldPathResultExtractor.BiObjectIntFunction<HollowAPI, T> extractor = (a, i) -> {
+                    try {
+                        @SuppressWarnings("unchecked")
+                        T s = (T) selectInstantiate.invoke(a, i);
+                        return s;
+                    } catch (RuntimeException | Error e) {
+                        throw e;
+                    } catch (Throwable e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+
+                return new SelectFieldPathResultExtractor<>(fp, extractor);
+            }
+        }
+    }
+
+    /**
+     * The builder of a {@link HashIndexSelect}.
+     *
+     * @param <T> the root type
+     * @param <S> the select, and result, type
+     */
+    public static class BuilderWithSelect<T extends HollowRecord, S extends HollowRecord> {
+        final HollowConsumer consumer;
+        final Class<T> rootType;
+        final boolean listenToDataRefresh;
+        final String selectFieldPath;
+        final Class<S> selectFieldType;
+
+        BuilderWithSelect(
+                HollowConsumer consumer, Class<T> rootType,
+                boolean listenToDataRefresh,
+                String selectFieldPath, Class<S> selectFieldType) {
+            this.consumer = consumer;
+            this.rootType = rootType;
+            this.listenToDataRefresh = listenToDataRefresh;
+            this.selectFieldPath = selectFieldPath;
+            this.selectFieldType = selectFieldType;
+        }
+
+        /**
+         * Creates a {@link HashIndexSelect} for matching with field paths and types declared by
+         * {@link FieldPath} annotated fields or methods on the given query type.
+         *
+         * @param queryType the query type
+         * @param <Q> the query type
+         * @return a {@code HashIndexSelect}
+         * @throws IllegalArgumentException if the query type declares one or more invalid field paths
+         * or invalid types given resolution of corresponding field paths
+         * @throws IllegalArgumentException if the select field path is invalid, or the select field type
+         * is invalid given resolution of the select field path.
+         */
+        public <Q> HashIndexSelect<T, S, Q> usingBean(Class<Q> queryType) {
+            Objects.requireNonNull(queryType);
+            return new HashIndexSelect<>(consumer, rootType, listenToDataRefresh,
+                    selectFieldType, selectFieldPath, queryType);
+        }
+
+        /**
+         * Creates a {@link HashIndexSelect} for matching with a single query field path and type.
+         *
+         * @param queryFieldPath the query field path
+         * @param queryFieldType the query type
+         * @param <Q> the query type
+         * @return a {@code HashIndexSelect}
+         * @throws IllegalArgumentException if the query field path is empty or invalid
+         * @throws IllegalArgumentException if the query field type is invalid given resolution of the
+         * query field path
+         * @throws IllegalArgumentException if the select field path is invalid, or the select field type
+         * is invalid given resolution of the select field path.
+         */
+        public <Q> HashIndexSelect<T, S, Q> usingPath(String queryFieldPath, Class<Q> queryFieldType) {
+            Objects.requireNonNull(queryFieldPath);
+            if (queryFieldPath.isEmpty()) {
+                throw new IllegalArgumentException("selectFieldPath argument is an empty String");
+            }
+            Objects.requireNonNull(queryFieldType);
+            return new HashIndexSelect<>(consumer, rootType, listenToDataRefresh,
+                    selectFieldType, selectFieldPath, queryFieldPath, queryFieldType);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/index/FieldPaths.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/FieldPaths.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.core.index;
 
 import static java.util.stream.Collectors.joining;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPreindexer.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPreindexer.java
@@ -24,7 +24,6 @@ import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.schema.HollowCollectionSchema;
 import com.netflix.hollow.core.schema.HollowMapSchema;
-import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import com.netflix.hollow.core.schema.HollowSchema;
 import java.util.Arrays;
@@ -53,7 +52,7 @@ public class HollowPreindexer {
     }
 
     public void buildFieldSpecifications() {
-        Map<String, Integer> baseFieldToIndexMap = new HashMap<String, Integer>();
+        Map<String, Integer> baseFieldToIndexMap = new HashMap<>();
 
         this.typeState = stateEngine.getTypeState(type);
 
@@ -80,13 +79,12 @@ public class HollowPreindexer {
         FieldPaths.FieldPath<FieldPaths.FieldSegment> path = FieldPaths.createFieldPathForHashIndex(
                 stateEngine, type, selectField);
 
-        HollowTypeReadState typeState = originalTypeState;
         HollowTypeReadState baseTypeState = originalTypeState;
 
         int baseFieldPathIdx = 0;
 
         List<FieldPaths.FieldSegment> segments = path.getSegments();
-        int fieldPathIndexes[] = new int[segments.size()];
+        int[] fieldPathIndexes = new int[segments.size()];
         FieldType fieldType = FieldType.REFERENCE;
 
         for (int i = 0; i < segments.size(); i++) {
@@ -99,9 +97,6 @@ public class HollowPreindexer {
                     fieldType = objectSegment.getType();
                     fieldPathIndexes[i] = objectSegment.getIndex();
 
-                    HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
-                    typeState = objectSchema.getReferencedTypeState(objectSegment.getIndex());
-
                     if(!truncate)
                         baseFieldPathIdx = i + 1;
                     break;
@@ -110,7 +105,7 @@ public class HollowPreindexer {
                     fieldType = FieldType.REFERENCE;
 
                     HollowCollectionSchema collectionSchema = (HollowCollectionSchema) schema;
-                    baseTypeState = typeState = collectionSchema.getElementTypeState();
+                    baseTypeState = collectionSchema.getElementTypeState();
 
                     baseFieldPathIdx = i + 1;
                     break;
@@ -119,7 +114,7 @@ public class HollowPreindexer {
 
                     HollowMapSchema mapSchema = (HollowMapSchema) schema;
                     boolean isKey = "key".equals(segment.getName());
-                    baseTypeState = typeState = isKey ? mapSchema.getKeyTypeState() : mapSchema.getValueTypeState();
+                    baseTypeState = isKey ? mapSchema.getKeyTypeState() : mapSchema.getValueTypeState();
 
                     baseFieldPathIdx = i + 1;
                     break;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/traversal/HollowIndexerListTraversalNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/traversal/HollowIndexerListTraversalNode.java
@@ -31,6 +31,9 @@ class HollowIndexerListTraversalNode extends HollowIndexerCollectionTraversalNod
 
     @Override
     public int doTraversal(int ordinal) {
+        if(child == null)
+            return 1;
+
         int size = dataAccess().size(ordinal);
         
         int numMatches = 0;

--- a/hollow/src/main/java/com/netflix/hollow/core/read/HollowReadFieldUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/HollowReadFieldUtils.java
@@ -231,6 +231,10 @@ public class HollowReadFieldUtils {
                 if(testObject instanceof Long)
                     return testObject.equals(typeAccess.readLong(ordinal, fieldPosition));
                 return testObject == null && typeAccess.readLong(ordinal, fieldPosition) == Long.MIN_VALUE;
+            case REFERENCE:
+                if(testObject instanceof Integer)
+                    return testObject.equals(typeAccess.readOrdinal(ordinal, fieldPosition));
+                return testObject == null && typeAccess.readOrdinal(ordinal, fieldPosition) < 0;
             default:
         }
 

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/index/DataModel.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/index/DataModel.java
@@ -1,0 +1,379 @@
+package com.netflix.hollow.api.consumer.index;
+
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.api.objects.HollowList;
+import com.netflix.hollow.api.objects.HollowMap;
+import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.api.objects.HollowSet;
+import com.netflix.hollow.api.objects.delegate.HollowListDelegate;
+import com.netflix.hollow.api.objects.delegate.HollowMapDelegate;
+import com.netflix.hollow.api.objects.delegate.HollowObjectDelegate;
+import com.netflix.hollow.api.objects.delegate.HollowObjectGenericDelegate;
+import com.netflix.hollow.api.objects.delegate.HollowSetDelegate;
+import com.netflix.hollow.api.objects.provider.HollowFactory;
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.write.objectmapper.HollowInline;
+import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class DataModel {
+    static class Producer {
+        public static class Values {
+            final boolean _boolean;
+            final byte _byte;
+            final short _short;
+            final char _char;
+            final int _int;
+            final long _long;
+            final float _float;
+            final double _double;
+            final byte[] _bytes;
+            final char[] _chars;
+
+            public Values() {
+                this._boolean = true;
+                this._byte = 1;
+                this._short = 1;
+                this._char = 1;
+                this._int = 1;
+                this._long = 1L;
+                this._float = 1.0f;
+                this._double = 1.0d;
+                this._bytes = new byte[] {1};
+                this._chars = "1".toCharArray();
+            }
+        }
+
+        public static class Boxes {
+            final Boolean _boolean;
+            final Byte _byte;
+            final Short _short;
+            final Character _char;
+            final Integer _int;
+            final Long _long;
+            final Float _float;
+            final Double _double;
+            final String _string;
+
+            public Boxes() {
+                this._boolean = true;
+                this._byte = 1;
+                this._short = 1;
+                this._char = 1;
+                this._int = 1;
+                this._long = 1L;
+                this._float = 1.0f;
+                this._double = 1.0d;
+                this._string = "1";
+            }
+        }
+
+        public static class InlineBoxes {
+            @HollowInline final Boolean _boolean;
+            @HollowInline final Byte _byte;
+            @HollowInline final Short _short;
+            @HollowInline final Character _char;
+            @HollowInline final Integer _int;
+            @HollowInline final Long _long;
+            @HollowInline final Float _float;
+            @HollowInline final Double _double;
+            @HollowInline final String _string;
+
+            public InlineBoxes() {
+                this._boolean = true;
+                this._byte = 1;
+                this._short = 1;
+                this._char = 1;
+                this._int = 1;
+                this._long = 1L;
+                this._float = 1.0f;
+                this._double = 1.0d;
+                this._string = "1";
+            }
+        }
+
+        public static class MappedReferencesToValues {
+            enum Number {
+                ONE,
+                TWO
+            }
+
+            final Date date;
+            final Number number;
+
+            public MappedReferencesToValues() {
+                this.date = new Date(0);
+                this.number = Number.ONE;
+            }
+        }
+
+        @HollowTypeName(name = "ReferenceWithStringsRenamed")
+        public static class ReferenceWithStrings {
+            final String _string1;
+
+            @HollowTypeName(name = "FieldOfStringRenamed") final String _string2;
+
+            public ReferenceWithStrings() {
+                this._string1 = "1";
+                this._string2 = "1";
+            }
+        }
+
+        public static class TypeA {
+            final int i;
+            final String s;
+
+            public TypeA(int i, String s) {
+                this.i = i;
+                this.s = s;
+            }
+        }
+
+        public static class Sequences {
+            final List<Boxes> list;
+
+            final Set<Boxes> set;
+
+            final Map<Boxes, Boxes> map;
+
+            public Sequences() {
+                this.list = new ArrayList<>(Arrays.asList(new Boxes()));
+                this.set = new HashSet<>(list);
+                this.map = new HashMap<>();
+                map.put(new Boxes(), new Boxes());
+            }
+        }
+
+        public static class References {
+            final Values values;
+            final Boxes boxes;
+            final InlineBoxes inlineBoxes;
+            final MappedReferencesToValues mapped;
+            final Sequences sequences;
+            final ReferenceWithStrings referenceWithStrings;
+
+            public References() {
+                this.values = new Values();
+                this.boxes = new Boxes();
+                this.inlineBoxes = new InlineBoxes();
+                this.mapped = new MappedReferencesToValues();
+                this.sequences = new Sequences();
+                this.referenceWithStrings = new ReferenceWithStrings();
+            }
+        }
+    }
+
+    public static class Consumer {
+        public static class Api extends HollowAPI {
+            private final HollowObjectTypeDataAccess stringTypeDataAccess;
+            private final HollowObjectGenericDelegate stringDelegate;
+
+            private final HollowObjectTypeDataAccess fieldOfStringRenamedTypeDataAccess;
+            private final HollowObjectGenericDelegate fieldOfStringRenamedDelegate;
+
+            public Api(HollowDataAccess dataAccess) {
+                this(dataAccess, Collections.<String>emptySet());
+            }
+
+            public Api(HollowDataAccess dataAccess, Set<String> cachedTypes) {
+                this(dataAccess, cachedTypes, Collections.<String, HollowFactory<?>>emptyMap());
+            }
+
+            public Api(
+                    HollowDataAccess dataAccess, Set<String> cachedTypes,
+                    Map<String, HollowFactory<?>> factoryOverrides) {
+                this(dataAccess, cachedTypes, factoryOverrides, null);
+            }
+
+            public Api(
+                    HollowDataAccess dataAccess, Set<String> cachedTypes,
+                    Map<String, HollowFactory<?>> factoryOverrides, Api previousCycleAPI) {
+                super(dataAccess);
+
+                this.stringTypeDataAccess = (HollowObjectTypeDataAccess) dataAccess.getTypeDataAccess("String");
+                this.stringDelegate = new HollowObjectGenericDelegate(stringTypeDataAccess);
+
+                this.fieldOfStringRenamedTypeDataAccess = (HollowObjectTypeDataAccess) dataAccess.getTypeDataAccess(
+                        "FieldOfStringRenamed");
+                this.fieldOfStringRenamedDelegate = new HollowObjectGenericDelegate(fieldOfStringRenamedTypeDataAccess);
+            }
+
+            public HString getHString(int ordinal) {
+                return new HString(stringDelegate, ordinal);
+            }
+
+            public Values getValues(int ordinal) {
+                return new Values(null, ordinal);
+            }
+
+            public Boxes getBoxes(int ordinal) {
+                return new Boxes(null, ordinal);
+            }
+
+            public InlineBoxes getInlineBoxes(int ordinal) {
+                return new InlineBoxes(null, ordinal);
+            }
+
+            public MappedReferencesToValues getMappedReferencesToValues(int ordinal) {
+                return new MappedReferencesToValues(null, ordinal);
+            }
+
+            public ReferenceWithStringsRenamed getReferenceWithStringsRenamed(int ordinal) {
+                return new ReferenceWithStringsRenamed(null, ordinal);
+            }
+
+            public FieldOfStringRenamed getFieldOfStringRenamed(int ordinal) {
+                return new FieldOfStringRenamed(fieldOfStringRenamedDelegate, ordinal);
+            }
+
+            public TypeA getTypeA(int ordinal) {
+                return new TypeA(null, ordinal);
+            }
+
+            public ListOfBoxes getListOfBoxes(int ordinal) {
+                return new ListOfBoxes(null, ordinal);
+            }
+
+            public SetOfBoxes getSetOfBoxes(int ordinal) {
+                return new SetOfBoxes(null, ordinal);
+            }
+
+            public MapOfBoxesToBoxes getMapOfBoxesToBoxes(int ordinal) {
+                return new MapOfBoxesToBoxes(null, ordinal);
+            }
+
+            public References getReferences(int ordinal) {
+                return new References(null, ordinal);
+            }
+        }
+
+        public static class HString extends HollowObject {
+            public HString(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+
+            public String getValue() {
+                return ((HollowObjectGenericDelegate) getDelegate()).getString(getOrdinal(), "value");
+            }
+        }
+
+        public static class Values extends HollowObject {
+            public Values(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        public static class Boxes extends HollowObject {
+            public Boxes(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        public static class InlineBoxes extends HollowObject {
+            public InlineBoxes(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        public static class MappedReferencesToValues extends HollowObject {
+            public MappedReferencesToValues(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        public static class ReferenceWithStringsRenamed extends HollowObject {
+            public ReferenceWithStringsRenamed(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        public static class FieldOfStringRenamed extends HollowObject {
+            public FieldOfStringRenamed(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+
+            public String getValue() {
+                return ((HollowObjectGenericDelegate) getDelegate()).getString(0, "value");
+            }
+        }
+
+        public static class TypeA extends HollowObject {
+            public TypeA(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        public static class ListOfBoxes extends HollowList<Boxes> {
+            public ListOfBoxes(HollowListDelegate<Boxes> delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+
+            @Override
+            public Boxes instantiateElement(int ordinal) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean equalsElement(int elementOrdinal, Object testObject) {
+                throw new UnsupportedOperationException();
+            }
+        }
+
+        public static class SetOfBoxes extends HollowSet<Boxes> {
+            public SetOfBoxes(HollowSetDelegate<Boxes> delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+
+            @Override
+            public Boxes instantiateElement(int ordinal) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean equalsElement(int elementOrdinal, Object testObject) {
+                throw new UnsupportedOperationException();
+            }
+        }
+
+        public static class MapOfBoxesToBoxes extends HollowMap<Boxes, Boxes> {
+            public MapOfBoxesToBoxes(HollowMapDelegate<Boxes, Boxes> delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+
+            @Override
+            public Boxes instantiateKey(int ordinal) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Boxes instantiateValue(int ordinal) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean equalsKey(int keyOrdinal, Object testObject) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean equalsValue(int valueOrdinal, Object testObject) {
+                throw new UnsupportedOperationException();
+            }
+        }
+
+        public static class References extends HollowObject {
+            public References(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/index/HashIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/index/HashIndexTest.java
@@ -1,0 +1,625 @@
+package com.netflix.hollow.api.consumer.index;
+
+import static java.util.stream.Collectors.toList;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.api.objects.HollowRecord;
+import com.netflix.hollow.api.objects.delegate.HollowObjectDelegate;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+public class HashIndexTest {
+    // Map of primitive class to box class
+    static final Map<Class<?>, Class<?>> primitiveClasses;
+    static {
+        primitiveClasses = new HashMap<>();
+        primitiveClasses.put(boolean.class, Boolean.class);
+        primitiveClasses.put(byte.class, Byte.class);
+        primitiveClasses.put(short.class, Short.class);
+        primitiveClasses.put(char.class, Character.class);
+        primitiveClasses.put(int.class, Integer.class);
+        primitiveClasses.put(long.class, Long.class);
+        primitiveClasses.put(float.class, Float.class);
+        primitiveClasses.put(double.class, Double.class);
+    }
+
+    static HollowConsumer consumer;
+
+    static DataModel.Consumer.Api api;
+
+    @BeforeClass
+    public static void setup() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.References());
+
+            for (int i = 0; i < 100; i++) {
+                ws.add(new DataModel.Producer.TypeA(1, "TypeA" + i));
+            }
+        });
+
+        consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withGeneratedAPIClass(DataModel.Consumer.Api.class)
+                .build();
+        consumer.triggerRefreshTo(v1);
+
+        api = consumer.getAPI(DataModel.Consumer.Api.class);
+    }
+
+    public static abstract class MatchTestParameterized<T extends HollowObject, Q> extends HashIndexTest {
+        final String path;
+        final Class<Q> type;
+        final Q value;
+        final Class<T> selectType;
+
+        public MatchTestParameterized(String path, Class<Q> type, Q value, Class<T> selectType) {
+            this.path = path;
+            this.type = type;
+            this.value = value;
+            this.selectType = selectType;
+        }
+
+        @Test
+        public void test() {
+            HashIndex<T, Q> hi = HashIndex
+                    .from(consumer, selectType)
+                    .usingPath(path, type);
+
+            List<T> r = hi
+                    .findMatches(value)
+                    .collect(toList());
+
+            Assert.assertEquals(1, r.size());
+            Assert.assertTrue(selectType.isInstance(r.get(0)));
+            Assert.assertEquals(0, r.get(0).getOrdinal());
+        }
+    }
+
+    // path, type, value
+    static List<Object[]> valuesDataProvider() {
+        DataModel.Producer.Values values = new DataModel.Producer.Values();
+        return Stream.of(DataModel.Producer.Values.class.getDeclaredFields())
+                .flatMap(f -> {
+                    String path = f.getName();
+                    Class<?> type = f.getType();
+                    Object value;
+                    try {
+                        value = f.get(values);
+                    } catch (IllegalAccessException e) {
+                        throw new InternalError();
+                    }
+
+                    Object[] args = new Object[] {path, type, value};
+                    if (type.isPrimitive()) {
+                        return Stream.of(args,
+                                new Object[] {path, primitiveClasses.get(type), value}
+                        );
+                    } else {
+                        return Stream.<Object[]>of(args);
+                    }
+                })
+                .collect(toList());
+    }
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnValuesTest<Q> extends MatchTestParameterized<DataModel.Consumer.Values, Q> {
+        // path[type] = value
+        @Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return valuesDataProvider();
+        }
+
+        public MatchOnValuesTest(String path, Class<Q> type, Q value) {
+            super(path, type, value, DataModel.Consumer.Values.class);
+        }
+    }
+
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnValuesIllegalTypeTest extends HashIndexTest {
+        // path[type] = value
+        @Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return valuesDataProvider();
+        }
+
+        final String path;
+        final Class<?> type;
+        final Object value;
+
+        public MatchOnValuesIllegalTypeTest(String path, Class<?> type, Object value) {
+            this.path = path;
+            this.type = type;
+            this.value = value;
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void test() {
+            HashIndex
+                    .from(consumer, DataModel.Consumer.Values.class)
+                    .usingPath(path, Object.class);
+        }
+    }
+
+    public static class MatchOnValuesBeanTest extends HashIndexTest {
+        static class ValueFieldsQuery {
+            @FieldPath
+            boolean _boolean;
+            @FieldPath
+            byte _byte;
+            @FieldPath
+            short _short;
+            @FieldPath
+            char _char;
+            @FieldPath
+            int _int;
+            @FieldPath
+            long _long;
+            @FieldPath
+            float _float;
+            @FieldPath
+            double _double;
+            @FieldPath
+            byte[] _bytes;
+            @FieldPath
+            char[] _chars;
+
+            ValueFieldsQuery(DataModel.Producer.Values v) {
+                this._boolean = v._boolean;
+                this._byte = v._byte;
+                this._short = v._short;
+                this._char = v._char;
+                this._int = v._int;
+                this._long = v._long;
+                this._float = v._float;
+                this._double = v._double;
+                this._bytes = v._bytes.clone();
+                this._chars = v._chars.clone();
+            }
+
+            static ValueFieldsQuery create() {
+                return new ValueFieldsQuery(new DataModel.Producer.Values());
+            }
+        }
+
+        @Test
+        public void testFields() {
+            HashIndex<DataModel.Consumer.Values, ValueFieldsQuery> hi = HashIndex
+                    .from(consumer, DataModel.Consumer.Values.class)
+                    .usingBean(ValueFieldsQuery.class);
+
+            List<DataModel.Consumer.Values> r = hi.findMatches(ValueFieldsQuery.create())
+                    .collect(toList());
+
+            Assert.assertEquals(1, r.size());
+            Assert.assertEquals(0, r.get(0).getOrdinal());
+        }
+
+        static class ValueMethodsQuery {
+            boolean _boolean;
+            byte _byte;
+            short _short;
+            char _char;
+            int _int;
+            long _long;
+            float _float;
+            double _double;
+            byte[] _bytes;
+            char[] _chars;
+
+            @FieldPath("_boolean")
+            boolean is_boolean() {
+                return _boolean;
+            }
+
+            @FieldPath("_byte")
+            byte get_byte() {
+                return _byte;
+            }
+
+            @FieldPath("_short")
+            short get_short() {
+                return _short;
+            }
+
+            @FieldPath("_char")
+            char get_char() {
+                return _char;
+            }
+
+            @FieldPath("_int")
+            int get_int() {
+                return _int;
+            }
+
+            @FieldPath("_long")
+            long get_long() {
+                return _long;
+            }
+
+            @FieldPath("_float")
+            float get_float() {
+                return _float;
+            }
+
+            @FieldPath("_double")
+            double get_double() {
+                return _double;
+            }
+
+            @FieldPath("_bytes")
+            byte[] get_bytes() {
+                return _bytes;
+            }
+
+            @FieldPath("_chars")
+            char[] get_chars() {
+                return _chars;
+            }
+
+            ValueMethodsQuery(DataModel.Producer.Values v) {
+                this._boolean = v._boolean;
+                this._byte = v._byte;
+                this._short = v._short;
+                this._char = v._char;
+                this._int = v._int;
+                this._long = v._long;
+                this._float = v._float;
+                this._double = v._double;
+                this._bytes = v._bytes.clone();
+                this._chars = v._chars.clone();
+            }
+
+            static ValueMethodsQuery create() {
+                return new ValueMethodsQuery(new DataModel.Producer.Values());
+            }
+        }
+
+        @Test
+        public void testMethods() {
+            HashIndex<DataModel.Consumer.Values, ValueMethodsQuery> hi = HashIndex
+                    .from(consumer, DataModel.Consumer.Values.class)
+                    .usingBean(ValueMethodsQuery.class);
+
+            List<DataModel.Consumer.Values> r = hi.findMatches(ValueMethodsQuery.create())
+                    .collect(toList());
+
+            Assert.assertEquals(1, r.size());
+            Assert.assertEquals(0, r.get(0).getOrdinal());
+        }
+    }
+
+    // path, type, value
+    static List<Object[]> boxesDataProvider() {
+        DataModel.Producer.Boxes values = new DataModel.Producer.Boxes();
+        return Stream.of(DataModel.Producer.Boxes.class.getDeclaredFields())
+                .map(f -> {
+                    String path = f.getName() + ".value";
+                    Class<?> type = f.getType();
+                    Object value;
+                    try {
+                        value = f.get(values);
+                    } catch (IllegalAccessException e) {
+                        throw new InternalError();
+                    }
+
+                    return new Object[] {path, type, value};
+                })
+                .collect(toList());
+    }
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnBoxesValuesTest<Q> extends MatchTestParameterized<DataModel.Consumer.Boxes, Q> {
+        // path[type] = value
+        @Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return boxesDataProvider();
+        }
+
+        public MatchOnBoxesValuesTest(String path, Class<Q> type, Q value) {
+            super(path, type, value, DataModel.Consumer.Boxes.class);
+        }
+    }
+
+
+    static List<Object[]> inlineBoxesDataProvider() {
+        DataModel.Producer.InlineBoxes values = new DataModel.Producer.InlineBoxes();
+        return Stream.of(DataModel.Producer.InlineBoxes.class.getDeclaredFields())
+                .map(f -> {
+                    String path = f.getName();
+                    Class<?> type = f.getType();
+                    Object value;
+                    try {
+                        value = f.get(values);
+                    } catch (IllegalAccessException e) {
+                        throw new InternalError();
+                    }
+
+                    return new Object[] {path, type, value};
+                })
+                .collect(toList());
+    }
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnInlineBoxesTest<Q> extends MatchTestParameterized<DataModel.Consumer.InlineBoxes, Q> {
+        // path[type] = value
+        @Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return inlineBoxesDataProvider();
+        }
+
+        public MatchOnInlineBoxesTest(String path, Class<Q> type, Q value) {
+            super(path, type, value, DataModel.Consumer.InlineBoxes.class);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnMappedReferencesTest<Q>
+            extends MatchTestParameterized<DataModel.Consumer.MappedReferencesToValues, Q> {
+        // path[type] = value
+        @Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return Arrays.<Object[]>asList(
+                    new Object[] {"date.value", long.class, 0L},
+                    new Object[] {"number._name", String.class, "ONE"}
+            );
+        }
+
+        public MatchOnMappedReferencesTest(String path, Class<Q> type, Q value) {
+            super(path, type, value, DataModel.Consumer.MappedReferencesToValues.class);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnReferencesTest<Q extends HollowRecord> extends HashIndexTest {
+        @Parameters(name = "{index}: {0}[{1} = {2}]")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(
+                    args("values", DataModel.Consumer.Values.class,
+                            () -> api.getValues(0)),
+                    args("boxes._string", DataModel.Consumer.HString.class,
+                            () -> api.getHString(0)),
+                    args("sequences.list", DataModel.Consumer.ListOfBoxes.class,
+                            () -> api.getListOfBoxes(0)),
+                    args("sequences.map.key._string", DataModel.Consumer.HString.class,
+                            () -> api.getHString(0)),
+                    args("referenceWithStrings", DataModel.Consumer.ReferenceWithStringsRenamed.class,
+                            () -> api.getReferenceWithStringsRenamed(0)),
+                    args("referenceWithStrings._string1", DataModel.Consumer.HString.class,
+                            () -> api.getHString(0)),
+                    args("referenceWithStrings._string2", DataModel.Consumer.FieldOfStringRenamed.class,
+                            () -> api.getFieldOfStringRenamed(0))
+            );
+        }
+
+        static <Q extends HollowRecord> Object[] args(String path, Class<Q> type, Supplier<Q> s) {
+            return new Object[] {path, type, s};
+        }
+
+        final String path;
+        final Class<Q> type;
+        final Q value;
+
+        public MatchOnReferencesTest(String path, Class<Q> type, Supplier<Q> value) {
+            this.path = path;
+            this.type = type;
+            this.value = value.get();
+        }
+
+        @Test
+        public void test() {
+            HashIndex<DataModel.Consumer.References, Q> hi = HashIndex
+                    .from(consumer, DataModel.Consumer.References.class)
+                    .usingPath(path, type);
+
+            List<DataModel.Consumer.References> r = hi.findMatches(value)
+                    .collect(toList());
+
+            Assert.assertEquals(1, r.size());
+            Assert.assertEquals(0, r.get(0).getOrdinal());
+        }
+    }
+
+
+    @RunWith(Parameterized.class)
+    public static class SelectOnValuesTest extends HashIndexTest {
+        // path[type] = value
+        @Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return valuesDataProvider();
+        }
+
+        final String path;
+        final Class<?> type;
+        final Object value;
+
+        public SelectOnValuesTest(String path, Class<?> type, Object value) {
+            this.path = path;
+            this.type = type;
+            this.value = value;
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void test() {
+            HashIndex
+                    .from(consumer, DataModel.Consumer.Values.class)
+                    .selectField(path, GenericHollowObject.class)
+                    .usingPath("values._int", int.class);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class SelectTest<S extends HollowRecord> extends HashIndexTest {
+        @Parameters(name = "{index}: {0}[{1}]")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(
+                    args("boxes._string", DataModel.Consumer.HString.class),
+
+                    args("boxes._string", GenericHollowObject.class),
+
+                    args("sequences.list", DataModel.Consumer.ListOfBoxes.class),
+                    args("sequences.list.element", DataModel.Consumer.Boxes.class),
+                    args("sequences.list.element._string", DataModel.Consumer.HString.class),
+
+                    args("sequences.set", DataModel.Consumer.SetOfBoxes.class),
+                    args("sequences.set.element", DataModel.Consumer.Boxes.class),
+                    args("sequences.set.element._string", DataModel.Consumer.HString.class),
+
+                    args("sequences.map", DataModel.Consumer.MapOfBoxesToBoxes.class),
+                    args("sequences.map.key", DataModel.Consumer.Boxes.class),
+                    args("sequences.map.key._string", DataModel.Consumer.HString.class),
+                    args("sequences.map.value", DataModel.Consumer.Boxes.class),
+                    args("sequences.map.value._string", DataModel.Consumer.HString.class),
+
+                    args("referenceWithStrings", DataModel.Consumer.ReferenceWithStringsRenamed.class),
+                    args("referenceWithStrings._string1", DataModel.Consumer.HString.class),
+                    args("referenceWithStrings._string2", DataModel.Consumer.FieldOfStringRenamed.class)
+            );
+        }
+
+        static <S extends HollowRecord> Object[] args(String path, Class<S> type) {
+            return new Object[] {path, type};
+        }
+
+        final String path;
+        final Class<S> type;
+
+        public SelectTest(String path, Class<S> type) {
+            this.path = path;
+            this.type = type;
+        }
+
+        @Test
+        public void test() {
+            HashIndexSelect<DataModel.Consumer.References, S, Integer> hi = HashIndex
+                    .from(consumer, DataModel.Consumer.References.class)
+                    .selectField(path, type)
+                    .usingPath("values._int", int.class);
+
+            List<S> r = hi.findMatches(1)
+                    .collect(toList());
+
+            Assert.assertEquals(1, r.size());
+            Assert.assertTrue(type.isInstance(r.get(0)));
+            Assert.assertEquals(0, r.get(0).getOrdinal());
+        }
+    }
+
+
+    public static class TestManyMatches extends HashIndexTest {
+        @Test
+        public void test() {
+            HashIndex<DataModel.Consumer.TypeA, Integer> hi = HashIndex
+                    .from(consumer, DataModel.Consumer.TypeA.class)
+                    .usingPath("i", int.class);
+
+            List<DataModel.Consumer.TypeA> r = hi.findMatches(1)
+                    .sorted(Comparator.comparingInt(HollowObject::getOrdinal)).collect(toList());
+            Assert.assertEquals(100, r.size());
+            for (int i = 0; i < r.size(); i++) {
+                Assert.assertEquals(i, r.get(i).getOrdinal());
+            }
+        }
+
+        @Test
+        public void testWithSelect() {
+            HashIndexSelect<DataModel.Consumer.TypeA, DataModel.Consumer.HString, Integer> hi = HashIndex
+                    .from(consumer, DataModel.Consumer.TypeA.class)
+                    .selectField("s", DataModel.Consumer.HString.class)
+                    .usingPath("i", int.class);
+
+            List<String> r = hi.findMatches(1)
+                    .sorted(Comparator.comparingInt(HollowObject::getOrdinal))
+                    .map(DataModel.Consumer.HString::getValue)
+                    .collect(toList());
+            Assert.assertEquals(100, r.size());
+            for (int i = 0; i < r.size(); i++) {
+                Assert.assertEquals("TypeA" + i, r.get(i));
+            }
+        }
+
+        @Test
+        public void testWithSelectRootTypeGenericHollowObject() {
+            HashIndexSelect<DataModel.Consumer.TypeA, GenericHollowObject, Integer> hi = HashIndex
+                    .from(consumer, DataModel.Consumer.TypeA.class)
+                    .selectField("", GenericHollowObject.class)
+                    .usingPath("i", int.class);
+
+            boolean r = hi.findMatches(1)
+                    .sorted(Comparator.comparingInt(HollowObject::getOrdinal))
+                    .mapToInt(gho -> gho.getInt("i"))
+                    .allMatch(i -> i == 1);
+            Assert.assertTrue(r);
+        }
+
+        @Test
+        public void testWithSelectGenericHollowObject() {
+            HashIndexSelect<DataModel.Consumer.TypeA, GenericHollowObject, Integer> hi = HashIndex
+                    .from(consumer, DataModel.Consumer.TypeA.class)
+                    .selectField("s", GenericHollowObject.class)
+                    .usingPath("i", int.class);
+
+            List<String> r = hi.findMatches(1)
+                    .sorted(Comparator.comparingInt(HollowObject::getOrdinal))
+                    .map(gho -> gho.getString("value"))
+                    .collect(toList());
+            Assert.assertEquals(100, r.size());
+            for (int i = 0; i < r.size(); i++) {
+                Assert.assertEquals("TypeA" + i, r.get(i));
+            }
+        }
+    }
+
+
+    public static class ErrorsTest extends HashIndexTest {
+        static class Unknown extends HollowObject {
+            Unknown(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testUnknownRootSelectType() {
+            HashIndex
+                    .from(consumer, Unknown.class)
+                    .usingPath("values", DataModel.Consumer.Values.class);
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testUnknownSelectType() {
+            HashIndex
+                    .from(consumer, DataModel.Consumer.References.class)
+                    .selectField("values", Unknown.class)
+                    .usingPath("values", DataModel.Consumer.Values.class);
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testEmptyMatchPath() {
+            HashIndex
+                    .from(consumer, DataModel.Consumer.References.class)
+                    .usingPath("", DataModel.Consumer.References.class);
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/index/HashIndexUpdatesTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/index/HashIndexUpdatesTest.java
@@ -1,0 +1,100 @@
+package com.netflix.hollow.api.consumer.index;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HashIndexUpdatesTest {
+    InMemoryBlobStore blobStore;
+
+    @Before
+    public void setUp() {
+        blobStore = new InMemoryBlobStore();
+    }
+
+    @Test
+    public void deltaUpdates() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.TypeA(1, "1"));
+        });
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withGeneratedAPIClass(DataModel.Consumer.Api.class)
+                .build();
+        consumer.triggerRefreshTo(v1);
+
+        HashIndex<DataModel.Consumer.TypeA, Integer> hi = HashIndex.from(consumer, DataModel.Consumer.TypeA.class)
+                .usingPath("i", int.class);
+
+        Assert.assertEquals(1L, hi.findMatches(1).count());
+
+
+        long v2 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.TypeA(1, "1"));
+            ws.add(new DataModel.Producer.TypeA(1, "2"));
+        });
+        consumer.triggerRefreshTo(v2);
+
+        Assert.assertEquals(2L, hi.findMatches(1).count());
+
+
+        hi.detachFromDataRefresh();
+        long v3 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.TypeA(1, "1"));
+            ws.add(new DataModel.Producer.TypeA(1, "2"));
+            ws.add(new DataModel.Producer.TypeA(1, "3"));
+        });
+        consumer.triggerRefreshTo(v3);
+
+        Assert.assertEquals(2L, hi.findMatches(1).count());
+    }
+
+    @Test
+    public void snapshotUpdates() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.TypeA(1, "1"));
+        });
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withGeneratedAPIClass(DataModel.Consumer.Api.class)
+                .build();
+        consumer.triggerRefreshTo(v1);
+
+        HashIndex<DataModel.Consumer.TypeA, Integer> hi = HashIndex.from(consumer, DataModel.Consumer.TypeA.class)
+                .usingPath("i", int.class);
+
+        Assert.assertEquals(1L, hi.findMatches(1).count());
+
+
+        long v2 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.TypeA(1, "1"));
+            ws.add(new DataModel.Producer.TypeA(1, "2"));
+        });
+        consumer.forceDoubleSnapshotNextUpdate();
+        consumer.triggerRefreshTo(v2);
+
+        Assert.assertEquals(2L, hi.findMatches(1).count());
+
+
+        hi.detachFromDataRefresh();
+        long v3 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.TypeA(1, "1"));
+            ws.add(new DataModel.Producer.TypeA(1, "2"));
+            ws.add(new DataModel.Producer.TypeA(1, "3"));
+        });
+        consumer.forceDoubleSnapshotNextUpdate();
+        consumer.triggerRefreshTo(v3);
+
+        Assert.assertEquals(2L, hi.findMatches(1).count());
+    }
+}


### PR DESCRIPTION
Replaces the generated API for supporting high-level hash indexing with a generic and type safe API for building a `HashIndex` or a `HashIndexSelect` where the latter supports result selection based on a select field path.  This leverages the prior work on the unification of field path parsing.  Future work includes expanding the Java documentation and applying the same pattern to primary key and prefix indexers.

In addition the following changes were made:

- Adds a `stream` method to `HollowHashIndexResult` returning an `IntStream` of matching ordinals.  This is utilized by the type safe hash indexer mapping ordinals to results. (Future work: enhance the underlying spliterator to split across buckets thereby making it possible to derive more efficient parallelism when using parallel streams.) 

- Deprecates the generated API for the hash indexer and `com.netflix.hollow.api.consumer.index.AbstractHollowHashIndex`

- Fix NPE in `HollowIndexerListTraversalNode.doTraversal` when a field path resolves to the list records itself

- Fix lack of support for `REFERENCE` fields in `HollowReadFieldUtils.fieldValueEquals`

- Fix lack of removing of a `HollowTypeStateListener` listener in `HollowTypeReadState.removeListener`

