### PR TITLE
Efficient hollow collection equality.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/objects/HollowList.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/objects/HollowList.java
@@ -84,4 +84,24 @@ public abstract class HollowList<T> extends AbstractList<T> implements HollowRec
     public HollowRecordDelegate getDelegate() {
         return delegate;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        // Note: hashCode is computed from the list's contents, see AbstractList.hashCode
+
+        if (this == o) {
+            return true;
+        }
+
+        // If type state is the same then compare ordinals
+        if (o instanceof HollowList) {
+            HollowList<?> that = (HollowList<?>) o;
+            if (delegate.getTypeDataAccess() == that.delegate.getTypeDataAccess()) {
+                return ordinal == that.ordinal;
+            }
+        }
+
+        // Otherwise, compare the contents
+        return super.equals(o);
+    }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/objects/HollowMap.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/objects/HollowMap.java
@@ -26,6 +26,8 @@ import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -100,10 +102,35 @@ public abstract class HollowMap<K, V> extends AbstractMap<K, V> implements Hollo
         return delegate.getTypeDataAccess();
     }
 
+    @Override
+    public HollowRecordDelegate getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        // Note: hashCode is computed from the map's contents, see AbstractMap.hashCode
+
+        if (this == o) {
+            return true;
+        }
+
+        // If type state is the same then compare ordinals
+        if (o instanceof HollowMap) {
+            HollowMap<?, ?> that = (HollowMap<?, ?>) o;
+            if (delegate.getTypeDataAccess() == that.delegate.getTypeDataAccess()) {
+                return ordinal == that.ordinal;
+            }
+        }
+
+        // Otherwise, compare the contents
+        return super.equals(o);
+    }
+
     private final class EntrySet extends AbstractSet<Map.Entry<K, V>> {
 
         @Override
-        public Iterator<java.util.Map.Entry<K, V>> iterator() {
+        public Iterator<Map.Entry<K, V>> iterator() {
             return new EntryItr();
         }
 
@@ -111,7 +138,6 @@ public abstract class HollowMap<K, V> extends AbstractMap<K, V> implements Hollo
         public int size() {
             return delegate.size(ordinal);
         }
-
     }
 
     private final class EntryItr implements Iterator<Map.Entry<K, V>> {
@@ -119,7 +145,7 @@ public abstract class HollowMap<K, V> extends AbstractMap<K, V> implements Hollo
         private final HollowMapEntryOrdinalIterator ordinalIterator;
         private Map.Entry<K, V> next;
 
-        private EntryItr() {
+        EntryItr() {
             this.ordinalIterator = delegate.iterator(ordinal);
             positionNext();
         }
@@ -130,7 +156,11 @@ public abstract class HollowMap<K, V> extends AbstractMap<K, V> implements Hollo
         }
 
         @Override
-        public java.util.Map.Entry<K, V> next() {
+        public Map.Entry<K, V> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+
             Map.Entry<K, V> current = next;
             positionNext();
             return current;
@@ -138,42 +168,65 @@ public abstract class HollowMap<K, V> extends AbstractMap<K, V> implements Hollo
 
         private void positionNext() {
             if(ordinalIterator.next()) {
-                next = new Entry(ordinalIterator.getKey(), ordinalIterator.getValue());
+                next = new OrdinalEntry<>(HollowMap.this, ordinalIterator.getKey(), ordinalIterator.getValue());
             } else {
                 next = null;
             }
         }
+    }
+
+    private final static class OrdinalEntry<K, V> implements Map.Entry<K, V> {
+        private final HollowMap<K, V> map;
+        private final int keyOrdinal;
+        private final int valueOrdinal;
+
+        OrdinalEntry(HollowMap<K, V> map, int keyOrdinal, int valueOrdinal) {
+            this.map = map;
+            this.keyOrdinal = keyOrdinal;
+            this.valueOrdinal = valueOrdinal;
+        }
 
         @Override
-        public void remove() {
+        public K getKey() {
+            return map.instantiateKey(keyOrdinal);
+        }
+
+        @Override
+        public V getValue() {
+            return map.instantiateValue(valueOrdinal);
+        }
+
+        @Override
+        public V setValue(V value) {
             throw new UnsupportedOperationException();
         }
 
-        private class Entry implements Map.Entry<K, V> {
-            private final int keyOrdinal;
-            private final int valueOrdinal;
-
-            public Entry(int keyOrdinal, int valueOrdinal) {
-                this.keyOrdinal = keyOrdinal;
-                this.valueOrdinal = valueOrdinal;
-            }
-
-            public K getKey() {
-                return instantiateKey(keyOrdinal);
-            }
-
-            public V getValue() {
-                return instantiateValue(valueOrdinal);
-            }
-
-            public V setValue(V value) {
-                throw new UnsupportedOperationException();
-            }
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(getKey()) ^ Objects.hashCode(getValue());
         }
-    }
 
-    @Override
-    public HollowRecordDelegate getDelegate() {
-        return delegate;
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (!(o instanceof Map.Entry)) {
+                return false;
+            }
+
+            if (o instanceof OrdinalEntry) {
+                OrdinalEntry<?, ?> that = (OrdinalEntry) o;
+                if (map.delegate.getTypeDataAccess() == that.map.delegate.getTypeDataAccess()) {
+                    return keyOrdinal == that.keyOrdinal &&
+                            valueOrdinal == that.valueOrdinal;
+                }
+            }
+
+            Map.Entry<?, ?> that = (Map.Entry) o;
+            return Objects.equals(getKey(),that.getKey()) &&
+                    Objects.equals(getValue(),that.getValue());
+        }
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/objects/HollowSet.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/objects/HollowSet.java
@@ -24,6 +24,7 @@ import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 import java.util.AbstractSet;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * A HollowSet provides an implementation of the {@link java.util.Set} interface over
@@ -84,12 +85,37 @@ public abstract class HollowSet<T> extends AbstractSet<T> implements HollowRecor
         return new Itr();
     }
 
+    @Override
+    public HollowRecordDelegate getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        // Note: hashCode is computed from the set's contents, see AbstractSet.hashCode
+
+        if (this == o) {
+            return true;
+        }
+
+        // If type state is the same then compare ordinals
+        if (o instanceof HollowSet) {
+            HollowSet<?> that = (HollowSet<?>) o;
+            if (delegate.getTypeDataAccess() == that.delegate.getTypeDataAccess()) {
+                return ordinal == that.ordinal;
+            }
+        }
+
+        // Otherwise, compare the contents
+        return super.equals(o);
+    }
+
     private final class Itr implements Iterator<T> {
 
         private final HollowOrdinalIterator ordinalIterator;
         private T next;
 
-        private Itr() {
+        Itr() {
             this.ordinalIterator = delegate.iterator(ordinal);
             positionNext();
         }
@@ -101,6 +127,10 @@ public abstract class HollowSet<T> extends AbstractSet<T> implements HollowRecor
 
         @Override
         public T next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+
             T current = next;
             positionNext();
             return current;
@@ -114,16 +144,5 @@ public abstract class HollowSet<T> extends AbstractSet<T> implements HollowRecor
             else
                 next = null;
         }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException();
-        }
     }
-
-    @Override
-    public HollowRecordDelegate getDelegate() {
-        return delegate;
-    }
-
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowListSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowListSchema.java
@@ -60,6 +60,8 @@ public class HollowListSchema extends HollowCollectionSchema {
     
     @Override
     public boolean equals(Object other) {
+        if (this == other)
+            return true;
         if(!(other instanceof HollowListSchema))
             return false;
         HollowListSchema otherSchema = (HollowListSchema)other;

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowMapSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowMapSchema.java
@@ -83,6 +83,8 @@ public class HollowMapSchema extends HollowSchema {
 
     @Override
     public boolean equals(Object other) {
+        if (this == other)
+            return true;
         if(!(other instanceof HollowMapSchema))
             return false;
         HollowMapSchema otherSchema = (HollowMapSchema)other;

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowObjectSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowObjectSchema.java
@@ -244,6 +244,8 @@ public class HollowObjectSchema extends HollowSchema {
 
     @Override
     public boolean equals(Object other) {
+        if (this == other)
+            return true;
         if(!(other instanceof HollowObjectSchema))
             return false;
         HollowObjectSchema otherSchema = (HollowObjectSchema) other;

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSetSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSetSchema.java
@@ -70,6 +70,8 @@ public class HollowSetSchema extends HollowCollectionSchema {
 
     @Override
     public boolean equals(Object other) {
+        if (this == other)
+            return true;
         if(!(other instanceof HollowSetSchema))
             return false;
         HollowSetSchema otherSchema = (HollowSetSchema)other;

--- a/hollow/src/test/java/com/netflix/hollow/core/read/list/HollowListCollectionTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/list/HollowListCollectionTest.java
@@ -1,0 +1,138 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.read.list;
+
+import static java.util.stream.Collectors.toList;
+
+import com.netflix.hollow.api.objects.HollowRecord;
+import com.netflix.hollow.api.objects.generic.GenericHollowList;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.stream.IntStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HollowListCollectionTest {
+
+    static class Top {
+        List<Integer> ints;
+        List<String> strings;
+
+        Top(int... vs) {
+            this.ints = IntStream.of(vs).boxed().collect(toList());
+            this.strings = IntStream.of(vs).mapToObj(Integer::toString).collect(toList());
+        }
+    }
+
+    @Test
+    public void testIterator() throws IOException {
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+
+        mapper.add(new Top(1, 2, 3));
+
+        HollowReadStateEngine rse = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, rse);
+
+        GenericHollowList l = new GenericHollowList(rse, "ListOfInteger", 0);
+
+        List<Integer> keys = l.stream()
+                .map(r -> (GenericHollowObject) r)
+                .map(o -> o.getInt("value"))
+                .collect(toList());
+        Assert.assertEquals(Arrays.asList(1, 2, 3), keys);
+
+        Iterator<HollowRecord> iterator = l.iterator();
+        iterator.forEachRemaining(e -> {});
+        Assert.assertFalse(iterator.hasNext());
+        try {
+            iterator.next();
+            Assert.fail();
+        } catch (NoSuchElementException e) {
+        }
+    }
+
+    @Test
+    public void testEquals() throws IOException {
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+
+        mapper.add(new Top(1, 2, 3));
+        mapper.add(new Top(1, 2, 4));
+        mapper.add(new Top(1, 2, 3, 4));
+
+        HollowReadStateEngine rse = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, rse);
+
+        GenericHollowList l1 = new GenericHollowList(rse, "ListOfString", 0);
+        GenericHollowList l2 = new GenericHollowList(rse, "ListOfString", 0);
+        GenericHollowList l3 = new GenericHollowList(rse, "ListOfString", 1);
+        GenericHollowList l4 = new GenericHollowList(rse, "ListOfString", 2);
+        GenericHollowList l5 = new GenericHollowList(rse, "ListOfInteger", 0);
+
+        assertListEquals(l1, l1, true);
+        assertListEquals(l1, l2, true);
+        assertListEquals(l1, new ArrayList<>(l1), true);
+
+        assertListEquals(l1, l3, false);
+        assertListEquals(l1, l4, false);
+        assertListEquals(l1, l5, false);
+
+        Assert.assertNotEquals(l1, new HashSet<>(l1));
+    }
+
+    static void assertListEquals(List<?> a, List<?> b, boolean equal) {
+        if (equal) {
+            Assert.assertEquals(a.hashCode(), b.hashCode());
+            Assert.assertEquals(a, b);
+            Assert.assertTrue(equalsUsingIterator(a, b));
+
+            Assert.assertEquals(b, a);
+            Assert.assertTrue(equalsUsingIterator(b, a));
+        } else {
+            Assert.assertNotEquals(a, b);
+            Assert.assertFalse(equalsUsingIterator(a, b));
+
+            Assert.assertNotEquals(b, a);
+            Assert.assertFalse(equalsUsingIterator(b, a));
+        }
+    }
+
+    static boolean equalsUsingIterator(List<?> a, List<?> b) {
+        ListIterator<?> ia = a.listIterator();
+        ListIterator<?> ib = b.listIterator();
+        while (ia.hasNext() && ib.hasNext()) {
+            if (!Objects.equals(ia.next(), ib.next())) {
+                return false;
+            }
+        }
+        return !(ia.hasNext() || ib.hasNext());
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/map/HollowMapCollectionTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/map/HollowMapCollectionTest.java
@@ -1,0 +1,135 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.read.map;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import com.netflix.hollow.api.objects.HollowRecord;
+import com.netflix.hollow.api.objects.generic.GenericHollowMap;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HollowMapCollectionTest {
+
+    @Test
+    public void testEntryIterator() throws IOException {
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+
+        mapper.add(new Top(1, 2, 3));
+
+        HollowReadStateEngine rse = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, rse);
+
+        GenericHollowMap m = new GenericHollowMap(rse, "MapOfIntegerToInteger", 0);
+
+        List<Integer> keys = m.entrySet().stream().map(Map.Entry::getKey)
+                .map(r -> (GenericHollowObject) r)
+                .map(o -> o.getInt("value"))
+                .sorted()
+                .collect(toList());
+        Assert.assertEquals(Arrays.asList(1, 2, 3), keys);
+
+        Iterator<Map.Entry<HollowRecord, HollowRecord>> iterator = m.entrySet().iterator();
+        iterator.forEachRemaining(e -> {});
+        Assert.assertFalse(iterator.hasNext());
+        try {
+            iterator.next();
+            Assert.fail();
+        } catch (NoSuchElementException e) {
+        }
+    }
+
+    @Test
+    public void testEquals() throws IOException {
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+
+        mapper.add(new Top(1, 2, 3));
+        mapper.add(new Top(1, 2, 4));
+        mapper.add(new Top(1, 2, 3, 4));
+
+        HollowReadStateEngine rse = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, rse);
+
+        GenericHollowMap m1 = new GenericHollowMap(rse, "MapOfStringToString", 0);
+        GenericHollowMap m2 = new GenericHollowMap(rse, "MapOfStringToString", 0);
+        GenericHollowMap m3 = new GenericHollowMap(rse, "MapOfStringToString", 1);
+        GenericHollowMap m4 = new GenericHollowMap(rse, "MapOfStringToString", 2);
+        GenericHollowMap m5 = new GenericHollowMap(rse, "MapOfIntegerToInteger", 0);
+
+        assertMapEquals(m1, m1, true);
+        assertMapEquals(m1, m2, true);
+        assertMapEquals(m1, new HashMap<>(m1), true);
+
+        assertMapEquals(m1, m3, false);
+        assertMapEquals(m1, m4, false);
+        assertMapEquals(m1, m5, false);
+
+        Assert.assertNotEquals(m1, new ArrayList<>(m1.keySet()));
+    }
+
+    static void assertMapEquals(Map<?, ?> a, Map<?, ?> b, boolean equal) {
+        if (equal) {
+            Assert.assertEquals(a.hashCode(), b.hashCode());
+            Assert.assertEquals(a, b);
+            Assert.assertTrue(equalsUsingContains(a, b));
+
+            Assert.assertEquals(b, a);
+            Assert.assertTrue(equalsUsingContains(b, a));
+        } else {
+            Assert.assertNotEquals(a, b);
+            Assert.assertFalse(equalsUsingContains(a, b));
+
+            Assert.assertNotEquals(b, a);
+            Assert.assertFalse(equalsUsingContains(b, a));
+        }
+    }
+
+    static class Top {
+        Map<Integer, Integer> ints;
+        Map<String, String> strings;
+
+        Top(int... vs) {
+            this.ints = IntStream.of(vs).boxed().collect(toMap(e -> e, e -> e));
+            this.strings = IntStream.of(vs).mapToObj(Integer::toString).collect(toMap(e -> e, e -> e));
+        }
+    }
+
+    static boolean equalsUsingContains(Map<?, ?> a, Map<?, ?> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        return a.entrySet().containsAll(b.entrySet());
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/set/HollowSetCollectionTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/set/HollowSetCollectionTest.java
@@ -1,0 +1,140 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.read.set;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+import com.netflix.hollow.api.objects.HollowRecord;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.api.objects.generic.GenericHollowSet;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HollowSetCollectionTest {
+
+    static class Top {
+        Set<Integer> ints;
+        Set<String> strings;
+
+        Top(int... vs) {
+            this.ints = IntStream.of(vs).boxed().collect(toSet());
+            this.strings = IntStream.of(vs).mapToObj(Integer::toString).collect(toSet());
+        }
+    }
+
+    @Test
+    public void testIterator() throws IOException {
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+
+        mapper.add(new Top(1, 2, 3));
+
+        HollowReadStateEngine rse = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, rse);
+
+        GenericHollowSet s = new GenericHollowSet(rse, "SetOfInteger", 0);
+
+        List<Integer> keys = s.stream()
+                .map(r -> (GenericHollowObject) r)
+                .map(o -> o.getInt("value"))
+                .sorted()
+                .collect(toList());
+        Assert.assertEquals(Arrays.asList(1, 2, 3), keys);
+
+        Iterator<HollowRecord> iterator = s.iterator();
+        iterator.forEachRemaining(e -> {});
+        Assert.assertFalse(iterator.hasNext());
+        try {
+            iterator.next();
+            Assert.fail();
+        } catch (NoSuchElementException e) {
+        }
+    }
+
+    @Test
+    public void testEquals() throws IOException {
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+
+        mapper.add(new Top(1, 2, 3));
+        mapper.add(new Top(1, 2, 4));
+        mapper.add(new Top(1, 2, 3, 4));
+
+        HollowReadStateEngine rse = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, rse);
+
+        GenericHollowSet s1 = new GenericHollowSet(rse, "SetOfString", 0);
+        GenericHollowSet s2 = new GenericHollowSet(rse, "SetOfString", 0);
+        GenericHollowSet s3 = new GenericHollowSet(rse, "SetOfString", 1);
+        GenericHollowSet s4 = new GenericHollowSet(rse, "SetOfString", 2);
+        GenericHollowSet s5 = new GenericHollowSet(rse, "SetOfInteger", 0);
+
+        assertSetEquals(s1, s1, true);
+        assertSetEquals(s1, s2, true);
+        assertSetEquals(s1, new HashSet<>(s1), true);
+
+        assertSetEquals(s1, s3, false);
+        assertSetEquals(s1, s4, false);
+        assertSetEquals(s1, s5, false);
+
+        Assert.assertNotEquals(s1, new ArrayList<>(s1));
+    }
+
+    static void assertSetEquals(Set<?> a, Set<?> b, boolean equal) {
+        if (equal) {
+            Assert.assertEquals(a.hashCode(), b.hashCode());
+            Assert.assertEquals(a, b);
+            Assert.assertTrue(equalsUsingContains(a, b));
+
+            Assert.assertEquals(b, a);
+            Assert.assertTrue(equalsUsingContains(b, a));
+        } else {
+            Assert.assertNotEquals(a, b);
+            Assert.assertFalse(equalsUsingContains(a, b));
+
+            Assert.assertNotEquals(b, a);
+            Assert.assertFalse(equalsUsingContains(b, a));
+        }
+    }
+
+    static boolean equalsUsingContains(Set<?> a, Set<?> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+
+        try {
+            return a.containsAll(b);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
1. `HollowList`, `HollowSet`, and `HollowMap` equals with optimization for ordinal equality when possible instead of content equality.

2. `HollowSet` iterator and `HollowMap` entry set iterator throw `NoSuchMethodElement`.

3. `HollowMap` entries support equals and hash code. The former uses the same optimization as 1) and the hash code is calculated from the key and value. 