### PR TITLE
Use fence to apply stricter ordering for optimisic read of state.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
@@ -26,17 +26,19 @@ import sun.misc.Unsafe;
 @SuppressWarnings("restriction")
 public class HollowUnsafeHandle {
     private static final Logger log = Logger.getLogger(HollowUnsafeHandle.class.getName());
-    private static Unsafe unsafe;
+    private static final Unsafe unsafe;
 
     static {
         Field theUnsafe;
+        Unsafe u = null;
         try {
             theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
             theUnsafe.setAccessible(true);
-            unsafe = (Unsafe) theUnsafe.get(null);
+            u = (Unsafe) theUnsafe.get(null);
         } catch (Exception e) {
             log.log(Level.SEVERE, "Unsafe access failed", e);
         }
+        unsafe = u;
     }
 
     public static Unsafe getUnsafe() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateShard.java
@@ -19,6 +19,7 @@ package com.netflix.hollow.core.read.engine.list;
 
 import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
 
+import com.netflix.hollow.core.memory.HollowUnsafeHandle;
 import com.netflix.hollow.tools.checksum.HollowChecksum;
 import java.util.BitSet;
 
@@ -89,6 +90,7 @@ class HollowListTypeReadStateShard {
     }
 
     private boolean readWasUnsafe(HollowListTypeDataElements data) {
+        HollowUnsafeHandle.getUnsafe().loadFence();
         return data != currentDataVolatile;
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadStateShard.java
@@ -20,6 +20,7 @@ package com.netflix.hollow.core.read.engine.map;
 import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
 
 import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
+import com.netflix.hollow.core.memory.HollowUnsafeHandle;
 import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.read.engine.SetMapKeyHasher;
 import com.netflix.hollow.tools.checksum.HollowChecksum;
@@ -200,6 +201,7 @@ class HollowMapTypeReadStateShard {
     }
 
     private boolean readWasUnsafe(HollowMapTypeDataElements data) {
+        HollowUnsafeHandle.getUnsafe().loadFence();
         return data != currentDataVolatile;
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateShard.java
@@ -20,6 +20,7 @@ package com.netflix.hollow.core.read.engine.set;
 import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
 
 import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
+import com.netflix.hollow.core.memory.HollowUnsafeHandle;
 import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.read.engine.SetMapKeyHasher;
 import com.netflix.hollow.tools.checksum.HollowChecksum;
@@ -156,6 +157,7 @@ class HollowSetTypeReadStateShard {
     }
 
     private boolean readWasUnsafe(HollowSetTypeDataElements data) {
+        HollowUnsafeHandle.getUnsafe().loadFence();
         return data != currentDataVolatile;
     }
 


### PR DESCRIPTION
See comment and http://gee.cs.oswego.edu/dl/html/j9mm.html (and the older http://gee.cs.oswego.edu/dl/jmm/cookbook.html) for more details.