### PR TITLE
Events for blob stage and async blob publish

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowProducerMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowProducerMetrics.java
@@ -20,13 +20,16 @@ import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.api.producer.HollowProducerListener;
 import com.netflix.hollow.api.producer.Status;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class HollowProducerMetrics extends HollowMetrics {
     private int cyclesCompleted = 0;
     private int cyclesSucceeded = 0;
     private int cycleFailed = 0;
-    private int snapshotsCompleted = 0;
-    private int snapshotsFailed = 0;
+    // Snapshots can be published asynchronously resulting concurrent
+    // access to the snapshot metrics
+    private AtomicInteger snapshotsCompleted = new AtomicInteger();
+    private AtomicInteger snapshotsFailed = new AtomicInteger();
     private int deltasCompleted = 0;
     private int deltasFailed = 0;
     private int reverseDeltasCompleted = 0;
@@ -81,9 +84,9 @@ public class HollowProducerMetrics extends HollowMetrics {
         switch (blobType) {
             case SNAPSHOT:
                 if(status.getType() == Status.StatusType.SUCCESS)
-                    snapshotsCompleted++;
+                    snapshotsCompleted.incrementAndGet();
                 else
-                    snapshotsFailed++;
+                    snapshotsFailed.incrementAndGet();
                 break;
             case DELTA:
                 if(status.getType() == Status.StatusType.SUCCESS)
@@ -113,11 +116,11 @@ public class HollowProducerMetrics extends HollowMetrics {
     }
 
     public int getSnapshotsCompleted() {
-        return snapshotsCompleted;
+        return snapshotsCompleted.get();
     }
 
     public int getSnapshotsFailed() {
-        return snapshotsFailed;
+        return snapshotsFailed.get();
     }
 
     public int getDeltasCompleted() {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ListenerSupport.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
@@ -216,6 +217,20 @@ final class ListenerSupport {
                     l -> l.onPublishStart(version));
 
             return new Status.StageBuilder().version(version);
+        }
+
+        void fireBlobStage(Status.PublishBuilder b) {
+            Status s = b.build();
+            HollowProducer.Blob blob = b.blob;
+            Duration elapsed = b.elapsed();
+
+            fire(PublishListener.class,
+                    l -> l.onBlobStage(s, blob, elapsed));
+        }
+
+        void fireBlobPublishAsync(CompletableFuture<HollowProducer.Blob> f) {
+            fire(PublishListener.class,
+                    l -> l.onBlobPublishAsync(f));
         }
 
         void fireBlobPublish(Status.PublishBuilder b) {

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerListenerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerListenerTest.java
@@ -1,55 +1,778 @@
 package com.netflix.hollow.api.producer;
 
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
 import com.netflix.hollow.api.producer.enforcer.SingleProducerEnforcer;
-import java.util.concurrent.TimeUnit;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.api.producer.listener.AnnouncementListener;
+import com.netflix.hollow.api.producer.listener.CycleListener;
+import com.netflix.hollow.api.producer.listener.DataModelInitializationListener;
+import com.netflix.hollow.api.producer.listener.IntegrityCheckListener;
+import com.netflix.hollow.api.producer.listener.PopulateListener;
+import com.netflix.hollow.api.producer.listener.PublishListener;
+import com.netflix.hollow.api.producer.listener.RestoreListener;
+import com.netflix.hollow.api.producer.validation.ValidationStatus;
+import com.netflix.hollow.api.producer.validation.ValidationStatusListener;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
 
 /**
  * Unit tests to verify that HollowProducerListener objects provided to HollowProducers
  * are invoked at the right times.
  */
 public class HollowProducerListenerTest {
-    private HollowProducer producer;
-
-    // Spy on the listeners to only mock the abstract methods, otherwise
-    // the default (non-abstract) methods will be mocked which changes the
-    // behaviour
-    @Spy
-    private HollowProducerListener listener;
-
-    @Mock
-    private SingleProducerEnforcer singleProducerEnforcer;
+    private InMemoryBlobStore blobStore;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
-        this.producer = new HollowProducer.Builder()
-                .withListeners(listener).withSingleProducerEnforcer(singleProducerEnforcer).build();
+        blobStore = new InMemoryBlobStore();
+    }
+
+    static class BaseListener {
+        Map<String, Integer> callCount = new HashMap<>();
+
+        void reportCaller() {
+            Throwable t = new Throwable();
+            StackTraceElement caller = t.getStackTrace()[1];
+            callCount.compute(caller.getMethodName(), (k, v) -> v == null ? 1 : v + 1);
+        }
     }
 
     @Test
-    public void testCycleSkip() {
-        Mockito.when(singleProducerEnforcer.isPrimary()).thenReturn(false);
-        this.producer.runCycle(null);
-        Mockito.verify(listener).onCycleSkip(
-                HollowProducerListener.CycleSkipReason.NOT_PRIMARY_PRODUCER);
-        Mockito.verify(listener, Mockito.never()).onCycleStart(
-                ArgumentMatchers.anyLong());
+    public void testFirstCycle() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withAnnouncer((HollowProducer.Announcer) stateVersion -> { })
+                .build();
+
+        class Listeners extends BaseListener implements
+                DataModelInitializationListener,
+                RestoreListener,
+                CycleListener,
+                PopulateListener,
+                IntegrityCheckListener,
+                ValidationStatusListener,
+                PublishListener,
+                AnnouncementListener {
+
+            @Override public void onProducerInit(Duration elapsed) {
+                reportCaller();
+            }
+
+            @Override public void onProducerRestoreStart(long restoreVersion) {
+                Assert.fail();
+            }
+
+            @Override public void onProducerRestoreComplete(
+                    Status status, long versionDesired, long versionReached, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                Assert.fail();
+            }
+
+            @Override public void onCycleSkip(CycleSkipReason reason) {
+                Assert.fail();
+            }
+
+            long newDeltaChainVersion;
+
+            @Override public void onNewDeltaChain(long version) {
+                reportCaller();
+                newDeltaChainVersion = version;
+            }
+
+            @Override public void onCycleStart(long version) {
+                reportCaller();
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onCycleComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onCycleStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onIntegrityCheckStart(long version) {
+                reportCaller();
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onIntegrityCheckComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onIntegrityCheckStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onPopulateStart(long version) {
+                reportCaller();
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onPopulateComplete(Status status, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onPopulateStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onNoDeltaAvailable(long version) {
+                Assert.fail();
+            }
+
+            @Override public void onPublishStart(long version) {
+                reportCaller();
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onBlobStage(Status status, HollowProducer.Blob blob, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertEquals(HollowProducer.Blob.Type.SNAPSHOT, blob.getType());
+                Assert.assertTrue(callCount.containsKey("onPublishStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+            }
+
+            @Override public void onBlobPublishAsync(
+                    CompletableFuture<HollowProducer.Blob> blob) {
+                Assert.fail();
+            }
+
+            @Override public void onBlobPublish(Status status, HollowProducer.Blob blob, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertEquals(HollowProducer.Blob.Type.SNAPSHOT, blob.getType());
+                Assert.assertTrue(callCount.containsKey("onBlobStage"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+            }
+
+            @Override public void onPublishComplete(Status status, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onBlobPublish"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onValidationStatusStart(long version) {
+                reportCaller();
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onValidationStatusComplete(
+                    ValidationStatus status, long version, Duration elapsed) {
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onValidationStatusStart"));
+                Assert.assertTrue(status.passed());
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onAnnouncementStart(long version) {
+                reportCaller();
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+
+            @Override public void onAnnouncementComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onAnnouncementStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(newDeltaChainVersion, version);
+            }
+        }
+
+        Listeners ls = new Listeners();
+        producer.addListener(ls);
+        producer.initializeDataModel(Top.class);
+
+        producer.runCycle(ws -> ws.add(new Top(1)));
+
+        Assert.assertTrue(ls.callCount.values().stream().allMatch(c -> c == 1));
+        Assert.assertEquals(16, ls.callCount.size());
+    }
+
+
+    @Test
+    public void testSecondCycleWithChanges() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+        producer.initializeDataModel(Top.class);
+
+        producer.runCycle(ws -> ws.add(new Top(1)));
+
+        class Listeners extends BaseListener implements
+                DataModelInitializationListener,
+                RestoreListener,
+                CycleListener,
+                PopulateListener,
+                IntegrityCheckListener,
+                ValidationStatusListener,
+                PublishListener,
+                AnnouncementListener {
+
+            @Override public void onProducerInit(Duration elapsed) {
+                Assert.fail();
+            }
+
+            @Override public void onProducerRestoreStart(long restoreVersion) {
+                Assert.fail();
+            }
+
+            @Override public void onProducerRestoreComplete(
+                    Status status, long versionDesired, long versionReached, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                Assert.fail();
+            }
+
+            @Override public void onCycleSkip(CycleSkipReason reason) {
+                Assert.fail();
+            }
+
+            long cycleStartVersion;
+
+            @Override public void onNewDeltaChain(long version) {
+                Assert.fail();
+            }
+
+            @Override public void onCycleStart(long version) {
+                reportCaller();
+                cycleStartVersion = version;
+            }
+
+            @Override public void onCycleComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onCycleStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onIntegrityCheckStart(long version) {
+                reportCaller();
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onIntegrityCheckComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onIntegrityCheckStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onPopulateStart(long version) {
+                reportCaller();
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onPopulateComplete(Status status, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onPopulateStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onNoDeltaAvailable(long version) {
+                Assert.fail();
+            }
+
+            @Override public void onPublishStart(long version) {
+                reportCaller();
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onBlobStage(Status status, HollowProducer.Blob blob, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onPublishStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+            }
+
+            @Override public void onBlobPublishAsync(
+                    CompletableFuture<HollowProducer.Blob> blob) {
+                Assert.fail();
+            }
+
+            @Override public void onBlobPublish(Status status, HollowProducer.Blob blob, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onBlobStage"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+            }
+
+            @Override public void onPublishComplete(Status status, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onBlobPublish"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onValidationStatusStart(long version) {
+                reportCaller();
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onValidationStatusComplete(
+                    ValidationStatus status, long version, Duration elapsed) {
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onValidationStatusStart"));
+                Assert.assertTrue(status.passed());
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onAnnouncementStart(long version) {
+                reportCaller();
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onAnnouncementComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onAnnouncementStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+        }
+
+        Listeners ls = new Listeners();
+        producer.addListener(ls);
+
+        producer.runCycle(ws -> ws.add(new Top(2)));
+
+        Assert.assertTrue(ls.callCount.entrySet().stream()
+                .filter(e -> !e.getKey().equals("onBlobStage"))
+                .filter(e -> !e.getKey().equals("onBlobPublish"))
+                .map(Map.Entry::getValue)
+                .allMatch(c -> c == 1));
+        Assert.assertEquals(3, ls.callCount.get("onBlobStage").intValue());
+        Assert.assertEquals(3, ls.callCount.get("onBlobPublish").intValue());
+        Assert.assertEquals(12, ls.callCount.size());
     }
 
     @Test
-    public void testCycleStartEnd() {
-        Mockito.when(singleProducerEnforcer.isPrimary()).thenReturn(true);
-        this.producer.runCycle(Mockito.mock(HollowProducer.Populator.class));
-        Mockito.verify(listener).onCycleStart(ArgumentMatchers.anyLong());
-        Mockito.verify(listener).onCycleComplete(
-                Mockito.any(HollowProducerListener.ProducerStatus.class),
-                ArgumentMatchers.anyLong(), Mockito.any(TimeUnit.class));
+    public void testSecondCycleNoChanges() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+        producer.initializeDataModel(Top.class);
+
+        producer.runCycle(ws -> ws.add(new Top(1)));
+
+        class Listeners extends BaseListener implements
+                DataModelInitializationListener,
+                RestoreListener,
+                CycleListener,
+                PopulateListener,
+                IntegrityCheckListener,
+                ValidationStatusListener,
+                PublishListener,
+                AnnouncementListener {
+
+            @Override public void onProducerInit(Duration elapsed) {
+                Assert.fail();
+            }
+
+            @Override public void onProducerRestoreStart(long restoreVersion) {
+                Assert.fail();
+            }
+
+            @Override public void onProducerRestoreComplete(
+                    Status status, long versionDesired, long versionReached, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                Assert.fail();
+            }
+
+            @Override public void onCycleSkip(CycleSkipReason reason) {
+                Assert.fail();
+            }
+
+            long cycleStartVersion;
+
+            @Override public void onNewDeltaChain(long version) {
+                Assert.fail();
+            }
+
+            @Override public void onCycleStart(long version) {
+                reportCaller();
+                cycleStartVersion = version;
+            }
+
+            @Override public void onCycleComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onCycleStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onIntegrityCheckStart(long version) {
+                Assert.fail();
+            }
+
+            @Override public void onIntegrityCheckComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                Assert.fail();
+            }
+
+            @Override public void onPopulateStart(long version) {
+                reportCaller();
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onPopulateComplete(Status status, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onPopulateStart"));
+                Assert.assertEquals(Status.StatusType.SUCCESS, status.getType());
+                Assert.assertEquals(cycleStartVersion, version);
+            }
+
+            @Override public void onNoDeltaAvailable(long version) {
+                reportCaller();
+                Assert.assertTrue(callCount.containsKey("onPopulateComplete"));
+            }
+
+            @Override public void onPublishStart(long version) {
+                Assert.fail();
+            }
+
+            @Override public void onBlobStage(Status status, HollowProducer.Blob blob, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                Assert.fail();
+            }
+
+            @Override public void onBlobPublishAsync(
+                    CompletableFuture<HollowProducer.Blob> blob) {
+                Assert.fail();
+            }
+
+            @Override public void onBlobPublish(Status status, HollowProducer.Blob blob, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                Assert.fail();
+            }
+
+            @Override public void onPublishComplete(Status status, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                Assert.fail();
+            }
+
+            @Override public void onValidationStatusStart(long version) {
+                Assert.fail();
+            }
+
+            @Override public void onValidationStatusComplete(
+                    ValidationStatus status, long version, Duration elapsed) {
+                Assert.fail();
+            }
+
+            @Override public void onAnnouncementStart(long version) {
+                Assert.fail();
+            }
+
+            @Override public void onAnnouncementComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                if (status.getCause() instanceof AssertionError) {
+                    return;
+                }
+                Assert.fail();
+            }
+        }
+
+        Listeners ls = new Listeners();
+        producer.addListener(ls);
+
+        producer.runCycle(ws -> ws.add(new Top(1)));
+
+        Assert.assertTrue(ls.callCount.values().stream().allMatch(c -> c == 1));
+        Assert.assertEquals(5, ls.callCount.size());
+    }
+
+    @Test
+    public void testCycleSkipWithSingleEnforcer() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withSingleProducerEnforcer(new SingleProducerEnforcer() {
+                    @Override public void enable() {
+                    }
+
+                    @Override public void disable() {
+                    }
+
+                    @Override public boolean isPrimary() {
+                        return false;
+                    }
+
+                    @Override public void force() {
+                    }
+                })
+                .build();
+
+        class Listeners extends BaseListener implements CycleListener {
+            @Override public void onCycleSkip(CycleSkipReason reason) {
+                reportCaller();
+                Assert.assertEquals(HollowProducerListener.CycleSkipReason.NOT_PRIMARY_PRODUCER, reason);
+            }
+
+            @Override public void onNewDeltaChain(long version) {
+                Assert.fail();
+            }
+
+            @Override public void onCycleStart(long version) {
+                Assert.fail();
+            }
+
+            @Override public void onCycleComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                Assert.fail();
+            }
+        }
+
+        Listeners ls = new Listeners();
+        producer.addListener(ls);
+
+        producer.runCycle(ws -> ws.add(new Top(1)));
+
+        Assert.assertEquals(1, ls.callCount.size());
+    }
+
+    @Test
+    public void testCycleStartEndWithSingleEnforcer() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withSingleProducerEnforcer(new SingleProducerEnforcer() {
+                    @Override public void enable() {
+                    }
+
+                    @Override public void disable() {
+                    }
+
+                    @Override public boolean isPrimary() {
+                        return true;
+                    }
+
+                    @Override public void force() {
+                    }
+                })
+                .build();
+
+        class Listeners extends BaseListener implements CycleListener {
+            @Override public void onCycleSkip(CycleSkipReason reason) {
+                Assert.fail();
+            }
+
+            @Override public void onNewDeltaChain(long version) {
+                reportCaller();
+            }
+
+            @Override public void onCycleStart(long version) {
+                reportCaller();
+            }
+
+            @Override public void onCycleComplete(
+                    Status status, HollowProducer.ReadState readState, long version, Duration elapsed) {
+                reportCaller();
+            }
+        }
+
+        Listeners ls = new Listeners();
+        producer.addListener(ls);
+
+        producer.runCycle(ws -> ws.add(new Top(1)));
+
+        Assert.assertEquals(3, ls.callCount.size());
+    }
+
+    @Test
+    public void testBlobPublishAsync() {
+        ExecutorService executor = Executors.newCachedThreadPool();
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withSnapshotPublishExecutor(executor)
+                .build();
+        producer.initializeDataModel(Top.class);
+
+        producer.runCycle(ws -> ws.add(new Top(1)));
+
+        class Listeners extends BaseListener implements PublishListener {
+            CompletableFuture<HollowProducer.Blob> snapshotBlob;
+
+            @Override public void onNoDeltaAvailable(long version) {
+            }
+
+            @Override public void onPublishStart(long version) {
+            }
+
+            @Override public void onBlobStage(Status status, HollowProducer.Blob blob, Duration elapsed) {
+            }
+
+            @Override public void onBlobPublish(Status status, HollowProducer.Blob blob, Duration elapsed) {
+                Assert.assertNotEquals(HollowProducer.Blob.Type.SNAPSHOT, blob.getType());
+            }
+
+            @Override public void onBlobPublishAsync(CompletableFuture<HollowProducer.Blob> blob) {
+                reportCaller();
+                this.snapshotBlob = blob.thenApply(b -> {
+                    Assert.assertEquals(HollowProducer.Blob.Type.SNAPSHOT, b.getType());
+                    try {
+                        InputStream contents = b.newInputStream();
+                        contents.read();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    return b;
+                });
+            }
+
+            @Override public void onPublishComplete(Status status, long version, Duration elapsed) {
+            }
+        }
+
+        Listeners ls = new Listeners();
+        producer.addListener(ls);
+
+        producer.runCycle(ws -> ws.add(new Top(2)));
+
+        Assert.assertEquals(1, ls.callCount.size());
+        Assert.assertNotNull(ls.snapshotBlob);
+
+        HollowProducer.Blob b = ls.snapshotBlob.join();
+    }
+
+    @Test
+    public void testBlobPublishAsyncExecutorFail() {
+        Executor executor = (r) -> { throw new RejectedExecutionException(); };
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withSnapshotPublishExecutor(executor)
+                .build();
+        producer.initializeDataModel(Top.class);
+
+        producer.runCycle(ws -> ws.add(new Top(1)));
+
+        class Listeners extends BaseListener implements PublishListener {
+            CompletableFuture<HollowProducer.Blob> snapshotBlob;
+
+            @Override public void onNoDeltaAvailable(long version) {
+            }
+
+            @Override public void onPublishStart(long version) {
+            }
+
+            @Override public void onBlobStage(Status status, HollowProducer.Blob blob, Duration elapsed) {
+            }
+
+            @Override public void onBlobPublish(Status status, HollowProducer.Blob blob, Duration elapsed) {
+                Assert.assertNotEquals(HollowProducer.Blob.Type.SNAPSHOT, blob.getType());
+            }
+
+            @Override public void onBlobPublishAsync(CompletableFuture<HollowProducer.Blob> blob) {
+                reportCaller();
+                this.snapshotBlob = blob;
+            }
+
+            @Override public void onPublishComplete(Status status, long version, Duration elapsed) {
+                reportCaller();
+                Assert.assertEquals(Status.StatusType.FAIL, status.getType());
+                Assert.assertTrue(status.getCause() instanceof RejectedExecutionException);
+            }
+        }
+
+        Listeners ls = new Listeners();
+        producer.addListener(ls);
+
+        try {
+            producer.runCycle(ws -> ws.add(new Top(2)));
+            Assert.fail();
+        } catch (RejectedExecutionException e) {
+        }
+
+        Assert.assertEquals(2, ls.callCount.size());
+        Assert.assertNotNull(ls.snapshotBlob);
+        Assert.assertTrue(ls.snapshotBlob.isCompletedExceptionally());
+
+        try {
+            ls.snapshotBlob.join();
+            Assert.fail();
+        } catch (CompletionException e) {
+            Assert.assertTrue(e.getCause() instanceof RejectedExecutionException);
+        }
+    }
+
+    static class Top {
+        final int id;
+
+        Top(int id) {
+            this.id = id;
+        }
     }
 }


### PR DESCRIPTION
- Emit a `onBlobStage` event after a blob has been staged.  This enables direct operation on blob contents before they have been published.

- When a snapshot publish executor is registered with a producer then emit a `onBlobPublishAsync` event instead of a `onBlobPublish` event.
Prior to this change the latter event would be emitted asynchronously, concurrently, and out of order with respect to other events, possibly leading to concurrency issues in client code.
The former event provides a `CompletableFuture<Blob>` that completes successfully when the snapshot blob has been published, otherwise completes exceptionally if the publish fails.
It is anticipated that the use of snapshot publish executor is currently rare so the change in behavior is acceptable.

- The listener test is significantly improved.  Given the extent to which listeners are relied upon this fills an important gap in the tests.
