### PR TITLE
Bugfix: TransitiveSetTraverser was throwing an NPE for missing types

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/tools/traverse/TransitiveSetTraverser.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/traverse/TransitiveSetTraverser.java
@@ -160,7 +160,7 @@ public class TransitiveSetTraverser {
         for(int i=0;i<schema.numFields();i++) {
             if(schema.getFieldType(i) == FieldType.REFERENCE) {
                 HollowTypeReadState childTypeState = stateEngine.getTypeState(schema.getReferencedType(i));
-                if(childTypeState.maxOrdinal() >= 0)
+                if(childTypeState != null && childTypeState.maxOrdinal() >= 0)
                     childOrdinals[i] = getOrCreateBitSet(matches, schema.getReferencedType(i), childTypeState.maxOrdinal());
             }
         }
@@ -168,7 +168,7 @@ public class TransitiveSetTraverser {
         int ordinal = matchingOrdinals.nextSetBit(0);
         while(ordinal != -1) {
             for(int i=0;i<childOrdinals.length;i++) {
-                if(schema.getFieldType(i) == FieldType.REFERENCE) {
+                if(childOrdinals[i] != null) {
                     int childOrdinal = typeState.readOrdinal(ordinal, i);
                     if(childOrdinal != -1) {
                         childOrdinals[i].set(childOrdinal);


### PR DESCRIPTION
Missing types may occur from either:
- incorrectly specified schemas on the producer side, 
- filtered types at the producer (i.e. using the `FilteredHollowBlobWriter`), or
- filtered types on the consumer side.