### PR TITLE
Incremental producer restore should not preserve record hash positions

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -295,7 +295,7 @@ public class HollowProducer {
 
     HollowProducer.ReadState hardRestore(long versionDesired, HollowConsumer.BlobRetriever blobRetriever) {
         return restore(versionDesired, blobRetriever,
-                (restoreFrom, restoreTo) -> HollowWriteStateCreator.populateUsingReadEngine(restoreTo, restoreFrom));
+                (restoreFrom, restoreTo) -> HollowWriteStateCreator.populateUsingReadEngine(restoreTo, restoreFrom, false));
     }
 
     private interface RestoreAction {

--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
@@ -34,6 +34,7 @@ import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.copy.HollowRecordCopier;
+import com.netflix.hollow.tools.combine.IdentityOrdinalRemapper;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -144,7 +145,11 @@ public class HollowWriteStateCreator {
      * @param writeEngine the write state engine
      * @param readEngine the read state engine
      */
-    public static void populateUsingReadEngine(final HollowWriteStateEngine writeEngine, final HollowReadStateEngine readEngine) {
+    public static void populateUsingReadEngine(HollowWriteStateEngine writeEngine, HollowReadStateEngine readEngine) {
+        populateUsingReadEngine(writeEngine, readEngine, true);
+    }
+
+    public static void populateUsingReadEngine(HollowWriteStateEngine writeEngine, HollowReadStateEngine readEngine, boolean preserveHashPositions) {
         SimultaneousExecutor executor = new SimultaneousExecutor();
         
         for(HollowTypeWriteState writeState : writeEngine.getOrderedTypeStates()) {
@@ -160,7 +165,7 @@ public class HollowWriteStateCreator {
                     if(writeState != null) {
                         writeState.setNumShards(readState.numShards());
                         
-                        HollowRecordCopier copier = HollowRecordCopier.createCopier(readState, writeState.getSchema());
+                        HollowRecordCopier copier = HollowRecordCopier.createCopier(readState, writeState.getSchema(), IdentityOrdinalRemapper.INSTANCE, preserveHashPositions);
                         
                         BitSet populatedOrdinals = readState.getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
 


### PR DESCRIPTION
When the incremental producer restarted and restored `SET` and/or `MAP` types, the preservation of hash _positions_ was causing a lot of false diffs, because the _actual_ hash codes were lost to history.  Since hash codes are encoded into the records in the write state, this caused the byte sequence representing these records in the write state to differ when the _same_ records were legitimately added back.

"Preserving hash positions" is only a useful concept in the context of the deprecated `HollowObjectHashCodeFinder`. 

I am hesitant to change the behavior of the `HollowWriteStateCreator`, so I am adding a new method to access the new behavior.  I am comfortable with changing the behavior of the `HollowIncrementalProducer`, because:

* it is unlikely that anyone is using a `HollowObjectHashCodeFinder` in the context of an incremental producer, and
* `HollowIncrementalProducer` is still marked as a beta API.

