### PR TITLE
Ignore failed transitions when no double snapshot

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -222,8 +222,9 @@ public class HollowClientUpdater {
 
     private HollowDataHolder newHollowDataHolder() {
         return new HollowDataHolder(newStateEngine(), apiFactory,
-                failedTransitionTracker, staleReferenceDetector,
-                objectLongevityConfig).setFilter(filter);
+                doubleSnapshotConfig, failedTransitionTracker,
+                staleReferenceDetector, objectLongevityConfig)
+                .setFilter(filter);
     }
 
     private HollowReadStateEngine newStateEngine() {

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -130,8 +130,8 @@ public class HollowConsumer {
                              HollowObjectHashCodeFinder hashCodeFinder,
                              Executor refreshExecutor) {
         this(blobRetriever, announcementWatcher, refreshListeners, apiFactory, dataFilter,
-                objectLongevityConfig, objectLongevityDetector, doubleSnapshotConfig
-                , hashCodeFinder, refreshExecutor, null);
+                objectLongevityConfig, objectLongevityDetector, doubleSnapshotConfig,
+                hashCodeFinder, refreshExecutor, null);
     }
 
     protected HollowConsumer(BlobRetriever blobRetriever,

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/FailedTransitionTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/FailedTransitionTest.java
@@ -4,6 +4,8 @@ import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -21,13 +23,15 @@ public class FailedTransitionTest {
             ws.add(1);
         });
 
+        AtomicBoolean failer = new AtomicBoolean();
         HollowConsumer consumer = HollowConsumer
-                .withBlobRetriever(new FailingBlobRetriever(1, bs))
-                .withAnnouncementWatcher(new FixedAnnouncementWatcher(version))
+                .withBlobRetriever(new FailingBlobRetriever(failer::get, bs))
                 .build();
 
+        // Fail transitioning to snapshot
+        failer.set(true);
         try {
-            consumer.triggerRefresh();
+            consumer.triggerRefreshTo(version);
             Assert.fail();
         } catch (Exception e) {
             Throwable cause = e.getCause();
@@ -37,20 +41,79 @@ public class FailedTransitionTest {
             Assert.assertEquals(1, consumer.getNumFailedSnapshotTransitions());
         }
 
+        // Fail for existing transition
+        failer.set(false);
         try {
-            consumer.triggerRefresh();
+            consumer.triggerRefreshTo(version);
             Assert.fail();
         } catch (RuntimeException e) {
             Assert.assertEquals(1, consumer.getNumFailedSnapshotTransitions());
         }
 
         try {
-            consumer.triggerRefresh();
+            consumer.triggerRefreshTo(version);
             Assert.fail();
         } catch (RuntimeException e) {
             Assert.assertEquals(1, consumer.getNumFailedSnapshotTransitions());
         }
+
+
+        version = producer.runCycle(ws -> {
+            ws.add(2);
+        });
+
+        // Pass for new transition
+        // Consumer double snapshots
+        consumer.triggerRefreshTo(version);
+        Assert.assertEquals(1, consumer.getNumFailedSnapshotTransitions());
     }
+
+
+    @Test
+    public void testDeltaBlobFailure() {
+        InMemoryBlobStore bs = new InMemoryBlobStore();
+
+        HollowProducer producer = HollowProducer.withPublisher(bs)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long version = producer.runCycle(ws -> {
+            ws.add(1);
+        });
+
+        AtomicBoolean failer = new AtomicBoolean();
+        HollowConsumer consumer = HollowConsumer
+                .withBlobRetriever(new FailingBlobRetriever(failer::get, bs))
+                .build();
+
+        // Transition to snapshot
+        consumer.triggerRefreshTo(version);
+
+
+        version = producer.runCycle(ws -> {
+            ws.add(2);
+        });
+
+        // Fail transitioning to delta
+        failer.set(true);
+        try {
+            consumer.triggerRefreshTo(version);
+            Assert.fail();
+        } catch (Exception e) {
+            Throwable cause = e.getCause();
+            Assert.assertNotNull(cause);
+            Assert.assertTrue(cause instanceof IOException);
+            Assert.assertEquals("FAILED", cause.getMessage());
+            Assert.assertEquals(1, consumer.getNumFailedDeltaTransitions());
+        }
+
+
+        // Pass for new transition
+        // Consumer double snapshots
+        failer.set(false);
+        consumer.triggerRefreshTo(version);
+    }
+
 
     @Test
     public void testSnapshotBlobFailureNoDoubleSnapshot() {
@@ -64,22 +127,16 @@ public class FailedTransitionTest {
             ws.add(1);
         });
 
+        AtomicBoolean failer = new AtomicBoolean();
         HollowConsumer consumer = HollowConsumer
-                .withBlobRetriever(new FailingBlobRetriever(1, bs))
-                .withAnnouncementWatcher(new FixedAnnouncementWatcher(version))
-                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
-                    @Override public boolean allowDoubleSnapshot() {
-                        return false;
-                    }
-
-                    @Override public int maxDeltasBeforeDoubleSnapshot() {
-                        return 32;
-                    }
-                })
+                .withBlobRetriever(new FailingBlobRetriever(failer::get, bs))
+                .withDoubleSnapshotConfig(new NoDoubleSnapshotConfig())
                 .build();
 
+        // Fail transitioning to snapshot
+        failer.set(true);
         try {
-            consumer.triggerRefresh();
+            consumer.triggerRefreshTo(version);
             Assert.fail();
         } catch (Exception e) {
             Throwable cause = e.getCause();
@@ -89,65 +146,109 @@ public class FailedTransitionTest {
             Assert.assertEquals(1, consumer.getNumFailedSnapshotTransitions());
         }
 
+        // Pass on retry
+        failer.set(false);
+        consumer.triggerRefreshTo(version);
+    }
+
+    @Test
+    public void testDeltaBlobFailureNoDoubleSnapshot() {
+        InMemoryBlobStore bs = new InMemoryBlobStore();
+
+        HollowProducer producer = HollowProducer.withPublisher(bs)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long version = producer.runCycle(ws -> {
+            ws.add(1);
+        });
+
+        AtomicBoolean failer = new AtomicBoolean();
+        HollowConsumer consumer = HollowConsumer
+                .withBlobRetriever(new FailingBlobRetriever(failer::get, bs))
+                .withDoubleSnapshotConfig(new NoDoubleSnapshotConfig())
+                .build();
+
+        // Transition to snapshot
+        consumer.triggerRefreshTo(version);
+
+
+        version = producer.runCycle(ws -> {
+            ws.add(2);
+        });
+
+        // Fail transitioning to delta
+        failer.set(true);
         try {
-            consumer.triggerRefresh();
+            consumer.triggerRefreshTo(version);
             Assert.fail();
-        } catch (RuntimeException e) {
-            Assert.assertEquals(1, consumer.getNumFailedSnapshotTransitions());
+        } catch (Exception e) {
+            Throwable cause = e.getCause();
+            Assert.assertNotNull(cause);
+            Assert.assertTrue(cause instanceof IOException);
+            Assert.assertEquals("FAILED", cause.getMessage());
+            Assert.assertEquals(1, consumer.getNumFailedDeltaTransitions());
         }
 
-        try {
-            consumer.triggerRefresh();
-            Assert.fail();
-        } catch (RuntimeException e) {
-            Assert.assertEquals(1, consumer.getNumFailedSnapshotTransitions());
+        // Pass on retry
+        failer.set(false);
+        consumer.triggerRefreshTo(version);
+    }
+
+
+    static class NoDoubleSnapshotConfig implements HollowConsumer.DoubleSnapshotConfig {
+        @Override public boolean allowDoubleSnapshot() {
+            return false;
+        }
+
+        @Override public int maxDeltasBeforeDoubleSnapshot() {
+            return 32;
         }
     }
 
     static class FailingBlobRetriever implements HollowConsumer.BlobRetriever {
-        final int failLimit;
+        final BooleanSupplier failer;
         final HollowConsumer.BlobRetriever br;
 
-        FailingBlobRetriever(int failLimit, HollowConsumer.BlobRetriever br) {
-            this.failLimit = failLimit;
+        FailingBlobRetriever(BooleanSupplier failer, HollowConsumer.BlobRetriever br) {
+            this.failer = failer;
             this.br = br;
         }
 
         @Override public HollowConsumer.Blob retrieveSnapshotBlob(long desiredVersion) {
+            HollowConsumer.Blob blob = br.retrieveSnapshotBlob(desiredVersion);
             return new HollowConsumer.Blob(desiredVersion) {
-                int c;
-
                 @Override public InputStream getInputStream() throws IOException {
-                    if (c++ < failLimit) {
+                    if (failer.getAsBoolean()) {
                         throw new IOException("FAILED");
                     }
-                    return br.retrieveSnapshotBlob(desiredVersion).getInputStream();
+                    return blob.getInputStream();
                 }
             };
         }
 
         @Override public HollowConsumer.Blob retrieveDeltaBlob(long currentVersion) {
-            return null;
+            HollowConsumer.Blob blob = br.retrieveDeltaBlob(currentVersion);
+            return new HollowConsumer.Blob(blob.getFromVersion(), blob.getToVersion()) {
+                @Override public InputStream getInputStream() throws IOException {
+                    if (failer.getAsBoolean()) {
+                        throw new IOException("FAILED");
+                    }
+                    return blob.getInputStream();
+                }
+            };
         }
 
         @Override public HollowConsumer.Blob retrieveReverseDeltaBlob(long currentVersion) {
-            return null;
-        }
-    }
-
-    static class FixedAnnouncementWatcher implements HollowConsumer.AnnouncementWatcher {
-        final long version;
-
-        FixedAnnouncementWatcher(long version) {
-            this.version = version;
-        }
-
-        @Override public long getLatestVersion() {
-            return version;
-        }
-
-        @Override public void subscribeToUpdates(HollowConsumer consumer) {
-
+            HollowConsumer.Blob blob = br.retrieveReverseDeltaBlob(currentVersion);
+            return new HollowConsumer.Blob(blob.getFromVersion(), blob.getToVersion()) {
+                @Override public InputStream getInputStream() throws IOException {
+                    if (failer.getAsBoolean()) {
+                        throw new IOException("FAILED");
+                    }
+                    return blob.getInputStream();
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
This is a temporary solution until it is decided what to do with the feature, likely removing it or enhancing to make it more configurable/accurate/actionable. 