### PR TITLE
Bugfix: NPE in onCycleSkip ProducerMetricsListener

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListener.java
@@ -31,7 +31,6 @@ import java.util.OptionalLong;
 public abstract class AbstractProducerMetricsListener extends AbstractHollowProducerListener implements
         ProducerMetricsReporting {
 
-    private CycleMetrics.Builder cycleMetricsBuilder;
     private AnnouncementMetrics.Builder announcementMetricsBuilder;
 
     // visible for testing
@@ -44,11 +43,6 @@ public abstract class AbstractProducerMetricsListener extends AbstractHollowProd
         consecutiveFailures = 0l;
         lastCycleSuccessTimeNanoOptional = OptionalLong.empty();
         lastAnnouncementSuccessTimeNanoOptional = OptionalLong.empty();
-    }
-
-    @Override
-    public void onCycleStart(long version) {
-        cycleMetricsBuilder = new CycleMetrics.Builder();
     }
 
     @Override
@@ -65,12 +59,11 @@ public abstract class AbstractProducerMetricsListener extends AbstractHollowProd
      */
     @Override
     public void onCycleSkip(CycleSkipReason reason) {
-        cycleMetricsBuilder.setConsecutiveFailures(consecutiveFailures);
+        CycleMetrics.Builder cycleMetricsBuilder = new CycleMetrics.Builder();
 
+        cycleMetricsBuilder.setConsecutiveFailures(consecutiveFailures);
         lastCycleSuccessTimeNanoOptional.ifPresent(cycleMetricsBuilder::setLastCycleSuccessTimeNano);
-
         // isCycleSuccess and cycleDurationMillis are not set for skipped cycles
-        cycleMetricsBuilder.setConsecutiveFailures(consecutiveFailures);
 
         cycleMetricsReporting(cycleMetricsBuilder.build());
     }
@@ -99,7 +92,6 @@ public abstract class AbstractProducerMetricsListener extends AbstractHollowProd
                 .setDataSizeBytes(dataSizeBytes)
                 .setIsAnnouncementSuccess(isAnnouncementSuccess)
                 .setAnnouncementDurationMillis(elapsed.toMillis());
-
         lastAnnouncementSuccessTimeNanoOptional.ifPresent(announcementMetricsBuilder::setLastAnnouncementSuccessTimeNano);
 
         announcementMetricsReporting(announcementMetricsBuilder.build());
@@ -126,11 +118,10 @@ public abstract class AbstractProducerMetricsListener extends AbstractHollowProd
             consecutiveFailures ++;
         }
 
-        cycleMetricsBuilder
+        CycleMetrics.Builder cycleMetricsBuilder = new CycleMetrics.Builder()
                 .setConsecutiveFailures(consecutiveFailures)
                 .setCycleDurationMillis(elapsed.toMillis())
                 .setIsCycleSuccess(isCycleSuccess);
-
         lastCycleSuccessTimeNanoOptional.ifPresent(cycleMetricsBuilder::setLastCycleSuccessTimeNano);
 
         cycleMetricsReporting(cycleMetricsBuilder.build());

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListenerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListenerTest.java
@@ -53,7 +53,6 @@ public class AbstractProducerMetricsListenerTest {
             }
         }
         AbstractProducerMetricsListener concreteProducerMetricsListener = new TestProducerMetricsListener();
-        concreteProducerMetricsListener.onCycleStart(TEST_VERSION);
         concreteProducerMetricsListener.onCycleSkip(CycleListener.CycleSkipReason.NOT_PRIMARY_PRODUCER);
     }
 
@@ -71,7 +70,6 @@ public class AbstractProducerMetricsListenerTest {
         }
         AbstractProducerMetricsListener concreteProducerMetricsListener = new TestProducerMetricsListener();
         concreteProducerMetricsListener.lastCycleSuccessTimeNanoOptional = OptionalLong.of(TEST_LAST_CYCLE_NANOS);
-        concreteProducerMetricsListener.onCycleStart(TEST_VERSION);
         concreteProducerMetricsListener.onCycleSkip(CycleListener.CycleSkipReason.NOT_PRIMARY_PRODUCER);
     }
 


### PR DESCRIPTION
Code incorrectly assumed that onCycleStart() was called for skipped cycles.