### PR TITLE
Producer cycle and announcement metrics using listeners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,15 +3,10 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.netflixoss' version '6.0.3'
 }
 
 subprojects {
-  apply plugin: 'nebula.netflixoss'
   apply plugin: 'checkstyle'
-
-  sourceCompatibility = 1.8
-  targetCompatibility = 1.8
 
   tasks.withType(JavaCompile) {
     sourceCompatibility = 1.8

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/AbstractRefreshMetricsListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/metrics/AbstractRefreshMetricsListener.java
@@ -85,13 +85,12 @@ public abstract class AbstractRefreshMetricsListener extends AbstractRefreshList
      * that there was an exception, and continuing with the consumer refresh.
      * @param refreshMetrics Consumer refresh metrics being reported
      */
-
     private final void noFailRefreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
         try {
             refreshEndMetricsReporting(refreshMetrics);
         } catch (Exception e) {
             // Metric reporting is not considered critical to consumer refresh. Log exceptions and continue.
-            log.log(Level.WARNING, "Encountered an exception in reporting consumer refresh metrics, ignoring exception and continuing with consumer refresh", e);
+            log.log(Level.SEVERE, "Encountered an exception in reporting consumer refresh metrics, ignoring exception and continuing with consumer refresh", e);
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -212,7 +212,7 @@ public class HollowProducer {
      * Initializes the data model for the given classes.
      * <p>
      * After initialization a data model initialization event will be emitted
-     * to all registered data model initialization
+     * to all registered data model initialization listeners
      * {@link com.netflix.hollow.api.producer.listener.DataModelInitializationListener listeners}.
      *
      * @param classes the data model classes
@@ -231,7 +231,7 @@ public class HollowProducer {
      * Initializes the producer data model for the given schemas.
      * <p>
      * After initialization a data model initialization event will be emitted
-     * to all registered data model initialization
+     * to all registered data model initialization listeners
      * {@link com.netflix.hollow.api.producer.listener.DataModelInitializationListener listeners}.
      *
      * @param schemas the data model classes

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -220,7 +220,7 @@ public class HollowProducer {
      * producer's current data model).
      * <p>
      * After initialization a data model initialization event will be emitted
-     * to all registered data model initialization
+     * to all registered data model initialization listeners
      * {@link com.netflix.hollow.api.producer.listener.DataModelInitializationListener listeners}.
      *
      * @param classes the data model classes
@@ -253,7 +253,7 @@ public class HollowProducer {
      * producer's current data model).
      * <p>
      * After initialization a data model initialization event will be emitted
-     * to all registered data model initialization
+     * to all registered data model initialization listeners
      * {@link com.netflix.hollow.api.producer.listener.DataModelInitializationListener listeners}.
      *
      * @param schemas the data model classes

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListener.java
@@ -1,0 +1,120 @@
+package com.netflix.hollow.api.producer.metrics;
+
+import com.netflix.hollow.api.producer.AbstractHollowProducerListener;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * A class for computing Hollow Producer metrics, that requires extending subclasses to implement custom metrics reporting.
+ * <p>
+ * This class computes Hollow Producer metrics by listening to the stages of a producer's lifecycle. This class implements the
+ * {@code ProducerMetricsReporting} interface which enforces concrete subclasses to implement custom metrics reporting behavior.
+ */
+public abstract class AbstractProducerMetricsListener extends AbstractHollowProducerListener implements
+        ProducerMetricsReporting {
+
+    private CycleMetrics.Builder cycleMetricsBuilder;
+    private AnnouncementMetrics.Builder announcementMetricsBuilder;
+
+    // visible for testing
+    private long consecutiveFailures;
+    OptionalLong lastCycleSuccessTimeNanoOptional;
+    OptionalLong lastAnnouncementSuccessTimeNanoOptional;
+
+
+    public AbstractProducerMetricsListener() {
+        consecutiveFailures = 0l;
+        lastCycleSuccessTimeNanoOptional = OptionalLong.empty();
+        lastAnnouncementSuccessTimeNanoOptional = OptionalLong.empty();
+    }
+
+    @Override
+    public void onCycleStart(long version) {
+        cycleMetricsBuilder = new CycleMetrics.Builder();
+    }
+
+    @Override
+    public void onAnnouncementStart(long version) {
+        announcementMetricsBuilder = new AnnouncementMetrics.Builder();
+    }
+
+    /**
+     * Reports metrics for when cycle is skipped due to reasons such as the producer not being the leader in a multiple-producer setting.
+     * In a multiple producer setting, leader election typically favors long-lived leaders to avoid producer runs from frequently requiring
+     * to reload the full state before publishing data. When a cycle is skipped because the producer wasn't primary, the current value of
+     * no. of consecutive failures and most recent cycle success time are retained, and no cycle status (success or fail) is reported.
+     * @param reason Reason why the run was skipped
+     */
+    @Override
+    public void onCycleSkip(CycleSkipReason reason) {
+        cycleMetricsBuilder
+                .setConsecutiveFailures(consecutiveFailures)
+                .setIsCycleSuccessOptional(Optional.empty())
+                .setCycleDurationMillisOptional(OptionalLong.empty())
+                .setLastCycleSuccessTimeNanoOptional(lastCycleSuccessTimeNanoOptional);
+
+        cycleMetricsReporting(cycleMetricsBuilder.build());
+    }
+
+    /**
+     * Reports announcement-related metrics.
+     * @param status Indicates whether the announcement succeeded of failed
+     * @param readState Hollow data state that is being published, used in this method for computing data size
+     * @param version Version of data that was announced
+     * @param elapsed Announcement start to end duration
+     */
+    @Override
+    public void onAnnouncementComplete(com.netflix.hollow.api.producer.Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+        boolean isAnnouncementSuccess = false;
+        long dataSizeBytes = 0l;
+
+        if (status.getType() == com.netflix.hollow.api.producer.Status.StatusType.SUCCESS) {
+            isAnnouncementSuccess = true;
+            lastAnnouncementSuccessTimeNanoOptional = OptionalLong.of(System.nanoTime());
+        }
+
+        HollowReadStateEngine stateEngine = readState.getStateEngine();
+        dataSizeBytes = stateEngine.calcApproxDataSize();
+
+        announcementMetricsBuilder
+                .setDataSizeBytes(dataSizeBytes)
+                .setIsAnnouncementSuccess(isAnnouncementSuccess)
+                .setAnnouncementDurationMillis(elapsed.toMillis())
+                .setLastAnnouncementSuccessTimeNanoOptional(lastAnnouncementSuccessTimeNanoOptional);
+
+        announcementMetricsReporting(announcementMetricsBuilder.build());
+    }
+
+    /**
+     * On cycle completion this method reports cycle metrics.
+     * @param status Whether the cycle succeeded or failed
+     * @param readState Hollow data state published by cycle, not used here because data size is known from when announcement completed
+     * @param version Version of data that was published in this cycle
+     * @param elapsed Cycle start to end duration
+     */
+    @Override
+    public void onCycleComplete(com.netflix.hollow.api.producer.Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+        Optional<Boolean> isCycleSuccess;
+        long cycleEndTimeNano = System.nanoTime();
+
+        if (status.getType() == com.netflix.hollow.api.producer.Status.StatusType.SUCCESS) {
+            isCycleSuccess = Optional.of(true);
+            consecutiveFailures = 0l;
+            lastCycleSuccessTimeNanoOptional = OptionalLong.of(cycleEndTimeNano);
+        } else {
+            isCycleSuccess = Optional.of(false);
+            consecutiveFailures ++;
+        }
+
+        cycleMetricsBuilder
+                .setConsecutiveFailures(consecutiveFailures)
+                .setCycleDurationMillisOptional(OptionalLong.of(elapsed.toMillis()))
+                .setIsCycleSuccessOptional(isCycleSuccess)
+                .setLastCycleSuccessTimeNanoOptional(lastCycleSuccessTimeNanoOptional);
+
+        cycleMetricsReporting(cycleMetricsBuilder.build());
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListener.java
@@ -51,8 +51,7 @@ public abstract class AbstractProducerMetricsListener extends AbstractHollowProd
     public void onCycleSkip(CycleSkipReason reason) {
         cycleMetricsBuilder.setConsecutiveFailures(consecutiveFailures);
 
-        if (lastCycleSuccessTimeNanoOptional.isPresent())
-            cycleMetricsBuilder.setLastCycleSuccessTimeNanoOptional((lastCycleSuccessTimeNanoOptional.getAsLong()));
+        lastCycleSuccessTimeNanoOptional.ifPresent(cycleMetricsBuilder::setLastCycleSuccessTimeNano);
 
         // isCycleSuccess and cycleDurationMillis are not set for skipped cycles
         cycleMetricsBuilder.setConsecutiveFailures(consecutiveFailures);
@@ -85,8 +84,7 @@ public abstract class AbstractProducerMetricsListener extends AbstractHollowProd
                 .setIsAnnouncementSuccess(isAnnouncementSuccess)
                 .setAnnouncementDurationMillis(elapsed.toMillis());
 
-        if (lastAnnouncementSuccessTimeNanoOptional.isPresent())
-            announcementMetricsBuilder.setLastAnnouncementSuccessTimeNanoOptional(lastAnnouncementSuccessTimeNanoOptional.getAsLong());
+        lastAnnouncementSuccessTimeNanoOptional.ifPresent(announcementMetricsBuilder::setLastAnnouncementSuccessTimeNano);
 
         announcementMetricsReporting(announcementMetricsBuilder.build());
     }
@@ -114,11 +112,10 @@ public abstract class AbstractProducerMetricsListener extends AbstractHollowProd
 
         cycleMetricsBuilder
                 .setConsecutiveFailures(consecutiveFailures)
-                .setCycleDurationMillisOptional(elapsed.toMillis())
-                .setIsCycleSuccessOptional(isCycleSuccess);
+                .setCycleDurationMillis(elapsed.toMillis())
+                .setIsCycleSuccess(isCycleSuccess);
 
-        if (lastCycleSuccessTimeNanoOptional.isPresent())
-                cycleMetricsBuilder.setLastCycleSuccessTimeNanoOptional(lastCycleSuccessTimeNanoOptional.getAsLong());
+        lastCycleSuccessTimeNanoOptional.ifPresent(cycleMetricsBuilder::setLastCycleSuccessTimeNano);
 
         cycleMetricsReporting(cycleMetricsBuilder.build());
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AnnouncementMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AnnouncementMetrics.java
@@ -52,8 +52,8 @@ public class AnnouncementMetrics {
             this.isAnnouncementSuccess = isAnnouncementSuccess;
             return this;
         }
-        public Builder setLastAnnouncementSuccessTimeNanoOptional(OptionalLong lastAnnouncementSuccessTimeNanoOptional) {
-            this.lastAnnouncementSuccessTimeNanoOptional = lastAnnouncementSuccessTimeNanoOptional;
+        public Builder setLastAnnouncementSuccessTimeNanoOptional(long lastAnnouncementSuccessTimeNano) {
+            this.lastAnnouncementSuccessTimeNanoOptional = OptionalLong.of(lastAnnouncementSuccessTimeNano);
             return this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AnnouncementMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AnnouncementMetrics.java
@@ -1,0 +1,64 @@
+package com.netflix.hollow.api.producer.metrics;
+
+import java.util.OptionalLong;
+
+public class AnnouncementMetrics {
+
+    private long dataSizeBytes;                                     // Heap footprint of announced blob in bytes
+    private long announcementDurationMillis;                        // Announcement duration in ms, only applicable to completed cycles (skipped cycles dont announce)
+    private boolean isAnnouncementSuccess;                          // true if announcement was successful, false if announcement failed
+    private OptionalLong lastAnnouncementSuccessTimeNanoOptional;   // monotonic time of last successful announcement (no relation to wall clock), N/A until first successful announcement
+
+
+    public long getDataSizeBytes() {
+        return dataSizeBytes;
+    }
+    public long getAnnouncementDurationMillis() {
+        return announcementDurationMillis;
+    }
+    public boolean getIsAnnouncementSuccess() {
+        return isAnnouncementSuccess;
+    }
+    public OptionalLong getLastAnnouncementSuccessTimeNanoOptional() {
+        return lastAnnouncementSuccessTimeNanoOptional;
+    }
+
+    private AnnouncementMetrics(Builder builder) {
+        this.dataSizeBytes = builder.dataSizeBytes;
+        this.announcementDurationMillis = builder.announcementDurationMillis;
+        this.isAnnouncementSuccess = builder.isAnnouncementSuccess;
+        this.lastAnnouncementSuccessTimeNanoOptional = builder.lastAnnouncementSuccessTimeNanoOptional;
+    }
+
+    public static final class Builder {
+        private long dataSizeBytes;
+        private long announcementDurationMillis;
+        private boolean isAnnouncementSuccess;
+        private OptionalLong lastAnnouncementSuccessTimeNanoOptional;
+
+        public Builder() {
+            lastAnnouncementSuccessTimeNanoOptional = OptionalLong.empty();
+        }
+
+        public Builder setDataSizeBytes(long dataSizeBytes) {
+            this.dataSizeBytes = dataSizeBytes;
+            return this;
+        }
+        public Builder setAnnouncementDurationMillis(long announcementDurationMillis) {
+            this.announcementDurationMillis = announcementDurationMillis;
+            return this;
+        }
+        public Builder setIsAnnouncementSuccess(boolean isAnnouncementSuccess) {
+            this.isAnnouncementSuccess = isAnnouncementSuccess;
+            return this;
+        }
+        public Builder setLastAnnouncementSuccessTimeNanoOptional(OptionalLong lastAnnouncementSuccessTimeNanoOptional) {
+            this.lastAnnouncementSuccessTimeNanoOptional = lastAnnouncementSuccessTimeNanoOptional;
+            return this;
+        }
+
+        public AnnouncementMetrics build() {
+            return new AnnouncementMetrics(this);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AnnouncementMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AnnouncementMetrics.java
@@ -4,10 +4,10 @@ import java.util.OptionalLong;
 
 public class AnnouncementMetrics {
 
-    private long dataSizeBytes;                                     // Heap footprint of announced blob in bytes
-    private long announcementDurationMillis;                        // Announcement duration in ms, only applicable to completed cycles (skipped cycles dont announce)
-    private boolean isAnnouncementSuccess;                          // true if announcement was successful, false if announcement failed
-    private OptionalLong lastAnnouncementSuccessTimeNanoOptional;   // monotonic time of last successful announcement (no relation to wall clock), N/A until first successful announcement
+    private long dataSizeBytes;                             // Heap footprint of announced blob in bytes
+    private long announcementDurationMillis;                // Announcement duration in ms, only applicable to completed cycles (skipped cycles dont announce)
+    private boolean isAnnouncementSuccess;                  // true if announcement was successful, false if announcement failed
+    private OptionalLong lastAnnouncementSuccessTimeNano;   // monotonic time of last successful announcement (no relation to wall clock), N/A until first successful announcement
 
 
     public long getDataSizeBytes() {
@@ -19,25 +19,25 @@ public class AnnouncementMetrics {
     public boolean getIsAnnouncementSuccess() {
         return isAnnouncementSuccess;
     }
-    public OptionalLong getLastAnnouncementSuccessTimeNanoOptional() {
-        return lastAnnouncementSuccessTimeNanoOptional;
+    public OptionalLong getLastAnnouncementSuccessTimeNano() {
+        return lastAnnouncementSuccessTimeNano;
     }
 
     private AnnouncementMetrics(Builder builder) {
         this.dataSizeBytes = builder.dataSizeBytes;
         this.announcementDurationMillis = builder.announcementDurationMillis;
         this.isAnnouncementSuccess = builder.isAnnouncementSuccess;
-        this.lastAnnouncementSuccessTimeNanoOptional = builder.lastAnnouncementSuccessTimeNanoOptional;
+        this.lastAnnouncementSuccessTimeNano = builder.lastAnnouncementSuccessTimeNano;
     }
 
     public static final class Builder {
         private long dataSizeBytes;
         private long announcementDurationMillis;
         private boolean isAnnouncementSuccess;
-        private OptionalLong lastAnnouncementSuccessTimeNanoOptional;
+        private OptionalLong lastAnnouncementSuccessTimeNano;
 
         public Builder() {
-            lastAnnouncementSuccessTimeNanoOptional = OptionalLong.empty();
+            lastAnnouncementSuccessTimeNano = OptionalLong.empty();
         }
 
         public Builder setDataSizeBytes(long dataSizeBytes) {
@@ -52,8 +52,8 @@ public class AnnouncementMetrics {
             this.isAnnouncementSuccess = isAnnouncementSuccess;
             return this;
         }
-        public Builder setLastAnnouncementSuccessTimeNanoOptional(long lastAnnouncementSuccessTimeNano) {
-            this.lastAnnouncementSuccessTimeNanoOptional = OptionalLong.of(lastAnnouncementSuccessTimeNano);
+        public Builder setLastAnnouncementSuccessTimeNano(long lastAnnouncementSuccessTimeNano) {
+            this.lastAnnouncementSuccessTimeNano = OptionalLong.of(lastAnnouncementSuccessTimeNano);
             return this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/CycleMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/CycleMetrics.java
@@ -1,0 +1,64 @@
+package com.netflix.hollow.api.producer.metrics;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+public class CycleMetrics {
+
+    private long consecutiveFailures;
+    private OptionalLong cycleDurationMillisOptional;               // Cycle start to end duration, only applicable to completed cycles
+    private Optional<Boolean> isCycleSuccessOptional;               // true if cycle was successful, false if cycle failed, N/A if cycle was skipped
+    private OptionalLong lastCycleSuccessTimeNanoOptional;          // monotonic time of last successful cycle (no relation to wall clock), N/A until first successful cycle
+
+    public long getConsecutiveFailures() {
+        return consecutiveFailures;
+    }
+    public OptionalLong getCycleDurationMillisOptional() {
+        return cycleDurationMillisOptional;
+    }
+    public Optional<Boolean> getIsCycleSuccessOptional() {
+        return isCycleSuccessOptional;
+    }
+    public OptionalLong getLastCycleSuccessTimeNanoOptional() {
+        return lastCycleSuccessTimeNanoOptional;
+    }
+
+    private CycleMetrics(Builder builder) {
+        this.consecutiveFailures = builder.consecutiveFailures;
+        this.cycleDurationMillisOptional = builder.cycleDurationMillisOptional;
+        this.isCycleSuccessOptional = builder.isCycleSuccessOptional;
+        this.lastCycleSuccessTimeNanoOptional = builder.lastCycleSuccessTimeNanoOptional;
+    }
+
+    public static final class Builder {
+        private long consecutiveFailures;
+        private OptionalLong cycleDurationMillisOptional;
+        private Optional<Boolean> isCycleSuccessOptional;
+        private OptionalLong lastCycleSuccessTimeNanoOptional;
+
+        public Builder() {
+            lastCycleSuccessTimeNanoOptional = OptionalLong.empty();
+        }
+
+        public Builder setConsecutiveFailures(long consecutiveFailures) {
+            this.consecutiveFailures = consecutiveFailures;
+            return this;
+        }
+        public Builder setCycleDurationMillisOptional(OptionalLong cycleDurationMillisOptional) {
+            this.cycleDurationMillisOptional = cycleDurationMillisOptional;
+            return this;
+        }
+        public Builder setIsCycleSuccessOptional(Optional<Boolean> isCycleSuccessOptional) {
+            this.isCycleSuccessOptional = isCycleSuccessOptional;
+            return this;
+        }
+        public Builder setLastCycleSuccessTimeNanoOptional(OptionalLong lastCycleSuccessTimeNanoOptional) {
+            this.lastCycleSuccessTimeNanoOptional = lastCycleSuccessTimeNanoOptional;
+            return this;
+        }
+
+        public CycleMetrics build() {
+            return new CycleMetrics(this);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/CycleMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/CycleMetrics.java
@@ -44,16 +44,16 @@ public class CycleMetrics {
             this.consecutiveFailures = consecutiveFailures;
             return this;
         }
-        public Builder setCycleDurationMillisOptional(OptionalLong cycleDurationMillisOptional) {
-            this.cycleDurationMillisOptional = cycleDurationMillisOptional;
+        public Builder setCycleDurationMillisOptional(long cycleDurationMillis) {
+            this.cycleDurationMillisOptional = OptionalLong.of(cycleDurationMillis);
             return this;
         }
-        public Builder setIsCycleSuccessOptional(Optional<Boolean> isCycleSuccessOptional) {
-            this.isCycleSuccessOptional = isCycleSuccessOptional;
+        public Builder setIsCycleSuccessOptional(boolean isCycleSuccessOptional) {
+            this.isCycleSuccessOptional = Optional.of(isCycleSuccessOptional);
             return this;
         }
-        public Builder setLastCycleSuccessTimeNanoOptional(OptionalLong lastCycleSuccessTimeNanoOptional) {
-            this.lastCycleSuccessTimeNanoOptional = lastCycleSuccessTimeNanoOptional;
+        public Builder setLastCycleSuccessTimeNanoOptional(long lastCycleSuccessTimeNano) {
+            this.lastCycleSuccessTimeNanoOptional = OptionalLong.of(lastCycleSuccessTimeNano);
             return this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/CycleMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/CycleMetrics.java
@@ -6,56 +6,56 @@ import java.util.OptionalLong;
 public class CycleMetrics {
 
     private long consecutiveFailures;
-    private OptionalLong cycleDurationMillisOptional;               // Cycle start to end duration, only applicable to completed cycles
-    private Optional<Boolean> isCycleSuccessOptional;               // true if cycle was successful, false if cycle failed, N/A if cycle was skipped
-    private OptionalLong lastCycleSuccessTimeNanoOptional;          // monotonic time of last successful cycle (no relation to wall clock), N/A until first successful cycle
+    private OptionalLong cycleDurationMillis;               // Cycle start to end duration, only applicable to completed cycles
+    private Optional<Boolean> isCycleSuccess;               // true if cycle was successful, false if cycle failed, N/A if cycle was skipped
+    private OptionalLong lastCycleSuccessTimeNano;          // monotonic time of last successful cycle (no relation to wall clock), N/A until first successful cycle
 
     public long getConsecutiveFailures() {
         return consecutiveFailures;
     }
-    public OptionalLong getCycleDurationMillisOptional() {
-        return cycleDurationMillisOptional;
+    public OptionalLong getCycleDurationMillis() {
+        return cycleDurationMillis;
     }
-    public Optional<Boolean> getIsCycleSuccessOptional() {
-        return isCycleSuccessOptional;
+    public Optional<Boolean> getIsCycleSuccess() {
+        return isCycleSuccess;
     }
-    public OptionalLong getLastCycleSuccessTimeNanoOptional() {
-        return lastCycleSuccessTimeNanoOptional;
+    public OptionalLong getLastCycleSuccessTimeNano() {
+        return lastCycleSuccessTimeNano;
     }
 
     private CycleMetrics(Builder builder) {
         this.consecutiveFailures = builder.consecutiveFailures;
-        this.cycleDurationMillisOptional = builder.cycleDurationMillisOptional;
-        this.isCycleSuccessOptional = builder.isCycleSuccessOptional;
-        this.lastCycleSuccessTimeNanoOptional = builder.lastCycleSuccessTimeNanoOptional;
+        this.cycleDurationMillis = builder.cycleDurationMillis;
+        this.isCycleSuccess = builder.isCycleSuccess;
+        this.lastCycleSuccessTimeNano = builder.lastCycleSuccessTimeNano;
     }
 
     public static final class Builder {
         private long consecutiveFailures;
-        private OptionalLong cycleDurationMillisOptional;
-        private Optional<Boolean> isCycleSuccessOptional;
-        private OptionalLong lastCycleSuccessTimeNanoOptional;
+        private OptionalLong cycleDurationMillis;
+        private Optional<Boolean> isCycleSuccess;
+        private OptionalLong lastCycleSuccessTimeNano;
 
         public Builder() {
-            isCycleSuccessOptional = Optional.empty();
-            cycleDurationMillisOptional = OptionalLong.empty();
-            lastCycleSuccessTimeNanoOptional = OptionalLong.empty();
+            isCycleSuccess = Optional.empty();
+            cycleDurationMillis = OptionalLong.empty();
+            lastCycleSuccessTimeNano = OptionalLong.empty();
         }
 
         public Builder setConsecutiveFailures(long consecutiveFailures) {
             this.consecutiveFailures = consecutiveFailures;
             return this;
         }
-        public Builder setCycleDurationMillisOptional(long cycleDurationMillis) {
-            this.cycleDurationMillisOptional = OptionalLong.of(cycleDurationMillis);
+        public Builder setCycleDurationMillis(long cycleDurationMillis) {
+            this.cycleDurationMillis = OptionalLong.of(cycleDurationMillis);
             return this;
         }
-        public Builder setIsCycleSuccessOptional(boolean isCycleSuccessOptional) {
-            this.isCycleSuccessOptional = Optional.of(isCycleSuccessOptional);
+        public Builder setIsCycleSuccess(boolean isCycleSuccess) {
+            this.isCycleSuccess = Optional.of(isCycleSuccess);
             return this;
         }
-        public Builder setLastCycleSuccessTimeNanoOptional(long lastCycleSuccessTimeNano) {
-            this.lastCycleSuccessTimeNanoOptional = OptionalLong.of(lastCycleSuccessTimeNano);
+        public Builder setLastCycleSuccessTimeNano(long lastCycleSuccessTimeNano) {
+            this.lastCycleSuccessTimeNano = OptionalLong.of(lastCycleSuccessTimeNano);
             return this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/ProducerMetricsReporting.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/ProducerMetricsReporting.java
@@ -1,0 +1,16 @@
+package com.netflix.hollow.api.producer.metrics;
+
+/**
+ * Allows implementations to plug in custom reporting of producer metrics, while not enforcing that any or all metrics
+ * are reported. For example, an implementation might only be insterested in cycle metrics but not announcement metrics, etc.
+ */
+public interface ProducerMetricsReporting {
+
+    default void cycleMetricsReporting(CycleMetrics cycleMetrics) {
+        // no-op
+    }
+
+    default void announcementMetricsReporting(AnnouncementMetrics announcementMetrics) {
+        // no-op
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
@@ -162,6 +162,19 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
         }
     }
 
+    /**
+     * Calculates the data size of a read state engine which is defined as the approximate heap footprint by iterating
+     * over the read state shards in each type state
+     * @return the heap footprint of the read state engine
+     */
+    public long calcApproxDataSize() {
+        return this.getAllTypes()
+                .stream()
+                .map(this::getTypeState)
+                .mapToLong(HollowTypeReadState::getApproximateHeapFootprintInBytes)
+                .sum();
+    }
+
     @Override
     public HollowTypeDataAccess getTypeDataAccess(String type) {
         return typeStates.get(type);

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
@@ -156,6 +156,19 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
         }
     }
 
+    /**
+     * Calculates the data size of a read state engine which is defined as the approximate heap footprint by iterating
+     * over the read state shards in each type state
+     * @return the heap footprint of the read state engine
+     */
+    public long calcApproxDataSize() {
+        return this.getAllTypes()
+                .stream()
+                .map(this::getTypeState)
+                .mapToLong(HollowTypeReadState::getApproximateHeapFootprintInBytes)
+                .sum();
+    }
+
     @Override
     public HollowTypeDataAccess getTypeDataAccess(String type) {
         return typeStates.get(type);

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListenerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListenerTest.java
@@ -47,9 +47,9 @@ public class AbstractProducerMetricsListenerTest {
             public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
                 Assert.assertNotNull(cycleMetrics);
                 Assert.assertEquals(0l, cycleMetrics.getConsecutiveFailures());
-                Assert.assertEquals(Optional.empty(), cycleMetrics.getIsCycleSuccessOptional());
-                Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getCycleDurationMillisOptional());
-                Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getLastCycleSuccessTimeNanoOptional());
+                Assert.assertEquals(Optional.empty(), cycleMetrics.getIsCycleSuccess());
+                Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getCycleDurationMillis());
+                Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getLastCycleSuccessTimeNano());
             }
         }
         AbstractProducerMetricsListener concreteProducerMetricsListener = new TestProducerMetricsListener();
@@ -64,9 +64,9 @@ public class AbstractProducerMetricsListenerTest {
             public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
                 Assert.assertNotNull(cycleMetrics);
                 Assert.assertEquals(0l, cycleMetrics.getConsecutiveFailures());
-                Assert.assertEquals(Optional.empty(), cycleMetrics.getIsCycleSuccessOptional());
-                Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getCycleDurationMillisOptional());
-                Assert.assertEquals(OptionalLong.of(TEST_LAST_CYCLE_NANOS), cycleMetrics.getLastCycleSuccessTimeNanoOptional());
+                Assert.assertEquals(Optional.empty(), cycleMetrics.getIsCycleSuccess());
+                Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getCycleDurationMillis());
+                Assert.assertEquals(OptionalLong.of(TEST_LAST_CYCLE_NANOS), cycleMetrics.getLastCycleSuccessTimeNano());
             }
         }
         AbstractProducerMetricsListener concreteProducerMetricsListener = new TestProducerMetricsListener();
@@ -82,10 +82,10 @@ public class AbstractProducerMetricsListenerTest {
             public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
                 Assert.assertNotNull(cycleMetrics);
                 Assert.assertEquals(0l, cycleMetrics.getConsecutiveFailures());
-                Assert.assertEquals(Optional.of(true), cycleMetrics.getIsCycleSuccessOptional());
-                Assert.assertEquals(OptionalLong.of(TEST_CYCLE_DURATION_MILLIS.toMillis()), cycleMetrics.getCycleDurationMillisOptional());
-                Assert.assertNotEquals(OptionalLong.of(TEST_LAST_CYCLE_NANOS), cycleMetrics.getLastCycleSuccessTimeNanoOptional());
-                Assert.assertNotEquals(OptionalLong.empty(), cycleMetrics.getLastCycleSuccessTimeNanoOptional());
+                Assert.assertEquals(Optional.of(true), cycleMetrics.getIsCycleSuccess());
+                Assert.assertEquals(OptionalLong.of(TEST_CYCLE_DURATION_MILLIS.toMillis()), cycleMetrics.getCycleDurationMillis());
+                Assert.assertNotEquals(OptionalLong.of(TEST_LAST_CYCLE_NANOS), cycleMetrics.getLastCycleSuccessTimeNano());
+                Assert.assertNotEquals(OptionalLong.empty(), cycleMetrics.getLastCycleSuccessTimeNano());
             }
         }
 
@@ -102,9 +102,9 @@ public class AbstractProducerMetricsListenerTest {
             public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
                 Assert.assertNotNull(cycleMetrics);
                 Assert.assertEquals(1l, cycleMetrics.getConsecutiveFailures());
-                Assert.assertEquals(Optional.of(false), cycleMetrics.getIsCycleSuccessOptional());
-                Assert.assertEquals(OptionalLong.of(TEST_CYCLE_DURATION_MILLIS.toMillis()), cycleMetrics.getCycleDurationMillisOptional());
-                Assert.assertEquals(OptionalLong.of(TEST_LAST_CYCLE_NANOS), cycleMetrics.getLastCycleSuccessTimeNanoOptional());
+                Assert.assertEquals(Optional.of(false), cycleMetrics.getIsCycleSuccess());
+                Assert.assertEquals(OptionalLong.of(TEST_CYCLE_DURATION_MILLIS.toMillis()), cycleMetrics.getCycleDurationMillis());
+                Assert.assertEquals(OptionalLong.of(TEST_LAST_CYCLE_NANOS), cycleMetrics.getLastCycleSuccessTimeNano());
             }
         }
 
@@ -125,7 +125,7 @@ public class AbstractProducerMetricsListenerTest {
                 Assert.assertEquals(TEST_ANNOUNCEMENT_DURATION_MILLIS,
                         announcementMetrics.getAnnouncementDurationMillis());
                 Assert.assertNotEquals(OptionalLong.of(TEST_LAST_ANNOUNCEMENT_NANOS),
-                        announcementMetrics.getLastAnnouncementSuccessTimeNanoOptional());
+                        announcementMetrics.getLastAnnouncementSuccessTimeNano());
             }
         }
 
@@ -147,7 +147,7 @@ public class AbstractProducerMetricsListenerTest {
                 Assert.assertEquals(TEST_ANNOUNCEMENT_DURATION_MILLIS,
                         announcementMetrics.getAnnouncementDurationMillis());
                 Assert.assertEquals(OptionalLong.of(TEST_LAST_ANNOUNCEMENT_NANOS),
-                        announcementMetrics.getLastAnnouncementSuccessTimeNanoOptional());
+                        announcementMetrics.getLastAnnouncementSuccessTimeNano());
             }
         }
 

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListenerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListenerTest.java
@@ -1,0 +1,160 @@
+package com.netflix.hollow.api.producer.metrics;
+
+import static org.mockito.Mockito.when;
+
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.Status;
+import com.netflix.hollow.api.producer.listener.CycleListener;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.OptionalLong;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AbstractProducerMetricsListenerTest {
+
+    private final long TEST_VERSION = 123l;
+    private final long TEST_LAST_CYCLE_NANOS = 100l;
+    private final long TEST_LAST_ANNOUNCEMENT_NANOS = 200l;
+    private final long TEST_DATA_SIZE = 55l;
+    private final com.netflix.hollow.api.producer.Status TEST_STATUS_SUCCESS = new Status(Status.StatusType.SUCCESS, null);
+    private final com.netflix.hollow.api.producer.Status TEST_STATUS_FAIL = new Status(Status.StatusType.FAIL, null);
+    private final Duration TEST_CYCLE_DURATION_MILLIS = Duration.ofMillis(4l);
+    private final long TEST_ANNOUNCEMENT_DURATION_MILLIS = 2l;
+
+    @Mock
+    private HollowProducer.ReadState mockReadState;
+
+    @Mock
+    private HollowReadStateEngine mockStateEngine;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        when(mockReadState.getStateEngine()).thenReturn(mockStateEngine);
+        when(mockStateEngine.calcApproxDataSize()).thenReturn(TEST_DATA_SIZE);
+    }
+
+    @Test
+    public void testCycleSkipWhenNeverBeenPrimaryProducer() {
+        final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
+            @Override
+            public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
+                Assert.assertNotNull(cycleMetrics);
+                Assert.assertEquals(0l, cycleMetrics.getConsecutiveFailures());
+                Assert.assertEquals(Optional.empty(), cycleMetrics.getIsCycleSuccessOptional());
+                Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getCycleDurationMillisOptional());
+                Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getLastCycleSuccessTimeNanoOptional());
+            }
+        }
+        AbstractProducerMetricsListener concreteProducerMetricsListener = new TestProducerMetricsListener();
+        concreteProducerMetricsListener.onCycleStart(TEST_VERSION);
+        concreteProducerMetricsListener.onCycleSkip(CycleListener.CycleSkipReason.NOT_PRIMARY_PRODUCER);
+    }
+
+    @Test
+    public void testCycleSkipWhenPreviouslyPrimaryProducer() {
+        final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
+            @Override
+            public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
+                Assert.assertNotNull(cycleMetrics);
+                Assert.assertEquals(0l, cycleMetrics.getConsecutiveFailures());
+                Assert.assertEquals(Optional.empty(), cycleMetrics.getIsCycleSuccessOptional());
+                Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getCycleDurationMillisOptional());
+                Assert.assertEquals(OptionalLong.of(TEST_LAST_CYCLE_NANOS), cycleMetrics.getLastCycleSuccessTimeNanoOptional());
+            }
+        }
+        AbstractProducerMetricsListener concreteProducerMetricsListener = new TestProducerMetricsListener();
+        concreteProducerMetricsListener.lastCycleSuccessTimeNanoOptional = OptionalLong.of(TEST_LAST_CYCLE_NANOS);
+        concreteProducerMetricsListener.onCycleStart(TEST_VERSION);
+        concreteProducerMetricsListener.onCycleSkip(CycleListener.CycleSkipReason.NOT_PRIMARY_PRODUCER);
+    }
+
+    @Test
+    public void testCycleCompleteWithSuccess() {
+        final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
+            @Override
+            public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
+                Assert.assertNotNull(cycleMetrics);
+                Assert.assertEquals(0l, cycleMetrics.getConsecutiveFailures());
+                Assert.assertEquals(Optional.of(true), cycleMetrics.getIsCycleSuccessOptional());
+                Assert.assertEquals(OptionalLong.of(TEST_CYCLE_DURATION_MILLIS.toMillis()), cycleMetrics.getCycleDurationMillisOptional());
+                Assert.assertNotEquals(OptionalLong.of(TEST_LAST_CYCLE_NANOS), cycleMetrics.getLastCycleSuccessTimeNanoOptional());
+                Assert.assertNotEquals(OptionalLong.empty(), cycleMetrics.getLastCycleSuccessTimeNanoOptional());
+            }
+        }
+
+        AbstractProducerMetricsListener concreteProducerMetricsListener = new TestProducerMetricsListener();
+        concreteProducerMetricsListener.lastCycleSuccessTimeNanoOptional = OptionalLong.of(TEST_LAST_CYCLE_NANOS);
+        concreteProducerMetricsListener.onCycleStart(TEST_VERSION);
+        concreteProducerMetricsListener.onCycleComplete(TEST_STATUS_SUCCESS, mockReadState, TEST_VERSION, TEST_CYCLE_DURATION_MILLIS);
+    }
+
+    @Test
+    public void testCycleCompleteWithFail() {
+        final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
+            @Override
+            public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
+                Assert.assertNotNull(cycleMetrics);
+                Assert.assertEquals(1l, cycleMetrics.getConsecutiveFailures());
+                Assert.assertEquals(Optional.of(false), cycleMetrics.getIsCycleSuccessOptional());
+                Assert.assertEquals(OptionalLong.of(TEST_CYCLE_DURATION_MILLIS.toMillis()), cycleMetrics.getCycleDurationMillisOptional());
+                Assert.assertEquals(OptionalLong.of(TEST_LAST_CYCLE_NANOS), cycleMetrics.getLastCycleSuccessTimeNanoOptional());
+            }
+        }
+
+        AbstractProducerMetricsListener concreteProducerMetricsListener = new TestProducerMetricsListener();
+        concreteProducerMetricsListener.lastCycleSuccessTimeNanoOptional = OptionalLong.of(TEST_LAST_CYCLE_NANOS);
+        concreteProducerMetricsListener.onCycleStart(TEST_VERSION);
+        concreteProducerMetricsListener.onCycleComplete(TEST_STATUS_FAIL, mockReadState, TEST_VERSION, TEST_CYCLE_DURATION_MILLIS);
+    }
+
+    @Test
+    public void testAnnouncementCompleteWithSuccess() {
+        final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
+            @Override
+            public void announcementMetricsReporting(AnnouncementMetrics announcementMetrics) {
+                Assert.assertNotNull(announcementMetrics);
+                Assert.assertEquals(TEST_DATA_SIZE, announcementMetrics.getDataSizeBytes());
+                Assert.assertEquals(true, announcementMetrics.getIsAnnouncementSuccess());
+                Assert.assertEquals(TEST_ANNOUNCEMENT_DURATION_MILLIS,
+                        announcementMetrics.getAnnouncementDurationMillis());
+                Assert.assertNotEquals(OptionalLong.of(TEST_LAST_ANNOUNCEMENT_NANOS),
+                        announcementMetrics.getLastAnnouncementSuccessTimeNanoOptional());
+            }
+        }
+
+        AbstractProducerMetricsListener concreteProducerMetricsListener = new TestProducerMetricsListener();
+        concreteProducerMetricsListener.lastAnnouncementSuccessTimeNanoOptional = OptionalLong.of(
+                TEST_LAST_ANNOUNCEMENT_NANOS);
+        concreteProducerMetricsListener.onAnnouncementStart(TEST_VERSION);
+        concreteProducerMetricsListener.onAnnouncementComplete(TEST_STATUS_SUCCESS, mockReadState, TEST_VERSION, Duration.ofMillis(TEST_ANNOUNCEMENT_DURATION_MILLIS));
+    }
+
+    @Test
+    public void testAnnouncementCompleteWithFail() {
+        final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
+            @Override
+            public void announcementMetricsReporting(AnnouncementMetrics announcementMetrics) {
+                Assert.assertNotNull(announcementMetrics);
+                Assert.assertEquals(TEST_DATA_SIZE, announcementMetrics.getDataSizeBytes());
+                Assert.assertEquals(false, announcementMetrics.getIsAnnouncementSuccess());
+                Assert.assertEquals(TEST_ANNOUNCEMENT_DURATION_MILLIS,
+                        announcementMetrics.getAnnouncementDurationMillis());
+                Assert.assertEquals(OptionalLong.of(TEST_LAST_ANNOUNCEMENT_NANOS),
+                        announcementMetrics.getLastAnnouncementSuccessTimeNanoOptional());
+            }
+        }
+
+        AbstractProducerMetricsListener concreteProducerMetricsListener = new TestProducerMetricsListener();
+        concreteProducerMetricsListener.lastAnnouncementSuccessTimeNanoOptional = OptionalLong.of(
+                TEST_LAST_ANNOUNCEMENT_NANOS);
+        concreteProducerMetricsListener.onAnnouncementStart(TEST_VERSION);
+        concreteProducerMetricsListener.onAnnouncementComplete(TEST_STATUS_FAIL, mockReadState, TEST_VERSION, Duration.ofMillis(TEST_ANNOUNCEMENT_DURATION_MILLIS));
+    }
+}


### PR DESCRIPTION
Following the Consumer refresh metrics change, this PR brings parity to the producer side in how metrics are being computed in Hollow. Clients can plug in their custom metrics reporting behavior. 