### PR TITLE
Size ByteArrayOrdinalMap.

### DIFF
--- a/hollow-perf/src/jmh/java/com/netflix/hollow/core/memory/encoding/OrdinalMapResize.java
+++ b/hollow-perf/src/jmh/java/com/netflix/hollow/core/memory/encoding/OrdinalMapResize.java
@@ -1,0 +1,112 @@
+package com.netflix.hollow.core.memory.encoding;
+
+import com.netflix.hollow.core.memory.ByteArrayOrdinalMap;
+import com.netflix.hollow.core.memory.ByteDataBuffer;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class OrdinalMapResize {
+
+    @Param("256")
+    int n = 256;
+
+    @Param("32")
+    int contentSize = 32;
+
+    ByteDataBuffer[] content;
+
+    @Setup
+    public void setUp() {
+        SplittableRandom r = new SplittableRandom(0);
+
+        content = new ByteDataBuffer[n];
+        for (int i = 0; i < n; i++) {
+            ByteDataBuffer buf = new ByteDataBuffer();
+            for (int j = 0; j < contentSize; j++) {
+                buf.write((byte) r.nextInt(0, 256));
+            }
+            content[i] = buf;
+        }
+    }
+
+    @Benchmark
+    public ByteArrayOrdinalMap defaultGet() {
+        ByteArrayOrdinalMap map = new ByteArrayOrdinalMap();
+        for (int i = 0; i < n; i++) {
+            map.getOrAssignOrdinal(content[i]);
+        }
+        return map;
+    }
+
+    @Benchmark
+    public ByteArrayOrdinalMap sizedGet() {
+        ByteArrayOrdinalMap map = new ByteArrayOrdinalMap(n << 1);
+        for (int i = 0; i < n; i++) {
+            map.getOrAssignOrdinal(content[i]);
+        }
+        return map;
+    }
+}
+
+/*
+
+Benchmark                    (contentSize)     (n)  Mode  Cnt          Score          Error  Units
+OrdinalMapResize.defaultGet              8    2048  avgt    5     524669.559 ±    94661.993  ns/op
+OrdinalMapResize.defaultGet              8    8192  avgt    5    2864984.097 ±   973573.341  ns/op
+OrdinalMapResize.defaultGet              8   32768  avgt    5   14644216.493 ±   461996.760  ns/op
+OrdinalMapResize.defaultGet              8  131072  avgt    5   64906816.288 ±  5527376.480  ns/op
+OrdinalMapResize.defaultGet             16    2048  avgt    5     579804.853 ±    35227.500  ns/op
+OrdinalMapResize.defaultGet             16    8192  avgt    5    3226875.857 ±  1200816.411  ns/op
+OrdinalMapResize.defaultGet             16   32768  avgt    5   16333522.740 ±  1645155.319  ns/op
+OrdinalMapResize.defaultGet             16  131072  avgt    5   72300430.931 ±  8243987.662  ns/op
+OrdinalMapResize.defaultGet             32    2048  avgt    5     708348.638 ±    48480.615  ns/op
+OrdinalMapResize.defaultGet             32    8192  avgt    5    3845712.806 ±   659749.886  ns/op
+OrdinalMapResize.defaultGet             32   32768  avgt    5   19132132.938 ±  2578367.604  ns/op
+OrdinalMapResize.defaultGet             32  131072  avgt    5   81810115.046 ±  5377543.308  ns/op
+OrdinalMapResize.defaultGet             64    2048  avgt    5     988812.959 ±   139916.394  ns/op
+OrdinalMapResize.defaultGet             64    8192  avgt    5    5247170.001 ±   961661.753  ns/op
+OrdinalMapResize.defaultGet             64   32768  avgt    5   24915997.247 ±  5133110.667  ns/op
+OrdinalMapResize.defaultGet             64  131072  avgt    5  106995398.542 ± 14459051.669  ns/op
+OrdinalMapResize.defaultGet            128    2048  avgt    5    1575062.220 ±   110460.192  ns/op
+OrdinalMapResize.defaultGet            128    8192  avgt    5    7735092.080 ±   411007.955  ns/op
+OrdinalMapResize.defaultGet            128   32768  avgt    5   35920602.082 ±  7833800.705  ns/op
+OrdinalMapResize.defaultGet            128  131072  avgt    5  156354984.171 ± 13402008.695  ns/op
+OrdinalMapResize.sizedGet                8    2048  avgt    5     196358.861 ±    15371.176  ns/op
+OrdinalMapResize.sizedGet                8    8192  avgt    5    1250185.898 ±   337449.745  ns/op
+OrdinalMapResize.sizedGet                8   32768  avgt    5    7569535.480 ±   768681.941  ns/op
+OrdinalMapResize.sizedGet                8  131072  avgt    5   34166531.026 ±  2601826.357  ns/op
+OrdinalMapResize.sizedGet               16    2048  avgt    5     233474.915 ±     4107.039  ns/op
+OrdinalMapResize.sizedGet               16    8192  avgt    5    1618315.403 ±   503515.257  ns/op
+OrdinalMapResize.sizedGet               16   32768  avgt    5    8423144.202 ±  1531274.146  ns/op
+OrdinalMapResize.sizedGet               16  131072  avgt    5   37380396.196 ±  3756140.945  ns/op
+OrdinalMapResize.sizedGet               32    2048  avgt    5     291975.497 ±    30660.463  ns/op
+OrdinalMapResize.sizedGet               32    8192  avgt    5    1930925.813 ±   162060.695  ns/op
+OrdinalMapResize.sizedGet               32   32768  avgt    5    9944128.175 ±  2468853.190  ns/op
+OrdinalMapResize.sizedGet               32  131072  avgt    5   43925098.941 ±  3336023.251  ns/op
+OrdinalMapResize.sizedGet               64    2048  avgt    5     423357.848 ±    60510.201  ns/op
+OrdinalMapResize.sizedGet               64    8192  avgt    5    2553086.582 ±   298923.441  ns/op
+OrdinalMapResize.sizedGet               64   32768  avgt    5   12388266.041 ±  4230163.664  ns/op
+OrdinalMapResize.sizedGet               64  131072  avgt    5   55145939.840 ±  6016040.570  ns/op
+OrdinalMapResize.sizedGet              128    2048  avgt    5     687408.861 ±    39354.473  ns/op
+OrdinalMapResize.sizedGet              128    8192  avgt    5    4023545.068 ±   124931.913  ns/op
+OrdinalMapResize.sizedGet              128   32768  avgt    5   17758789.247 ±  5952902.676  ns/op
+OrdinalMapResize.sizedGet              128  131072  avgt    5   77575714.649 ± 10985599.044  ns/op
+
+ */

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
@@ -17,24 +17,6 @@
  */
 package com.netflix.hollow.core.memory;
 
-/*
-*
-*  Copyright 2013 Netflix, Inc.
-*
-*     Licensed under the Apache License, Version 2.0 (the "License");
-*     you may not use this file except in compliance with the License.
-*     You may obtain a copy of the License at
-*
-*         http://www.apache.org/licenses/LICENSE-2.0
-*
-*     Unless required by applicable law or agreed to in writing, software
-*     distributed under the License is distributed on an "AS IS" BASIS,
-*     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*     See the License for the specific language governing permissions and
-*     limitations under the License.
-*
-*/
-
 import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.memory.pool.WastefulRecycler;
@@ -43,471 +25,477 @@ import java.util.BitSet;
 import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
-*
-* This data structure maps byte sequences to ordinals.  This is a hash table.
-*
-* The <code>pointersAndOrdinals</code> AtomicLongArray contains keys, and the {@link ByteDataBuffer}
-* contains values.  Each key has two components.
-*
-* The high 29 bits in the key represents the ordinal.  The low 35 bits represents the pointer to the start position
-* of the byte sequence in the ByteDataBuffer.  Each byte sequence is preceded by a variable-length integer
-* (see {@link VarInt}), indicating the length of the sequence.<p>
-*
-* @author dkoszewnik
-*
-*/
+ * This data structure maps byte sequences to ordinals.  This is a hash table.
+ * <p>
+ * The <code>pointersAndOrdinals</code> AtomicLongArray contains keys, and the {@link ByteDataBuffer}
+ * contains values.  Each key has two components.
+ * <p>
+ * The high 29 bits in the key represents the ordinal.  The low 35 bits represents the pointer to the start position
+ * of the byte sequence in the ByteDataBuffer.  Each byte sequence is preceded by a variable-length integer
+ * (see {@link VarInt}), indicating the length of the sequence.<p>
+ *
+ * @author dkoszewnik
+ */
 public class ByteArrayOrdinalMap {
 
-   private static final long EMPTY_BUCKET_VALUE = -1L;
-
-   private static final int BITS_PER_ORDINAL = 29;
-   private static final int BITS_PER_POINTER = Long.SIZE - BITS_PER_ORDINAL;
-   private static final long POINTER_MASK = (1L << BITS_PER_POINTER) - 1;
-   private static final long ORDINAL_MASK = (1L << BITS_PER_ORDINAL) - 1;
-
-   /// Thread safety:  We need volatile access semantics to the individual elements in the
-   /// pointersAndOrdinals array.
-   /// Ordinal is the high 29 bits.  Pointer to byte data is the low 35 bits.
-   private AtomicLongArray pointersAndOrdinals;
-   private final ByteDataBuffer byteData;
-   private final FreeOrdinalTracker freeOrdinalTracker;
-   private int size;
-   private int sizeBeforeGrow;
-
-   private BitSet unusedPreviousOrdinals;
-
-   private long pointersByOrdinal[];
-
-
-   public ByteArrayOrdinalMap() {
-       this.freeOrdinalTracker = new FreeOrdinalTracker();
-       this.byteData = new ByteDataBuffer(WastefulRecycler.DEFAULT_INSTANCE);
-       this.pointersAndOrdinals = emptyKeyArray(256);
-       this.sizeBeforeGrow = 179; /// 70% load factor
-       this.size = 0;
-   }
-
-   public int getOrAssignOrdinal(ByteDataBuffer serializedRepresentation) {
-       return getOrAssignOrdinal(serializedRepresentation, -1);
-   }
-
-   /**
-    * Add a sequence of bytes to this map.  If the sequence of bytes has already been added to this map, return the originally assigned ordinal.
-    * If the sequence of bytes has not been added to this map, assign and return a new ordinal.  This operation is thread-safe.
-    *
-    * @param serializedRepresentation the serialized representation
-    * @param preferredOrdinal the preferred ordinal
-    * @return the assigned ordinal
-    */
-   public int getOrAssignOrdinal(ByteDataBuffer serializedRepresentation, int preferredOrdinal) {
-       int hash = HashCodes.hashCode(serializedRepresentation);
-
-       int modBitmask = pointersAndOrdinals.length() - 1;
-       int bucket = hash & modBitmask;
-       long key = pointersAndOrdinals.get(bucket);
-
-       /// linear probing to resolve collisions.
-       while(key != EMPTY_BUCKET_VALUE) {
-           if(compare(serializedRepresentation, key)) {
-               return (int)(key >>> BITS_PER_POINTER);
-           }
-
-           bucket = (bucket + 1) & modBitmask;
-           key = pointersAndOrdinals.get(bucket);
-       }
-
-       return assignOrdinal(serializedRepresentation, hash, preferredOrdinal);
-   }
-
-   /// acquire the lock before writing.
-   private synchronized int assignOrdinal(ByteDataBuffer serializedRepresentation, int hash, int preferredOrdinal) {
-       if(size > sizeBeforeGrow)
-           growKeyArray();
-
-       /// check to make sure that after acquiring the lock, the element still does not exist.
-       /// this operation is akin to double-checked locking which is 'fixed' with the JSR 133 memory model in JVM >= 1.5.
-       int modBitmask = pointersAndOrdinals.length() - 1;
-       int bucket = hash & modBitmask;
-       long key = pointersAndOrdinals.get(bucket);
-
-       while(key != EMPTY_BUCKET_VALUE) {
-           if(compare(serializedRepresentation, key)) {
-               return (int)(key >>> BITS_PER_POINTER);
-           }
-
-           bucket = (bucket + 1) & modBitmask;
-           key = pointersAndOrdinals.get(bucket);
-       }
-
-       /// the ordinal for this object still does not exist in the list, even after the lock has been acquired.
-       /// it is up to this thread to add it at the current bucket position.
-       int ordinal = findFreeOrdinal(preferredOrdinal);
-       long pointer = byteData.length();
-
-       VarInt.writeVInt(byteData, (int)serializedRepresentation.length());
-       serializedRepresentation.copyTo(byteData);
-
-       key = ((long)ordinal << BITS_PER_POINTER) | pointer;
-
-       size++;
-
-       /// this set on the AtomicLongArray has volatile semantics (i.e. behaves like a monitor release).
-       /// Any other thread reading this element in the AtomicLongArray will have visibility to all memory writes this thread has made up to this point.
-       /// This means the entire byte sequence is guaranteed to be visible to any thread which reads the pointer to that data.
-       pointersAndOrdinals.set(bucket, key);
-
-       return ordinal;
-   }
-
-   /**
-    * If the preferredOrdinal has not already been used, mark it and use it.  Otherwise,
-    * delegate to the FreeOrdinalTracker.
-    */
-   private int findFreeOrdinal(int preferredOrdinal) {
-       if(preferredOrdinal != -1 && unusedPreviousOrdinals.get(preferredOrdinal)) {
-           unusedPreviousOrdinals.clear(preferredOrdinal);
-           return preferredOrdinal;
-       }
-
-       return freeOrdinalTracker.getFreeOrdinal();
-   }
-
-   /**
-    * Assign a predefined ordinal to a serialized representation.<p>
-    *
-    * WARNING: THIS OPERATION IS NOT THREAD-SAFE.<p>
-    * WARNING: THIS OPERATION WILL NOT UPDATE THE FreeOrdinalTracker.
-    *
-    * @param serializedRepresentation the serialized representation
-    * @param ordinal the ordinal
-    */
-   public void put(ByteDataBuffer serializedRepresentation, int ordinal) {
-       if(size > sizeBeforeGrow)
-           growKeyArray();
-
-       int hash = HashCodes.hashCode(serializedRepresentation);
-
-       int modBitmask = pointersAndOrdinals.length() - 1;
-       int bucket = hash & modBitmask;
-       long key = pointersAndOrdinals.get(bucket);
-
-       while(key != EMPTY_BUCKET_VALUE) {
-           bucket = (bucket + 1) & modBitmask;
-           key = pointersAndOrdinals.get(bucket);
-       }
-
-       long pointer = byteData.length();
-
-       VarInt.writeVInt(byteData, (int)serializedRepresentation.length());
-       serializedRepresentation.copyTo(byteData);
-
-       key = ((long)ordinal << BITS_PER_POINTER) | pointer;
-
-       size++;
-
-       pointersAndOrdinals.set(bucket, key);
-   }
-
-   public void recalculateFreeOrdinals() {
-       BitSet populatedOrdinals = new BitSet();
-
-       for(int i=0;i<pointersAndOrdinals.length();i++) {
-           long key = pointersAndOrdinals.get(i);
-           if(key != EMPTY_BUCKET_VALUE) {
-               int ordinal = (int)(key >>> BITS_PER_POINTER);
-               populatedOrdinals.set(ordinal);
-           }
-       }
-
-       recalculateFreeOrdinals(populatedOrdinals);
-   }
-
-   public void reservePreviouslyPopulatedOrdinals(BitSet populatedOrdinals) {
-       unusedPreviousOrdinals = BitSet.valueOf(populatedOrdinals.toLongArray());
-
-       recalculateFreeOrdinals(populatedOrdinals);
-   }
-
-   private void recalculateFreeOrdinals(BitSet populatedOrdinals) {
-       freeOrdinalTracker.reset();
-
-       int length = populatedOrdinals.length();
-       int ordinal = populatedOrdinals.nextClearBit(0);
-
-       while(ordinal < length) {
-           freeOrdinalTracker.returnOrdinalToPool(ordinal);
-           ordinal = populatedOrdinals.nextClearBit(ordinal + 1);
-       }
-
-       freeOrdinalTracker.setNextEmptyOrdinal(length);
-   }
-
-   public BitSet getUnusedPreviousOrdinals() {
-       return unusedPreviousOrdinals;
-   }
-
-   /**
-    * Returns the ordinal for a previously added byte sequence.  If this byte sequence has not been added to the map, then -1 is returned.<p>
-    *
-    * This is intended for use in the client-side heap-safe double snapshot load.
-    *
-    * @param serializedRepresentation the serialized representation
-    * @return The ordinal for this serialized representation, or -1.
-    */
-   public int get(ByteDataBuffer serializedRepresentation) {
-       int hash = HashCodes.hashCode(serializedRepresentation);
-
-       int modBitmask = pointersAndOrdinals.length() - 1;
-       int bucket = hash & modBitmask;
-       long key = pointersAndOrdinals.get(bucket);
-
-       /// linear probing to resolve collisions.
-       while(key != EMPTY_BUCKET_VALUE) {
-           if(compare(serializedRepresentation, key)) {
-               return (int)(key >>> BITS_PER_POINTER);
-           }
-
-           bucket = (bucket + 1) & modBitmask;
-           key = pointersAndOrdinals.get(bucket);
-       }
-
-       return -1;
-   }
-
-   /**
-    * Create an array mapping the ordinals to pointers, so that they can be easily looked up
-    * when writing to blob streams.
-    *
-    */
-   public void prepareForWrite() {
-       int maxOrdinal = 0;
-
-       for(int i=0;i<pointersAndOrdinals.length();i++) {
-           long key = pointersAndOrdinals.get(i);
-           if(key != EMPTY_BUCKET_VALUE) {
-               int ordinal = (int)(key >>> BITS_PER_POINTER);
-               if(ordinal > maxOrdinal)
-                   maxOrdinal = ordinal;
-           }
-       }
-
-       pointersByOrdinal = new long[maxOrdinal + 1];
-       Arrays.fill(pointersByOrdinal, -1);
-
-       for(int i=0;i<pointersAndOrdinals.length();i++) {
-           long key = pointersAndOrdinals.get(i);
-           if(key != EMPTY_BUCKET_VALUE) {
-               int ordinal = (int)(key >>> BITS_PER_POINTER);
-               pointersByOrdinal[ordinal] = key & POINTER_MASK;
-           }
-       }
-   }
-
-   /**
-    * Reclaim space in the byte array used in the previous cycle, but not referenced in this cycle.<p>
-    *
-    * This is achieved by shifting all used byte sequences down in the byte array, then updating
-    * the key array to reflect the new pointers and exclude the removed entries.  This is also where ordinals
-    * which are unused are returned to the pool.<p>
-    *
-    * @param usedOrdinals a bit set representing the ordinals which are currently referenced by any image.
-    */
-   public void compact(ThreadSafeBitSet usedOrdinals) {
-       long populatedReverseKeys[] = new long[size];
-
-       int counter = 0;
-
-       for(int i=0;i<pointersAndOrdinals.length();i++) {
-           long key = pointersAndOrdinals.get(i);
-           if(key != EMPTY_BUCKET_VALUE) {
-               populatedReverseKeys[counter++] = key << BITS_PER_ORDINAL | key >>> BITS_PER_POINTER;
-           }
-       }
-
-       Arrays.sort(populatedReverseKeys);
-
-       SegmentedByteArray arr = byteData.getUnderlyingArray();
-       long currentCopyPointer = 0;
-
-       for(int i=0;i<populatedReverseKeys.length;i++) {
-           int ordinal = (int)(populatedReverseKeys[i] & ORDINAL_MASK);
-
-           if(usedOrdinals.get(ordinal)) {
-               long pointer = populatedReverseKeys[i] >>> BITS_PER_ORDINAL;
-               int length = VarInt.readVInt(arr, pointer);
-               length += VarInt.sizeOfVInt(length);
-
-               if(currentCopyPointer != pointer)
-                   arr.copy(arr, pointer, currentCopyPointer, length);
-
-               populatedReverseKeys[i] = populatedReverseKeys[i] << BITS_PER_POINTER | currentCopyPointer;
-
-               currentCopyPointer += length;
-           } else {
-               freeOrdinalTracker.returnOrdinalToPool(ordinal);
-               populatedReverseKeys[i] = EMPTY_BUCKET_VALUE;
-           }
-       }
-
-       byteData.setPosition(currentCopyPointer);
-       freeOrdinalTracker.sort();
-
-       for(int i=0;i<pointersAndOrdinals.length();i++) {
-           pointersAndOrdinals.set(i, EMPTY_BUCKET_VALUE);
-       }
-
-       populateNewHashArray(pointersAndOrdinals, populatedReverseKeys);
-       size = usedOrdinals.cardinality();
-
-       pointersByOrdinal = null;
-       unusedPreviousOrdinals = null;
-   }
-
-   public long getPointerForData(int ordinal) {
-       long pointer = pointersByOrdinal[ordinal] & POINTER_MASK;
-       return pointer + VarInt.nextVLongSize(byteData.getUnderlyingArray(), pointer);
-   }
-
-   public boolean isReadyForWriting() {
-       return pointersByOrdinal != null;
-   }
-
-   public boolean isReadyForAddingObjects() {
-       return pointersByOrdinal == null;
-   }
-
-   public long getDataSize() {
-       return byteData.length();
-   }
-
-   public int maxOrdinal() {
-       int maxOrdinal = -1;
-       for(int i=0;i<pointersAndOrdinals.length();i++) {
-           long key = pointersAndOrdinals.get(i);
-           if(key != EMPTY_BUCKET_VALUE) {
-               int ordinal = (int)(pointersAndOrdinals.get(i) >>> BITS_PER_POINTER);
-               if(ordinal > maxOrdinal)
-                   maxOrdinal = ordinal;
-           }
-       }
-       return maxOrdinal;
-   }
-
-   /**
-    * Compare the byte sequence contained in the supplied ByteDataBuffer with the
-    * sequence contained in the map pointed to by the specified key, byte by byte.
-    */
-   private boolean compare(ByteDataBuffer serializedRepresentation, long key) {
-       long position = key & POINTER_MASK;
-
-       int sizeOfData = VarInt.readVInt(byteData.getUnderlyingArray(), position);
-
-       if(sizeOfData != serializedRepresentation.length())
-           return false;
-
-       position += VarInt.sizeOfVInt(sizeOfData);
-
-       for(int i=0;i<sizeOfData;i++) {
-           if(serializedRepresentation.get(i) != byteData.get(position++))
-               return false;
-       }
-
-       return true;
-   }
-
-   /**
-    * Grow the key array.  All of the values in the current array must be re-hashed and added to the new array.
-    */
-   private void growKeyArray() {
-       int newSize = pointersAndOrdinals.length() * 2;
-       if (newSize < 0) {
-           throw new IllegalStateException("New size computed to grow the underlying array for the map is negative. " +
-                   "This is most likely due to the total number of keys added to map has exceeded the max capacity of the keys map can hold. " +
-                   "Current array size :" + pointersAndOrdinals.length() + " and size to grow :" + newSize);
-       }
-       AtomicLongArray newKeys = emptyKeyArray(pointersAndOrdinals.length() * 2);
-
-       long valuesToAdd[] = new long[size];
-
-       int counter = 0;
-
-       /// do not iterate over these values in the same order in which they appear in the hashed array.
-       /// if we do so, we cause large clusters of collisions to appear (because we resolve collisions with linear probing).
-       for(int i=0;i<pointersAndOrdinals.length();i++) {
-           long key = pointersAndOrdinals.get(i);
-           if(key != EMPTY_BUCKET_VALUE) {
-               valuesToAdd[counter++] = key;
-           }
-       }
-
-       Arrays.sort(valuesToAdd);
-
-       populateNewHashArray(newKeys, valuesToAdd);
-
-       /// 70% load factor
-       sizeBeforeGrow = (int) (((float) newKeys.length()) * 0.7);
-       pointersAndOrdinals = newKeys;
-   }
-
-   /**
-    * Hash all of the existing values specified by the keys in the supplied long array
-    * into the supplied AtomicLongArray.
-    */
-   private void populateNewHashArray(AtomicLongArray newKeys, long[] valuesToAdd) {
-       int modBitmask = newKeys.length() - 1;
-
-       for(int i=0;i<valuesToAdd.length;i++) {
-           if(valuesToAdd[i] != EMPTY_BUCKET_VALUE) {
-               int hash = rehashPreviouslyAddedData(valuesToAdd[i]);
-               int bucket = hash & modBitmask;
-               while(newKeys.get(bucket) != EMPTY_BUCKET_VALUE)
-                   bucket = (bucket + 1) & modBitmask;
-               newKeys.set(bucket, valuesToAdd[i]);
-           }
-       }
-   }
-
-   /**
-    * Get the hash code for the byte array pointed to by the specified key.
-    */
-   private int rehashPreviouslyAddedData(long key) {
-       long position = key & POINTER_MASK;
-
-       int sizeOfData = VarInt.readVInt(byteData.getUnderlyingArray(), position);
-       position += VarInt.sizeOfVInt(sizeOfData);
-
-       return HashCodes.hashCode(byteData.getUnderlyingArray(), position, sizeOfData);
-   }
-
-   /**
-    * Create an AtomicLongArray of the specified size, each value in the array will be EMPTY_BUCKET_VALUE
-    */
-   private AtomicLongArray emptyKeyArray(int size) {
-       AtomicLongArray arr = new AtomicLongArray(size);
-       for(int i=0;i<arr.length();i++) {
-           arr.set(i, EMPTY_BUCKET_VALUE);
-       }
-       return arr;
-   }
-
-   public ByteDataBuffer getByteData() {
-       return byteData;
-   }
-
-   public AtomicLongArray getPointersAndOrdinals() {
-       return pointersAndOrdinals;
-   }
-
-   public static boolean isPointerAndOrdinalEmpty(long pointerAndOrdinal) {
-       return pointerAndOrdinal == EMPTY_BUCKET_VALUE;
-   }
-
-   public static long getPointer(long pointerAndOrdinal) {
-       return pointerAndOrdinal & POINTER_MASK;
-   }
-
-   public static int getOrdinal(long pointerAndOrdinal) {
-       return (int)(pointerAndOrdinal >>> BITS_PER_POINTER);
-   }
+    private static final long EMPTY_BUCKET_VALUE = -1L;
+
+    private static final int BITS_PER_ORDINAL = 29;
+    private static final int BITS_PER_POINTER = Long.SIZE - BITS_PER_ORDINAL;
+    private static final long POINTER_MASK = (1L << BITS_PER_POINTER) - 1;
+    private static final long ORDINAL_MASK = (1L << BITS_PER_ORDINAL) - 1;
+
+    /// Thread safety:  We need volatile access semantics to the individual elements in the
+    /// pointersAndOrdinals array.
+    /// Ordinal is the high 29 bits.  Pointer to byte data is the low 35 bits.
+    private AtomicLongArray pointersAndOrdinals;
+    private final ByteDataBuffer byteData;
+    private final FreeOrdinalTracker freeOrdinalTracker;
+    private int size;
+    private int sizeBeforeGrow;
+
+    private BitSet unusedPreviousOrdinals;
+
+    private long pointersByOrdinal[];
+
+
+    public ByteArrayOrdinalMap() {
+        this.freeOrdinalTracker = new FreeOrdinalTracker();
+        this.byteData = new ByteDataBuffer(WastefulRecycler.DEFAULT_INSTANCE);
+        this.pointersAndOrdinals = emptyKeyArray(256);
+        this.sizeBeforeGrow = 179; /// 70% load factor
+        this.size = 0;
+    }
+
+    public int getOrAssignOrdinal(ByteDataBuffer serializedRepresentation) {
+        return getOrAssignOrdinal(serializedRepresentation, -1);
+    }
+
+    /**
+     * Add a sequence of bytes to this map.  If the sequence of bytes has already been added to this map, return the originally assigned ordinal.
+     * If the sequence of bytes has not been added to this map, assign and return a new ordinal.  This operation is thread-safe.
+     *
+     * @param serializedRepresentation the serialized representation
+     * @param preferredOrdinal the preferred ordinal
+     * @return the assigned ordinal
+     */
+    public int getOrAssignOrdinal(ByteDataBuffer serializedRepresentation, int preferredOrdinal) {
+        int hash = HashCodes.hashCode(serializedRepresentation);
+
+        int modBitmask = pointersAndOrdinals.length() - 1;
+        int bucket = hash & modBitmask;
+        long key = pointersAndOrdinals.get(bucket);
+
+        /// linear probing to resolve collisions.
+        while (key != EMPTY_BUCKET_VALUE) {
+            if (compare(serializedRepresentation, key)) {
+                return (int) (key >>> BITS_PER_POINTER);
+            }
+
+            bucket = (bucket + 1) & modBitmask;
+            key = pointersAndOrdinals.get(bucket);
+        }
+
+        return assignOrdinal(serializedRepresentation, hash, preferredOrdinal);
+    }
+
+    /// acquire the lock before writing.
+    private synchronized int assignOrdinal(ByteDataBuffer serializedRepresentation, int hash, int preferredOrdinal) {
+        if (size > sizeBeforeGrow) {
+            growKeyArray();
+        }
+
+        /// check to make sure that after acquiring the lock, the element still does not exist.
+        /// this operation is akin to double-checked locking which is 'fixed' with the JSR 133 memory model in JVM >= 1.5.
+        int modBitmask = pointersAndOrdinals.length() - 1;
+        int bucket = hash & modBitmask;
+        long key = pointersAndOrdinals.get(bucket);
+
+        while (key != EMPTY_BUCKET_VALUE) {
+            if (compare(serializedRepresentation, key)) {
+                return (int) (key >>> BITS_PER_POINTER);
+            }
+
+            bucket = (bucket + 1) & modBitmask;
+            key = pointersAndOrdinals.get(bucket);
+        }
+
+        /// the ordinal for this object still does not exist in the list, even after the lock has been acquired.
+        /// it is up to this thread to add it at the current bucket position.
+        int ordinal = findFreeOrdinal(preferredOrdinal);
+        long pointer = byteData.length();
+
+        VarInt.writeVInt(byteData, (int) serializedRepresentation.length());
+        serializedRepresentation.copyTo(byteData);
+
+        key = ((long) ordinal << BITS_PER_POINTER) | pointer;
+
+        size++;
+
+        /// this set on the AtomicLongArray has volatile semantics (i.e. behaves like a monitor release).
+        /// Any other thread reading this element in the AtomicLongArray will have visibility to all memory writes this thread has made up to this point.
+        /// This means the entire byte sequence is guaranteed to be visible to any thread which reads the pointer to that data.
+        pointersAndOrdinals.set(bucket, key);
+
+        return ordinal;
+    }
+
+    /**
+     * If the preferredOrdinal has not already been used, mark it and use it.  Otherwise,
+     * delegate to the FreeOrdinalTracker.
+     */
+    private int findFreeOrdinal(int preferredOrdinal) {
+        if (preferredOrdinal != -1 && unusedPreviousOrdinals.get(preferredOrdinal)) {
+            unusedPreviousOrdinals.clear(preferredOrdinal);
+            return preferredOrdinal;
+        }
+
+        return freeOrdinalTracker.getFreeOrdinal();
+    }
+
+    /**
+     * Assign a predefined ordinal to a serialized representation.<p>
+     * <p>
+     * WARNING: THIS OPERATION IS NOT THREAD-SAFE.<p>
+     * WARNING: THIS OPERATION WILL NOT UPDATE THE FreeOrdinalTracker.
+     *
+     * @param serializedRepresentation the serialized representation
+     * @param ordinal the ordinal
+     */
+    public void put(ByteDataBuffer serializedRepresentation, int ordinal) {
+        if (size > sizeBeforeGrow) {
+            growKeyArray();
+        }
+
+        int hash = HashCodes.hashCode(serializedRepresentation);
+
+        int modBitmask = pointersAndOrdinals.length() - 1;
+        int bucket = hash & modBitmask;
+        long key = pointersAndOrdinals.get(bucket);
+
+        while (key != EMPTY_BUCKET_VALUE) {
+            bucket = (bucket + 1) & modBitmask;
+            key = pointersAndOrdinals.get(bucket);
+        }
+
+        long pointer = byteData.length();
+
+        VarInt.writeVInt(byteData, (int) serializedRepresentation.length());
+        serializedRepresentation.copyTo(byteData);
+
+        key = ((long) ordinal << BITS_PER_POINTER) | pointer;
+
+        size++;
+
+        pointersAndOrdinals.set(bucket, key);
+    }
+
+    public void recalculateFreeOrdinals() {
+        BitSet populatedOrdinals = new BitSet();
+
+        for (int i = 0; i < pointersAndOrdinals.length(); i++) {
+            long key = pointersAndOrdinals.get(i);
+            if (key != EMPTY_BUCKET_VALUE) {
+                int ordinal = (int) (key >>> BITS_PER_POINTER);
+                populatedOrdinals.set(ordinal);
+            }
+        }
+
+        recalculateFreeOrdinals(populatedOrdinals);
+    }
+
+    public void reservePreviouslyPopulatedOrdinals(BitSet populatedOrdinals) {
+        unusedPreviousOrdinals = BitSet.valueOf(populatedOrdinals.toLongArray());
+
+        recalculateFreeOrdinals(populatedOrdinals);
+    }
+
+    private void recalculateFreeOrdinals(BitSet populatedOrdinals) {
+        freeOrdinalTracker.reset();
+
+        int length = populatedOrdinals.length();
+        int ordinal = populatedOrdinals.nextClearBit(0);
+
+        while (ordinal < length) {
+            freeOrdinalTracker.returnOrdinalToPool(ordinal);
+            ordinal = populatedOrdinals.nextClearBit(ordinal + 1);
+        }
+
+        freeOrdinalTracker.setNextEmptyOrdinal(length);
+    }
+
+    public BitSet getUnusedPreviousOrdinals() {
+        return unusedPreviousOrdinals;
+    }
+
+    /**
+     * Returns the ordinal for a previously added byte sequence.  If this byte sequence has not been added to the map, then -1 is returned.<p>
+     * <p>
+     * This is intended for use in the client-side heap-safe double snapshot load.
+     *
+     * @param serializedRepresentation the serialized representation
+     * @return The ordinal for this serialized representation, or -1.
+     */
+    public int get(ByteDataBuffer serializedRepresentation) {
+        int hash = HashCodes.hashCode(serializedRepresentation);
+
+        int modBitmask = pointersAndOrdinals.length() - 1;
+        int bucket = hash & modBitmask;
+        long key = pointersAndOrdinals.get(bucket);
+
+        /// linear probing to resolve collisions.
+        while (key != EMPTY_BUCKET_VALUE) {
+            if (compare(serializedRepresentation, key)) {
+                return (int) (key >>> BITS_PER_POINTER);
+            }
+
+            bucket = (bucket + 1) & modBitmask;
+            key = pointersAndOrdinals.get(bucket);
+        }
+
+        return -1;
+    }
+
+    /**
+     * Create an array mapping the ordinals to pointers, so that they can be easily looked up
+     * when writing to blob streams.
+     */
+    public void prepareForWrite() {
+        int maxOrdinal = 0;
+
+        for (int i = 0; i < pointersAndOrdinals.length(); i++) {
+            long key = pointersAndOrdinals.get(i);
+            if (key != EMPTY_BUCKET_VALUE) {
+                int ordinal = (int) (key >>> BITS_PER_POINTER);
+                if (ordinal > maxOrdinal) {
+                    maxOrdinal = ordinal;
+                }
+            }
+        }
+
+        pointersByOrdinal = new long[maxOrdinal + 1];
+        Arrays.fill(pointersByOrdinal, -1);
+
+        for (int i = 0; i < pointersAndOrdinals.length(); i++) {
+            long key = pointersAndOrdinals.get(i);
+            if (key != EMPTY_BUCKET_VALUE) {
+                int ordinal = (int) (key >>> BITS_PER_POINTER);
+                pointersByOrdinal[ordinal] = key & POINTER_MASK;
+            }
+        }
+    }
+
+    /**
+     * Reclaim space in the byte array used in the previous cycle, but not referenced in this cycle.<p>
+     * <p>
+     * This is achieved by shifting all used byte sequences down in the byte array, then updating
+     * the key array to reflect the new pointers and exclude the removed entries.  This is also where ordinals
+     * which are unused are returned to the pool.<p>
+     *
+     * @param usedOrdinals a bit set representing the ordinals which are currently referenced by any image.
+     */
+    public void compact(ThreadSafeBitSet usedOrdinals) {
+        long populatedReverseKeys[] = new long[size];
+
+        int counter = 0;
+
+        for (int i = 0; i < pointersAndOrdinals.length(); i++) {
+            long key = pointersAndOrdinals.get(i);
+            if (key != EMPTY_BUCKET_VALUE) {
+                populatedReverseKeys[counter++] = key << BITS_PER_ORDINAL | key >>> BITS_PER_POINTER;
+            }
+        }
+
+        Arrays.sort(populatedReverseKeys);
+
+        SegmentedByteArray arr = byteData.getUnderlyingArray();
+        long currentCopyPointer = 0;
+
+        for (int i = 0; i < populatedReverseKeys.length; i++) {
+            int ordinal = (int) (populatedReverseKeys[i] & ORDINAL_MASK);
+
+            if (usedOrdinals.get(ordinal)) {
+                long pointer = populatedReverseKeys[i] >>> BITS_PER_ORDINAL;
+                int length = VarInt.readVInt(arr, pointer);
+                length += VarInt.sizeOfVInt(length);
+
+                if (currentCopyPointer != pointer) {
+                    arr.copy(arr, pointer, currentCopyPointer, length);
+                }
+
+                populatedReverseKeys[i] = populatedReverseKeys[i] << BITS_PER_POINTER | currentCopyPointer;
+
+                currentCopyPointer += length;
+            } else {
+                freeOrdinalTracker.returnOrdinalToPool(ordinal);
+                populatedReverseKeys[i] = EMPTY_BUCKET_VALUE;
+            }
+        }
+
+        byteData.setPosition(currentCopyPointer);
+        freeOrdinalTracker.sort();
+
+        for (int i = 0; i < pointersAndOrdinals.length(); i++) {
+            pointersAndOrdinals.set(i, EMPTY_BUCKET_VALUE);
+        }
+
+        populateNewHashArray(pointersAndOrdinals, populatedReverseKeys);
+        size = usedOrdinals.cardinality();
+
+        pointersByOrdinal = null;
+        unusedPreviousOrdinals = null;
+    }
+
+    public long getPointerForData(int ordinal) {
+        long pointer = pointersByOrdinal[ordinal] & POINTER_MASK;
+        return pointer + VarInt.nextVLongSize(byteData.getUnderlyingArray(), pointer);
+    }
+
+    public boolean isReadyForWriting() {
+        return pointersByOrdinal != null;
+    }
+
+    public boolean isReadyForAddingObjects() {
+        return pointersByOrdinal == null;
+    }
+
+    public long getDataSize() {
+        return byteData.length();
+    }
+
+    public int maxOrdinal() {
+        int maxOrdinal = -1;
+        for (int i = 0; i < pointersAndOrdinals.length(); i++) {
+            long key = pointersAndOrdinals.get(i);
+            if (key != EMPTY_BUCKET_VALUE) {
+                int ordinal = (int) (pointersAndOrdinals.get(i) >>> BITS_PER_POINTER);
+                if (ordinal > maxOrdinal) {
+                    maxOrdinal = ordinal;
+                }
+            }
+        }
+        return maxOrdinal;
+    }
+
+    /**
+     * Compare the byte sequence contained in the supplied ByteDataBuffer with the
+     * sequence contained in the map pointed to by the specified key, byte by byte.
+     */
+    private boolean compare(ByteDataBuffer serializedRepresentation, long key) {
+        long position = key & POINTER_MASK;
+
+        int sizeOfData = VarInt.readVInt(byteData.getUnderlyingArray(), position);
+
+        if (sizeOfData != serializedRepresentation.length()) {
+            return false;
+        }
+
+        position += VarInt.sizeOfVInt(sizeOfData);
+
+        for (int i = 0; i < sizeOfData; i++) {
+            if (serializedRepresentation.get(i) != byteData.get(position++)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Grow the key array.  All of the values in the current array must be re-hashed and added to the new array.
+     */
+    private void growKeyArray() {
+        int newSize = pointersAndOrdinals.length() * 2;
+        if (newSize < 0) {
+            throw new IllegalStateException("New size computed to grow the underlying array for the map is negative. " +
+                    "This is most likely due to the total number of keys added to map has exceeded the max capacity of the keys map can hold. "
+                    +
+                    "Current array size :" + pointersAndOrdinals.length() + " and size to grow :" + newSize);
+        }
+        AtomicLongArray newKeys = emptyKeyArray(pointersAndOrdinals.length() * 2);
+
+        long valuesToAdd[] = new long[size];
+
+        int counter = 0;
+
+        /// do not iterate over these values in the same order in which they appear in the hashed array.
+        /// if we do so, we cause large clusters of collisions to appear (because we resolve collisions with linear probing).
+        for (int i = 0; i < pointersAndOrdinals.length(); i++) {
+            long key = pointersAndOrdinals.get(i);
+            if (key != EMPTY_BUCKET_VALUE) {
+                valuesToAdd[counter++] = key;
+            }
+        }
+
+        Arrays.sort(valuesToAdd);
+
+        populateNewHashArray(newKeys, valuesToAdd);
+
+        /// 70% load factor
+        sizeBeforeGrow = (int) (((float) newKeys.length()) * 0.7);
+        pointersAndOrdinals = newKeys;
+    }
+
+    /**
+     * Hash all of the existing values specified by the keys in the supplied long array
+     * into the supplied AtomicLongArray.
+     */
+    private void populateNewHashArray(AtomicLongArray newKeys, long[] valuesToAdd) {
+        int modBitmask = newKeys.length() - 1;
+
+        for (int i = 0; i < valuesToAdd.length; i++) {
+            if (valuesToAdd[i] != EMPTY_BUCKET_VALUE) {
+                int hash = rehashPreviouslyAddedData(valuesToAdd[i]);
+                int bucket = hash & modBitmask;
+                while (newKeys.get(bucket) != EMPTY_BUCKET_VALUE) {
+                    bucket = (bucket + 1) & modBitmask;
+                }
+                newKeys.set(bucket, valuesToAdd[i]);
+            }
+        }
+    }
+
+    /**
+     * Get the hash code for the byte array pointed to by the specified key.
+     */
+    private int rehashPreviouslyAddedData(long key) {
+        long position = key & POINTER_MASK;
+
+        int sizeOfData = VarInt.readVInt(byteData.getUnderlyingArray(), position);
+        position += VarInt.sizeOfVInt(sizeOfData);
+
+        return HashCodes.hashCode(byteData.getUnderlyingArray(), position, sizeOfData);
+    }
+
+    /**
+     * Create an AtomicLongArray of the specified size, each value in the array will be EMPTY_BUCKET_VALUE
+     */
+    private AtomicLongArray emptyKeyArray(int size) {
+        AtomicLongArray arr = new AtomicLongArray(size);
+        for (int i = 0; i < arr.length(); i++) {
+            arr.set(i, EMPTY_BUCKET_VALUE);
+        }
+        return arr;
+    }
+
+    public ByteDataBuffer getByteData() {
+        return byteData;
+    }
+
+    public AtomicLongArray getPointersAndOrdinals() {
+        return pointersAndOrdinals;
+    }
+
+    public static boolean isPointerAndOrdinalEmpty(long pointerAndOrdinal) {
+        return pointerAndOrdinal == EMPTY_BUCKET_VALUE;
+    }
+
+    public static long getPointer(long pointerAndOrdinal) {
+        return pointerAndOrdinal & POINTER_MASK;
+    }
+
+    public static int getOrdinal(long pointerAndOrdinal) {
+        return (int) (pointerAndOrdinal >>> BITS_PER_POINTER);
+    }
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
@@ -448,6 +448,8 @@ public class ByteArrayOrdinalMap {
      * Resize the ordinal map by increasing its capacity.
      * <p>
      * No action is take if the current capacity is sufficient for the given size.
+     * <p>
+     * WARNING: THIS OPERATION IS NOT THREAD-SAFE.
      *
      * @param size the size to increase to, rounded up to the nearest power of two.
      */

--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
@@ -163,7 +163,8 @@ public class HollowWriteStateCreator {
                         HollowRecordCopier copier = HollowRecordCopier.createCopier(readState, writeState.getSchema());
                         
                         BitSet populatedOrdinals = readState.getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
-                        
+
+                        writeState.resizeOrdinalMap(populatedOrdinals.cardinality());
                         int ordinal = populatedOrdinals.nextSetBit(0);
                         while(ordinal != -1) {
                             HollowWriteRecord rec = copier.copy(ordinal);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -308,14 +308,14 @@ public abstract class HollowTypeWriteState {
         BitSet populatedOrdinals = listener.getPopulatedOrdinals();
 
         restoredReadState = readState;
-        restoredMap = new ByteArrayOrdinalMap();
         if(schema instanceof HollowObjectSchema)
             restoredSchema = ((HollowObjectSchema)schema).findCommonSchema((HollowObjectSchema)readState.getSchema());
         else
             restoredSchema = readState.getSchema();
         HollowRecordCopier copier = HollowRecordCopier.createCopier(restoredReadState, restoredSchema);
 
-
+        // Size the restore map to avoid resizing when adding ordinals
+        restoredMap = new ByteArrayOrdinalMap(populatedOrdinals.cardinality());
         int ordinal = populatedOrdinals.nextSetBit(0);
         while(ordinal != -1) {
             previousCyclePopulated.set(ordinal);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -241,6 +241,10 @@ public abstract class HollowTypeWriteState {
         }
     }
 
+    public void resizeOrdinalMap(int size) {
+        ordinalMap.resize(size);
+    }
+
     /**
      * Called to perform a state transition.<p>
      *

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -314,8 +314,9 @@ public abstract class HollowTypeWriteState {
             restoredSchema = readState.getSchema();
         HollowRecordCopier copier = HollowRecordCopier.createCopier(restoredReadState, restoredSchema);
 
-        // Size the restore map to avoid resizing when adding ordinals
-        restoredMap = new ByteArrayOrdinalMap(populatedOrdinals.cardinality());
+        // Size the restore ordinal map to avoid resizing when adding ordinals
+        int size = populatedOrdinals.cardinality();
+        restoredMap = new ByteArrayOrdinalMap(size);
         int ordinal = populatedOrdinals.nextSetBit(0);
         while(ordinal != -1) {
             previousCyclePopulated.set(ordinal);
@@ -323,6 +324,8 @@ public abstract class HollowTypeWriteState {
             ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
         }
 
+        // Resize the ordinal map to avoid resizing when populating
+        ordinalMap.resize(size);
         ordinalMap.reservePreviouslyPopulatedOrdinals(populatedOrdinals);
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/ByteArrayOrdinalTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/ByteArrayOrdinalTest.java
@@ -1,0 +1,57 @@
+package com.netflix.hollow.core.memory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ByteArrayOrdinalTest {
+
+    @Test
+    public void testResize() {
+        ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
+
+        int[] ordinals = new int[179];
+        for (int i = 0; i < ordinals.length; i++) {
+            ordinals[i] = m.getOrAssignOrdinal(createBuffer("TEST" + i));
+        }
+
+        m.resize(4096);
+
+        int[] newOrdinals = new int[ordinals.length];
+        for (int i = 0; i < ordinals.length; i++) {
+            newOrdinals[i] = m.get(createBuffer("TEST" + i));
+        }
+
+        Assert.assertArrayEquals(ordinals, newOrdinals);
+    }
+
+    @Test
+    public void testResizeWhenEmpty() {
+        ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
+        m.resize(4096);
+
+        int[] ordinals = new int[179];
+        for (int i = 0; i < ordinals.length; i++) {
+            ordinals[i] = m.getOrAssignOrdinal(createBuffer("TEST" + i));
+        }
+
+        m.resize(16384);
+
+        int[] newOrdinals = new int[ordinals.length];
+        for (int i = 0; i < ordinals.length; i++) {
+            newOrdinals[i] = m.get(createBuffer("TEST" + i));
+        }
+
+        Assert.assertArrayEquals(ordinals, newOrdinals);
+    }
+
+    static ByteDataBuffer createBuffer(String s) {
+        return write(new ByteDataBuffer(), s);
+    }
+
+    static ByteDataBuffer write(ByteDataBuffer bdb, String s) {
+        for (byte b : s.getBytes()) {
+            bdb.write(b);
+        }
+        return bdb;
+    }
+}


### PR DESCRIPTION
The first commit reformats `ByteArrayOrdinalMap`. The second commit adds a new constructor that accepts a `size` argument that is used to pre-size the hash array.  Type write state restoration will size instances of ByteArrayOrdinalMap according to the cardinality of the populated ordinals on the read state.