### PR TITLE
Allow creating indices when schema name != generated class name

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
@@ -39,6 +39,7 @@ import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
 import com.netflix.hollow.tools.stringifier.HollowRecordStringifier;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -89,6 +90,7 @@ public class HollowObjectJavaGenerator extends HollowConsumerJavaFileGenerator {
     public String generate() {
         StringBuilder classBuilder = new StringBuilder();
         appendPackageAndCommonImports(classBuilder, apiClassname);
+        boolean requiresHollowTypeName = !className.equals(schema.getName());
 
         classBuilder.append("import " + HollowConsumer.class.getName() + ";\n");
         if (schema.getPrimaryKey() != null && schema.getPrimaryKey().numFields() > 1) {
@@ -99,12 +101,18 @@ public class HollowObjectJavaGenerator extends HollowConsumerJavaFileGenerator {
         }
         classBuilder.append("import " + HollowObject.class.getName() + ";\n");
         classBuilder.append("import " + HollowObjectSchema.class.getName() + ";\n");
+        if (requiresHollowTypeName) {
+            classBuilder.append("import " + HollowTypeName.class.getName() + ";\n");
+        }
         if (config.isUseVerboseToString()) {
             classBuilder.append("import " + HollowRecordStringifier.class.getName() + ";\n");
         }
         classBuilder.append("\n");
 
         classBuilder.append("@SuppressWarnings(\"all\")\n");
+        if (requiresHollowTypeName) {
+            classBuilder.append("@" + HollowTypeName.class.getSimpleName() + "(name=\"" + schema.getName() + "\")\n");
+        }
         classBuilder.append("public class " + className + " extends HollowObject {\n\n");
 
         appendConstructor(classBuilder);

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndexSelect.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/HashIndexSelect.java
@@ -25,6 +25,7 @@ import com.netflix.hollow.core.index.FieldPaths;
 import com.netflix.hollow.core.index.HollowHashIndex;
 import com.netflix.hollow.core.index.HollowHashIndexResult;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectTypeMapper;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -79,7 +80,7 @@ public class HashIndexSelect<T extends HollowRecord, S extends HollowRecord, Q>
                 .map(mf -> mf.fieldPath.getSegments().stream().map(FieldPaths.FieldSegment::getName)
                         .collect(joining(".")))
                 .toArray(String[]::new);
-        this.rootTypeName = rootType.getSimpleName();
+        this.rootTypeName = HollowObjectTypeMapper.getDefaultTypeName(rootType);
 
         this.hhi = new HollowHashIndex(consumer.getStateEngine(), rootTypeName, selectFieldPath, matchFieldPaths);
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/MatchFieldPathArgumentExtractor.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/MatchFieldPathArgumentExtractor.java
@@ -24,6 +24,7 @@ import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.index.FieldPaths;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectTypeMapper;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.AnnotatedElement;
@@ -169,7 +170,7 @@ final class MatchFieldPathArgumentExtractor<Q> {
             HollowDataset dataset, Class<?> rootType, String fieldPath,
             Class<T> extractorType, Function<Q, T> extractorFunction,
             FieldPathResolver fpResolver) {
-        String rootTypeName = rootType.getSimpleName();
+        String rootTypeName = HollowObjectTypeMapper.getDefaultTypeName(rootType);
         FieldPaths.FieldPath<? extends FieldPaths.FieldSegment> fp = fpResolver.resolve(dataset, rootTypeName,
                 fieldPath);
 

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/index/SelectFieldPathResultExtractor.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/index/SelectFieldPathResultExtractor.java
@@ -24,6 +24,7 @@ import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.index.FieldPaths;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectTypeMapper;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -71,7 +72,7 @@ final class SelectFieldPathResultExtractor<T> {
     static <T> SelectFieldPathResultExtractor<T> from(
             Class<? extends HollowAPI> apiType, HollowDataset dataset, Class<?> rootType, String fieldPath,
             Class<T> selectType) {
-        String rootTypeName = rootType.getSimpleName();
+        String rootTypeName = HollowObjectTypeMapper.getDefaultTypeName(rootType);
         FieldPaths.FieldPath<FieldPaths.FieldSegment> fp =
                 FieldPaths.createFieldPathForHashIndex(dataset, rootTypeName, fieldPath);
 
@@ -101,7 +102,7 @@ final class SelectFieldPathResultExtractor<T> {
                     throw incompatibleSelectType(selectType, fieldPath, typeName);
                 }
                 // @@@ Check that object schema has single value field of String type such as HString
-            } else if (!selectType.getSimpleName().equals(typeName)) {
+            } else if (!HollowObjectTypeMapper.getDefaultTypeName(selectType).equals(typeName)) {
                 if (schemaType != HollowSchema.SchemaType.OBJECT && !GenericHollowObject.class.isAssignableFrom(
                         selectType)) {
                     throw incompatibleSelectType(selectType, fieldPath, typeName);

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/AbstractHollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/AbstractHollowAPIGeneratorTest.java
@@ -15,11 +15,17 @@
  */
 package com.netflix.hollow.api.codegen;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
 import java.io.File;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.function.UnaryOperator;
 import org.junit.After;
 
@@ -55,7 +61,15 @@ public class AbstractHollowAPIGeneratorTest {
         assertTrue("File at " + relativePath + " should exist", f.exists() && f.length() > 0L);
     }
 
-    void assertFileDoesNotExist(String relativePath) throws IOException {
+    void assertClassHasHollowTypeName(String clazz, String typeName) throws IOException, ClassNotFoundException {
+        ClassLoader cl = new URLClassLoader(new URL[]{new File(clazzFolder).toURI().toURL()});
+        Class cls = cl.loadClass(clazz);
+        Annotation annotation = cls.getAnnotation(HollowTypeName.class);
+        assertNotNull(annotation);
+        assertEquals(typeName, ((HollowTypeName) annotation).name());
+    }
+
+    void assertFileDoesNotExist(String relativePath) {
         if (relativePath.startsWith("/")) {
             throw new IllegalArgumentException("Relative paths should not start with /");
         }

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -14,6 +14,7 @@ public class HollowAPIGeneratorTest extends AbstractHollowAPIGeneratorTest {
         runGenerator("MyClassTestAPI", "codegen.api", MyClass.class,
                 builder -> builder.withClassPostfix("Generated"));
         assertNonEmptyFileExists("codegen/api/StringGenerated.java");
+        assertClassHasHollowTypeName("codegen.api.MyClassGenerated", "MyClass");
     }
 
     @Test

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/index/DataModel.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/index/DataModel.java
@@ -164,12 +164,31 @@ public class DataModel {
             }
         }
 
+        public static class TypeWithTypeB {
+            final String foo;
+            final TypeB typeB;
+
+            public TypeWithTypeB(String foo, TypeB typeB) {
+                this.foo = foo;
+                this.typeB = typeB;
+            }
+        }
+
         public static class SubTypeOfTypeWithPrimaryKey {
             final String s;
             final int i;
 
             public SubTypeOfTypeWithPrimaryKey(String s, int i) {
                 this.s = s;
+                this.i = i;
+            }
+        }
+
+        @HollowPrimaryKey(fields = {"i"})
+        public static class TypeWithPrimaryKey2 {
+            final int i;
+
+            public TypeWithPrimaryKey2(int i) {
                 this.i = i;
             }
         }
@@ -280,8 +299,8 @@ public class DataModel {
                 return new TypeA(null, ordinal);
             }
 
-            public TypeB getTypeB(int ordinal) {
-                return new TypeB(null, ordinal);
+            public TypeBSuffixed getTypeBSuffixed(int ordinal) {
+                return new TypeBSuffixed(null, ordinal);
             }
 
             public TypeWithPrimaryKey getTypeWithPrimaryKey(int ordinal) {
@@ -290,6 +309,10 @@ public class DataModel {
 
             public SubTypeOfTypeWithPrimaryKey getSubTypeOfTypeWithPrimaryKey(int ordinal) {
                 return new SubTypeOfTypeWithPrimaryKey(null, ordinal);
+            }
+
+            public TypeWithPrimaryKeySuffixed getTypeWithPrimaryKeySuffixed(int ordinal) {
+                return new TypeWithPrimaryKeySuffixed(null, ordinal);
             }
 
             public ListOfBoxes getListOfBoxes(int ordinal) {
@@ -365,8 +388,9 @@ public class DataModel {
             }
         }
 
-        public static class TypeB extends HollowObject {
-            public TypeB(HollowObjectDelegate delegate, int ordinal) {
+        @HollowTypeName(name = "TypeB")
+        public static class TypeBSuffixed extends HollowObject {
+            public TypeBSuffixed(HollowObjectDelegate delegate, int ordinal) {
                 super(delegate, ordinal);
             }
         }
@@ -377,8 +401,21 @@ public class DataModel {
             }
         }
 
+        public static class TypeWithTypeB extends HollowObject {
+            public TypeWithTypeB(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
         public static class SubTypeOfTypeWithPrimaryKey extends HollowObject {
             public SubTypeOfTypeWithPrimaryKey(HollowObjectDelegate delegate, int ordinal) {
+                super(delegate, ordinal);
+            }
+        }
+
+        @HollowTypeName(name = "TypeWithPrimaryKey2")
+        public static class TypeWithPrimaryKeySuffixed extends HollowObject {
+            public TypeWithPrimaryKeySuffixed(HollowObjectDelegate delegate, int ordinal) {
                 super(delegate, ordinal);
             }
         }


### PR DESCRIPTION
- generate classes with @HollowTypeName if name does not match schema
- read the schema name using any @HollowTypeName when inspecting types during index creation

Fixes #427.