### PR TITLE
Blob write to temp file then rename instead of write to destination

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemBlobRetriever.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemBlobRetriever.java
@@ -26,6 +26,8 @@ import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
 
 public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriever {
     
@@ -196,15 +198,19 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
         @Override
         public InputStream getInputStream() throws IOException {
 
+            Path tempPath = Paths.get(path.toString() + "-" + UUID.randomUUID().toString());
             try(
                     InputStream is = remoteBlob.getInputStream();
-                    OutputStream os = Files.newOutputStream(path)
+                    OutputStream os = Files.newOutputStream(tempPath)
             ) {
                 byte buf[] = new byte[4096];
                 int n;
                 while (-1 != (n = is.read(buf)))
                     os.write(buf, 0, n);
             }
+
+            File f = tempPath.toFile();
+            f.renameTo(path.toFile());
 
             return new BufferedInputStream(Files.newInputStream(path));
         }

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemBlobRetriever.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemBlobRetriever.java
@@ -16,6 +16,8 @@
  */
 package com.netflix.hollow.api.consumer.fs;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.core.HollowConstants;
 import java.io.BufferedInputStream;
@@ -26,7 +28,6 @@ import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.UUID;
 
 public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriever {
@@ -198,7 +199,7 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
         @Override
         public InputStream getInputStream() throws IOException {
 
-            Path tempPath = Paths.get(path.toString() + "-" + UUID.randomUUID().toString());
+            Path tempPath = path.resolveSibling(path.getName(path.getNameCount()-1) + "-" + UUID.randomUUID().toString());
             try(
                     InputStream is = remoteBlob.getInputStream();
                     OutputStream os = Files.newOutputStream(tempPath)
@@ -208,9 +209,7 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
                 while (-1 != (n = is.read(buf)))
                     os.write(buf, 0, n);
             }
-
-            File f = tempPath.toFile();
-            f.renameTo(path.toFile());
+            Files.move(tempPath, path, REPLACE_EXISTING);
 
             return new BufferedInputStream(Files.newInputStream(path));
         }


### PR DESCRIPTION
Protection against corrupt snapshot getting cached on disk because of partial write.