### PR TITLE
HollowJsonAdapter can convert json into FlatRecords

### DIFF
--- a/hollow-jsonadapter/src/main/java/com/netflix/hollow/jsonadapter/AbstractHollowJsonAdaptorTask.java
+++ b/hollow-jsonadapter/src/main/java/com/netflix/hollow/jsonadapter/AbstractHollowJsonAdaptorTask.java
@@ -43,10 +43,18 @@ public abstract class AbstractHollowJsonAdaptorTask {
     protected final String actionName;
     protected final Map<String, Map<String, FieldProcessor>> fieldProcessors;
 
+    public AbstractHollowJsonAdaptorTask(String typeName) {
+        this(typeName, null);
+    }
+
     public AbstractHollowJsonAdaptorTask(String typeName, String actionName) {
         this.typeName = typeName;
         this.actionName = actionName;
         this.fieldProcessors = new HashMap<String, Map<String,FieldProcessor>>();
+    }
+
+    public String getTypeName() {
+        return typeName;
     }
 
     public void addFieldProcessor(FieldProcessor... processors) {

--- a/hollow-jsonadapter/src/main/java/com/netflix/hollow/jsonadapter/HollowJsonToFlatRecordTask.java
+++ b/hollow-jsonadapter/src/main/java/com/netflix/hollow/jsonadapter/HollowJsonToFlatRecordTask.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.jsonadapter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecord;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.HollowSchemaIdentifierMapper;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.function.Consumer;
+
+public class HollowJsonToFlatRecordTask extends AbstractHollowJsonAdaptorTask {
+
+    private final HollowJsonAdapter adapter;
+    private final HollowSchemaIdentifierMapper schemaIdMapper;
+    private final Consumer<FlatRecord> action;
+
+    private final ThreadLocal<FlatRecordWriter> flatRecordWriter;
+
+    public HollowJsonToFlatRecordTask(HollowJsonAdapter adapter, 
+                                      HollowSchemaIdentifierMapper schemaIdMapper,
+                                      Consumer<FlatRecord> action) {
+        super(adapter.getTypeName());
+        this.adapter = adapter;
+        this.schemaIdMapper = schemaIdMapper;
+        this.flatRecordWriter = new ThreadLocal<>();
+        this.action = action;
+    }
+
+    public void process(Reader jsonReader) throws Exception {
+        processFile(jsonReader, Integer.MAX_VALUE);
+    }
+
+    @Override
+    protected int processRecord(JsonParser parser) throws IOException {
+        FlatRecordWriter recWriter = getFlatRecordWriter();
+        int ordinal = adapter.processRecord(parser, recWriter);
+        FlatRecord rec = recWriter.generateFlatRecord();
+        action.accept(rec);
+        return ordinal;
+    }
+
+    private FlatRecordWriter getFlatRecordWriter() {
+        FlatRecordWriter writer = flatRecordWriter.get();
+        if(writer == null) {
+            writer = new FlatRecordWriter(adapter.stateEngine, schemaIdMapper);
+            flatRecordWriter.set(writer);
+        }
+        writer.reset();
+        return writer;
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/SimpleHollowDataset.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/SimpleHollowDataset.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.schema;
+
+import com.netflix.hollow.api.error.SchemaNotFoundException;
+import com.netflix.hollow.core.HollowDataset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A HollowDataset implementation which only describes a set of schemas comprising a dataset. 
+ */
+public class SimpleHollowDataset implements HollowDataset {
+
+    private final Map<String, HollowSchema> schemas;
+    
+    public SimpleHollowDataset(Map<String, HollowSchema> schemas) {
+        this.schemas = schemas;
+    }
+    
+    public SimpleHollowDataset(List<HollowSchema> schemas) {
+        Map<String, HollowSchema> schemaMap = new HashMap<>(schemas.size());
+        
+        for(HollowSchema schema : schemas) {
+            schemaMap.put(schema.getName(), schema);
+        }
+        
+        this.schemas = schemaMap;
+    }
+    
+    @Override
+    public List<HollowSchema> getSchemas() {
+        return new ArrayList<>(schemas.values());
+    }
+
+    @Override
+    public HollowSchema getSchema(String typeName) {
+        return schemas.get(typeName);
+    }
+
+    @Override
+    public HollowSchema getNonNullSchema(String typeName) throws SchemaNotFoundException {
+        HollowSchema schema = getSchema(typeName);
+        if(schema == null)
+            throw new SchemaNotFoundException(typeName, schemas.keySet());
+        return schema;
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordWriter.java
@@ -101,6 +101,8 @@ public class FlatRecordWriter {
                 existingRecLocs.add(newRecordLocation);
             }
 
+            recordLocationsByOrdinal.add(recStart);
+
             return newRecordLocation.ordinal;
         }
     }


### PR DESCRIPTION
* Added `SimpleHollowDataset`, since I seem to keep recreating this class in various projects.
* Bugfix: FlatRecordWriter was not logging a new record's ordinal when it's hash collided with an existing record.
* `HollowJsonAdapter`: added ability to parse json directly into `FlatRecord`s.