### PR TITLE
Producer Listener support refactored for code reuse

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/common/EventListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/common/EventListener.java
@@ -1,0 +1,7 @@
+package com.netflix.hollow.api.common;
+
+/**
+ * The top-level type for all listeners.
+ */
+public interface EventListener {
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/common/ListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/common/ListenerSupport.java
@@ -1,0 +1,30 @@
+package com.netflix.hollow.api.common;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class ListenerSupport {
+
+    protected final CopyOnWriteArrayList<EventListener> eventListeners;
+
+    public ListenerSupport() {
+        eventListeners = new CopyOnWriteArrayList<>();
+    }
+
+    public ListenerSupport(List<? extends EventListener> listeners) {
+        eventListeners = new CopyOnWriteArrayList<>(listeners);
+    }
+
+    public ListenerSupport(ListenerSupport that) {
+        eventListeners = new CopyOnWriteArrayList<>(that.eventListeners);
+    }
+
+    public void addListener(EventListener listener) {
+        eventListeners.addIfAbsent(listener);
+    }
+
+    public void removeListener(EventListener listener) {
+        eventListeners.remove(listener);
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/common/Listeners.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/common/Listeners.java
@@ -1,0 +1,44 @@
+package com.netflix.hollow.api.common;
+
+import com.netflix.hollow.api.producer.listener.VetoableListener;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+public abstract class Listeners {
+
+    private static final Logger LOG = Logger.getLogger(Listeners.class.getName());
+
+    protected final EventListener[] listeners;
+
+    protected Listeners(EventListener[] listeners) {
+        this.listeners = listeners;
+    }
+
+    public <T extends EventListener> Stream<T> getListeners(Class<T> c) {
+        return Arrays.stream(listeners).filter(c::isInstance).map(c::cast);
+    }
+
+    protected <T extends EventListener> void fire(
+            Class<T> c, Consumer<? super T> r) {
+        fireStream(getListeners(c), r);
+    }
+
+    protected <T extends EventListener> void fireStream(
+            Stream<T> s, Consumer<? super T> r) {
+        s.forEach(l -> {
+            try {
+                r.accept(l);
+            } catch (VetoableListener.ListenerVetoException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                if (l instanceof VetoableListener) {
+                    throw e;
+                }
+                LOG.log(Level.WARNING, "Error executing listener", e);
+            }
+        });
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowIncrementalProducer.java
@@ -46,7 +46,7 @@ public class HollowIncrementalProducer {
     private final HollowProducer producer;
     private final ConcurrentHashMap<RecordPrimaryKey, Object> mutations;
     private final HollowProducer.Populator populator;
-    private final ListenerSupport listeners;
+    private final ProducerListenerSupport listeners;
     private final Map<String, Object> cycleMetadata;
     private final Class<?>[] dataModel;
     private final HollowConsumer.AnnouncementWatcher announcementWatcher;
@@ -70,7 +70,7 @@ public class HollowIncrementalProducer {
         this.dataModel = classes;
         this.announcementWatcher = announcementWatcher;
         this.blobRetriever = blobRetriever;
-        this.listeners = new ListenerSupport();
+        this.listeners = new ProducerListenerSupport();
         this.cycleMetadata = new HashMap<String, Object>();
         this.threadsPerCpu = threadsPerCpu;
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -693,7 +693,7 @@ public class HollowProducer extends AbstractHollowProducer {
          * @throws IllegalArgumentException if the listener does not implement a recognized event listener type
          */
         public B withListener(HollowProducerEventListener listener) {
-            if (!ListenerSupport.isValidListener(listener)) {
+            if (!ProducerListenerSupport.isValidListener(listener)) {
                 throw new IllegalArgumentException(
                         "Listener does not implement a recognized event listener type: " + listener);
             }
@@ -711,7 +711,7 @@ public class HollowProducer extends AbstractHollowProducer {
          */
         public B withListeners(HollowProducerEventListener... listeners) {
             for (HollowProducerEventListener listener : listeners) {
-                if (!ListenerSupport.isValidListener(listener)) {
+                if (!ProducerListenerSupport.isValidListener(listener)) {
                     throw new IllegalArgumentException(
                             "Listener does not implement a recognized event listener type: " + listener);
                 }

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ProducerListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ProducerListenerSupport.java
@@ -68,8 +68,6 @@ final class ProducerListenerSupport extends ListenerSupport {
     }
 
     ProducerListenerSupport() {
-        super();
-
         // @@@ This is used only by HollowIncrementalProducer, and should be
         // separated out
         incrementalCycleListeners = new CopyOnWriteArraySet<>();
@@ -84,7 +82,7 @@ final class ProducerListenerSupport extends ListenerSupport {
     }
 
     ProducerListenerSupport(ProducerListenerSupport that) {
-        super();
+        super(that);
 
         // @@@ This is used only by HollowIncrementalProducer, and should be
         // separated out

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ProducerListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ProducerListenerSupport.java
@@ -19,6 +19,8 @@ package com.netflix.hollow.api.producer;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 
+import com.netflix.hollow.api.common.ListenerSupport;
+import com.netflix.hollow.api.common.Listeners;
 import com.netflix.hollow.api.producer.HollowProducerListener.ProducerStatus;
 import com.netflix.hollow.api.producer.IncrementalCycleListener.IncrementalCycleStatus;
 import com.netflix.hollow.api.producer.listener.AnnouncementListener;
@@ -30,27 +32,24 @@ import com.netflix.hollow.api.producer.listener.IntegrityCheckListener;
 import com.netflix.hollow.api.producer.listener.PopulateListener;
 import com.netflix.hollow.api.producer.listener.PublishListener;
 import com.netflix.hollow.api.producer.listener.RestoreListener;
-import com.netflix.hollow.api.producer.listener.VetoableListener;
 import com.netflix.hollow.api.producer.validation.ValidationStatus;
 import com.netflix.hollow.api.producer.validation.ValidationStatusListener;
 import com.netflix.hollow.api.producer.validation.ValidatorListener;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-final class ListenerSupport {
+final class ProducerListenerSupport extends ListenerSupport {
 
-    private static final Logger LOG = Logger.getLogger(ListenerSupport.class.getName());
+    private static final Logger LOG = Logger.getLogger(ProducerListenerSupport.class.getName());
 
     private static final Collection<Class<? extends HollowProducerEventListener>> LISTENERS =
             Stream.of(DataModelInitializationListener.class,
@@ -68,38 +67,28 @@ final class ListenerSupport {
         return LISTENERS.stream().anyMatch(c -> c.isInstance(l));
     }
 
-    private final CopyOnWriteArrayList<HollowProducerEventListener> eventListeners;
-
-    ListenerSupport() {
-        eventListeners = new CopyOnWriteArrayList<>();
+    ProducerListenerSupport() {
+        super();
 
         // @@@ This is used only by HollowIncrementalProducer, and should be
         // separated out
         incrementalCycleListeners = new CopyOnWriteArraySet<>();
     }
 
-    ListenerSupport(List<? extends HollowProducerEventListener> listeners) {
-        eventListeners = new CopyOnWriteArrayList<>(listeners);
+    ProducerListenerSupport(List<? extends HollowProducerEventListener> listeners) {
+        super(listeners);
 
         // @@@ This is used only by HollowIncrementalProducer, and should be
         // separated out
         incrementalCycleListeners = new CopyOnWriteArraySet<>();
     }
 
-    ListenerSupport(ListenerSupport that) {
-        eventListeners = new CopyOnWriteArrayList<>(that.eventListeners);
+    ProducerListenerSupport(ProducerListenerSupport that) {
+        super();
 
         // @@@ This is used only by HollowIncrementalProducer, and should be
         // separated out
         incrementalCycleListeners = new CopyOnWriteArraySet<>(that.incrementalCycleListeners);
-    }
-
-    void addListener(HollowProducerEventListener listener) {
-        eventListeners.addIfAbsent(listener);
-    }
-
-    void removeListener(HollowProducerEventListener listener) {
-        eventListeners.remove(listener);
     }
 
     //
@@ -109,40 +98,14 @@ final class ListenerSupport {
      * From the returned copy events may be fired.
      * Any addition or removal of listeners will take effect on the next cycle.
      */
-    Listeners listeners() {
-        return new Listeners(eventListeners.toArray(new HollowProducerEventListener[0]));
+    ProducerListeners listeners() {
+        return new ProducerListeners(eventListeners.toArray(new HollowProducerEventListener[0]));
     }
 
-    static final class Listeners {
-        final HollowProducerEventListener[] listeners;
+    static final class ProducerListeners extends Listeners {
 
-        Listeners(HollowProducerEventListener[] listeners) {
-            this.listeners = listeners;
-        }
-
-        <T extends HollowProducerEventListener> Stream<T> getListeners(Class<T> c) {
-            return Arrays.stream(listeners).filter(c::isInstance).map(c::cast);
-        }
-
-        private <T extends HollowProducerEventListener> void fire(
-                Class<T> c, Consumer<? super T> r) {
-            fireStream(getListeners(c), r);
-        }
-
-        private <T extends HollowProducerEventListener> void fireStream(
-                Stream<T> s, Consumer<? super T> r) {
-            s.forEach(l -> {
-                try {
-                    r.accept(l);
-                } catch (VetoableListener.ListenerVetoException e) {
-                    throw e;
-                } catch (RuntimeException e) {
-                    if (l instanceof VetoableListener) {
-                        throw e;
-                    }
-                    LOG.log(Level.WARNING, "Error executing listener", e);
-                }
-            });
+        ProducerListeners(HollowProducerEventListener[] listeners) {
+            super(listeners);
         }
 
         void fireProducerInit(long elapsedMillis) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/listener/HollowProducerEventListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/listener/HollowProducerEventListener.java
@@ -16,9 +16,10 @@
  */
 package com.netflix.hollow.api.producer.listener;
 
-/**
- * The top-level type for all producer listeners.
- */
-public interface HollowProducerEventListener {
+import com.netflix.hollow.api.common.EventListener;
 
+/**
+ * The top-level type for all producer-specific listeners.
+ */
+public interface HollowProducerEventListener extends EventListener {
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
@@ -260,7 +260,7 @@ public class HollowProducerTest {
         Assert.assertEquals("Should have no populated ordinals", 0,
                 producer.getWriteEngine().getTypeState("TestPojo").getPopulatedBitSet().cardinality());
         doThrow(new RuntimeException("Publish failed")).when(producer).publish(
-                any(ListenerSupport.Listeners.class), any(Long.class), any(AbstractHollowProducer.Artifacts.class));
+                any(ProducerListenerSupport.ProducerListeners.class), any(Long.class), any(AbstractHollowProducer.Artifacts.class));
         try {
             producer.runCycle(newState -> newState.add(new TestPojoV1(1, 1)));
         } catch (RuntimeException e) { // expected

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/ProducerListenerSupportTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/ProducerListenerSupportTest.java
@@ -29,12 +29,12 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-public class ListenerSupportTest {
+public class ProducerListenerSupportTest {
     interface ProducerAndValidationStatusListener
             extends HollowProducerListener, ValidationStatusListener {
     }
 
-    private ListenerSupport listenerSupport;
+    private ProducerListenerSupport listenerSupport;
 
     @Mock
     private HollowProducerListener listener;
@@ -46,7 +46,7 @@ public class ListenerSupportTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        listenerSupport = new ListenerSupport();
+        listenerSupport = new ProducerListenerSupport();
         listenerSupport.addListener(listener);
         listenerSupport.addListener(validationStatusListener);
         listenerSupport.addListener(producerAndValidationStatusListener);
@@ -54,12 +54,12 @@ public class ListenerSupportTest {
 
     @Test
     public void testDuplicates() {
-        ListenerSupport ls = new ListenerSupport();
+        ProducerListenerSupport ls = new ProducerListenerSupport();
         CycleListener l = Mockito.mock(CycleListener.class);
         ls.addListener(l);
         ls.addListener(l);
 
-        ListenerSupport.Listeners s = ls.listeners();
+        ProducerListenerSupport.ProducerListeners s = ls.listeners();
         s.fireCycleStart(1);
 
         Mockito.verify(l, Mockito.times(1)).onCycleStart(1);
@@ -67,7 +67,7 @@ public class ListenerSupportTest {
 
     @Test
     public void testAddDuringCycle() {
-        ListenerSupport ls = new ListenerSupport();
+        ProducerListenerSupport ls = new ProducerListenerSupport();
 
         class SecondCycleListener implements CycleListener {
             int cycleStart;
@@ -100,7 +100,7 @@ public class ListenerSupportTest {
         FirstCycleListener fcl = new FirstCycleListener();
         ls.addListener(fcl);
 
-        ListenerSupport.Listeners s = ls.listeners();
+        ProducerListenerSupport.ProducerListeners s = ls.listeners();
         s.fireCycleStart(1);
         s.fireCycleComplete(new Status.StageWithStateBuilder());
 
@@ -121,7 +121,7 @@ public class ListenerSupportTest {
 
     @Test
     public void testRemoveDuringCycle() {
-        ListenerSupport ls = new ListenerSupport();
+        ProducerListenerSupport ls = new ProducerListenerSupport();
 
         class SecondCycleListener implements CycleListener {
             int cycleStart;
@@ -160,7 +160,7 @@ public class ListenerSupportTest {
         ls.addListener(fcl);
         ls.addListener(scl);
 
-        ListenerSupport.Listeners s = ls.listeners();
+        ProducerListenerSupport.ProducerListeners s = ls.listeners();
         s.fireCycleStart(1);
         s.fireCycleComplete(new Status.StageWithStateBuilder());
 


### PR DESCRIPTION
For reuse in abstractions that compose a producer (eg. transformer).

Note the following breaking changes:
`final class ListenerSupport` -> `final class ProducerListenerSupport extends ListenerSupport`
`public interface HollowProducerEventListener` -> `public interface HollowProducerEventListener extends EventListener`
