### PR TITLE
Don't fail with NPE when DuplicateDDValidator for missing type

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -49,10 +49,15 @@ public class DuplicateDataDetectionValidator implements ValidatorListener {
     private static final String DUPLICATE_KEYS_FOUND_ERRRO_MSG_FORMAT =
             "Duplicate keys found for type %s. Primarykey in schema is %s. "
                     + "Duplicate IDs are: %s";
-    private static final String NO_PRIMARY_KEY_ERRRO_MSG_FORMAT =
+    private static final String NO_PRIMARY_KEY_ERROR_MSG_FORMAT =
             "DuplicateDataDetectionValidator defined but unable to find primary key "
                     + "for data type %s. Please check schema definition.";
-    private static final String NOT_AN_OBJECT_ERROR_MSGR_FORMAT =
+
+    private static final String NO_SCHEMA_FOUND_MSG_FORMAT =
+            "DuplicateDataDetectionValidator defined for data type %s but schema not found."
+            + "Please check that the HollowProducer is initialized with the data type's schema "
+            + "(see initializeDataModel)";
+    private static final String NOT_AN_OBJECT_ERROR_MSG_FORMAT =
             "DuplicateDataDetectionValidator is defined but schema type of %s "
                     + "is not Object. This validation cannot be done.";
 
@@ -125,14 +130,17 @@ public class DuplicateDataDetectionValidator implements ValidatorListener {
         PrimaryKey primaryKey;
         if (fieldPathNames == null) {
             HollowSchema schema = readState.getStateEngine().getSchema(dataTypeName);
+            if (schema == null) {
+                return vrb.failed(String.format(NO_SCHEMA_FOUND_MSG_FORMAT, dataTypeName));
+            }
             if (schema.getSchemaType() != SchemaType.OBJECT) {
-                return vrb.failed(String.format(NOT_AN_OBJECT_ERROR_MSGR_FORMAT, dataTypeName));
+                return vrb.failed(String.format(NOT_AN_OBJECT_ERROR_MSG_FORMAT, dataTypeName));
             }
 
             HollowObjectSchema oSchema = (HollowObjectSchema) schema;
             primaryKey = oSchema.getPrimaryKey();
             if (primaryKey == null) {
-                return vrb.failed(String.format(NO_PRIMARY_KEY_ERRRO_MSG_FORMAT, dataTypeName));
+                return vrb.failed(String.format(NO_PRIMARY_KEY_ERROR_MSG_FORMAT, dataTypeName));
             }
         } else {
             primaryKey = new PrimaryKey(dataTypeName, fieldPathNames);

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer.validation;
+
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DuplicateDataDetectionValidatorTests {
+    private InMemoryBlobStore blobStore;
+
+    @Before
+    public void setUp() {
+        blobStore = new InMemoryBlobStore();
+    }
+
+    @Test
+    public void failTestMissingSchema() {
+        try {
+            HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                    .withBlobStager(new HollowInMemoryBlobStager())
+                    .withListener(new DuplicateDataDetectionValidator("FakeType")).build();
+            producer.runCycle(writeState -> writeState.add("hello"));
+        } catch (ValidationStatusException expected) {
+            Assert.assertEquals(1, expected.getValidationStatus().getResults().size());
+            Assert.assertTrue(expected.getValidationStatus().getResults().get(0).getMessage()
+                    .endsWith("(see initializeDataModel)"));
+        }
+    }
+}


### PR DESCRIPTION
If the user added a DuplicateDataDetectionValidator for a
missing type we would fail with an unhelpful NPE. Instead,
provide a useful and vaguely snarky error message.