### PR TITLE
Schema to POJO: STRING field to @HollowInline String field

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowPOJOClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowPOJOClassGenerator.java
@@ -30,6 +30,7 @@ import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSetSchema;
+import com.netflix.hollow.core.write.objectmapper.HollowInline;
 import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
 import java.util.ArrayList;
@@ -148,6 +149,10 @@ public class HollowPOJOClassGenerator implements HollowJavaFileGenerator {
         for (int i = 0;i < schema.numFields();i++) {
             if (fieldNeedsTypeNameAnnotation(i)) {
                 classBodyBuilder.append("    @HollowTypeName(name=\"").append(schema.getReferencedType(i)).append("\")\n");
+            }
+            if (fieldNeedsInlineAnnotation(i)) {
+                importClasses.add(HollowInline.class);
+                classBodyBuilder.append("    @HollowInline\n");
             }
             classBodyBuilder.append("    public ");
             classBodyBuilder.append(fieldType(i));
@@ -326,6 +331,10 @@ public class HollowPOJOClassGenerator implements HollowJavaFileGenerator {
             return !referencedSchema.getName().equals(expectedCollectionClassName(referencedSchema));
         }
         return false;
+    }
+
+    private boolean fieldNeedsInlineAnnotation(int i) {
+        return schema.getFieldType(i) == FieldType.STRING;
     }
 
     private String fieldType(int i) {


### PR DESCRIPTION
In a prior release the schema to POJO generator would given a `STRING` field schema type generate a `char[]` Java field in the generated POJO.  This was changed to `String`, which also changed the schema type from value type to reference type.  Such fields should be annotated `@HollowInline` to ensure they are a value type (of `STRING`) and not a reference (of `REFERENCE`).