### PR TITLE
Hash code updates.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/key/PrimaryKey.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/key/PrimaryKey.java
@@ -64,7 +64,7 @@ public class PrimaryKey {
     }
 
     public String[] getFieldPaths() {
-        return fieldPaths;
+        return fieldPaths.clone();
     }
 
     public FieldType getFieldType(HollowDataset dataset, int fieldPathIdx) {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -195,7 +195,7 @@ public class HollowBlobReader {
                 HollowSetSchema setSchema = (HollowSetSchema) schema;
                 // Filter out hash key if overridden by a hash code finder
                 if (hasDefinedHashCode(setSchema.getElementType())) {
-                    setSchema = setSchema.withoutKeys();
+                    setSchema = setSchema.withoutHashKey();
                 }
                 populateTypeStateSnapshot(is, new HollowSetTypeReadState(stateEngine, setSchema, numShards));
             }
@@ -206,7 +206,7 @@ public class HollowBlobReader {
                 HollowMapSchema mapSchema = (HollowMapSchema) schema;
                 // Filter out hash key if overridden by a hash code finder
                 if (hasDefinedHashCode(mapSchema.getKeyType())) {
-                    mapSchema = mapSchema.withoutKeys();
+                    mapSchema = mapSchema.withoutHashKey();
                 }
                 populateTypeStateSnapshot(is, new HollowMapTypeReadState(stateEngine, mapSchema, numShards));
             }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -165,6 +165,10 @@ public class HollowBlobReader {
         }
     }
 
+    private boolean hasDefinedHashCode(String type) {
+        return stateEngine.getHashCodeFinder().getTypesWithDefinedHashCodes().contains(type);
+    }
+
     private String readTypeStateSnapshot(DataInputStream is, HollowBlobHeader header, HollowFilterConfig filter) throws IOException {
         HollowSchema schema = HollowSchema.readFrom(is);
 
@@ -188,13 +192,23 @@ public class HollowBlobReader {
             if(!filter.doesIncludeType(schema.getName())) {
                 HollowSetTypeReadState.discardSnapshot(is, numShards);
             } else {
-                populateTypeStateSnapshot(is, new HollowSetTypeReadState(stateEngine, (HollowSetSchema)schema, numShards));
+                HollowSetSchema setSchema = (HollowSetSchema) schema;
+                // Filter out hash key if overridden by a hash code finder
+                if (hasDefinedHashCode(setSchema.getElementType())) {
+                    setSchema = setSchema.withoutKeys();
+                }
+                populateTypeStateSnapshot(is, new HollowSetTypeReadState(stateEngine, setSchema, numShards));
             }
         } else if(schema instanceof HollowMapSchema) {
             if(!filter.doesIncludeType(schema.getName())) {
                 HollowMapTypeReadState.discardSnapshot(is, numShards);
             } else {
-                populateTypeStateSnapshot(is, new HollowMapTypeReadState(stateEngine, (HollowMapSchema)schema, numShards));
+                HollowMapSchema mapSchema = (HollowMapSchema) schema;
+                // Filter out hash key if overridden by a hash code finder
+                if (hasDefinedHashCode(mapSchema.getKeyType())) {
+                    mapSchema = mapSchema.withoutKeys();
+                }
+                populateTypeStateSnapshot(is, new HollowMapTypeReadState(stateEngine, mapSchema, numShards));
             }
         }
         

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
@@ -288,6 +288,7 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
         return false;
     }
 
+    @Deprecated
     public Set<String> getTypesWithDefinedHashCodes() {
         return typesWithDefinedHashCodes;
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -260,9 +260,8 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     @Override
     protected void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema) {
         if(!getSchema().equals(withSchema)) {
-            // Apply checksum if one or other schema does not declare a hash key
-            if (getSchema().getHashKey() != null &&
-                    (!(withSchema instanceof HollowMapSchema) || ((HollowMapSchema) withSchema).getHashKey() != null)) {
+            // Apply checksum if withSchema does not declare a hash key
+            if (getSchema().getHashKey() != null && !getSchema().withoutKeys().equals(withSchema)) {
                 throw new IllegalArgumentException(
                         "HollowMapTypeReadState cannot calculate checksum with unequal schemas: " + getSchema()
                                 .getName());

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -259,9 +259,16 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
 
     @Override
     protected void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema) {
-        if(!getSchema().equals(withSchema))
-            throw new IllegalArgumentException("HollowMapTypeReadState cannot calculate checksum with unequal schemas: " + getSchema().getName());
-        
+        if(!getSchema().equals(withSchema)) {
+            // Apply checksum if one or other schema does not declare a hash key
+            if (getSchema().getHashKey() != null &&
+                    (!(withSchema instanceof HollowMapSchema) || ((HollowMapSchema) withSchema).getHashKey() != null)) {
+                throw new IllegalArgumentException(
+                        "HollowMapTypeReadState cannot calculate checksum with unequal schemas: " + getSchema()
+                                .getName());
+            }
+        }
+
         BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
 
         for(int i=0; i<shards.length; i++)
@@ -295,9 +302,11 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     }
     
     public void buildKeyDeriver() {
-        if(getSchema().getHashKey() != null)
+        if (getSchema().getHashKey() != null &&
+                getStateEngine().getSchema(getSchema().getKeyType()) != null) {
             this.keyDeriver = new HollowPrimaryKeyValueDeriver(getSchema().getHashKey(), getStateEngine());
-        
+        }
+
         for(int i=0; i<shards.length; i++)
             shards[i].setKeyDeriver(keyDeriver);
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -261,7 +261,7 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     protected void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema) {
         if(!getSchema().equals(withSchema)) {
             // Apply checksum if withSchema does not declare a hash key
-            if (getSchema().getHashKey() != null && !getSchema().withoutKeys().equals(withSchema)) {
+            if (getSchema().getHashKey() != null && !getSchema().withoutHashKey().equals(withSchema)) {
                 throw new IllegalArgumentException(
                         "HollowMapTypeReadState cannot calculate checksum with unequal schemas: " + getSchema()
                                 .getName());

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -237,9 +237,16 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
 
     @Override
     protected void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema) {
-        if(!getSchema().equals(withSchema))
-            throw new IllegalArgumentException("HollowSetTypeReadState cannot calculate checksum with unequal schemas: " + getSchema().getName());
-        
+        if (!getSchema().equals(withSchema)) {
+            // Apply checksum if one or other schema does not declare a hash key
+            if (getSchema().getHashKey() != null &&
+                    (!(withSchema instanceof HollowSetSchema) || ((HollowSetSchema) withSchema).getHashKey() != null)) {
+                throw new IllegalArgumentException(
+                        "HollowSetTypeReadState cannot calculate checksum with unequal schemas: " + getSchema()
+                                .getName());
+            }
+        }
+
         BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
 
         for(int i=0;i<shards.length;i++)
@@ -273,8 +280,10 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
 	}
 	
 	public void buildKeyDeriver() {
-	    if(getSchema().getHashKey() != null)
-	        this.keyDeriver = new HollowPrimaryKeyValueDeriver(getSchema().getHashKey(), getStateEngine());
+        if (getSchema().getHashKey() != null &&
+                getStateEngine().getSchema(getSchema().getElementType()) != null) {
+            this.keyDeriver = new HollowPrimaryKeyValueDeriver(getSchema().getHashKey(), getStateEngine());
+        }
 	    
 	    for(int i=0;i<shards.length;i++)
 	        shards[i].setKeyDeriver(keyDeriver);

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -238,9 +238,8 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
     @Override
     protected void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema) {
         if (!getSchema().equals(withSchema)) {
-            // Apply checksum if one or other schema does not declare a hash key
-            if (getSchema().getHashKey() != null &&
-                    (!(withSchema instanceof HollowSetSchema) || ((HollowSetSchema) withSchema).getHashKey() != null)) {
+            // Apply checksum if withSchema does not declare a hash key
+            if (getSchema().getHashKey() != null && !getSchema().withoutKeys().equals(withSchema)) {
                 throw new IllegalArgumentException(
                         "HollowSetTypeReadState cannot calculate checksum with unequal schemas: " + getSchema()
                                 .getName());

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -239,7 +239,7 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
     protected void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema) {
         if (!getSchema().equals(withSchema)) {
             // Apply checksum if withSchema does not declare a hash key
-            if (getSchema().getHashKey() != null && !getSchema().withoutKeys().equals(withSchema)) {
+            if (getSchema().getHashKey() != null && !getSchema().withoutHashKey().equals(withSchema)) {
                 throw new IllegalArgumentException(
                         "HollowSetTypeReadState cannot calculate checksum with unequal schemas: " + getSchema()
                                 .getName());

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowMapSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowMapSchema.java
@@ -22,6 +22,7 @@ import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Arrays;
 
 /**
  * A schema for a Map record type
@@ -44,7 +45,13 @@ public class HollowMapSchema extends HollowSchema {
         super(schemaName);
         this.keyType = keyType;
         this.valueType = valueType;
-        this.hashKey = hashKeyFieldPaths == null || hashKeyFieldPaths.length == 0 ? null : new PrimaryKey(keyType, hashKeyFieldPaths);
+        if (hashKeyFieldPaths == null || hashKeyFieldPaths.length == 0) {
+            this.hashKey = null;
+        } else if (Arrays.equals(ORDINAL_HASH_KEY_FIELD_NAMES, hashKeyFieldPaths)) {
+            this.hashKey = HollowCollectionSchema.ORDINAL_PRIMARY_KEY;
+        } else {
+            this.hashKey = new PrimaryKey(keyType, hashKeyFieldPaths);
+        }
     }
 
     public String getKeyType() {
@@ -56,7 +63,7 @@ public class HollowMapSchema extends HollowSchema {
     }
 
     public PrimaryKey getHashKey() {
-        return hashKey;
+        return hashKey == ORDINAL_PRIMARY_KEY ? null : hashKey;
     }
 
     public HollowTypeReadState getKeyTypeState() {
@@ -80,6 +87,14 @@ public class HollowMapSchema extends HollowSchema {
         return SchemaType.MAP;
     }
 
+    public HollowMapSchema withoutKeys() {
+        if (hashKey == null) {
+            return this;
+        }
+
+        return new HollowMapSchema(getName(), getKeyType(), getValueType());
+    }
+
     @Override
     public boolean equals(Object other) {
         if(!(other instanceof HollowMapSchema))
@@ -92,7 +107,7 @@ public class HollowMapSchema extends HollowSchema {
         if(!getValueType().equals(otherSchema.getValueType()))
             return false;
 
-        return isNullableObjectEquals(hashKey, otherSchema.getHashKey());
+        return isNullableObjectEquals(getHashKey(), otherSchema.getHashKey());
     }
 
     @Override
@@ -102,7 +117,7 @@ public class HollowMapSchema extends HollowSchema {
 
         if(hashKey != null) {
             builder.append(" @HashKey(");
-            if(hashKey.numFields() > 0) {
+            if(hashKey != ORDINAL_PRIMARY_KEY) {
                 builder.append(hashKey.getFieldPath(0));
                 for(int i=1;i<hashKey.numFields();i++) {
                     builder.append(", ").append(hashKey.getFieldPath(i));
@@ -119,7 +134,7 @@ public class HollowMapSchema extends HollowSchema {
     public void writeTo(OutputStream os) throws IOException {
         DataOutputStream dos = new DataOutputStream(os);
 
-        if(getHashKey() != null)
+        if(hashKey != null)
             dos.write(SchemaType.MAP.getTypeIdWithPrimaryKey());
         else
             dos.write(SchemaType.MAP.getTypeId());
@@ -128,12 +143,13 @@ public class HollowMapSchema extends HollowSchema {
         dos.writeUTF(getKeyType());
         dos.writeUTF(getValueType());
 
-        if(getHashKey() != null) {
+        if (hashKey == ORDINAL_PRIMARY_KEY) {
+            VarInt.writeVInt(dos, 0);
+        } else if (hashKey != null) {
             VarInt.writeVInt(dos, getHashKey().numFields());
             for(int i=0;i<getHashKey().numFields();i++) {
                 dos.writeUTF(getHashKey().getFieldPath(i));
             }
         }
     }
-
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchema.java
@@ -46,12 +46,6 @@ import java.io.OutputStream;
  */
 public abstract class HollowSchema {
 
-    /**
-     * A constant that may be passed as an argument to the constructor of {@link HollowSetSchema} or
-     * {@link HollowMapSchema} to indicate that ordinals should be utilized as hash codes.
-     */
-    public static final String[] ORDINAL_HASH_KEY_FIELD_NAMES = {};
-
     private final String name;
 
     public HollowSchema(String name) {
@@ -69,9 +63,9 @@ public abstract class HollowSchema {
     public static HollowSchema withoutKeys(HollowSchema schema) {
         switch(schema.getSchemaType()) {
         case SET:
-            return ((HollowSetSchema)schema).withoutKeys();
+            return ((HollowSetSchema)schema).withoutHashKey();
         case MAP:
-            return ((HollowMapSchema)schema).withoutKeys();
+            return ((HollowMapSchema)schema).withoutHashKey();
         default:
             return schema;
         }
@@ -128,13 +122,9 @@ public abstract class HollowSchema {
 
         if(hasHashKey) {
             int numFields = VarInt.readVInt(is);
-            if (numFields > 0) {
-                hashKeyFields = new String[numFields];
-                for (int i = 0; i < numFields; i++) {
-                    hashKeyFields[i] = is.readUTF();
-                }
-            } else {
-                hashKeyFields = HollowSchema.ORDINAL_HASH_KEY_FIELD_NAMES;
+            hashKeyFields = new String[numFields];
+            for (int i = 0; i < numFields; i++) {
+                hashKeyFields[i] = is.readUTF();
             }
         }
 
@@ -155,13 +145,9 @@ public abstract class HollowSchema {
 
         if(hasHashKey) {
             int numFields = VarInt.readVInt(is);
-            if (numFields > 0) {
-                hashKeyFields = new String[numFields];
-                for (int i = 0; i < numFields; i++) {
-                    hashKeyFields[i] = is.readUTF();
-                }
-            } else {
-                hashKeyFields = HollowSchema.ORDINAL_HASH_KEY_FIELD_NAMES;
+            hashKeyFields = new String[numFields];
+            for (int i = 0; i < numFields; i++) {
+                hashKeyFields[i] = is.readUTF();
             }
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchema.java
@@ -16,7 +16,6 @@
  */
 package com.netflix.hollow.core.schema;
 
-import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.io.DataInputStream;
@@ -48,22 +47,10 @@ import java.io.OutputStream;
 public abstract class HollowSchema {
 
     /**
-     * A special constant for determining if a hollow set or map schema supports a hash key
-     * for ordinal values.
+     * A constant that may be passed as an argument to the constructor of {@link HollowSetSchema} or
+     * {@link HollowMapSchema} to indicate that ordinals should be utilized as hash codes.
      */
-    static final String ORDINAL_HASH_KEY_FIELD_NAME = "0rdinal";
-
-    /**
-     * A special constant for determining if a hollow set or map schema supports a hash key
-     * for ordinal values.
-     */
-    static final String[] ORDINAL_HASH_KEY_FIELD_NAMES = { ORDINAL_HASH_KEY_FIELD_NAME };
-
-    /**
-     * A special constant for determining if a hollow set or map schema supports a hash key
-     * for ordinal values.
-     */
-    static final PrimaryKey ORDINAL_PRIMARY_KEY = new PrimaryKey(ORDINAL_HASH_KEY_FIELD_NAME, ORDINAL_HASH_KEY_FIELD_NAMES);
+    public static final String[] ORDINAL_HASH_KEY_FIELD_NAMES = {};
 
     private final String name;
 

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaParser.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaParser.java
@@ -201,11 +201,15 @@ public class HollowSchemaParser {
             throw new IOException("Invalid Syntax: Expected '>' element type declaration: " + typeName);
 
         tok = tokenizer.nextToken();
-        String hashKeyPaths[] = parseHashKey(tokenizer);
+        String[] hashKeyPaths = parseHashKey(tokenizer);
 
         if(tokenizer.ttype != ';')
             throw new IOException("Invalid Syntax: Expected semicolon after Set schema declaration: " + typeName);
 
+
+        if (hashKeyPaths.length == 0) {
+            hashKeyPaths = HollowSchema.ORDINAL_HASH_KEY_FIELD_NAMES;
+        }
         return new HollowSetSchema(typeName, elementType, hashKeyPaths);
     }
 
@@ -238,11 +242,14 @@ public class HollowSchemaParser {
             throw new IOException("Invalid Syntax: Expected '>' after value type declaration: " + typeName);
 
         tok = tokenizer.nextToken();
-        String hashKeyPaths[] = parseHashKey(tokenizer);
+        String[] hashKeyPaths = parseHashKey(tokenizer);
 
         if(tokenizer.ttype != ';')
             throw new IOException("Invalid Syntax: Expected semicolon after Map schema declaration: " + typeName);
 
+        if (hashKeyPaths.length == 0) {
+            hashKeyPaths = HollowSchema.ORDINAL_HASH_KEY_FIELD_NAMES;
+        }
         return new HollowMapSchema(typeName, keyType, valueType, hashKeyPaths);
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaParser.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaParser.java
@@ -207,9 +207,6 @@ public class HollowSchemaParser {
             throw new IOException("Invalid Syntax: Expected semicolon after Set schema declaration: " + typeName);
 
 
-        if (hashKeyPaths.length == 0) {
-            hashKeyPaths = HollowSchema.ORDINAL_HASH_KEY_FIELD_NAMES;
-        }
         return new HollowSetSchema(typeName, elementType, hashKeyPaths);
     }
 
@@ -247,9 +244,6 @@ public class HollowSchemaParser {
         if(tokenizer.ttype != ';')
             throw new IOException("Invalid Syntax: Expected semicolon after Map schema declaration: " + typeName);
 
-        if (hashKeyPaths.length == 0) {
-            hashKeyPaths = HollowSchema.ORDINAL_HASH_KEY_FIELD_NAMES;
-        }
         return new HollowMapSchema(typeName, keyType, valueType, hashKeyPaths);
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSetSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSetSchema.java
@@ -35,7 +35,6 @@ import java.util.Objects;
 public class HollowSetSchema extends HollowCollectionSchema {
 
     private final String elementType;
-    private final boolean ordinalHashKey;
     private final PrimaryKey hashKey;
 
     private HollowTypeReadState elementTypeState;
@@ -48,23 +47,15 @@ public class HollowSetSchema extends HollowCollectionSchema {
      * @param hashKeyFieldPaths the field paths of the hash key applied to a set of this schema.
      * If {@code null} or empty then the schema has no hash key and the hash function, applied to
      * an element of a set to produce a hash code, is unspecified by this schema.
-     * If of the constant {@link HollowSchema#ORDINAL_HASH_KEY_FIELD_NAMES} then schema has no hash key
-     * but the hash function, applied to an element of a set to produce a hash code, is specified to be a
-     * function that returns the element's ordinal.
      * Otherwise, the hash function is specified as described by
      * {@link com.netflix.hollow.core.write.objectmapper.HollowHashKey}.
      */
     public HollowSetSchema(String schemaName, String elementType, String... hashKeyFieldPaths) {
         super(schemaName);
         this.elementType = elementType;
-        if (hashKeyFieldPaths == ORDINAL_HASH_KEY_FIELD_NAMES) {
-            this.ordinalHashKey = true;
-            this.hashKey = null;
-        } else if (hashKeyFieldPaths == null || hashKeyFieldPaths.length == 0) {
-            this.ordinalHashKey = false;
+        if (hashKeyFieldPaths == null || hashKeyFieldPaths.length == 0) {
             this.hashKey = null;
         } else {
-            this.ordinalHashKey = false;
             this.hashKey = new PrimaryKey(elementType, hashKeyFieldPaths);
         }
     }
@@ -92,8 +83,8 @@ public class HollowSetSchema extends HollowCollectionSchema {
         return SchemaType.SET;
     }
 
-    public HollowSetSchema withoutKeys() {
-        if (hashKey == null && !ordinalHashKey) {
+    public HollowSetSchema withoutHashKey() {
+        if (hashKey == null) {
             return this;
         }
 
@@ -109,8 +100,6 @@ public class HollowSetSchema extends HollowCollectionSchema {
             return false;
         if(!getElementType().equals(otherSchema.getElementType()))
             return false;
-        if(ordinalHashKey != otherSchema.ordinalHashKey)
-            return false;
 
         return Objects.equals(getHashKey(), otherSchema.getHashKey());
     }
@@ -120,13 +109,11 @@ public class HollowSetSchema extends HollowCollectionSchema {
         StringBuilder builder = new StringBuilder(getName());
         builder.append(" Set<").append(getElementType()).append(">");
 
-        if(hashKey != null || ordinalHashKey) {
+        if(hashKey != null) {
             builder.append(" @HashKey(");
-            if(hashKey != null) {
-                builder.append(hashKey.getFieldPath(0));
-                for(int i=1;i<hashKey.numFields();i++) {
-                    builder.append(", ").append(hashKey.getFieldPath(i));
-                }
+            builder.append(hashKey.getFieldPath(0));
+            for(int i=1;i<hashKey.numFields();i++) {
+                builder.append(", ").append(hashKey.getFieldPath(i));
             }
             builder.append(")");
         }
@@ -139,7 +126,7 @@ public class HollowSetSchema extends HollowCollectionSchema {
     public void writeTo(OutputStream os) throws IOException {
         DataOutputStream dos = new DataOutputStream(os);
 
-        if (hashKey != null || ordinalHashKey)
+        if (hashKey != null)
             dos.write(SchemaType.SET.getTypeIdWithPrimaryKey());
         else
             dos.write(SchemaType.SET.getTypeId());
@@ -147,9 +134,7 @@ public class HollowSetSchema extends HollowCollectionSchema {
         dos.writeUTF(getName());
         dos.writeUTF(getElementType());
 
-        if (ordinalHashKey) {
-            VarInt.writeVInt(dos, 0);
-        } else if (hashKey != null) {
+        if (hashKey != null) {
             VarInt.writeVInt(dos, hashKey.numFields());
             for (int i = 0; i < getHashKey().numFields(); i++) {
                 dos.writeUTF(getHashKey().getFieldPath(i));

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -17,6 +17,7 @@
 package com.netflix.hollow.core.write.objectmapper;
 
 import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.write.HollowMapTypeWriteState;
 import com.netflix.hollow.core.write.HollowMapWriteRecord;
@@ -55,7 +56,7 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
             hashKeyFieldPaths = ((HollowObjectTypeMapper)keyMapper).getDefaultElementHashKey();
 
         if (hashKeyFieldPaths != null && hashKeyFieldPaths.length == 0) {
-            hashKeyFieldPaths = ORDINAL_HASH_KEY_FIELD_NAMES;
+            hashKeyFieldPaths = HollowSchema.ORDINAL_HASH_KEY_FIELD_NAMES;
         }
         this.schema = new HollowMapSchema(typeName, keyMapper.getTypeName(), valueMapper.getTypeName(), hashKeyFieldPaths);
         this.hashCodeFinder = stateEngine.getHashCodeFinder();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -17,7 +17,6 @@
 package com.netflix.hollow.core.write.objectmapper;
 
 import com.netflix.hollow.core.schema.HollowMapSchema;
-import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.write.HollowMapTypeWriteState;
 import com.netflix.hollow.core.write.HollowMapWriteRecord;
@@ -55,9 +54,6 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
         if(hashKeyFieldPaths == null && useDefaultHashKeys && (keyMapper instanceof HollowObjectTypeMapper))
             hashKeyFieldPaths = ((HollowObjectTypeMapper)keyMapper).getDefaultElementHashKey();
 
-        if (hashKeyFieldPaths != null && hashKeyFieldPaths.length == 0) {
-            hashKeyFieldPaths = HollowSchema.ORDINAL_HASH_KEY_FIELD_NAMES;
-        }
         this.schema = new HollowMapSchema(typeName, keyMapper.getTypeName(), valueMapper.getTypeName(), hashKeyFieldPaths);
         this.hashCodeFinder = stateEngine.getHashCodeFinder();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -53,7 +53,10 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
         
         if(hashKeyFieldPaths == null && useDefaultHashKeys && (keyMapper instanceof HollowObjectTypeMapper))
             hashKeyFieldPaths = ((HollowObjectTypeMapper)keyMapper).getDefaultElementHashKey();
-        
+
+        if (hashKeyFieldPaths != null && hashKeyFieldPaths.length == 0) {
+            hashKeyFieldPaths = ORDINAL_HASH_KEY_FIELD_NAMES;
+        }
         this.schema = new HollowMapSchema(typeName, keyMapper.getTypeName(), valueMapper.getTypeName(), hashKeyFieldPaths);
         this.hashCodeFinder = stateEngine.getHashCodeFinder();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.hollow.core.write.objectmapper;
 
+import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.write.HollowSetTypeWriteState;
@@ -49,7 +50,7 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
             hashKeyFieldPaths = ((HollowObjectTypeMapper)elementMapper).getDefaultElementHashKey();
 
         if (hashKeyFieldPaths != null && hashKeyFieldPaths.length == 0) {
-            hashKeyFieldPaths = ORDINAL_HASH_KEY_FIELD_NAMES;
+            hashKeyFieldPaths = HollowSchema.ORDINAL_HASH_KEY_FIELD_NAMES;
         }
         this.schema = new HollowSetSchema(typeName, elementMapper.getTypeName(), hashKeyFieldPaths);
         this.hashCodeFinder = stateEngine.getHashCodeFinder();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -16,7 +16,6 @@
  */
 package com.netflix.hollow.core.write.objectmapper;
 
-import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.write.HollowSetTypeWriteState;
@@ -49,9 +48,6 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
         if(hashKeyFieldPaths == null && useDefaultHashKeys && (elementMapper instanceof HollowObjectTypeMapper))
             hashKeyFieldPaths = ((HollowObjectTypeMapper)elementMapper).getDefaultElementHashKey();
 
-        if (hashKeyFieldPaths != null && hashKeyFieldPaths.length == 0) {
-            hashKeyFieldPaths = HollowSchema.ORDINAL_HASH_KEY_FIELD_NAMES;
-        }
         this.schema = new HollowSetSchema(typeName, elementMapper.getTypeName(), hashKeyFieldPaths);
         this.hashCodeFinder = stateEngine.getHashCodeFinder();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -47,7 +47,10 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
         
         if(hashKeyFieldPaths == null && useDefaultHashKeys && (elementMapper instanceof HollowObjectTypeMapper))
             hashKeyFieldPaths = ((HollowObjectTypeMapper)elementMapper).getDefaultElementHashKey();
-        
+
+        if (hashKeyFieldPaths != null && hashKeyFieldPaths.length == 0) {
+            hashKeyFieldPaths = ORDINAL_HASH_KEY_FIELD_NAMES;
+        }
         this.schema = new HollowSetSchema(typeName, elementMapper.getTypeName(), hashKeyFieldPaths);
         this.hashCodeFinder = stateEngine.getHashCodeFinder();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeMapper.java
@@ -29,12 +29,6 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class HollowTypeMapper {
-    /**
-     * A special constant for determining if a hollow set or map schema supports a hash key
-     * for ordinal values.
-     */
-    static final String[] ORDINAL_HASH_KEY_FIELD_NAMES = { "0rdinal" };
-
     public static final long ASSIGNED_ORDINAL_CYCLE_MASK = 0xFFFFFFFF00000000L;
 
     private final ThreadLocal<HollowWriteRecord> writeRec = new ThreadLocal<>();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeMapper.java
@@ -29,6 +29,11 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class HollowTypeMapper {
+    /**
+     * A special constant for determining if a hollow set or map schema supports a hash key
+     * for ordinal values.
+     */
+    static final String[] ORDINAL_HASH_KEY_FIELD_NAMES = { "0rdinal" };
 
     public static final long ASSIGNED_ORDINAL_CYCLE_MASK = 0xFFFFFFFF00000000L;
 

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/TestHashKey.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/TestHashKey.java
@@ -1,0 +1,663 @@
+package com.netflix.hollow.api.producer;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.objects.HollowMap;
+import com.netflix.hollow.api.objects.HollowSet;
+import com.netflix.hollow.api.objects.delegate.HollowMapLookupDelegate;
+import com.netflix.hollow.api.objects.delegate.HollowSetLookupDelegate;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.read.dataaccess.HollowMapTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowSetTypeDataAccess;
+import com.netflix.hollow.core.read.engine.HollowBlobReader;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.engine.map.HollowMapTypeReadState;
+import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
+import com.netflix.hollow.core.read.engine.set.HollowSetTypeReadState;
+import com.netflix.hollow.core.read.filter.HollowFilterConfig;
+import com.netflix.hollow.core.read.iterator.HollowMapEntryOrdinalIterator;
+import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchemaParser;
+import com.netflix.hollow.core.schema.HollowSetSchema;
+import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowHashKey;
+import com.netflix.hollow.core.write.objectmapper.HollowInline;
+import com.netflix.hollow.tools.filter.FilteredHollowBlobWriter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestHashKey {
+    private InMemoryBlobStore blobStore;
+
+    @Before
+    public void setup() {
+        blobStore = new InMemoryBlobStore();
+    }
+
+    /**
+     * Tests that a set or map declared with a hash key with empty fields, for ordinal lookup,
+     * is preserved in the schema.
+     */
+    @Test
+    public void testSchemaPreserve() throws Exception {
+        HollowProducer p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = p.runCycle(ws -> {
+            ws.add(new TopWithOrdinals(IntStream.range(0, 100).mapToObj(Integer::toString).toArray(String[]::new)));
+        });
+
+        HollowWriteStateEngine w = p.getWriteEngine();
+        Assert.assertTrue(w.getSchema("SetOfBoxString")
+                .toString().contains("@HashKey()"));
+        Assert.assertTrue(w.getSchema("MapOfBoxStringToBoxString")
+                .toString().contains("@HashKey()"));
+
+
+        HollowReadStateEngine r = new HollowReadStateEngine();
+        HollowBlobReader br = new HollowBlobReader(r);
+        br.readSnapshot(blobStore.retrieveSnapshotBlob(v1).getInputStream());
+
+        Assert.assertTrue(r.getSchema("SetOfBoxString")
+                .toString().contains("@HashKey()"));
+        Assert.assertTrue(r.getSchema("MapOfBoxStringToBoxString")
+                .toString().contains("@HashKey()"));
+
+
+        long v2 = p.runCycle(ws -> {
+            ws.add(new TopWithOrdinals(IntStream.range(0, 101).mapToObj(Integer::toString).toArray(String[]::new)));
+        });
+
+
+        br.applyDelta(blobStore.retrieveDeltaBlob(v1).getInputStream());
+
+        Assert.assertTrue(r.getSchema("SetOfBoxString")
+                .toString().contains("@HashKey()"));
+        Assert.assertTrue(r.getSchema("MapOfBoxStringToBoxString")
+                .toString().contains("@HashKey()"));
+
+
+        // Test without keys
+
+        Assert.assertFalse(((HollowSetSchema)r.getSchema("SetOfBoxString")).withoutKeys()
+                .toString().contains("@HashKey()"));
+        Assert.assertFalse(((HollowMapSchema)r.getSchema("MapOfBoxStringToBoxString")).withoutKeys()
+                .toString().contains("@HashKey()"));
+
+        Assert.assertFalse(HollowSchema.withoutKeys(r.getSchema("SetOfBoxString"))
+                .toString().contains("@HashKey()"));
+        Assert.assertFalse(HollowSchema.withoutKeys(r.getSchema("MapOfBoxStringToBoxString"))
+                .toString().contains("@HashKey()"));
+    }
+
+    /**
+     * Tests that the schema for a set or map declared with a hash key with empty fields, for ordinal lookup,
+     * can be parsed.
+     */
+    @Test
+    public void testSchemasParse() throws Exception {
+        HollowProducer p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = p.runCycle(ws -> {
+            ws.add(new TopWithOrdinals(IntStream.range(0, 100).mapToObj(Integer::toString).toArray(String[]::new)));
+        });
+
+        StringBuilder sb = new StringBuilder();
+        for (HollowSchema s : p.getWriteEngine().getSchemas()) {
+            sb.append(s.toString()).append("\n");
+        }
+
+        Map<String, HollowSchema> schema = HollowSchemaParser.parseCollectionOfSchemas(sb.toString()).stream().collect(
+                toMap(HollowSchema::getName, s -> s));
+
+        Assert.assertTrue(schema.get("SetOfBoxString")
+                .toString().contains("@HashKey()"));
+        Assert.assertTrue(schema.get("MapOfBoxStringToBoxString")
+                .toString().contains("@HashKey()"));
+    }
+
+    /**
+     * Tests that a set or map declared with a hash key with empty fields, for ordinal lookup
+     * overriding the write state useDefaultHashKeys, hashes using ordinal values rather than
+     * a key derived from the element type or key type.
+     */
+    @Test
+    public void testHashOrdinals() throws Exception {
+        HollowProducer p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = p.runCycle(ws -> {
+            ws.add(new TopWithOrdinals(IntStream.range(0, 100).mapToObj(Integer::toString).toArray(String[]::new)));
+        });
+
+        HollowReadStateEngine r = new HollowReadStateEngine();
+        HollowBlobReader br = new HollowBlobReader(r);
+        br.readSnapshot(blobStore.retrieveSnapshotBlob(v1).getInputStream());
+
+        HollowObjectTypeReadState boxString = (HollowObjectTypeReadState) r.getTypeState("BoxString");
+        HollowSetTypeReadState set = (HollowSetTypeReadState) r.getTypeState("SetOfBoxString");
+        HollowMapTypeReadState map = (HollowMapTypeReadState) r.getTypeState("MapOfBoxStringToBoxString");
+
+        int size = boxString.getPopulatedOrdinals().cardinality();
+
+        // Iterate through the ordinals using potentialMatchOrdinalIterator which should
+        // find the matching ordinal but not necessarily on first iteration
+        // (if there are hash collisions)
+
+        // Test the element ordinals of the set
+        for (int ordinal = 0; ordinal < size; ordinal++) {
+            HollowOrdinalIterator iter = set.potentialMatchOrdinalIterator(0, ordinal);
+            int potentialOrdinal;
+            while ((potentialOrdinal = iter.next()) != HollowOrdinalIterator.NO_MORE_ORDINALS) {
+                if (potentialOrdinal == ordinal) {
+                    break;
+                }
+            }
+            Assert.assertEquals(ordinal, potentialOrdinal);
+        }
+
+        // Test the key ordinals of the map
+        for (int ordinal = 0; ordinal < size; ordinal++) {
+            HollowMapEntryOrdinalIterator iter = map.potentialMatchOrdinalIterator(0, ordinal);
+            int potentialOrdinal = HollowOrdinalIterator.NO_MORE_ORDINALS;
+            while (iter.next()) {
+                potentialOrdinal = iter.getKey();
+                if (potentialOrdinal == ordinal) {
+                    break;
+                }
+            }
+            Assert.assertEquals(ordinal, potentialOrdinal);
+        }
+    }
+
+    /**
+     * Tests that a snapshot filtered to remove a type can be read if the
+     * type is the element type of a set or a key type of a map that declares
+     * a hash key and the set or map is not removed.
+     */
+    @Test
+    public void testHashFilter() throws Exception {
+        HollowProducer p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = p.runCycle(ws -> {
+            ws.add(new Top("One", "Two"));
+        });
+
+        HollowFilterConfig filterConfig = new HollowFilterConfig(true);
+        filterConfig.addType("BoxString");
+        FilteredHollowBlobWriter fbw = new FilteredHollowBlobWriter(filterConfig);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        fbw.filterSnapshot(blobStore.retrieveSnapshotBlob(v1).getInputStream(), baos);
+
+        HollowReadStateEngine r = new HollowReadStateEngine();
+        HollowBlobReader br = new HollowBlobReader(r);
+        br.readSnapshot(new ByteArrayInputStream(baos.toByteArray()));
+    }
+
+    /**
+     * Tests the transition from HollowObjectHashCodeFinder to HollowHashKey.
+     * Specifically a snapshot generated using HollowObjectHashCodeFinder can be
+     * used to restore state from which a new snapshot is generated using HollowHashKey.
+     */
+    @Test
+    public void testTransitionWithRestore() throws Exception {
+        HollowProducer p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+        p.getObjectMapper().doNotUseDefaultHashKeys();
+        setHashCodeFinder(p.getWriteEngine(), new CustomHashCodeFinder());
+
+        long v1 = p.runCycle(ws -> {
+            ws.add(new Top(
+                    IntStream.range(0, 100).mapToObj(Integer::toString).collect(toList()),
+                    IntStream.range(0, 100).boxed().collect(toList()),
+                    LongStream.range(Integer.MAX_VALUE, Integer.MAX_VALUE + 100L).boxed().collect(toList())
+            ));
+        });
+
+        p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+        p.initializeDataModel(Top.class);
+        p.restore(v1, blobStore);
+
+        // Checksum should fail if hash algorithm differs between v1 and v2
+        long v2 = p.runCycle(ws -> {
+            ws.add(new Top(
+                    IntStream.range(0, 101).mapToObj(Integer::toString).collect(toList()),
+                    IntStream.range(0, 101).boxed().collect(toList()),
+                    LongStream.range(Integer.MAX_VALUE, Integer.MAX_VALUE + 101L).boxed().collect(toList())
+            ));
+        });
+
+
+        // Although checksum should pass check the ordinals
+
+        HollowReadStateEngine r = new HollowReadStateEngine();
+        HollowBlobReader br = new HollowBlobReader(r);
+        br.readSnapshot(blobStore.retrieveSnapshotBlob(v2).getInputStream());
+
+        HollowObjectTypeReadState boxString = (HollowObjectTypeReadState) r.getTypeState("BoxString");
+        HollowSetTypeReadState set = (HollowSetTypeReadState) r.getTypeState("SetOfBoxString");
+        HollowMapTypeReadState map = (HollowMapTypeReadState) r.getTypeState("MapOfBoxStringToBoxString");
+
+        // Iterate through the ordinals using potentialMatchOrdinalIterator which should
+        // find the matching ordinal but not necessarily on first iteration
+        // (if there are hash collisions)
+
+        Map<Integer, String> boxStringOrdinalMap = boxString.getPopulatedOrdinals().stream().boxed().collect(
+                toMap(o -> o,
+                        o -> boxString.readString(o, 0)));
+
+        boxStringOrdinalMap.forEach((ordinal, string) -> {
+            HollowOrdinalIterator iter = set.potentialMatchOrdinalIterator(1, string.hashCode());
+            int potentialOrdinal;
+            while ((potentialOrdinal = iter.next()) != HollowOrdinalIterator.NO_MORE_ORDINALS) {
+                if (potentialOrdinal == ordinal) {
+                    break;
+                }
+            }
+            Assert.assertEquals((int) ordinal, potentialOrdinal);
+        });
+
+        boxStringOrdinalMap.forEach((ordinal, string) -> {
+            HollowMapEntryOrdinalIterator iter = map.potentialMatchOrdinalIterator(1, string.hashCode());
+            int potentialOrdinal = -1;
+            while (iter.next()) {
+                potentialOrdinal = iter.getKey();
+                if (potentialOrdinal == ordinal) {
+                    break;
+                }
+            }
+            Assert.assertEquals((int) ordinal, potentialOrdinal);
+        });
+    }
+
+    /**
+     * Tests that a produce fails with a checksum failure.
+     * The HollowObjectHashCodeFinder returns bogus hash codes causing failure.
+     */
+    @Test(expected = HollowProducer.ChecksumValidationException.class)
+    public void testTransitionWithRestoreFail() throws Exception {
+        HollowProducer p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+        p.getObjectMapper().doNotUseDefaultHashKeys();
+        setHashCodeFinder(p.getWriteEngine(), new CustomHashCodeFinder() {
+            @Override public int hashCode(String typeName, int ordinal, Object objectToHash) {
+                // Hash differs from @HollowHashKey hash
+                return 0;
+            }
+        });
+
+        long v1 = p.runCycle(ws -> {
+            ws.add(new Top(
+                    IntStream.range(0, 100).mapToObj(Integer::toString).collect(toList()),
+                    IntStream.range(0, 100).boxed().collect(toList()),
+                    LongStream.range(Integer.MAX_VALUE, Integer.MAX_VALUE + 100L).boxed().collect(toList())
+            ));
+        });
+
+        p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+        p.initializeDataModel(Top.class);
+        p.restore(v1, blobStore);
+
+        // Checksum should fail if hash algorithm differs between v1 and v2
+        long v2 = p.runCycle(ws -> {
+            ws.add(new Top(
+                    IntStream.range(0, 101).mapToObj(Integer::toString).collect(toList()),
+                    IntStream.range(0, 101).boxed().collect(toList()),
+                    LongStream.range(Integer.MAX_VALUE, Integer.MAX_VALUE + 101L).boxed().collect(toList())
+            ));
+        });
+    }
+
+    static void setHashCodeFinder(HollowWriteStateEngine e, HollowObjectHashCodeFinder f) throws Exception {
+        Field hashCodeFinder = e.getClass().getDeclaredField("hashCodeFinder");
+        hashCodeFinder.setAccessible(true);
+        hashCodeFinder.set(e, f);
+    }
+
+    /**
+     * Tests that a client can override the hash key in the schema and use its own
+     * HollowObjectHashCodeFinder when operating on sets or maps.
+     * The HollowObjectHashCodeFinder returns bogus hash codes causing failure to find
+     * elements or keys.
+     */
+    @Test
+    public void testClientFail() throws Exception {
+        HollowProducer p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = p.runCycle(ws -> {
+            ws.add(new Top(IntStream.range(0, 100).mapToObj(Integer::toString).toArray(String[]::new)));
+        });
+
+        HollowReadStateEngine r = new HollowReadStateEngine(new CustomHashCodeFinder() {
+            @Override public int hashCode(Object objectToHash) {
+                // Hash differs from @HollowHashKey hash
+                return 0;
+            }
+        });
+        HollowBlobReader br = new HollowBlobReader(r);
+        br.readSnapshot(blobStore.retrieveSnapshotBlob(v1).getInputStream());
+
+        SetOfBoxString s = new SetOfBoxString(r, 0);
+        Assert.assertTrue(IntStream.range(0, s.size()).
+                anyMatch(i -> !s.contains(new BoxString(Integer.toString(i)))));
+
+        MapOfBoxStringToBoxString m = new MapOfBoxStringToBoxString(r, 0);
+        Assert.assertTrue(IntStream.range(0, m.size()).
+                anyMatch(i -> !m.containsKey(new BoxString(Integer.toString(i)))));
+    }
+
+    /**
+     * Tests that a client can override the hash key in the schema and use its own
+     * HollowObjectHashCodeFinder when operating on sets or maps.
+     */
+    @Test
+    public void testClient() throws Exception {
+        testClient(true);
+        testClient(false);
+    }
+
+    void testClient(boolean override) throws Exception {
+        HollowProducer p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = p.runCycle(ws -> {
+            ws.add(new Top(IntStream.range(0, 100).mapToObj(Integer::toString).toArray(String[]::new)));
+        });
+
+        HollowReadStateEngine r = override
+                ? new HollowReadStateEngine(new CustomHashCodeFinder())
+                : new HollowReadStateEngine();
+        HollowBlobReader br = new HollowBlobReader(r);
+        br.readSnapshot(blobStore.retrieveSnapshotBlob(v1).getInputStream());
+
+        checkSchema(r, override);
+        checkContent(r);
+
+        long v2 = p.runCycle(ws -> {
+            ws.add(new Top(IntStream.range(0, 101).mapToObj(Integer::toString).toArray(String[]::new)));
+        });
+
+        br.applyDelta(blobStore.retrieveDeltaBlob(v1).getInputStream());
+
+        checkSchema(r, override);
+        checkContent(r);
+    }
+
+    static void checkContent(HollowReadStateEngine r) {
+        SetOfBoxString s = new SetOfBoxString(r, 1);
+        Assert.assertTrue(IntStream.range(0, s.size()).
+                allMatch(i -> s.contains(new BoxString(Integer.toString(i)))));
+
+        MapOfBoxStringToBoxString m = new MapOfBoxStringToBoxString(r, 1);
+        Assert.assertTrue(IntStream.range(0, m.size()).
+                allMatch(i -> m.containsKey(new BoxString(Integer.toString(i)))));
+    }
+
+    static void checkSchema(HollowReadStateEngine r, boolean override) {
+        for (HollowSchema s : r.getSchemas()) {
+            if (s instanceof HollowSetSchema) {
+                HollowSetSchema ss = (HollowSetSchema) s;
+                if (override) {
+                    Assert.assertNull(ss.getHashKey());
+                } else {
+                    Assert.assertNotNull(ss.getHashKey());
+                }
+            } else if (s instanceof HollowMapSchema) {
+                HollowMapSchema ms = (HollowMapSchema) s;
+                if (override) {
+                    Assert.assertNull(ms.getHashKey());
+                } else {
+                    Assert.assertNotNull(ms.getHashKey());
+                }
+            }
+        }
+    }
+
+    static class BoxString {
+        @HollowInline String value;
+
+        BoxString(String value) {
+            this.value = value;
+        }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            BoxString box = (BoxString) o;
+            return Objects.equals(value, box.value);
+        }
+
+        @Override public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+
+    static class SetOfBoxString extends HollowSet<BoxString> {
+        final HollowObjectTypeDataAccess daBoxString;
+
+        SetOfBoxString(HollowReadStateEngine r, int ordinal) {
+            super(getDelegate(r), ordinal);
+            this.daBoxString = (HollowObjectTypeDataAccess) r.getTypeDataAccess("BoxString");
+        }
+
+        @Override public BoxString instantiateElement(int elementOrdinal) {
+            String v = daBoxString.readString(elementOrdinal, 0);
+            return new BoxString(v);
+        }
+
+        @Override public boolean equalsElement(int elementOrdinal, Object testObject) {
+            BoxString v = instantiateElement(elementOrdinal);
+            return v.equals(testObject);
+        }
+
+        static HollowSetLookupDelegate<BoxString> getDelegate(HollowReadStateEngine r) {
+            return new HollowSetLookupDelegate<>((HollowSetTypeDataAccess) r.getTypeDataAccess("SetOfBoxString"));
+        }
+    }
+
+    static class MapOfBoxStringToBoxString extends HollowMap<BoxString, BoxString> {
+        final HollowObjectTypeDataAccess daBoxString;
+
+        MapOfBoxStringToBoxString(HollowReadStateEngine r, int ordinal) {
+            super(getDelegate(r), ordinal);
+            this.daBoxString = (HollowObjectTypeDataAccess) r.getTypeDataAccess("BoxString");
+        }
+
+        @Override public BoxString instantiateKey(int keyOrdinal) {
+            String v = daBoxString.readString(keyOrdinal, 0);
+            return new BoxString(v);
+        }
+
+        @Override public BoxString instantiateValue(int valueOrdinal) {
+            String v = daBoxString.readString(valueOrdinal, 0);
+            return new BoxString(v);
+        }
+
+        @Override public boolean equalsKey(int keyOrdinal, Object testObject) {
+            BoxString v = instantiateKey(keyOrdinal);
+            return v.equals(testObject);
+        }
+
+        @Override public boolean equalsValue(int valueOrdinal, Object testObject) {
+            BoxString v = instantiateValue(valueOrdinal);
+            return v.equals(testObject);
+        }
+
+        static HollowMapLookupDelegate<BoxString, BoxString> getDelegate(HollowReadStateEngine r) {
+            return new HollowMapLookupDelegate<>(
+                    (HollowMapTypeDataAccess) r.getTypeDataAccess("MapOfBoxStringToBoxString"));
+        }
+    }
+
+    static class BoxInt {
+        int value;
+
+        BoxInt(int value) {
+            this.value = value;
+        }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            BoxInt box = (BoxInt) o;
+            return value == box.value;
+        }
+
+        @Override public int hashCode() {
+            return Integer.hashCode(value);
+        }
+    }
+
+    static class BoxLong {
+        long value;
+
+        BoxLong(long value) {
+            this.value = value;
+        }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            BoxLong box = (BoxLong) o;
+            return value == box.value;
+        }
+
+        @Override public int hashCode() {
+            return Long.hashCode(value);
+        }
+    }
+
+    static class Top {
+        final Set<BoxString> setOfStrings;
+        final Map<BoxString, BoxString> mapOfStrings;
+
+        final Set<BoxInt> setOfInts;
+        final Map<BoxInt, BoxInt> mapOfInts;
+
+        final Set<BoxLong> setOfLongs;
+        final Map<BoxLong, BoxLong> mapOfLongs;
+
+        Top(String... setOfStrings) {
+            this.setOfStrings = Stream.of(setOfStrings).map(BoxString::new).collect(Collectors.toSet());
+            this.mapOfStrings = Stream.of(setOfStrings).collect(toMap(BoxString::new, BoxString::new));
+
+            this.setOfInts = Collections.emptySet();
+            this.mapOfInts = Collections.emptyMap();
+
+            this.setOfLongs = Collections.emptySet();
+            this.mapOfLongs = Collections.emptyMap();
+        }
+
+        Top(List<String> strings, List<Integer> ints, List<Long> longs) {
+            this.setOfStrings = strings.stream().map(BoxString::new).collect(Collectors.toSet());
+            this.mapOfStrings = strings.stream().collect(toMap(BoxString::new, BoxString::new));
+
+            this.setOfInts = ints.stream().map(BoxInt::new).collect(Collectors.toSet());
+            this.mapOfInts = ints.stream().collect(toMap(BoxInt::new, BoxInt::new));
+
+            this.setOfLongs = longs.stream().map(BoxLong::new).collect(Collectors.toSet());
+            this.mapOfLongs = longs.stream().collect(toMap(BoxLong::new, BoxLong::new));
+        }
+    }
+
+    static class TopWithOrdinals {
+        @HollowHashKey(fields = {}) final Set<BoxString> strings;
+
+        @HollowHashKey(fields = {}) final Map<BoxString, BoxString> map;
+
+        TopWithOrdinals(String... strings) {
+            this.strings = Stream.of(strings).map(BoxString::new).collect(Collectors.toSet());
+            this.map = Stream.of(strings).collect(toMap(BoxString::new, BoxString::new));
+        }
+    }
+
+    static class CustomHashCodeFinder implements HollowObjectHashCodeFinder {
+        @Override
+        public int hashCode(String typeName, int ordinal, Object objectToHash) {
+            if (typeName.equals("BoxString")) {
+                return ((BoxString) objectToHash).value.hashCode();
+            } else if (typeName.equals("BoxInt")) {
+                return ((BoxInt) objectToHash).value;
+            } else if (typeName.equals("BoxLong")) {
+                return Long.hashCode(((BoxLong) objectToHash).value);
+            } else {
+                return ordinal;
+            }
+        }
+
+        @Override
+        public int hashCode(Object objectToHash) {
+            if (objectToHash instanceof BoxString) {
+                return ((BoxString) objectToHash).value.hashCode();
+            } else if (objectToHash instanceof BoxInt) {
+                return Integer.hashCode(((BoxInt) objectToHash).value);
+            } else if (objectToHash instanceof BoxLong) {
+                return Long.hashCode(((BoxLong) objectToHash).value);
+            } else {
+                throw new IllegalArgumentException();
+            }
+        }
+
+        @Override
+        public Set<String> getTypesWithDefinedHashCodes() {
+            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+                    "BoxString", "BoxInt", "BoxLong"
+            )));
+        }
+
+        @Deprecated
+        @Override
+        public int hashCode(int ordinal, Object objectToHash) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
This pull request contains a number of updates related to the hash code of sets and maps primarily to enable the removal of `HollowObjectHashCodeFinder` and related hash code functionality at least on the producer side and limited use on the client side (specifically to ensure efficient lookup of elements or keys when using `HollowSet` or `HollowMap` until a solution is implemented that can reliably extract a hash key from an object).

- Support `@HollowHashKey` and hash key with empty fields for hollow set and map schema.  This feature can override the application of a default hash key (see `HollowObjectMapper.useDefaultHashKeys` which is true by default) when it is required that ordinals be used as the hash code.

- Allow a consumer to filter out hash keys of set or map schema.  The consumer needs to register an instance of `HollowObjectHashCodeFinder` whose method `getTypesWithDefinedHashCodes` returns a `Set` that contains the element or key type of the set or map schema.  This is a breaking change for an edge case: prior to this change a set/map with a hash key would override that of `HollowObjectHashCodeFinder`.  However, prior to this change it was not expected that a consumer implement `getTypesWithDefinedHashCodes` with anything but an empty set. 

- Ensure a map or set whose element or key type is filtered (or not present) can still be processed.  Any hash key is ignored since the field paths cannot be resolved.

- When performing a checksum calculation for a set or map relax the schema equality check for the hash keys if the schema evolved from no hash key to with a hash key.  This enables a transition from no hash key (the hash is defined externally using `HollowObjectHashCodeFinder`) to a hash key (the hash is defined by the hash key on the schema).

- Ensure a producer can transition (with restoration) from a state where `HollowObjectHashCodeFinder` was used (and where default hash keys were not enabled) to generate hash codes to where `HollowObjectHashCodeFinder` is not used (and where where default hash keys are enabled).  If hash codes are the same in both cases then the checksum calculation performed in the integrity check stage should not fail.