### PR TITLE
Indexers listen by addition to consumer as refresh listener.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -160,12 +160,25 @@ public class HollowClientUpdater {
         }
     }
 
-    public void addRefreshListener(HollowConsumer.RefreshListener refreshListener) {
-        refreshListeners.addIfAbsent(refreshListener);
+    public synchronized void addRefreshListener(HollowConsumer.RefreshListener refreshListener,
+            HollowConsumer c) {
+        if (refreshListener instanceof HollowConsumer.RefreshRegistrationListener) {
+            if (!refreshListeners.contains(refreshListener)) {
+                ((HollowConsumer.RefreshRegistrationListener)refreshListener).onBeforeAddition(c);
+            }
+            refreshListeners.add(refreshListener);
+        } else {
+            refreshListeners.addIfAbsent(refreshListener);
+        }
     }
 
-    public void removeRefreshListener(HollowConsumer.RefreshListener refreshListener) {
-        refreshListeners.remove(refreshListener);
+    public synchronized void removeRefreshListener(HollowConsumer.RefreshListener refreshListener,
+            HollowConsumer c) {
+        if (refreshListeners.remove(refreshListener)) {
+            if (refreshListener instanceof HollowConsumer.RefreshRegistrationListener) {
+                ((HollowConsumer.RefreshRegistrationListener)refreshListener).onAfterRemoval(c);
+            }
+        }
     }
 
     public long getCurrentVersionId() {

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/index/HashIndexUpdatesTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/index/HashIndexUpdatesTest.java
@@ -47,8 +47,8 @@ public class HashIndexUpdatesTest {
         consumer.triggerRefreshTo(v1);
 
         HashIndex<DataModel.Consumer.TypeA, Integer> hi = HashIndex.from(consumer, DataModel.Consumer.TypeA.class)
-                .listenToDataRefresh()
                 .usingPath("i", int.class);
+        consumer.addRefreshListener(hi);
 
         Assert.assertEquals(1L, hi.findMatches(1).count());
 
@@ -65,7 +65,7 @@ public class HashIndexUpdatesTest {
         Assert.assertEquals(2L, hi.findMatches(1).count());
 
 
-        hi.detachFromDataRefresh();
+        consumer.removeRefreshListener(hi);
         long v3 = producer.runCycle(ws -> {
             ws.add(new DataModel.Producer.TypeA(1, "1"));
             ws.add(new DataModel.Producer.TypeA(1, "2"));

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/index/UniqueKeyUpdatesTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/index/UniqueKeyUpdatesTest.java
@@ -64,13 +64,13 @@ public class UniqueKeyUpdatesTest {
                 .build();
         consumer.triggerRefreshTo(v1);
 
-        UniqueKeyIndex<DataModel.Consumer.TypeWithPrimaryKey, Key> hi = UniqueKeyIndex.from(consumer,
+        UniqueKeyIndex<DataModel.Consumer.TypeWithPrimaryKey, Key> uki = UniqueKeyIndex.from(consumer,
                 DataModel.Consumer.TypeWithPrimaryKey.class)
-                .listenToDataRefresh()
                 .bindToPrimaryKey()
                 .usingBean(Key.class);
+        consumer.addRefreshListener(uki);
 
-        Assert.assertNotNull(hi.findMatch(new Key(1, "1", 2)));
+        Assert.assertNotNull(uki.findMatch(new Key(1, "1", 2)));
 
 
         long v2 = producer.runCycle(ws -> {
@@ -89,10 +89,11 @@ public class UniqueKeyUpdatesTest {
         }
         consumer.triggerRefreshTo(v2);
 
-        Assert.assertNotNull(hi.findMatch(new Key(1, "1", 2)));
-        Assert.assertNotNull(hi.findMatch(new Key(2, "1", 2)));
+        Assert.assertNotNull(uki.findMatch(new Key(1, "1", 2)));
+        Assert.assertNotNull(uki.findMatch(new Key(2, "1", 2)));
 
-        hi.detachFromDataRefresh();
+
+        consumer.removeRefreshListener(uki);
         long v3 = producer.runCycle(ws -> {
             ws.add(new DataModel.Producer.TypeWithPrimaryKey(
                     1,
@@ -114,9 +115,9 @@ public class UniqueKeyUpdatesTest {
         }
         consumer.triggerRefreshTo(v3);
 
-        Assert.assertNotNull(hi.findMatch(new Key(1, "1", 2)));
-        Assert.assertNotNull(hi.findMatch(new Key(2, "1", 2)));
-        Assert.assertNull(hi.findMatch(new Key(3, "1", 2)));
+        Assert.assertNotNull(uki.findMatch(new Key(1, "1", 2)));
+        Assert.assertNotNull(uki.findMatch(new Key(2, "1", 2)));
+        Assert.assertNull(uki.findMatch(new Key(3, "1", 2)));
     }
 
     @Test


### PR DESCRIPTION
Redesign how the indexers track changes.  To track changes an index is registered with a consumer. This greatly simplifies the API.  Supporting this behaviour required an enhancement to addition and removal of `HollowConsumer.RefreshListener` instances such that the listener implementation gets notified before addition and after removal, thereby supporting the underlying addition and removal of listeners on the indexers `HollowObjectTypeReadState`. 
