### PR TITLE
Documentation POJO annotations.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowHashKey.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowHashKey.java
@@ -22,10 +22,43 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Indicates that a field, declared by a hollow object type (a POJO),
+ * of type {@code Set} or {@code Map} has a hash key defining how the
+ * hollow objects that are elements in a {@code Set} or are keys in a
+ * {@code Map} are hashed.
+ * <p>
+ * A hash is derived from the sequence of values obtained by resolving
+ * the {@link #fields field} paths (in order) given an hollow object that is
+ * the element or key.
+ * Such hashes are used to distribute the hollow objects encoded within a
+ * hollow set or map.
+ * <p>
+ * By default if this annotation is not declared on a field of type {@code Set} or {@code Map},
+ * referred to as the hash key field, then a hash key is derived from the element or key type
+ * as follows.
+ * If the type is annotated with {@link HollowPrimaryKey} then it's as if the
+ * hash key field is annotated with {@code HollowHashKey} with the same field paths as
+ * declared by the {@code HollowPrimaryKey}.
+ * Otherwise, if the type declares exactly one field whose type is a primitive type then
+ * it's as if the hash key field is annotated with {@code HollowHashKey} with a single
+ * field path that is the name of that one field.
+ * Otherwise, it's as if the field is annotated with {@code HollowHashKey} with an empty
+ * field paths array (indicating the ordinal of an element or key is used as the hash).
+ * This annotation with an empty array may be utilized to enforce the latter case,
+ * overriding one of the other prior cases, if applicable.
+ */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD})
+@Target(ElementType.FIELD)
 public @interface HollowHashKey {
 
+    /**
+     * Returns the field paths of the hash key.
+     * <p>
+     * An empty array indicates that the ordinal of an element in a set
+     * or a key in a map is used as the hash.
+     *
+     * @return the field paths of the hash key
+     */
     String[] fields();
-
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowInline.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowInline.java
@@ -22,7 +22,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Indicates that a field of a POJO is inlined as a value rather than
+ * a reference.
+ * <p>
+ * The field's type must a be boxed primitive type or {@code String}.
+ */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target( {ElementType.FIELD})
 public @interface HollowInline {
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowPrimaryKey.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowPrimaryKey.java
@@ -22,9 +22,28 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Indicates that a hollow object type (a POJO) has a primary key.
+ * <p>
+ * The primary key value of such a hollow object is the sequence of
+ * values obtained by resolving the {@link #fields field} paths (in order)
+ * given that hollow object.  There must be only one such hollow object, of
+ * a particular type, for a given primary key.  Therefore, a hollow object
+ * may be looked up given its primary key value
+ * (see
+ * {@link com.netflix.hollow.api.consumer.index.UniqueKeyIndex UniqueKeyIndex}
+ * and
+ * {@link com.netflix.hollow.core.index.HollowPrimaryKeyIndex HollowPrimaryKeyIndex}
+ * ).
+ */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE })
+@Target(ElementType.TYPE)
 public @interface HollowPrimaryKey {
 
+    /**
+     * Returns the field paths of the primary key.
+     *
+     * @return the field paths of the primary key
+     */
     String[] fields();
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowShardLargeType.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowShardLargeType.java
@@ -22,11 +22,47 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
+/**
+ * Indicates how many shards are used to encode hollow records, in effect
+ * partitioning records into {@code P} parts corresponding to the number of
+ * shards.
+ * <p>
+ * This annotation may be declared on a POJO or the field of a POJO that
+ * is of type {@code List}, {@code Set}, or {@code Map}.  It should be used
+ * when determining the number of shards automatically, given a target position
+ * size, is insufficient for a particular hollow record type.
+ * <p>
+ * If {@code N} records are encoded for a particular hollow record type,
+ * where each record has an unique ordinal {@code O},
+ * and where {@code 0 <= O < N}, and the records are encoded in {@code P}
+ * parts, then a record's assigned shard is the result of the expression
+ * {@code O & (P - 1)}.
+ * <p>
+ * If this annotation is absent then the number of shards is dynamically
+ * calculated given a target shard size in bytes
+ * (see
+ * {@link com.netflix.hollow.api.producer.HollowProducer.Builder#withTargetMaxTypeShardSize(long)
+ *  HollowProducer.Builder.withTargetMaxTypeShardSize}
+ * and
+ * {@link com.netflix.hollow.core.write.HollowWriteStateEngine#setTargetMaxTypeShardSize(long)
+ *  HollowWriteStateEngine.setTargetMaxTypeShardSize}
+ * )
+ * and the projected size in bytes of the hollow records for a particular type.
+ * For example, if the target shard size is set to a value in bytes of {@code 25MB} and the
+ * projected size of the hollow records for a type is {@code 50MB} then the number of shards
+ * will be {@code 2}.
+ * @see <a href="https://hollow.how/advanced-topics/#type-sharding">Type-sharding documentation</a>
+ */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.FIELD})
+@Target( {ElementType.TYPE, ElementType.FIELD})
 public @interface HollowShardLargeType {
-    
-    int numShards();
 
+    /**
+     * Returns the number of shards to partition a hollow record.
+     * <p>
+     * The number of shards must be a power of 2.
+     *
+     * @return the number of shards to partition a hollow record
+     */
+    int numShards();
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTransient.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTransient.java
@@ -22,6 +22,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Indicates that a field of a POJO is to be ignored.
+ * <p>
+ * This annotation should be used when the {@code transient} field
+ * modifier cannot be declared (for example if a JVM compatible
+ * language is used to represent the POJOs and there are limitations
+ * in expressing corresponding transient fields in Java byte code).
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface HollowTransient {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeName.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeName.java
@@ -22,10 +22,22 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Indicates the hollow type name of a POJO or the hollow field name of a field
+ * declared by a POJO.
+ * <p>
+ * This annotation may be used to override the hollow class name derived from the
+ * name of a {@code Class} of a POJO, or override the hollow field name derived
+ * from the name of a {@code Field} declared by a POJO.
+ */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.FIELD})
+@Target( {ElementType.TYPE, ElementType.FIELD})
 public @interface HollowTypeName {
 
+    /**
+     * Returns the hollow type name or hollow field name.
+     *
+     * @return the hollow type name or hollow field name
+     */
     String name();
-
 }


### PR DESCRIPTION
This commit started out as an explanation of `@HollowHashKey` and its use when the `fields` attribute is empty, since we can opportunistically specify that a declaration of `@HollowHashKey(fields = {}` means the ordinal is utilized as the hash (overriding default derivation, if applicable, from a primary key or a field). Documentation was expanded to include all annotations.

