### PR TITLE
Bugfix: NPE when refreshing to latest but no versions could be retrieved

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlanner.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlanner.java
@@ -94,14 +94,29 @@ public class HollowUpdatePlanner {
         return deltaPlan;
     }
 
+    /**
+     * Returns an update plan that if executed will update the client to a version that is either equal to or as close to but
+     * less than the desired version as possible. This plan normally contains one snapshot transition and zero or more delta
+     * transitions but if no previous versions were found then an empty plan, {@code HollowUpdatePlan.DO_NOTHING}, is returned.
+     *
+     * @param desiredVersion The desired version to which the client wishes to update to, or update to as close to as possible but lesser than this version
+     * @return An update plan containing 1 snapshot transition and 0+ delta transitions if requested versions were found,
+     *         or an empty plan, {@code HollowUpdatePlan.DO_NOTHING}, if no previous versions were found
+     */
     private HollowUpdatePlan snapshotPlan(long desiredVersion) {
         HollowUpdatePlan plan = new HollowUpdatePlan();
-        long currentVersion = includeNearestSnapshot(plan, desiredVersion);
+        long nearestPreviousSnapshotVersion = includeNearestSnapshot(plan, desiredVersion);
 
-        if(currentVersion > desiredVersion)
+        // The includeNearestSnapshot function returns a snapshot version that is less than or equal to the desired version
+        if(nearestPreviousSnapshotVersion > desiredVersion)
             return HollowUpdatePlan.DO_NOTHING;
 
-        plan.appendPlan(deltaPlan(currentVersion, desiredVersion, Integer.MAX_VALUE));
+        // If the nearest snapshot version is {@code HollowConstants.VERSION_LATEST} then no past snapshots were found, so
+        // skip the delta planning and the update plan does nothing
+        if(nearestPreviousSnapshotVersion == HollowConstants.VERSION_LATEST)
+            return HollowUpdatePlan.DO_NOTHING;
+
+        plan.appendPlan(deltaPlan(nearestPreviousSnapshotVersion, desiredVersion, Integer.MAX_VALUE));
 
         return plan;
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -233,8 +233,9 @@ public class HollowConsumer {
     }
 
     /**
-     * If a {@link HollowConsumer.AnnouncementWatcher} is not specified, then this method will update
-     * to the specified version.
+     * If a {@link HollowConsumer.AnnouncementWatcher} is not specified, then this method will attempt to update
+     * to the specified version, and if the specified version does not exist then to a different version as specified
+     * by functionality in the {@code BlobRetriever}.
      * <p>
      * Otherwise, an UnsupportedOperationException will be thrown.
      * <p>

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
@@ -37,7 +37,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class HollowClientUpdaterTest {
     private HollowConsumer.BlobRetriever retriever;
@@ -73,6 +75,24 @@ public class HollowClientUpdaterTest {
                 subject.shouldCreateSnapshotPlan());
         assertTrue(subject.updateTo(VERSION_NONE));
         assertTrue("Should still have no types", readStateEngine.getAllTypes().isEmpty());
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testUpdateTo_updateToLatestButNoVersionsRetrieved_throwsException() throws Throwable {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Could not create an update plan, because no existing versions could be retrieved.");
+        subject.updateTo(VERSION_LATEST);
+    }
+
+    @Test
+    public void testUpdateTo_updateToArbitraryVersionButNoVersionsRetrieved_throwsException() throws Throwable {
+        long v = Long.MAX_VALUE - 1;
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Could not create an update plan for version %s, because that version or any previous versions could not be retrieved.", v));
+        subject.updateTo(v);
     }
 
     @Test


### PR DESCRIPTION
Throwing a cleaner exception message for the case where the latest version is requested but no versions could be retrieved, for eg. for a Cinder namespace with no data.

**BEFORE**

_With Long.MAX_VALUE:_

$ java -jar build/libs/cinder-explorer-tool.jar --env=LOCAL_PROD explore cinder.gatekeeper.status -
Exception in thread "main" java.lang.NullPointerException
        at com.netflix.hollow.api.client.HollowClientUpdater.updateTo(HollowClientUpdater.java:136)
        at com.netflix.hollow.api.consumer.HollowConsumer.triggerRefreshTo(HollowConsumer.java:250)
        at com.netflix.cinder.explorer.Explorer.exploreVersionSingle(Explorer.java:42)
        at com.netflix.cinder.explorer.Launcher.main(Launcher.java:173)

_Lets subtract 1 from Long.MAX_VALUE:_

$ java -jar build/libs/cinder-explorer-tool.jar --env=LOCAL_PROD explore cinder.gatekeeper.status 9223372036854775806
Exception in thread "main" java.lang.RuntimeException: java.lang.Exception: Could not create an update plan for version 9223372036854775806
        at com.netflix.hollow.api.consumer.HollowConsumer.triggerRefreshTo(HollowConsumer.java:254)
        at com.netflix.cinder.explorer.Explorer.exploreVersionSingle(Explorer.java:42)
        at com.netflix.cinder.explorer.Launcher.main(Launcher.java:173)
Caused by: java.lang.Exception: Could not create an update plan for version 9223372036854775806
        at com.netflix.hollow.api.client.HollowClientUpdater.updateTo(HollowClientUpdater.java:124)
        at com.netflix.hollow.api.consumer.HollowConsumer.triggerRefreshTo(HollowConsumer.java:250)
        ... 2 more

**AFTER**

_With Long.MAX_VALUE:_

Exception in thread "main" java.lang.IllegalArgumentException: Could not create an update plan, because no existing versions could be retrieved.
	at com.netflix.hollow.api.client.HollowClientUpdater.updateTo(HollowClientUpdater.java:132)
	at com.netflix.hollow.api.consumer.HollowConsumer.triggerRefreshTo(HollowConsumer.java:250)
	at com.netflix.cinder.explorer.Explorer.exploreVersionSingle(Explorer.java:42)
	at com.netflix.cinder.explorer.Launcher.main(Launcher.java:168)

_Lets subtract 1 from Long.MAX_VALUE:_

Exception in thread "main" java.lang.IllegalArgumentException: Could not create an update plan for version 9223372036854775806, because that version or any previous versions could not be retrieved.
	at com.netflix.hollow.api.client.HollowClientUpdater.updateTo(HollowClientUpdater.java:128)
	at com.netflix.hollow.api.consumer.HollowConsumer.triggerRefreshTo(HollowConsumer.java:250)
	at com.netflix.cinder.explorer.Explorer.exploreVersionSingle(Explorer.java:42)
