### PR TITLE
Generate method on primary key type to create unique index.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndexSelect.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndexSelect.java
@@ -29,6 +29,7 @@ import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -48,7 +49,7 @@ import java.util.stream.Stream;
  * @param <Q> the query type
  */
 public class HashIndexSelect<T extends HollowRecord, S extends HollowRecord, Q>
-        implements HollowConsumer.RefreshListener, HollowConsumer.RefreshRegistrationListener {
+        implements HollowConsumer.RefreshListener, HollowConsumer.RefreshRegistrationListener, Function<Q, Stream<S>> {
     final HollowConsumer consumer;
     HollowAPI api;
     final SelectFieldPathResultExtractor<S> selectField;
@@ -113,6 +114,17 @@ public class HashIndexSelect<T extends HollowRecord, S extends HollowRecord, Q>
                         MatchFieldPathArgumentExtractor
                                 .fromPathAndType(consumer.getStateEngine(), rootType, fieldPath, matchFieldType,
                                         FieldPaths::createFieldPathForHashIndex)));
+    }
+
+    /**
+     * Finds matches for a given query.
+     *
+     * @param query the query
+     * @return a stream of matching records (may be empty if there are no matches)
+     */
+    @Override
+    public Stream<S> apply(Q query) {
+        return findMatches(query);
     }
 
     /**

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/UniqueKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/UniqueKeyIndex.java
@@ -31,6 +31,7 @@ import com.netflix.hollow.core.schema.HollowSchema;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -46,7 +47,7 @@ import java.util.stream.Stream;
  * @param <Q> the key type
  */
 public class UniqueKeyIndex<T extends HollowObject, Q>
-        implements HollowConsumer.RefreshListener, HollowConsumer.RefreshRegistrationListener {
+        implements HollowConsumer.RefreshListener, HollowConsumer.RefreshRegistrationListener, Function<Q, T> {
     final HollowConsumer consumer;
     HollowAPI api;
     final SelectFieldPathResultExtractor<T> uniqueTypeExtractor;
@@ -134,6 +135,18 @@ public class UniqueKeyIndex<T extends HollowObject, Q>
                         MatchFieldPathArgumentExtractor
                                 .fromPathAndType(consumer.getStateEngine(), uniqueType, fieldPath, matchFieldType,
                                         FieldPaths::createFieldPathForPrimaryKey)));
+    }
+
+
+    /**
+     * Finds the unique object, an instance of the unique type, for a given key.
+     *
+     * @param key the key
+     * @return the unique object
+     */
+    @Override
+    public T apply(Q key) {
+        return findMatch(key);
     }
 
     /**

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowPrimaryKeyAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowPrimaryKeyAPIGeneratorTest.java
@@ -36,7 +36,7 @@ public class HollowPrimaryKeyAPIGeneratorTest extends AbstractHollowAPIGenerator
                 builder -> builder.withClassPostfix("Generated").withPackageGrouping());
     }
 
-    @HollowPrimaryKey(fields = { "id", "hasSubtitles", "actor", "role.id!", "role.rank" })
+    @HollowPrimaryKey(fields = {"id", "hasSubtitles", "actor", "role.id!", "role.rank"})
     static class Movie {
         int id;
 
@@ -44,6 +44,19 @@ public class HollowPrimaryKeyAPIGeneratorTest extends AbstractHollowAPIGenerator
 
         Actor actor;
         Role role;
+
+        BoxedBoolean b1;
+        BoxedBytes b2;
+        BoxedBytes b3;
+        BoxedChar b4;
+        BoxedChars b5;
+        BoxedString b6;
+        BoxedInt b7;
+        BoxedLong b8;
+        BoxedFloat b9;
+        BoxedDouble b10;
+
+        Everything everything;
     }
 
     static class Actor {
@@ -56,5 +69,66 @@ public class HollowPrimaryKeyAPIGeneratorTest extends AbstractHollowAPIGenerator
         Long rank;
 
         String name;
+    }
+
+    @HollowPrimaryKey(fields = {"v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "ref!"})
+    static class Everything {
+        boolean v1;
+        char v2;
+        byte[] v3;
+        char v4;
+        char[] v5;
+        String v6;
+        int v7;
+        long v8;
+        float v9;
+        double v10;
+
+        BoxedInt ref;
+    }
+
+    @HollowPrimaryKey(fields = "v")
+    static class BoxedBoolean {
+        char v;
+    }
+
+    @HollowPrimaryKey(fields = "v")
+    static class BoxedBytes {
+        byte[] v;
+    }
+
+    @HollowPrimaryKey(fields = "v")
+    static class BoxedChar {
+        char v;
+    }
+
+    @HollowPrimaryKey(fields = "v")
+    static class BoxedChars {
+        char[] v;
+    }
+
+    @HollowPrimaryKey(fields = "v")
+    static class BoxedString {
+        String v;
+    }
+
+    @HollowPrimaryKey(fields = "v")
+    static class BoxedInt {
+        int v;
+    }
+
+    @HollowPrimaryKey(fields = "v")
+    static class BoxedLong {
+        long v;
+    }
+
+    @HollowPrimaryKey(fields = "v")
+    static class BoxedFloat {
+        float v;
+    }
+
+    @HollowPrimaryKey(fields = "v")
+    static class BoxedDouble {
+        double v;
     }
 }


### PR DESCRIPTION
For a hollow object with a primary key the generated client API for that object will include:

1.  A static method `uniqueIndex` that creates and returns `UniqueKeyIndex` for the hollow object and its primary key; and
2. If the primary key declares two or more field paths, a static inner class named `Key` that has annotated fields corresponding to the field paths (in declaration order).

Sample output from the updated test `HollowPrimaryKeyAPIGeneratorTest`:

```java
public class Movie extends HollowObject {
    ...

    /**
     * Creates a unique key index for {@code Movie} that has a primary key.
     * The primary key is represented by the class {@link Movie.Key}.
     * <p>
     * By default the unique key index will not track updates to the {@code consumer} and thus
     * any changes will not be reflected in matched results.  To track updates the index must be
     * {@link HollowConsumer#addRefreshListener(HollowConsumer.RefreshListener) registered}
     * with the {@code consumer}
     *
     * @param consumer the consumer
     * @return the unique key index
     */
    public static UniqueKeyIndex<Movie, Movie.Key> uniqueIndex(HollowConsumer consumer) {
        return UniqueKeyIndex.from(consumer, Movie.class)
            .bindToPrimaryKey()
            .usingBean(Movie.Key.class);
    }

    public static class Key {
        @FieldPath("id")
        public final int id;

        @FieldPath("hasSubtitles")
        public final boolean hasSubtitles;

        @FieldPath("actor")
        public final String actor;

        @FieldPath("role.id!")
        public final HInteger roleId;

        @FieldPath("role.rank")
        public final long roleRank;

        public Key(int id, boolean hasSubtitles, String actor, HInteger roleId, long roleRank) {
            this.id = id;
            this.hasSubtitles = hasSubtitles;
            this.actor = actor;
            this.roleId = roleId;
            this.roleRank = roleRank;
        }
    }
}
```

The documentation on the deprecated generated primary key index classes has been updated:

```java
/**
 * @deprecated see {@link com.netflix.hollow.api.consumer.index.UniqueKeyIndex} which can be created as follows:
 * <pre>{@code
 *     UniqueKeyIndex<Movie, Movie.Key> uki = Movie.uniqueIndex(consumer);
 *     Movie.Key k = new Movie.Key(...);
 *     Movie m = uki.findMatch(k);
 * }</pre>
 * @see Movie#uniqueIndex
 */
@Deprecated
@SuppressWarnings("all")
public class MoviePrimaryKeyIndex extends AbstractHollowUniqueKeyIndex<PrimaryKeyIndexTestAPI, Movie>
```