### PR TITLE
Deprecate HollowObjectHashCodeFinder and its usages.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClient.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClient.java
@@ -59,9 +59,6 @@ import java.util.Collections;
  *      <dd>Defines how to create a {@link HollowAPI} for the dataset, useful when wrapping a dataset with an api which has 
  *          been generated (via the {@link HollowAPIClassJavaGenerator})</dd>
  *          
- *      <dt>{@link HollowObjectHashCodeFinder}</dt>
- *      <dd>Defines the record hashing behavior for elements in set and map records</dd>
- *      
  *      <dt>{@link HollowClientMemoryConfig}</dt>
  *      <dd>Defines various aspects of data access guarantees and update behavior which impact the heap footprint/GC behavior
  *          of hollow.</dd>

--- a/hollow/src/main/java/com/netflix/hollow/core/read/dataaccess/HollowDataAccess.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/dataaccess/HollowDataAccess.java
@@ -37,32 +37,33 @@ public interface HollowDataAccess extends HollowDataset {
      * @param typeName the type name
      * @return The handle to data for a specific type in this dataset.
      */
-    public HollowTypeDataAccess getTypeDataAccess(String typeName);
+    HollowTypeDataAccess getTypeDataAccess(String typeName);
 
     /**
      * @param typeName The type name
      * @param ordinal optional parameter.  When known, may provide a more optimal data access implementation for traversal of historical data access.
      * @return The handle to data for a specific type in this dataset.
      */
-    public HollowTypeDataAccess getTypeDataAccess(String typeName, int ordinal);
+    HollowTypeDataAccess getTypeDataAccess(String typeName, int ordinal);
 
     /**
      * @return The names of all types in this dataset
      */
-    public Collection<String> getAllTypes();
+    Collection<String> getAllTypes();
     
     @Override
-    public List<HollowSchema> getSchemas();
+    List<HollowSchema> getSchemas();
     
     @Override
-    public HollowSchema getSchema(String name);
+    HollowSchema getSchema(String name);
 
-    public HollowObjectHashCodeFinder getHashCodeFinder();
+    @Deprecated
+    HollowObjectHashCodeFinder getHashCodeFinder();
 
-    public MissingDataHandler getMissingDataHandler();
+    MissingDataHandler getMissingDataHandler();
 
-    public void resetSampling();
+    void resetSampling();
 
-    public boolean hasSampleResults();
+    boolean hasSampleResults();
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
@@ -68,10 +68,6 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
         this(DefaultHashCodeFinder.INSTANCE, true, new RecyclingRecycler());
     }
 
-    public HollowReadStateEngine(HollowObjectHashCodeFinder hashCodeFinder) {
-        this(hashCodeFinder, true, new RecyclingRecycler());
-    }
-
     public HollowReadStateEngine(boolean listenToAllPopulatedOrdinals) {
         this(DefaultHashCodeFinder.INSTANCE, listenToAllPopulatedOrdinals, new RecyclingRecycler());
     }
@@ -80,6 +76,16 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
         this(DefaultHashCodeFinder.INSTANCE, true, recycler);
     }
 
+    public HollowReadStateEngine(boolean listenToAllPopulatedOrdinals, ArraySegmentRecycler recycler) {
+        this(DefaultHashCodeFinder.INSTANCE, listenToAllPopulatedOrdinals, recycler);
+    }
+
+    @Deprecated
+    public HollowReadStateEngine(HollowObjectHashCodeFinder hashCodeFinder) {
+        this(hashCodeFinder, true, new RecyclingRecycler());
+    }
+
+    @Deprecated
     public HollowReadStateEngine(HollowObjectHashCodeFinder hashCodeFinder, boolean listenToAllPopulatedOrdinals, ArraySegmentRecycler recycler) {
         this.typeStates = new HashMap<String, HollowTypeReadState>();
         this.listeners = new HashMap<String, List<HollowTypeStateListener>>();

--- a/hollow/src/main/java/com/netflix/hollow/core/util/DefaultHashCodeFinder.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/DefaultHashCodeFinder.java
@@ -21,6 +21,7 @@ import com.netflix.hollow.api.objects.HollowRecord;
 import java.util.HashSet;
 import java.util.Set;
 
+@Deprecated
 public class DefaultHashCodeFinder implements HollowObjectHashCodeFinder {
 
     public static final DefaultHashCodeFinder INSTANCE = new DefaultHashCodeFinder();

--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowObjectHashCodeFinder.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowObjectHashCodeFinder.java
@@ -25,7 +25,10 @@ import java.util.Set;
  * <p>
  * With this interface, in conjunction with a cooperating data ingestion mechanism, it is possible to use custom hash codes
  * in Hollow sets and maps.
+ * @deprecated Use hash key the <i>hash key</i> functionality available sets and maps
+ * @see com.netflix.hollow.core.write.objectmapper.HollowHashKey
  */
+@Deprecated
 public interface HollowObjectHashCodeFinder {
 
     String DEFINED_HASH_CODES_HEADER_NAME = "DEFINED_HASH_CODES";

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
@@ -80,6 +80,7 @@ public class HollowWriteStateEngine implements HollowStateEngine {
         this(new DefaultHashCodeFinder());
     }
 
+    @Deprecated
     public HollowWriteStateEngine(HollowObjectHashCodeFinder hasher) {
         this.writeStates = new HashMap<String, HollowTypeWriteState>();
         this.hollowSchemas = new HashMap<String, HollowSchema>();
@@ -372,6 +373,7 @@ public class HollowWriteStateEngine implements HollowStateEngine {
         return headerTags.get(name);
     }
 
+    @Deprecated
     public HollowObjectHashCodeFinder getHashCodeFinder() {
         return hashCodeFinder;
     }


### PR DESCRIPTION
This feature has been replaced with the hash key functionality
of sets and maps (see HollowHashKey).  Removing this
feature will greatly simplify many code paths within
the Hollow code base.  Further this removes the need
for the producer and consumer to share out of band
hashing logic.