### PR TITLE
Remove HollowObjectMapper performance bottleneck

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
@@ -132,7 +132,7 @@ public class HollowObjectMapper {
         // Compute the type name
         String typeName = declaredName != null
                 ? declaredName
-                : typeNameMappers.computeIfAbsent(type, HollowObjectTypeMapper::getDefaultTypeName);
+                : findTypeName(type);
         HollowTypeMapper typeMapper = typeMappers.get(typeName);
 
         if (typeMapper == null) {
@@ -171,6 +171,15 @@ public class HollowObjectMapper {
         }
 
         return typeMapper;
+    }
+
+    private String findTypeName(Type type) {
+        String typeName = typeNameMappers.get(type);
+        if(typeName == null) {
+            typeName = HollowObjectTypeMapper.getDefaultTypeName(type);
+            typeNameMappers.putIfAbsent(type, typeName);
+        }
+        return typeName;
     }
 
     int nextUnassignedTypeId() {


### PR DESCRIPTION
Significant speedup observed for certain workloads by avoiding use of `ConcurrentHashMap.computeIfAbsent` here.