### PR TITLE
Type safe primary key index.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndex.java
@@ -62,6 +62,7 @@ public final class HashIndex<T extends HollowRecord, Q> extends HashIndexSelect<
      * @param consumer the consumer containing instances of the given root type
      * @param rootType the root type to match and select from
      * @param <T> the root type
+     * @return a builder
      */
     public static <T extends HollowRecord> Builder<T> from(HollowConsumer consumer, Class<T> rootType) {
         Objects.requireNonNull(consumer);
@@ -71,10 +72,6 @@ public final class HashIndex<T extends HollowRecord, Q> extends HashIndexSelect<
 
     /**
      * The builder of a {@link HashIndex} or a {@link HashIndexSelect}.
-     * <p>
-     * The default configuration specifies, unless specified differently by an initiating builder method, that
-     * the hash index listen to {@code HollowConsumer} version updates as if by a call to {@link #listenToDataRefresh}
-     * with a value of {@code true}.
      *
      * @param <T> the root type
      */
@@ -128,13 +125,10 @@ public final class HashIndex<T extends HollowRecord, Q> extends HashIndexSelect<
          * On an update the index recalculates so updated data will be reflected in the results of a query
          * (performed after the update).
          *
-         * @param listen {@code true} if the index listens to {@code HollowConsumer} version updates,
-         * otherwise {@code false} and the index does not listen to {@code HollowConsumer} updates.  The default
-         * value is {@code true}, unless specified differently by the initiating builder method returning this builder.
          * @return this builder
          */
-        public Builder<T> listenToDataRefresh(boolean listen) {
-            listenToDataRefresh = listen;
+        public Builder<T> listenToDataRefresh() {
+            listenToDataRefresh = true;
             return this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndexSelect.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndexSelect.java
@@ -18,33 +18,17 @@
 package com.netflix.hollow.api.consumer.index;
 
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.custom.HollowAPI;
-import com.netflix.hollow.api.objects.HollowObject;
 import com.netflix.hollow.api.objects.HollowRecord;
-import com.netflix.hollow.api.objects.generic.GenericHollowObject;
-import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.index.FieldPaths;
 import com.netflix.hollow.core.index.HollowHashIndex;
 import com.netflix.hollow.core.index.HollowHashIndexResult;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
-import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.schema.HollowSchema;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
-import java.lang.reflect.Member;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -113,7 +97,8 @@ public class HashIndexSelect<T extends HollowRecord, S extends HollowRecord, Q> 
                         .from(consumer.getAPI().getClass(), consumer.getStateEngine(), rootType, selectField,
                                 selectType),
                 MatchFieldPathArgumentExtractor
-                        .fromHolderClass(consumer.getStateEngine(), rootType, matchFieldsType));
+                        .fromHolderClass(consumer.getStateEngine(), rootType, matchFieldsType,
+                                FieldPaths::createFieldPathForHashIndex));
     }
 
     HashIndexSelect(
@@ -130,7 +115,8 @@ public class HashIndexSelect<T extends HollowRecord, S extends HollowRecord, Q> 
                                 selectType),
                 Collections.singletonList(
                         MatchFieldPathArgumentExtractor
-                                .fromPathAndType(consumer.getStateEngine(), rootType, fieldPath, matchFieldType)));
+                                .fromPathAndType(consumer.getStateEngine(), rootType, fieldPath, matchFieldType,
+                                        FieldPaths::createFieldPathForHashIndex)));
     }
 
     /**
@@ -212,371 +198,6 @@ public class HashIndexSelect<T extends HollowRecord, S extends HollowRecord, Q> 
         }
 
         return matches.stream().mapToObj(i -> selectField.extract(api, i));
-    }
-
-    /**
-     * An extractor that extracts an argument value from an instance of a holding type for an associated match field
-     * path, transforming the value if necessary from a {@code HollowRecord} to an ordinal integer value.
-     *
-     * @param <Q> query type
-     */
-    static final class MatchFieldPathArgumentExtractor<Q> {
-        final FieldPaths.FieldPath<FieldPaths.FieldSegment> fieldPath;
-
-        final Function<Q, Object> extractor;
-
-        MatchFieldPathArgumentExtractor(
-                FieldPaths.FieldPath<FieldPaths.FieldSegment> fieldPath, Function<Q, ?> extractor) {
-            this.fieldPath = fieldPath;
-            @SuppressWarnings("unchecked")
-            Function<Q, Object> erasedResultExtractor = (Function<Q, Object>) extractor;
-            this.extractor = erasedResultExtractor;
-        }
-
-        Object extract(Q v) {
-            return extractor.apply(v);
-        }
-
-        static <Q> List<MatchFieldPathArgumentExtractor<Q>> fromHolderClass(
-                HollowDataset dataset, Class<?> rootType, Class<Q> holder) {
-            // @@@ Check for duplicates
-
-            // Query annotated fields
-            Stream<Field> fields = Stream.of(holder.getDeclaredFields())
-                    .filter(f -> f.isAnnotationPresent(FieldPath.class));
-
-            // Query annotated methods (abstract or concrete) that have
-            // a return type and no parameter types
-            Stream<Method> methods = Stream.of(holder.getDeclaredMethods())
-                    .filter(m -> m.isAnnotationPresent(FieldPath.class))
-                    .filter(m -> m.getReturnType() != void.class)
-                    .filter(m -> m.getParameterCount() == 0)
-                    .filter(m -> !m.isSynthetic())
-                    .filter(m -> !Modifier.isNative(m.getModifiers()));
-
-            return Stream.concat(fields, methods)
-                    .sorted(Comparator.comparingInt(f -> f.getDeclaredAnnotation(FieldPath.class).order()))
-                    .map(ae -> {
-                        try {
-                            if (ae instanceof Field) {
-                                return MatchFieldPathArgumentExtractor.<Q>fromField(dataset, rootType, (Field) ae);
-                            } else {
-                                return MatchFieldPathArgumentExtractor.<Q>fromMethod(dataset, rootType, (Method) ae);
-
-                            }
-                        } catch (IllegalAccessException e) {
-                            throw new RuntimeException(e);
-                        }
-                    })
-                    .collect(toList());
-        }
-
-        static <Q> MatchFieldPathArgumentExtractor<Q> fromField(HollowDataset dataset, Class<?> rootType, Field f)
-                throws IllegalAccessException {
-            f.setAccessible(true);
-            return fromHandle(dataset, rootType, getFieldPath(f), MethodHandles.lookup().unreflectGetter(f));
-        }
-
-        static <Q> MatchFieldPathArgumentExtractor<Q> fromMethod(HollowDataset dataset, Class<?> rootType, Method m)
-                throws IllegalAccessException {
-            if (m.getReturnType() == void.class || m.getParameterCount() > 0) {
-                throw new IllegalArgumentException(String.format(
-                        "A @FieldPath annotated method must have zero parameters and a non-void return type: %s",
-                        m.toGenericString()));
-            }
-            m.setAccessible(true);
-            return fromHandle(dataset, rootType, getFieldPath(m), MethodHandles.lookup().unreflect(m));
-        }
-
-        static <Q> MatchFieldPathArgumentExtractor<Q> fromHandle(
-                HollowDataset dataset, Class<?> rootType, String fieldPath, MethodHandle mh) {
-            return fromFunction(dataset, rootType, fieldPath, mh.type().returnType(), getterGenericExtractor(mh));
-        }
-
-        static <T> MatchFieldPathArgumentExtractor<T> fromPathAndType(
-                HollowDataset dataset, Class<?> rootType, String fieldPath, Class<T> type) {
-            return fromFunction(dataset, rootType, fieldPath, type, Function.identity());
-        }
-
-        static IllegalArgumentException incompatibleMatchType(
-                Class<?> extractorType, String fieldPath,
-                HollowObjectSchema.FieldType schemaFieldType) {
-            return new IllegalArgumentException(
-                    String.format("Match type %s incompatible with field path %s resolving to field of value type %s",
-                            extractorType.getName(), fieldPath, schemaFieldType));
-        }
-
-        static IllegalArgumentException incompatibleMatchType(
-                Class<?> extractorType, String fieldPath, String typeName) {
-            return new IllegalArgumentException(
-                    String.format(
-                            "Match type %s incompatible with field path %s resolving to field of reference type %s",
-                            extractorType.getName(), fieldPath, typeName));
-        }
-
-        static <Q, T> MatchFieldPathArgumentExtractor<Q> fromFunction(
-                HollowDataset dataset, Class<?> rootType, String fieldPath,
-                Class<T> extractorType, Function<Q, T> extractorFunction) {
-            String rootTypeName = rootType.getSimpleName();
-            FieldPaths.FieldPath<FieldPaths.FieldSegment> fp =
-                    FieldPaths.createFieldPathForHashIndex(dataset, rootTypeName, fieldPath);
-
-            // @@@ Method on FieldPath
-            FieldPaths.FieldSegment lastSegment = fp.getSegments().get(fp.getSegments().size() - 1);
-            HollowObjectSchema.FieldType schemaFieldType;
-            if (lastSegment.getEnclosingSchema().getSchemaType() == HollowSchema.SchemaType.OBJECT) {
-                FieldPaths.ObjectFieldSegment os = (FieldPaths.ObjectFieldSegment) lastSegment;
-                schemaFieldType = os.getType();
-            } else {
-                schemaFieldType = HollowObjectSchema.FieldType.REFERENCE;
-            }
-
-            Function<Q, ?> extractor = extractorFunction;
-            switch (schemaFieldType) {
-                case BOOLEAN:
-                    if (extractorType != boolean.class && extractorType != Boolean.class) {
-                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
-                    }
-                    break;
-                case DOUBLE:
-                    if (extractorType != double.class && extractorType != Double.class) {
-                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
-                    }
-                    break;
-                case FLOAT:
-                    if (extractorType != float.class && extractorType != Float.class) {
-                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
-                    }
-                    break;
-                case INT:
-                    if (extractorType == byte.class || extractorType == Byte.class) {
-                        @SuppressWarnings("unchecked")
-                        Function<Q, Byte> f = (Function<Q, Byte>) extractorFunction;
-                        extractor = f.andThen(Byte::intValue);
-                        break;
-                    } else if (extractorType == short.class || extractorType == Short.class) {
-                        @SuppressWarnings("unchecked")
-                        Function<Q, Short> f = (Function<Q, Short>) extractorFunction;
-                        extractor = f.andThen(Short::intValue);
-                        break;
-                    } else if (extractorType == char.class || extractorType == Character.class) {
-                        @SuppressWarnings("unchecked")
-                        Function<Q, Character> f = (Function<Q, Character>) extractorFunction;
-                        extractor = f.andThen(c -> (int) c);
-                    } else if (extractorType != int.class && extractorType != Integer.class) {
-                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
-                    }
-                    break;
-                case LONG:
-                    if (extractorType != long.class && extractorType != Long.class) {
-                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
-                    }
-                    break;
-                case REFERENCE: {
-                    // @@@ If extractorType == int.class then consider it an ordinal value
-                    //   and directly use the extractorFunction
-
-                    String typeName = lastSegment.getTypeName();
-
-                    // Manage for String and all box types
-                    if (typeName.equals("String")) {
-                        if (!HollowObject.class.isAssignableFrom(extractorType)) {
-                            throw incompatibleMatchType(extractorType, fieldPath, typeName);
-                        }
-                        // @@@ Check that object schema has single value field of String type such as HString
-                    } else if (!extractorType.getSimpleName().equals(typeName)) {
-                        throw incompatibleMatchType(extractorType, fieldPath, typeName);
-                    } else if (!HollowRecord.class.isAssignableFrom(extractorType)) {
-                        throw incompatibleMatchType(extractorType, fieldPath, typeName);
-                    }
-
-                    @SuppressWarnings("unchecked")
-                    Function<Q, HollowRecord> f = (Function<Q, HollowRecord>) extractorFunction;
-                    extractor = f.andThen(HollowRecord::getOrdinal);
-                    break;
-                }
-                case BYTES:
-                    if (extractorType != byte[].class) {
-                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
-                    }
-                    break;
-                case STRING:
-                    if (extractorType == char[].class) {
-                        @SuppressWarnings("unchecked")
-                        Function<Q, char[]> f = (Function<Q, char[]>) extractorFunction;
-                        extractor = f.andThen(String::valueOf);
-                        break;
-                    } else if (extractorType != String.class) {
-                        throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
-                    }
-                    break;
-            }
-
-            return new MatchFieldPathArgumentExtractor<>(fp, extractor);
-        }
-
-        private static <Q, T> Function<Q, T> getterGenericExtractor(MethodHandle getter) {
-            return h -> {
-                try {
-                    @SuppressWarnings("unchecked")
-                    T t = (T) getter.invoke(h);
-                    return t;
-                } catch (RuntimeException | Error e) {
-                    throw e;
-                } catch (Throwable e) {
-                    throw new RuntimeException(e);
-                }
-            };
-        }
-
-        private static String getFieldPath(Field f) {
-            return getFieldPath(f, f);
-        }
-
-        private static String getFieldPath(Method m) {
-            return getFieldPath(m, m);
-        }
-
-        private static String getFieldPath(Member m, AnnotatedElement e) {
-            FieldPath fpa = e.getDeclaredAnnotation(FieldPath.class);
-            if (fpa == null) {
-                return m.getName();
-            }
-
-            String fieldPath = e.getDeclaredAnnotation(FieldPath.class).value();
-            if (fieldPath.isEmpty()) {
-                return m.getName();
-            }
-
-            return fieldPath;
-        }
-    }
-
-    /**
-     * An extractor that extracts a result value for an associated select field path transforming the value if
-     * necessary from an ordinal integer to an instance of a {@code HollowRecord} depending on the result type.
-     *
-     * @param <T> the result type
-     */
-    // The select path will be utilized to choose the nearest reference type to the leaf
-    // i.e. if the last segment refers to a primitive value then the enclosing schema will be used
-    static final class SelectFieldPathResultExtractor<T> {
-        final FieldPaths.FieldPath<FieldPaths.FieldSegment> fieldPath;
-
-        final SelectFieldPathResultExtractor.BiObjectIntFunction<HollowAPI, T> extractor;
-
-        SelectFieldPathResultExtractor(
-                FieldPaths.FieldPath<FieldPaths.FieldSegment> fieldPath,
-                SelectFieldPathResultExtractor.BiObjectIntFunction<HollowAPI, T> extractor) {
-            this.fieldPath = fieldPath;
-            this.extractor = extractor;
-        }
-
-        interface BiObjectIntFunction<T, R> {
-            R apply(T t, int i);
-        }
-
-        T extract(HollowAPI api, int ordinal) {
-            return extractor.apply(api, ordinal);
-        }
-
-        static IllegalArgumentException incompatibleSelectType(
-                Class<?> selectType, String fieldPath, HollowObjectSchema.FieldType schemaFieldType) {
-            return new IllegalArgumentException(
-                    String.format("Select type %s incompatible with field path %s resolving to field of type %s",
-                            selectType.getName(), fieldPath, schemaFieldType));
-        }
-
-        static IllegalArgumentException incompatibleSelectType(Class<?> selectType, String fieldPath, String typeName) {
-            return new IllegalArgumentException(
-                    String.format(
-                            "Select type %s incompatible with field path %s resolving to field of reference type %s",
-                            selectType.getName(), fieldPath, typeName));
-        }
-
-        static <T> SelectFieldPathResultExtractor<T> from(
-                Class<? extends HollowAPI> apiType, HollowDataset dataset, Class<?> rootType, String fieldPath,
-                Class<T> selectType) {
-            String rootTypeName = rootType.getSimpleName();
-            FieldPaths.FieldPath<FieldPaths.FieldSegment> fp =
-                    FieldPaths.createFieldPathForHashIndex(dataset, rootTypeName, fieldPath);
-
-            String typeName;
-            if (!fp.getSegments().isEmpty()) {
-                // @@@ Method on FieldPath
-                FieldPaths.FieldSegment lastSegment = fp.getSegments().get(fp.getSegments().size() - 1);
-                HollowSchema.SchemaType schemaType = lastSegment.getEnclosingSchema().getSchemaType();
-                HollowObjectSchema.FieldType schemaFieldType;
-                if (schemaType == HollowSchema.SchemaType.OBJECT) {
-                    FieldPaths.ObjectFieldSegment os = (FieldPaths.ObjectFieldSegment) lastSegment;
-                    schemaFieldType = os.getType();
-                } else {
-                    schemaFieldType = HollowObjectSchema.FieldType.REFERENCE;
-                }
-                typeName = lastSegment.getTypeName();
-
-                if (schemaFieldType != HollowObjectSchema.FieldType.REFERENCE) {
-                    // The field path must reference a field of a reference type
-                    // This is contrary to the underlying HollowHashIndex which selects
-                    // the enclosing reference type for a field of a value type.
-                    // It is considered better to be consistent and literal with field path
-                    // expressions
-                    throw incompatibleSelectType(selectType, fieldPath, schemaFieldType);
-                } else if (typeName.equals("String")) {
-                    if (!HollowObject.class.isAssignableFrom(selectType)) {
-                        throw incompatibleSelectType(selectType, fieldPath, typeName);
-                    }
-                    // @@@ Check that object schema has single value field of String type such as HString
-                } else if (!selectType.getSimpleName().equals(typeName)) {
-                    if (schemaType != HollowSchema.SchemaType.OBJECT && !GenericHollowObject.class.isAssignableFrom(
-                            selectType)) {
-                        throw incompatibleSelectType(selectType, fieldPath, typeName);
-                    }
-                    // @@@ GenericHollow{List, Set, Map} based on schemaType
-                } else if (!HollowRecord.class.isAssignableFrom(selectType)) {
-                    throw incompatibleSelectType(selectType, fieldPath, typeName);
-                }
-            } else {
-                typeName = rootTypeName;
-            }
-
-            if (GenericHollowObject.class.isAssignableFrom(selectType)) {
-                SelectFieldPathResultExtractor.BiObjectIntFunction<HollowAPI, T> extractor =
-                        (a, o) -> {
-                            @SuppressWarnings("unchecked")
-                            T t = (T) new GenericHollowObject(a.getDataAccess(), typeName, o);
-                            return t;
-                        };
-                return new SelectFieldPathResultExtractor<>(fp, extractor);
-            } else {
-                MethodHandle selectInstantiate;
-                try {
-                    selectInstantiate = MethodHandles.lookup().findVirtual(
-                            apiType,
-                            "get" + selectType.getSimpleName(),
-                            MethodType.methodType(selectType, int.class));
-                } catch (NoSuchMethodException | IllegalAccessException e) {
-                    throw new IllegalArgumentException(
-                            String.format("Select type %s is not associated with API %s",
-                                    selectType.getName(), apiType.getName()),
-                            e);
-                }
-
-                SelectFieldPathResultExtractor.BiObjectIntFunction<HollowAPI, T> extractor = (a, i) -> {
-                    try {
-                        @SuppressWarnings("unchecked")
-                        T s = (T) selectInstantiate.invoke(a, i);
-                        return s;
-                    } catch (RuntimeException | Error e) {
-                        throw e;
-                    } catch (Throwable e) {
-                        throw new RuntimeException(e);
-                    }
-                };
-
-                return new SelectFieldPathResultExtractor<>(fp, extractor);
-            }
-        }
     }
 
     /**

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/MatchFieldPathArgumentExtractor.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/MatchFieldPathArgumentExtractor.java
@@ -1,0 +1,306 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.consumer.index;
+
+import static java.util.stream.Collectors.toList;
+
+import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.api.objects.HollowRecord;
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.index.FieldPaths;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * An extractor that extracts an argument value from an instance of a holding type for an associated match field
+ * path, transforming the value if necessary from a {@code HollowRecord} to an ordinal integer value.
+ *
+ * @param <Q> query type
+ */
+final class MatchFieldPathArgumentExtractor<Q> {
+
+    /**
+     * A resolver of a field path.
+     */
+    interface FieldPathResolver {
+        /**
+         * Resolves a field path to a {@link FieldPaths.FieldPath}.
+         */
+        FieldPaths.FieldPath<? extends FieldPaths.FieldSegment> resolve(
+                HollowDataset hollowDataAccess, String type, String fieldPath);
+    }
+
+    final FieldPaths.FieldPath<? extends FieldPaths.FieldSegment> fieldPath;
+
+    final Function<Q, Object> extractor;
+
+    MatchFieldPathArgumentExtractor(
+            FieldPaths.FieldPath<? extends FieldPaths.FieldSegment> fieldPath, Function<Q, ?> extractor) {
+        this.fieldPath = fieldPath;
+        @SuppressWarnings("unchecked")
+        Function<Q, Object> erasedResultExtractor = (Function<Q, Object>) extractor;
+        this.extractor = erasedResultExtractor;
+    }
+
+    Object extract(Q v) {
+        return extractor.apply(v);
+    }
+
+    static <Q> List<MatchFieldPathArgumentExtractor<Q>> fromHolderClass(
+            HollowDataset dataset, Class<?> rootType, Class<Q> holder,
+            FieldPathResolver fpResolver) {
+        // @@@ Check for duplicates
+        // @@@ Cache result for Q, needs to be associated with dataset
+        //     and resolving kind (currently implicit to implementation of fpResolver)
+        // @@@ Support holder type of Object[] accepting an instance of String[] for field paths
+        //     on construction and Object[] on match enabling "reflective" operation if
+        //     static beans are not desired
+
+        // Query annotated fields
+        Stream<Field> fields = Stream.of(holder.getDeclaredFields())
+                .filter(f -> f.isAnnotationPresent(FieldPath.class));
+
+        // Query annotated methods (abstract or concrete) that have
+        // a return type and no parameter types
+        Stream<Method> methods = Stream.of(holder.getDeclaredMethods())
+                .filter(m -> m.isAnnotationPresent(FieldPath.class))
+                .filter(m -> m.getReturnType() != void.class)
+                .filter(m -> m.getParameterCount() == 0)
+                .filter(m -> !m.isSynthetic())
+                .filter(m -> !Modifier.isNative(m.getModifiers()));
+
+        return Stream.concat(fields, methods)
+                .sorted(Comparator.comparingInt(f -> f.getDeclaredAnnotation(FieldPath.class).order()))
+                .map(ae -> {
+                    try {
+                        if (ae instanceof Field) {
+                            return MatchFieldPathArgumentExtractor.<Q>fromField(dataset, rootType, (Field) ae,
+                                    fpResolver);
+                        } else {
+                            return MatchFieldPathArgumentExtractor.<Q>fromMethod(dataset, rootType, (Method) ae,
+                                    fpResolver);
+                        }
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(toList());
+    }
+
+    static <Q> MatchFieldPathArgumentExtractor<Q> fromField(
+            HollowDataset dataset, Class<?> rootType, Field f,
+            FieldPathResolver fpResolver)
+            throws IllegalAccessException {
+        f.setAccessible(true);
+        return fromHandle(dataset, rootType, getFieldPath(f), MethodHandles.lookup().unreflectGetter(f),
+                fpResolver);
+    }
+
+    static <Q> MatchFieldPathArgumentExtractor<Q> fromMethod(
+            HollowDataset dataset, Class<?> rootType, Method m,
+            FieldPathResolver fpResolver)
+            throws IllegalAccessException {
+        if (m.getReturnType() == void.class || m.getParameterCount() > 0) {
+            throw new IllegalArgumentException(String.format(
+                    "A @FieldPath annotated method must have zero parameters and a non-void return type: %s",
+                    m.toGenericString()));
+        }
+        m.setAccessible(true);
+        return fromHandle(dataset, rootType, getFieldPath(m), MethodHandles.lookup().unreflect(m),
+                fpResolver);
+    }
+
+    static <Q> MatchFieldPathArgumentExtractor<Q> fromHandle(
+            HollowDataset dataset, Class<?> rootType, String fieldPath, MethodHandle mh,
+            FieldPathResolver fpResolver) {
+        return fromFunction(dataset, rootType, fieldPath, mh.type().returnType(), getterGenericExtractor(mh),
+                fpResolver);
+    }
+
+    static <T> MatchFieldPathArgumentExtractor<T> fromPathAndType(
+            HollowDataset dataset, Class<?> rootType, String fieldPath, Class<T> type,
+            FieldPathResolver fpResolver) {
+        return fromFunction(dataset, rootType, fieldPath, type, Function.identity(),
+                fpResolver);
+    }
+
+    static IllegalArgumentException incompatibleMatchType(
+            Class<?> extractorType, String fieldPath,
+            HollowObjectSchema.FieldType schemaFieldType) {
+        return new IllegalArgumentException(
+                String.format("Match type %s incompatible with field path %s resolving to field of value type %s",
+                        extractorType.getName(), fieldPath, schemaFieldType));
+    }
+
+    static IllegalArgumentException incompatibleMatchType(
+            Class<?> extractorType, String fieldPath, String typeName) {
+        return new IllegalArgumentException(
+                String.format(
+                        "Match type %s incompatible with field path %s resolving to field of reference type %s",
+                        extractorType.getName(), fieldPath, typeName));
+    }
+
+    static <Q, T> MatchFieldPathArgumentExtractor<Q> fromFunction(
+            HollowDataset dataset, Class<?> rootType, String fieldPath,
+            Class<T> extractorType, Function<Q, T> extractorFunction,
+            FieldPathResolver fpResolver) {
+        String rootTypeName = rootType.getSimpleName();
+        FieldPaths.FieldPath<? extends FieldPaths.FieldSegment> fp = fpResolver.resolve(dataset, rootTypeName,
+                fieldPath);
+
+        // @@@ Method on FieldPath
+        FieldPaths.FieldSegment lastSegment = fp.getSegments().get(fp.getSegments().size() - 1);
+        HollowObjectSchema.FieldType schemaFieldType;
+        if (lastSegment.getEnclosingSchema().getSchemaType() == HollowSchema.SchemaType.OBJECT) {
+            FieldPaths.ObjectFieldSegment os = (FieldPaths.ObjectFieldSegment) lastSegment;
+            schemaFieldType = os.getType();
+        } else {
+            schemaFieldType = HollowObjectSchema.FieldType.REFERENCE;
+        }
+
+        Function<Q, ?> extractor = extractorFunction;
+        switch (schemaFieldType) {
+            case BOOLEAN:
+                if (extractorType != boolean.class && extractorType != Boolean.class) {
+                    throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                }
+                break;
+            case DOUBLE:
+                if (extractorType != double.class && extractorType != Double.class) {
+                    throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                }
+                break;
+            case FLOAT:
+                if (extractorType != float.class && extractorType != Float.class) {
+                    throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                }
+                break;
+            case INT:
+                if (extractorType == byte.class || extractorType == Byte.class) {
+                    @SuppressWarnings("unchecked")
+                    Function<Q, Byte> f = (Function<Q, Byte>) extractorFunction;
+                    extractor = f.andThen(Byte::intValue);
+                    break;
+                } else if (extractorType == short.class || extractorType == Short.class) {
+                    @SuppressWarnings("unchecked")
+                    Function<Q, Short> f = (Function<Q, Short>) extractorFunction;
+                    extractor = f.andThen(Short::intValue);
+                    break;
+                } else if (extractorType == char.class || extractorType == Character.class) {
+                    @SuppressWarnings("unchecked")
+                    Function<Q, Character> f = (Function<Q, Character>) extractorFunction;
+                    extractor = f.andThen(c -> (int) c);
+                } else if (extractorType != int.class && extractorType != Integer.class) {
+                    throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                }
+                break;
+            case LONG:
+                if (extractorType != long.class && extractorType != Long.class) {
+                    throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                }
+                break;
+            case REFERENCE: {
+                // @@@ If extractorType == int.class then consider it an ordinal value
+                //   and directly use the extractorFunction
+
+                String typeName = lastSegment.getTypeName();
+
+                // Manage for String and all box types
+                if (typeName.equals("String")) {
+                    if (!HollowObject.class.isAssignableFrom(extractorType)) {
+                        throw incompatibleMatchType(extractorType, fieldPath, typeName);
+                    }
+                    // @@@ Check that object schema has single value field of String type such as HString
+                } else if (!extractorType.getSimpleName().equals(typeName)) {
+                    throw incompatibleMatchType(extractorType, fieldPath, typeName);
+                } else if (!HollowRecord.class.isAssignableFrom(extractorType)) {
+                    throw incompatibleMatchType(extractorType, fieldPath, typeName);
+                }
+
+                @SuppressWarnings("unchecked")
+                Function<Q, HollowRecord> f = (Function<Q, HollowRecord>) extractorFunction;
+                extractor = f.andThen(HollowRecord::getOrdinal);
+                break;
+            }
+            case BYTES:
+                if (extractorType != byte[].class) {
+                    throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                }
+                break;
+            case STRING:
+                if (extractorType == char[].class) {
+                    @SuppressWarnings("unchecked")
+                    Function<Q, char[]> f = (Function<Q, char[]>) extractorFunction;
+                    extractor = f.andThen(String::valueOf);
+                    break;
+                } else if (extractorType != String.class) {
+                    throw incompatibleMatchType(extractorType, fieldPath, schemaFieldType);
+                }
+                break;
+        }
+
+        return new MatchFieldPathArgumentExtractor<>(fp, extractor);
+    }
+
+    private static <Q, T> Function<Q, T> getterGenericExtractor(MethodHandle getter) {
+        return h -> {
+            try {
+                @SuppressWarnings("unchecked")
+                T t = (T) getter.invoke(h);
+                return t;
+            } catch (RuntimeException | Error e) {
+                throw e;
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    private static String getFieldPath(Field f) {
+        return getFieldPath(f, f);
+    }
+
+    private static String getFieldPath(Method m) {
+        return getFieldPath(m, m);
+    }
+
+    private static String getFieldPath(Member m, AnnotatedElement e) {
+        FieldPath fpa = e.getDeclaredAnnotation(FieldPath.class);
+        if (fpa == null) {
+            return m.getName();
+        }
+
+        String fieldPath = e.getDeclaredAnnotation(FieldPath.class).value();
+        if (fieldPath.isEmpty()) {
+            return m.getName();
+        }
+
+        return fieldPath;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/SelectFieldPathResultExtractor.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/SelectFieldPathResultExtractor.java
@@ -1,0 +1,155 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.consumer.index;
+
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.api.objects.HollowRecord;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.index.FieldPaths;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+/**
+ * An extractor that extracts a result value for an associated select field path transforming the value if
+ * necessary from an ordinal integer to an instance of a {@code HollowRecord} depending on the result type.
+ *
+ * @param <T> the result type
+ */
+final class SelectFieldPathResultExtractor<T> {
+    final FieldPaths.FieldPath<FieldPaths.FieldSegment> fieldPath;
+
+    final BiObjectIntFunction<HollowAPI, T> extractor;
+
+    SelectFieldPathResultExtractor(
+            FieldPaths.FieldPath<FieldPaths.FieldSegment> fieldPath,
+            BiObjectIntFunction<HollowAPI, T> extractor) {
+        this.fieldPath = fieldPath;
+        this.extractor = extractor;
+    }
+
+    interface BiObjectIntFunction<T, R> {
+        R apply(T t, int i);
+    }
+
+    T extract(HollowAPI api, int ordinal) {
+        return extractor.apply(api, ordinal);
+    }
+
+    static IllegalArgumentException incompatibleSelectType(
+            Class<?> selectType, String fieldPath, HollowObjectSchema.FieldType schemaFieldType) {
+        return new IllegalArgumentException(
+                String.format("Select type %s incompatible with field path %s resolving to field of type %s",
+                        selectType.getName(), fieldPath, schemaFieldType));
+    }
+
+    static IllegalArgumentException incompatibleSelectType(Class<?> selectType, String fieldPath, String typeName) {
+        return new IllegalArgumentException(
+                String.format(
+                        "Select type %s incompatible with field path %s resolving to field of reference type %s",
+                        selectType.getName(), fieldPath, typeName));
+    }
+
+    static <T> SelectFieldPathResultExtractor<T> from(
+            Class<? extends HollowAPI> apiType, HollowDataset dataset, Class<?> rootType, String fieldPath,
+            Class<T> selectType) {
+        String rootTypeName = rootType.getSimpleName();
+        FieldPaths.FieldPath<FieldPaths.FieldSegment> fp =
+                FieldPaths.createFieldPathForHashIndex(dataset, rootTypeName, fieldPath);
+
+        String typeName;
+        if (!fp.getSegments().isEmpty()) {
+            // @@@ Method on FieldPath
+            FieldPaths.FieldSegment lastSegment = fp.getSegments().get(fp.getSegments().size() - 1);
+            HollowSchema.SchemaType schemaType = lastSegment.getEnclosingSchema().getSchemaType();
+            HollowObjectSchema.FieldType schemaFieldType;
+            if (schemaType == HollowSchema.SchemaType.OBJECT) {
+                FieldPaths.ObjectFieldSegment os = (FieldPaths.ObjectFieldSegment) lastSegment;
+                schemaFieldType = os.getType();
+            } else {
+                schemaFieldType = HollowObjectSchema.FieldType.REFERENCE;
+            }
+            typeName = lastSegment.getTypeName();
+
+            if (schemaFieldType != HollowObjectSchema.FieldType.REFERENCE) {
+                // The field path must reference a field of a reference type
+                // This is contrary to the underlying HollowHashIndex which selects
+                // the enclosing reference type for a field of a value type.
+                // It is considered better to be consistent and literal with field path
+                // expressions
+                throw incompatibleSelectType(selectType, fieldPath, schemaFieldType);
+            } else if (typeName.equals("String")) {
+                if (!HollowObject.class.isAssignableFrom(selectType)) {
+                    throw incompatibleSelectType(selectType, fieldPath, typeName);
+                }
+                // @@@ Check that object schema has single value field of String type such as HString
+            } else if (!selectType.getSimpleName().equals(typeName)) {
+                if (schemaType != HollowSchema.SchemaType.OBJECT && !GenericHollowObject.class.isAssignableFrom(
+                        selectType)) {
+                    throw incompatibleSelectType(selectType, fieldPath, typeName);
+                }
+                // @@@ GenericHollow{List, Set, Map} based on schemaType
+            } else if (!HollowRecord.class.isAssignableFrom(selectType)) {
+                throw incompatibleSelectType(selectType, fieldPath, typeName);
+            }
+        } else {
+            typeName = rootTypeName;
+        }
+
+        if (GenericHollowObject.class.isAssignableFrom(selectType)) {
+            BiObjectIntFunction<HollowAPI, T> extractor =
+                    (a, o) -> {
+                        @SuppressWarnings("unchecked")
+                        T t = (T) new GenericHollowObject(a.getDataAccess(), typeName, o);
+                        return t;
+                    };
+            return new SelectFieldPathResultExtractor<>(fp, extractor);
+        } else {
+            MethodHandle selectInstantiate;
+            try {
+                selectInstantiate = MethodHandles.lookup().findVirtual(
+                        apiType,
+                        "get" + selectType.getSimpleName(),
+                        MethodType.methodType(selectType, int.class));
+            } catch (NoSuchMethodException | IllegalAccessException e) {
+                throw new IllegalArgumentException(
+                        String.format("Select type %s is not associated with API %s",
+                                selectType.getName(), apiType.getName()),
+                        e);
+            }
+
+            BiObjectIntFunction<HollowAPI, T> extractor = (a, i) -> {
+                try {
+                    @SuppressWarnings("unchecked")
+                    T s = (T) selectInstantiate.invoke(a, i);
+                    return s;
+                } catch (RuntimeException | Error e) {
+                    throw e;
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+            return new SelectFieldPathResultExtractor<>(fp, extractor);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/UniqueKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/UniqueKeyIndex.java
@@ -1,0 +1,312 @@
+package com.netflix.hollow.api.consumer.index;
+
+import static java.util.stream.Collectors.toList;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.core.index.FieldPaths;
+import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
+import com.netflix.hollow.core.index.key.PrimaryKey;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * A type safe index for indexing with a unique key (such as a primary key).
+ *
+ * @param <T> the unique type
+ * @param <Q> the key type
+ */
+public class UniqueKeyIndex<T extends HollowObject, Q> {
+    final HollowConsumer consumer;
+    HollowAPI api;
+    boolean listenToDataRefresh;
+    final SelectFieldPathResultExtractor<T> uniqueTypeExtractor;
+    final List<MatchFieldPathArgumentExtractor<Q>> matchFields;
+    final String uniqueTypeName;
+    final String[] matchFieldPaths;
+    HollowPrimaryKeyIndex hpki;
+    RefreshListener refreshListener;
+
+    UniqueKeyIndex(
+            HollowConsumer consumer,
+            Class<T> uniqueType,
+            PrimaryKey primaryTypeKey,
+            boolean listenToDataRefresh,
+            List<MatchFieldPathArgumentExtractor<Q>> matchFields) {
+        this.consumer = consumer;
+        this.api = consumer.getAPI();
+        this.uniqueTypeName = uniqueType.getSimpleName();
+
+        this.uniqueTypeExtractor = SelectFieldPathResultExtractor
+                .from(consumer.getAPI().getClass(), consumer.getStateEngine(), uniqueType, "", uniqueType);
+
+        if (primaryTypeKey != null) {
+            matchFields = validatePrimaryKeyFieldPaths(consumer, uniqueTypeName, primaryTypeKey, matchFields);
+        }
+
+        this.matchFields = matchFields;
+        this.matchFieldPaths = matchFields.stream()
+                .map(mf -> mf.fieldPath.toString())
+                .toArray(String[]::new);
+
+        this.hpki = new HollowPrimaryKeyIndex(consumer.getStateEngine(), uniqueTypeName, matchFieldPaths);
+
+        if (listenToDataRefresh) {
+            listenToDataRefresh();
+        }
+    }
+
+    static <Q> List<MatchFieldPathArgumentExtractor<Q>> validatePrimaryKeyFieldPaths(
+            HollowConsumer consumer, String primaryTypeName,
+            PrimaryKey primaryTypeKey, List<MatchFieldPathArgumentExtractor<Q>> matchFields) {
+
+        // Validate primary key field paths
+        List<FieldPaths.FieldPath<FieldPaths.ObjectFieldSegment>> paths = Stream.of(
+                primaryTypeKey.getFieldPaths())
+                .map(fp -> FieldPaths
+                        .createFieldPathForPrimaryKey(consumer.getStateEngine(), primaryTypeName, fp))
+                .collect(toList());
+
+        // Validate that primary key field paths are the same as that on the match fields
+        // If so then match field extractors are shuffled to have the same order as primary key field paths
+
+        List<MatchFieldPathArgumentExtractor<Q>> orderedMatchFields = paths.stream().flatMap(
+                path -> {
+                    MatchFieldPathArgumentExtractor<Q> mfe =
+                            matchFields.stream().filter(e -> e.fieldPath.equals(path)).findFirst().orElse(null);
+                    return mfe != null ? Stream.of(mfe) : null;
+                }).collect(toList());
+
+        if (orderedMatchFields.size() != paths.size()) {
+            // @@@
+            throw new IllegalArgumentException();
+        }
+        return orderedMatchFields;
+    }
+
+    UniqueKeyIndex(
+            HollowConsumer consumer,
+            Class<T> uniqueType,
+            PrimaryKey primaryTypeKey,
+            boolean listenToDataRefresh,
+            Class<Q> matchFieldsType) {
+        // @@@ Use FieldPaths.createFieldPathForPrimaryKey
+        this(consumer,
+                uniqueType,
+                primaryTypeKey,
+                listenToDataRefresh,
+                MatchFieldPathArgumentExtractor
+                        .fromHolderClass(consumer.getStateEngine(), uniqueType, matchFieldsType,
+                                FieldPaths::createFieldPathForPrimaryKey));
+    }
+
+    UniqueKeyIndex(
+            HollowConsumer consumer,
+            Class<T> uniqueType,
+            PrimaryKey primaryTypeKey,
+            boolean listenToDataRefresh,
+            String fieldPath, Class<Q> matchFieldType) {
+        // @@@ Use FieldPaths.createFieldPathForPrimaryKey
+        this(consumer,
+                uniqueType,
+                primaryTypeKey,
+                listenToDataRefresh,
+                Collections.singletonList(
+                        MatchFieldPathArgumentExtractor
+                                .fromPathAndType(consumer.getStateEngine(), uniqueType, fieldPath, matchFieldType,
+                                        FieldPaths::createFieldPathForPrimaryKey)));
+    }
+
+    /**
+     * Listens to {@code HollowConsumer} version updates.
+     * On an update the index recalculates so updated data will be reflected in the results of a query
+     * (performed after the update).
+     */
+    public void listenToDataRefresh() {
+        if (listenToDataRefresh) {
+            return;
+        }
+        listenToDataRefresh = true;
+
+        if (refreshListener == null) {
+            refreshListener = new RefreshListener();
+        }
+
+        hpki.listenForDeltaUpdates();
+        consumer.addRefreshListener(refreshListener);
+    }
+
+    /**
+     * Disables listening to {@code HollowConsumer} version updates.
+     * Updated data will not be reflected in the results of a query.
+     * <p>
+     * This method should be called before the index is discarded to ensure unnecessary recalculation
+     * is not performed and to ensure the index is reclaimed by the garbage collector.
+     */
+    public void detachFromDataRefresh() {
+        if (!listenToDataRefresh) {
+            return;
+        }
+        listenToDataRefresh = false;
+
+        hpki.detachFromDeltaUpdates();
+        consumer.removeRefreshListener(refreshListener);
+    }
+
+    final class RefreshListener implements HollowConsumer.RefreshListener {
+        @Override
+        public void snapshotUpdateOccurred(HollowAPI refreshAPI, HollowReadStateEngine stateEngine, long version) {
+            hpki.detachFromDeltaUpdates();
+            hpki = new HollowPrimaryKeyIndex(consumer.getStateEngine(), hpki.getPrimaryKey());
+            hpki.listenForDeltaUpdates();
+            api = refreshAPI;
+        }
+
+        @Override
+        public void deltaUpdateOccurred(HollowAPI refreshAPI, HollowReadStateEngine stateEngine, long version) {
+            api = refreshAPI;
+        }
+
+        @Override public void refreshStarted(long currentVersion, long requestedVersion) {
+        }
+
+        @Override public void blobLoaded(HollowConsumer.Blob transition) {
+        }
+
+        @Override public void refreshSuccessful(long beforeVersion, long afterVersion, long requestedVersion) {
+        }
+
+        @Override public void refreshFailed(
+                long beforeVersion, long afterVersion, long requestedVersion, Throwable failureCause) {
+        }
+    }
+
+    /**
+     * Finds the unique object, an instance of the unique type, for a given key.
+     *
+     * @param key the key
+     * @return the unique object
+     */
+    public T findMatch(Q key) {
+        Object[] keyArray = matchFields.stream().map(mf -> mf.extract(key)).toArray();
+
+        int ordinal = hpki.getMatchingOrdinal(keyArray);
+        if (ordinal == -1) {
+            return null;
+        }
+
+        return uniqueTypeExtractor.extract(api, ordinal);
+    }
+
+    /**
+     * Starts the building of a {@link UniqueKeyIndex}.
+     *
+     * @param consumer the consumer containing instances of the given unique type
+     * @param uniqueType the unique type
+     * @param <T> the unique type
+     * @return a builder
+     */
+    public static <T extends HollowObject> Builder<T> from(HollowConsumer consumer, Class<T> uniqueType) {
+        Objects.requireNonNull(consumer);
+        Objects.requireNonNull(uniqueType);
+        return new Builder<>(consumer, uniqueType);
+    }
+
+    /**
+     * The builder of a {@link UniqueKeyIndex}.
+     *
+     * @param <T> the unique type
+     */
+    public static final class Builder<T extends HollowObject> {
+        final HollowConsumer consumer;
+        final Class<T> uniqueType;
+        PrimaryKey primaryTypeKey; // non-null on bindWithPrimaryKeyOnType
+        boolean listenToDataRefresh;
+
+        Builder(HollowConsumer consumer, Class<T> uniqueType) {
+            this.consumer = consumer;
+            this.uniqueType = uniqueType;
+        }
+
+        /**
+         * Binds the field paths with those of the primary key associated with the schema of the unique type.
+         *
+         * @throws com.netflix.hollow.api.error.SchemaNotFoundException if there is no schema for the unique
+         * type
+         * @throws IllegalArgumentException if there is no primary key associated with the unique type
+         */
+        public Builder<T> bindToPrimaryKey() {
+            String primaryTypeName = uniqueType.getSimpleName();
+            HollowSchema schema = consumer.getStateEngine().getNonNullSchema(primaryTypeName);
+
+            assert schema.getSchemaType() == HollowSchema.SchemaType.OBJECT;
+
+            this.primaryTypeKey = ((HollowObjectSchema) schema).getPrimaryKey();
+            if (primaryTypeKey == null) {
+                throw new IllegalArgumentException(
+                        String.format("No primary key associated with primary type %s", uniqueType));
+            }
+            return this;
+        }
+
+        /**
+         * Configures the unique key index to listen to {@code HollowConsumer} version updates.
+         * On an update the index recalculates so updated data will be reflected in the results of a query
+         * (performed after the update).
+         *
+         * @return this builder
+         */
+        public Builder<T> listenToDataRefresh() {
+            listenToDataRefresh = true;
+            return this;
+        }
+
+        /**
+         * Creates a {@link UniqueKeyIndex} for matching with field paths and types declared by
+         * {@link FieldPath} annotated fields or methods on the given key type.
+         *
+         * @param keyType the key type
+         * @param <Q> the key type
+         * @return a {@code UniqueKeyIndex}
+         * @throws IllegalArgumentException if the key type declares one or more invalid field paths
+         * or invalid types given resolution of corresponding field paths
+         * @throws IllegalArgumentException if the builder is bound to the primary key of the unique type and
+         * the field paths declared by the key type are not the identical to those declared by the primary key
+         */
+        public <Q> UniqueKeyIndex<T, Q> usingBean(Class<Q> keyType) {
+            Objects.requireNonNull(keyType);
+            return new UniqueKeyIndex<>(consumer, uniqueType, primaryTypeKey, listenToDataRefresh,
+                    keyType);
+        }
+
+        /**
+         * Creates a {@link UniqueKeyIndex} for matching with a single key field path and type.
+         *
+         * @param keyFieldPath the key field path
+         * @param keyFieldType the key type
+         * @param <Q> the key type
+         * @return a {@code UniqueKeyIndex}
+         * @throws IllegalArgumentException if the key field path is empty or invalid
+         * @throws IllegalArgumentException if the key field type is invalid given resolution of the
+         * key field path
+         * @throws IllegalArgumentException if the builder is bound to the primary key of the unique type and
+         * the field path declared by the key type is not identical to the keyFieldPath
+         */
+        public <Q> UniqueKeyIndex<T, Q> usingPath(String keyFieldPath, Class<Q> keyFieldType) {
+            Objects.requireNonNull(keyFieldPath);
+            if (keyFieldPath.isEmpty()) {
+                throw new IllegalArgumentException("keyFieldPath argument is an empty String");
+            }
+            Objects.requireNonNull(keyFieldType);
+            return new UniqueKeyIndex<>(consumer, uniqueType, primaryTypeKey, listenToDataRefresh,
+                    keyFieldPath, keyFieldType);
+        }
+    }
+}
+

--- a/hollow/src/main/java/com/netflix/hollow/core/index/FieldPaths.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/FieldPaths.java
@@ -360,7 +360,6 @@ public final class FieldPaths {
      * @param <T> the field segment type
      */
     public final static class FieldPath<T extends FieldSegment> {
-        //        HollowDataset hd;
         final String rootType;
         final List<T> segments;
 
@@ -385,6 +384,32 @@ public final class FieldPaths {
          */
         public List<T> getSegments() {
             return segments;
+        }
+
+        /**
+         * Returns the field path in nominal form.
+         *
+         * @return the field path in nominal form
+         */
+        public String toString() {
+            return segments.stream().map(FieldPaths.FieldSegment::getName)
+                    .collect(joining("."));
+        }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            FieldPath<?> fieldPath = (FieldPath<?>) o;
+            return Objects.equals(rootType, fieldPath.rootType) &&
+                    Objects.equals(segments, fieldPath.segments);
+        }
+
+        @Override public int hashCode() {
+            return Objects.hash(rootType, segments);
         }
     }
 
@@ -428,6 +453,23 @@ public final class FieldPaths {
         public String getTypeName() {
             return typeName;
         }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            FieldSegment that = (FieldSegment) o;
+            return Objects.equals(enclosingSchema, that.enclosingSchema) &&
+                    Objects.equals(name, that.name) &&
+                    Objects.equals(typeName, that.typeName);
+        }
+
+        @Override public int hashCode() {
+            return Objects.hash(enclosingSchema, name, typeName);
+        }
     }
 
     /**
@@ -468,6 +510,25 @@ public final class FieldPaths {
          */
         public HollowObjectSchema.FieldType getType() {
             return type;
+        }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            ObjectFieldSegment that = (ObjectFieldSegment) o;
+            return index == that.index &&
+                    type == that.type;
+        }
+
+        @Override public int hashCode() {
+            return Objects.hash(super.hashCode(), index, type);
         }
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/index/DataModel.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/index/DataModel.java
@@ -14,6 +14,7 @@ import com.netflix.hollow.api.objects.provider.HollowFactory;
 import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
 import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
 import com.netflix.hollow.core.write.objectmapper.HollowInline;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -138,6 +139,31 @@ public class DataModel {
             }
         }
 
+        @HollowPrimaryKey(fields = {"i", "sub1.s", "sub2.i"})
+        public static class TypeWithPrimaryKey {
+            final int i;
+            final SubTypeOfTypeWithPrimaryKey sub1;
+            final SubTypeOfTypeWithPrimaryKey sub2;
+
+            public TypeWithPrimaryKey(
+                    int i, SubTypeOfTypeWithPrimaryKey sub1,
+                    SubTypeOfTypeWithPrimaryKey sub2) {
+                this.i = i;
+                this.sub1 = sub1;
+                this.sub2 = sub2;
+            }
+        }
+
+        public static class SubTypeOfTypeWithPrimaryKey {
+            final String s;
+            final int i;
+
+            public SubTypeOfTypeWithPrimaryKey(String s, int i) {
+                this.s = s;
+                this.i = i;
+            }
+        }
+
         public static class Sequences {
             final List<Boxes> list;
 
@@ -160,6 +186,7 @@ public class DataModel {
             final MappedReferencesToValues mapped;
             final Sequences sequences;
             final ReferenceWithStrings referenceWithStrings;
+            final TypeWithPrimaryKey typeWithPrimaryKey;
 
             public References() {
                 this.values = new Values();
@@ -168,6 +195,10 @@ public class DataModel {
                 this.mapped = new MappedReferencesToValues();
                 this.sequences = new Sequences();
                 this.referenceWithStrings = new ReferenceWithStrings();
+
+                this.typeWithPrimaryKey = new TypeWithPrimaryKey(1,
+                        new SubTypeOfTypeWithPrimaryKey("1", 1),
+                        new SubTypeOfTypeWithPrimaryKey("2", 2));
             }
         }
     }
@@ -239,6 +270,14 @@ public class DataModel {
                 return new TypeA(null, ordinal);
             }
 
+            public TypeWithPrimaryKey getTypeWithPrimaryKey(int ordinal) {
+                return new TypeWithPrimaryKey(null, ordinal);
+            }
+
+            public SubTypeOfTypeWithPrimaryKey getSubTypeOfTypeWithPrimaryKey(int ordinal) {
+                return new SubTypeOfTypeWithPrimaryKey(null, ordinal);
+            }
+
             public ListOfBoxes getListOfBoxes(int ordinal) {
                 return new ListOfBoxes(null, ordinal);
             }
@@ -308,6 +347,18 @@ public class DataModel {
 
         public static class TypeA extends HollowObject {
             public TypeA(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        public static class TypeWithPrimaryKey extends HollowObject {
+            public TypeWithPrimaryKey(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        public static class SubTypeOfTypeWithPrimaryKey extends HollowObject {
+            public SubTypeOfTypeWithPrimaryKey(HollowObjectDelegate delegate, int ordinal) {
                 super(delegate, ordinal);
             }
         }

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/index/HashIndexUpdatesTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/index/HashIndexUpdatesTest.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.api.consumer.index;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
@@ -16,8 +33,7 @@ public class HashIndexUpdatesTest {
         blobStore = new InMemoryBlobStore();
     }
 
-    @Test
-    public void deltaUpdates() {
+    void updates(boolean doubleSnapshot) {
         HollowProducer producer = HollowProducer.withPublisher(blobStore)
                 .withBlobStager(new HollowInMemoryBlobStager())
                 .build();
@@ -31,6 +47,7 @@ public class HashIndexUpdatesTest {
         consumer.triggerRefreshTo(v1);
 
         HashIndex<DataModel.Consumer.TypeA, Integer> hi = HashIndex.from(consumer, DataModel.Consumer.TypeA.class)
+                .listenToDataRefresh()
                 .usingPath("i", int.class);
 
         Assert.assertEquals(1L, hi.findMatches(1).count());
@@ -40,6 +57,9 @@ public class HashIndexUpdatesTest {
             ws.add(new DataModel.Producer.TypeA(1, "1"));
             ws.add(new DataModel.Producer.TypeA(1, "2"));
         });
+        if (doubleSnapshot) {
+            consumer.forceDoubleSnapshotNextUpdate();
+        }
         consumer.triggerRefreshTo(v2);
 
         Assert.assertEquals(2L, hi.findMatches(1).count());
@@ -51,50 +71,21 @@ public class HashIndexUpdatesTest {
             ws.add(new DataModel.Producer.TypeA(1, "2"));
             ws.add(new DataModel.Producer.TypeA(1, "3"));
         });
+        if (doubleSnapshot) {
+            consumer.forceDoubleSnapshotNextUpdate();
+        }
         consumer.triggerRefreshTo(v3);
 
         Assert.assertEquals(2L, hi.findMatches(1).count());
     }
 
     @Test
+    public void deltaUpdates() {
+        updates(false);
+    }
+
+    @Test
     public void snapshotUpdates() {
-        HollowProducer producer = HollowProducer.withPublisher(blobStore)
-                .withBlobStager(new HollowInMemoryBlobStager())
-                .build();
-
-        long v1 = producer.runCycle(ws -> {
-            ws.add(new DataModel.Producer.TypeA(1, "1"));
-        });
-        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
-                .withGeneratedAPIClass(DataModel.Consumer.Api.class)
-                .build();
-        consumer.triggerRefreshTo(v1);
-
-        HashIndex<DataModel.Consumer.TypeA, Integer> hi = HashIndex.from(consumer, DataModel.Consumer.TypeA.class)
-                .usingPath("i", int.class);
-
-        Assert.assertEquals(1L, hi.findMatches(1).count());
-
-
-        long v2 = producer.runCycle(ws -> {
-            ws.add(new DataModel.Producer.TypeA(1, "1"));
-            ws.add(new DataModel.Producer.TypeA(1, "2"));
-        });
-        consumer.forceDoubleSnapshotNextUpdate();
-        consumer.triggerRefreshTo(v2);
-
-        Assert.assertEquals(2L, hi.findMatches(1).count());
-
-
-        hi.detachFromDataRefresh();
-        long v3 = producer.runCycle(ws -> {
-            ws.add(new DataModel.Producer.TypeA(1, "1"));
-            ws.add(new DataModel.Producer.TypeA(1, "2"));
-            ws.add(new DataModel.Producer.TypeA(1, "3"));
-        });
-        consumer.forceDoubleSnapshotNextUpdate();
-        consumer.triggerRefreshTo(v3);
-
-        Assert.assertEquals(2L, hi.findMatches(1).count());
+        updates(true);
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/index/UniqueKeyIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/index/UniqueKeyIndexTest.java
@@ -1,0 +1,531 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.consumer.index;
+
+import static java.util.stream.Collectors.toList;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.api.objects.delegate.HollowObjectDelegate;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+public class UniqueKeyIndexTest {
+    // Map of primitive class to box class
+    static final Map<Class<?>, Class<?>> primitiveClasses;
+    static {
+        primitiveClasses = new HashMap<>();
+        primitiveClasses.put(boolean.class, Boolean.class);
+        primitiveClasses.put(byte.class, Byte.class);
+        primitiveClasses.put(short.class, Short.class);
+        primitiveClasses.put(char.class, Character.class);
+        primitiveClasses.put(int.class, Integer.class);
+        primitiveClasses.put(long.class, Long.class);
+        primitiveClasses.put(float.class, Float.class);
+        primitiveClasses.put(double.class, Double.class);
+    }
+
+    static HollowConsumer consumer;
+
+    static DataModel.Consumer.Api api;
+
+    @BeforeClass
+    public static void setup() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.References());
+
+            for (int i = 0; i < 100; i++) {
+                ws.add(new DataModel.Producer.TypeA(1, "TypeA" + i));
+            }
+        });
+
+        consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withGeneratedAPIClass(DataModel.Consumer.Api.class)
+                .build();
+        consumer.triggerRefreshTo(v1);
+
+        api = consumer.getAPI(DataModel.Consumer.Api.class);
+    }
+
+    public static abstract class MatchTestParameterized<T extends HollowObject, Q> extends UniqueKeyIndexTest {
+        final String path;
+        final Class<Q> type;
+        final Q value;
+        final Class<T> uniqueType;
+
+        public MatchTestParameterized(String path, Class<Q> type, Q value, Class<T> uniqueType) {
+            this.path = path;
+            this.type = type;
+            this.value = value;
+            this.uniqueType = uniqueType;
+        }
+
+        @Test
+        public void test() {
+            UniqueKeyIndex<T, Q> pki = UniqueKeyIndex
+                    .from(consumer, uniqueType)
+                    .usingPath(path, type);
+
+            T r = pki.findMatch(value);
+
+            Assert.assertNotNull(r);
+            Assert.assertEquals(0, r.getOrdinal());
+        }
+    }
+
+    // path, type, value
+    static List<Object[]> valuesDataProvider() {
+        DataModel.Producer.Values values = new DataModel.Producer.Values();
+        return Stream.of(DataModel.Producer.Values.class.getDeclaredFields())
+                .flatMap(f -> {
+                    String path = f.getName();
+                    Class<?> type = f.getType();
+                    Object value;
+                    try {
+                        value = f.get(values);
+                    } catch (IllegalAccessException e) {
+                        throw new InternalError();
+                    }
+
+                    Object[] args = new Object[] {path, type, value};
+                    if (type.isPrimitive()) {
+                        return Stream.of(args,
+                                new Object[] {path, primitiveClasses.get(type), value}
+                        );
+                    } else {
+                        return Stream.<Object[]>of(args);
+                    }
+                })
+                .collect(toList());
+    }
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnValuesTest<Q> extends MatchTestParameterized<DataModel.Consumer.Values, Q> {
+        // path[type] = value
+        @Parameterized.Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return valuesDataProvider();
+        }
+
+        public MatchOnValuesTest(String path, Class<Q> type, Q value) {
+            super(path, type, value, DataModel.Consumer.Values.class);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnValuesIllegalTypeTest extends UniqueKeyIndexTest {
+        // path[type] = value
+        @Parameterized.Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return valuesDataProvider();
+        }
+
+        final String path;
+        final Class<?> type;
+        final Object value;
+
+        public MatchOnValuesIllegalTypeTest(String path, Class<?> type, Object value) {
+            this.path = path;
+            this.type = type;
+            this.value = value;
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void test() {
+            UniqueKeyIndex
+                    .from(consumer, DataModel.Consumer.Values.class)
+                    .usingPath(path, Object.class);
+        }
+    }
+
+    public static class MatchOnValuesBeanTest extends UniqueKeyIndexTest {
+        static class ValueFieldsQuery {
+            @FieldPath
+            boolean _boolean;
+            @FieldPath
+            byte _byte;
+            @FieldPath
+            short _short;
+            @FieldPath
+            char _char;
+            @FieldPath
+            int _int;
+            @FieldPath
+            long _long;
+            @FieldPath
+            float _float;
+            @FieldPath
+            double _double;
+            @FieldPath
+            byte[] _bytes;
+            @FieldPath
+            char[] _chars;
+
+            ValueFieldsQuery(DataModel.Producer.Values v) {
+                this._boolean = v._boolean;
+                this._byte = v._byte;
+                this._short = v._short;
+                this._char = v._char;
+                this._int = v._int;
+                this._long = v._long;
+                this._float = v._float;
+                this._double = v._double;
+                this._bytes = v._bytes.clone();
+                this._chars = v._chars.clone();
+            }
+
+            static MatchOnValuesBeanTest.ValueFieldsQuery create() {
+                return new MatchOnValuesBeanTest.ValueFieldsQuery(new DataModel.Producer.Values());
+            }
+        }
+
+        @Test
+        public void testFields() {
+            UniqueKeyIndex<DataModel.Consumer.Values, ValueFieldsQuery> hi = UniqueKeyIndex
+                    .from(consumer, DataModel.Consumer.Values.class)
+                    .usingBean(MatchOnValuesBeanTest.ValueFieldsQuery.class);
+
+            DataModel.Consumer.Values r = hi.findMatch(MatchOnValuesBeanTest.ValueFieldsQuery.create());
+
+            Assert.assertNotNull(r);
+            Assert.assertEquals(0, r.getOrdinal());
+        }
+
+        static class ValueMethodsQuery {
+            boolean _boolean;
+            byte _byte;
+            short _short;
+            char _char;
+            int _int;
+            long _long;
+            float _float;
+            double _double;
+            byte[] _bytes;
+            char[] _chars;
+
+            @FieldPath("_boolean")
+            boolean is_boolean() {
+                return _boolean;
+            }
+
+            @FieldPath("_byte")
+            byte get_byte() {
+                return _byte;
+            }
+
+            @FieldPath("_short")
+            short get_short() {
+                return _short;
+            }
+
+            @FieldPath("_char")
+            char get_char() {
+                return _char;
+            }
+
+            @FieldPath("_int")
+            int get_int() {
+                return _int;
+            }
+
+            @FieldPath("_long")
+            long get_long() {
+                return _long;
+            }
+
+            @FieldPath("_float")
+            float get_float() {
+                return _float;
+            }
+
+            @FieldPath("_double")
+            double get_double() {
+                return _double;
+            }
+
+            @FieldPath("_bytes")
+            byte[] get_bytes() {
+                return _bytes;
+            }
+
+            @FieldPath("_chars")
+            char[] get_chars() {
+                return _chars;
+            }
+
+            ValueMethodsQuery(DataModel.Producer.Values v) {
+                this._boolean = v._boolean;
+                this._byte = v._byte;
+                this._short = v._short;
+                this._char = v._char;
+                this._int = v._int;
+                this._long = v._long;
+                this._float = v._float;
+                this._double = v._double;
+                this._bytes = v._bytes.clone();
+                this._chars = v._chars.clone();
+            }
+
+            static MatchOnValuesBeanTest.ValueMethodsQuery create() {
+                return new MatchOnValuesBeanTest.ValueMethodsQuery(new DataModel.Producer.Values());
+            }
+        }
+
+        @Test
+        public void testMethods() {
+            UniqueKeyIndex<DataModel.Consumer.Values, ValueMethodsQuery> hi = UniqueKeyIndex
+                    .from(consumer, DataModel.Consumer.Values.class)
+                    .usingBean(MatchOnValuesBeanTest.ValueMethodsQuery.class);
+
+            DataModel.Consumer.Values r = hi.findMatch(MatchOnValuesBeanTest.ValueMethodsQuery.create());
+
+            Assert.assertNotNull(r);
+            Assert.assertEquals(0, r.getOrdinal());
+        }
+    }
+
+
+    // path, type, value
+    static List<Object[]> boxesDataProvider() {
+        DataModel.Producer.Boxes values = new DataModel.Producer.Boxes();
+        return Stream.of(DataModel.Producer.Boxes.class.getDeclaredFields())
+                .map(f -> {
+                    // Path will be auto-expanded to append ".value"
+                    String path = f.getName();
+                    Class<?> type = f.getType();
+                    Object value;
+                    try {
+                        value = f.get(values);
+                    } catch (IllegalAccessException e) {
+                        throw new InternalError();
+                    }
+
+                    return new Object[] {path, type, value};
+                })
+                .collect(toList());
+    }
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnBoxesValuesTest<Q> extends MatchTestParameterized<DataModel.Consumer.Boxes, Q> {
+        // path[type] = value
+        @Parameterized.Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return boxesDataProvider();
+        }
+
+        public MatchOnBoxesValuesTest(String path, Class<Q> type, Q value) {
+            super(path, type, value, DataModel.Consumer.Boxes.class);
+        }
+    }
+
+
+    static List<Object[]> inlineBoxesDataProvider() {
+        DataModel.Producer.InlineBoxes values = new DataModel.Producer.InlineBoxes();
+        return Stream.of(DataModel.Producer.InlineBoxes.class.getDeclaredFields())
+                .map(f -> {
+                    String path = f.getName();
+                    Class<?> type = f.getType();
+                    Object value;
+                    try {
+                        value = f.get(values);
+                    } catch (IllegalAccessException e) {
+                        throw new InternalError();
+                    }
+
+                    return new Object[] {path, type, value};
+                })
+                .collect(toList());
+    }
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnInlineBoxesTest<Q> extends
+            MatchTestParameterized<DataModel.Consumer.InlineBoxes, Q> {
+        // path[type] = value
+        @Parameterized.Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return inlineBoxesDataProvider();
+        }
+
+        public MatchOnInlineBoxesTest(String path, Class<Q> type, Q value) {
+            super(path, type, value, DataModel.Consumer.InlineBoxes.class);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class MatchOnMappedReferencesTest<Q>
+            extends MatchTestParameterized<DataModel.Consumer.MappedReferencesToValues, Q> {
+        // path[type] = value
+        @Parameterized.Parameters(name = "{index}: {0}[{1}] = {2}")
+        public static Collection<Object[]> data() {
+            return Arrays.<Object[]>asList(
+                    new Object[] {"date.value", long.class, 0L},
+                    new Object[] {"number._name", String.class, "ONE"}
+            );
+        }
+
+        public MatchOnMappedReferencesTest(String path, Class<Q> type, Q value) {
+            super(path, type, value, DataModel.Consumer.MappedReferencesToValues.class);
+        }
+    }
+
+
+    public static class ErrorsTest extends UniqueKeyIndexTest {
+        static class Unknown extends HollowObject {
+            Unknown(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testUnknownRootSelectType() {
+            UniqueKeyIndex
+                    .from(consumer, ErrorsTest.Unknown.class)
+                    .usingPath("values", DataModel.Consumer.Values.class);
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testEmptyMatchPath() {
+            UniqueKeyIndex
+                    .from(consumer, DataModel.Consumer.References.class)
+                    .usingPath("", DataModel.Consumer.References.class);
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testNoPrimaryKey() {
+            UniqueKeyIndex
+                    .from(consumer, DataModel.Consumer.References.class)
+                    .bindToPrimaryKey()
+                    .usingPath("values._int", int.class);
+        }
+    }
+
+
+    public static class PrimaryKeyDeclarationTest extends UniqueKeyIndexTest {
+        // This class declares fields in the same order as those declared in
+        // the @HollowPrimaryKey on TypeWithPrimaryKey
+        static class KeyTypeSameOrder {
+            @FieldPath("i")
+            int i;
+            @FieldPath("sub1.s")
+            String sub1_s;
+            @FieldPath("sub2.i")
+            int sub2_i;
+
+            KeyTypeSameOrder(int i, String sub1_s, int sub2_i) {
+                this.i = i;
+                this.sub1_s = sub1_s;
+                this.sub2_i = sub2_i;
+            }
+        }
+
+        // This class declares fields in the reverse order as those declared in
+        // the @HollowPrimaryKey on TypeWithPrimaryKey
+        static class KeyTypeReverseOrder {
+            @FieldPath("sub2.i")
+            int sub2_i;
+            @FieldPath("sub1.s")
+            String sub1_s;
+            @FieldPath("i")
+            int i;
+
+            KeyTypeReverseOrder(int i, String sub1_s, int sub2_i) {
+                this.i = i;
+                this.sub1_s = sub1_s;
+                this.sub2_i = sub2_i;
+            }
+        }
+
+        static class KeyWithMissingPath {
+            @FieldPath("i")
+            int i;
+            @FieldPath("sub1.s")
+            String sub1_s;
+            int sub2_i;
+
+            KeyWithMissingPath(int i, String sub1_s, int sub2_i) {
+                this.i = i;
+                this.sub1_s = sub1_s;
+                this.sub2_i = sub2_i;
+            }
+        }
+
+        static class KeyWithWrongPath {
+            @FieldPath("i")
+            int i;
+            @FieldPath("sub1.s")
+            String sub1_s;
+            @FieldPath("sub2.s")
+            String sub2_s;
+
+            KeyWithWrongPath(int i, String sub1_s, String sub2_s) {
+                this.i = i;
+                this.sub1_s = sub1_s;
+                this.sub2_s = sub2_s;
+            }
+        }
+
+        public <T> void test(Class<T> keyType, T key) {
+            UniqueKeyIndex<DataModel.Consumer.TypeWithPrimaryKey, T> pki = UniqueKeyIndex
+                    .from(consumer, DataModel.Consumer.TypeWithPrimaryKey.class)
+                    .bindToPrimaryKey()
+                    .usingBean(keyType);
+
+            DataModel.Consumer.TypeWithPrimaryKey match = pki.findMatch(key);
+            Assert.assertNotNull(match);
+            Assert.assertEquals(0, match.getOrdinal());
+        }
+
+        @Test
+        public void testSameOrder() {
+            test(KeyTypeSameOrder.class, new KeyTypeSameOrder(1, "1", 2));
+        }
+
+        @Test
+        public void testReverseOrder() {
+            test(KeyTypeReverseOrder.class, new KeyTypeReverseOrder(1, "1", 2));
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testMissingPath() {
+            test(KeyWithMissingPath.class, new KeyWithMissingPath(1, "1", 2));
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testWrongPath() {
+            test(KeyWithWrongPath.class, new KeyWithWrongPath(1, "1", "2"));
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/index/UniqueKeyUpdatesTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/index/UniqueKeyUpdatesTest.java
@@ -1,0 +1,131 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.consumer.index;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UniqueKeyUpdatesTest {
+    InMemoryBlobStore blobStore;
+
+    @Before
+    public void setUp() {
+        blobStore = new InMemoryBlobStore();
+    }
+
+    static class Key {
+        @FieldPath("i")
+        int i;
+        @FieldPath("sub1.s")
+        String sub1_s;
+        @FieldPath("sub2.i")
+        int sub2_i;
+
+        Key(int i, String sub1_s, int sub2_i) {
+            this.i = i;
+            this.sub1_s = sub1_s;
+            this.sub2_i = sub2_i;
+        }
+    }
+
+    void updates(boolean doubleSnapshot) {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.TypeWithPrimaryKey(
+                    1,
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("1", 1),
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("2", 2)));
+        });
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withGeneratedAPIClass(DataModel.Consumer.Api.class)
+                .build();
+        consumer.triggerRefreshTo(v1);
+
+        UniqueKeyIndex<DataModel.Consumer.TypeWithPrimaryKey, Key> hi = UniqueKeyIndex.from(consumer,
+                DataModel.Consumer.TypeWithPrimaryKey.class)
+                .listenToDataRefresh()
+                .bindToPrimaryKey()
+                .usingBean(Key.class);
+
+        Assert.assertNotNull(hi.findMatch(new Key(1, "1", 2)));
+
+
+        long v2 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.TypeWithPrimaryKey(
+                    1,
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("1", 1),
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("2", 2)));
+
+            ws.add(new DataModel.Producer.TypeWithPrimaryKey(
+                    2,
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("1", 1),
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("2", 2)));
+        });
+        if (doubleSnapshot) {
+            consumer.forceDoubleSnapshotNextUpdate();
+        }
+        consumer.triggerRefreshTo(v2);
+
+        Assert.assertNotNull(hi.findMatch(new Key(1, "1", 2)));
+        Assert.assertNotNull(hi.findMatch(new Key(2, "1", 2)));
+
+        hi.detachFromDataRefresh();
+        long v3 = producer.runCycle(ws -> {
+            ws.add(new DataModel.Producer.TypeWithPrimaryKey(
+                    1,
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("1", 1),
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("2", 2)));
+
+            ws.add(new DataModel.Producer.TypeWithPrimaryKey(
+                    2,
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("1", 1),
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("2", 2)));
+
+            ws.add(new DataModel.Producer.TypeWithPrimaryKey(
+                    3,
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("1", 1),
+                    new DataModel.Producer.SubTypeOfTypeWithPrimaryKey("2", 2)));
+        });
+        if (doubleSnapshot) {
+            consumer.forceDoubleSnapshotNextUpdate();
+        }
+        consumer.triggerRefreshTo(v3);
+
+        Assert.assertNotNull(hi.findMatch(new Key(1, "1", 2)));
+        Assert.assertNotNull(hi.findMatch(new Key(2, "1", 2)));
+        Assert.assertNull(hi.findMatch(new Key(3, "1", 2)));
+    }
+
+    @Test
+    public void deltaUpdates() {
+        updates(false);
+    }
+
+    @Test
+    public void snapshotUpdates() {
+        updates(true);
+    }
+}


### PR DESCRIPTION
Replaces the generated API for supporting primary key indexing with a generic and type safe API for building a `PrimaryKeyIndex`.   Refactored code in `HashSelectIndex` to be reused by `PrimaryKeyIndex`.