### PR TITLE
Maintain correct read states after integrity check

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
@@ -288,6 +288,18 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
         return false;
     }
 
+    public boolean hasIdenticalSchemas(HollowReadStateEngine other) {
+        if (!other.getAllTypes().equals(getAllTypes())) {
+            return false;
+        }
+        for (String type : getAllTypes()) {
+            if (!getSchema(type).equals(other.getNonNullSchema(type))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public Set<String> getTypesWithDefinedHashCodes() {
         return typesWithDefinedHashCodes;
     }


### PR DESCRIPTION
Previously, we were swapping the current and pending read states (after applying the delta and reverse delta, respectively), for efficiency. However, this is not the correct thing to do when the two read states don't have the same schemas. For those cases, apply the delta back onto the pending state, and apply the reverse delta back onto the current state.