### PR TITLE
Rejuvenate log levels

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -98,7 +98,7 @@ public class HollowClientUpdater {
     public synchronized boolean updateTo(long requestedVersion) throws Throwable {
         if (requestedVersion == getCurrentVersionId()) {
             if (requestedVersion == HollowConstants.VERSION_NONE && hollowDataHolderVolatile == null) {
-                LOG.warning("No versions to update to, initializing to empty state");
+                LOG.severe("No versions to update to, initializing to empty state");
                 // attempting to refresh, but no available versions - initialize to empty state
                 hollowDataHolderVolatile = newHollowDataHolder();
                 forceDoubleSnapshotNextUpdate(); // intentionally ignore doubleSnapshotConfig

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -686,12 +686,12 @@ abstract class AbstractHollowProducer {
             if (readStates.hasCurrent()) {
                 HollowReadStateEngine current = readStates.current().getStateEngine();
 
-                log.info("CHECKSUMS");
+                log.finest("CHECKSUMS");
                 HollowChecksum currentChecksum = HollowChecksum.forStateEngineWithCommonSchemas(current, pending);
-                log.info("  CUR        " + currentChecksum);
+                log.finest("  CUR        " + currentChecksum);
 
                 HollowChecksum pendingChecksum = HollowChecksum.forStateEngineWithCommonSchemas(pending, current);
-                log.info("         PND " + pendingChecksum);
+                log.finest("         PND " + pendingChecksum);
 
                 if (artifacts.hasDelta()) {
                     if (!artifacts.hasReverseDelta()) {
@@ -714,11 +714,11 @@ abstract class AbstractHollowProducer {
                     }
                     if (!schemaChangedFromPriorVersion) {
                         // optimization - they have identical schemas, so just swap them
-                        log.log(Level.FINE, "current and pending have identical schemas, swapping");
+                        log.log(Level.FINEST, "current and pending have identical schemas, swapping");
                         result = readStates.swap();
                     } else {
                         // undo the changes we made to the read states
-                        log.log(Level.FINE, "current and pending have non-identical schemas, reverting");
+                        log.log(Level.FINEST, "current and pending have non-identical schemas, reverting");
                         applyDelta(artifacts.reverseDelta, current);
                         applyDelta(artifacts.delta, pending);
                     }


### PR DESCRIPTION
We appreciate your previous feedback! Here's a reissue of https://github.com/Netflix/hollow/pull/419 with a new version of our tool. The tool made fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: ff635ee9e3d7e466796c2c25e4760b1a66cf3e1f