### PR TITLE
Rejuvenate log levels

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -671,12 +671,12 @@ abstract class AbstractHollowProducer {
             if (readStates.hasCurrent()) {
                 HollowReadStateEngine current = readStates.current().getStateEngine();
 
-                log.info("CHECKSUMS");
+                log.finest("CHECKSUMS");
                 HollowChecksum currentChecksum = HollowChecksum.forStateEngineWithCommonSchemas(current, pending);
-                log.info("  CUR        " + currentChecksum);
+                log.finest("  CUR        " + currentChecksum);
 
                 HollowChecksum pendingChecksum = HollowChecksum.forStateEngineWithCommonSchemas(pending, current);
-                log.info("         PND " + pendingChecksum);
+                log.finest("         PND " + pendingChecksum);
 
                 if (artifacts.hasDelta()) {
                     if (!artifacts.hasReverseDelta()) {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -95,8 +95,8 @@ public class HollowBlobReader {
 
         long endTime = System.currentTimeMillis();
 
-        log.info("SNAPSHOT COMPLETED IN " + (endTime - startTime) + "ms");
-        log.info("TYPES: " + typeNames);
+        log.finest("SNAPSHOT COMPLETED IN " + (endTime - startTime) + "ms");
+        log.finest("TYPES: " + typeNames);
 
         notifyEndUpdate();
 
@@ -131,8 +131,8 @@ public class HollowBlobReader {
 
         long endTime = System.currentTimeMillis();
 
-        log.info("DELTA COMPLETED IN " + (endTime - startTime) + "ms");
-        log.info("TYPES: " + typeNames);
+        log.finest("DELTA COMPLETED IN " + (endTime - startTime) + "ms");
+        log.finest("TYPES: " + typeNames);
 
         notifyEndUpdate();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
@@ -159,7 +159,7 @@ public class HollowWriteStateEngine implements HollowStateEngine {
                 executor.execute(new Runnable() {
                     @Override
                     public void run() {
-                        log.info("RESTORE: " + typeName);
+                        log.finest("RESTORE: " + typeName);
                         writeState.restoreFrom(readState);
                     }
                 });

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiff.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiff.java
@@ -137,7 +137,7 @@ public class HollowDiff {
 
         long endTime = System.currentTimeMillis();
 
-        log.info("PREPARED IN " + (endTime - startTime) + "ms");
+        log.finest("PREPARED IN " + (endTime - startTime) + "ms");
 
         for(HollowTypeDiff typeDiff : typeDiffs.values()) {
             typeDiff.calculateDiffs();

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/exact/DiffEqualityMapping.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/exact/DiffEqualityMapping.java
@@ -88,9 +88,9 @@ public class DiffEqualityMapping {
         if(fromTypeState == null || toTypeState == null)
             return DiffEqualOrdinalMap.EMPTY_MAP;
 
-        log.info("starting to build equality map for " + type);
+        log.finest("starting to build equality map for " + type);
         DiffEqualOrdinalMap map = buildMap(fromTypeState, toTypeState);
-        log.info("finished building equality map for " + type);
+        log.finest("finished building equality map for " + type);
         return map;
     }
 


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Settings

We have several analysis settings . We can vary these settings and rerun our if you desire. The settings we are using in this pull request are:

1. Treat  CONFIG level as a category and not a traditional level, i.e., our tool ignores CONFIG log level.
1. Never lower the logging level of logging statements within catch blocks.
1. Never lower the logging level of logging statements within if statements.
1. Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
1. The greatest number of commits evaluated: 1000.

The head at time of analysis was: 43ca100034a01050fb764170bd32b085ac9a3c22