### PR TITLE
IGNORE: Add helper for history: index a type field for specific state

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryKeyIndex.java
@@ -84,6 +84,10 @@ public class HollowHistoryKeyIndex {
         indexTypeField(primaryKey, history.getLatestState());
     }
 
+    public void indexTypeFieldInState(HollowReadStateEngine stateEngine, PrimaryKey primaryKey) {
+        indexTypeField(primaryKey, stateEngine);
+    }
+
     public void indexTypeField(PrimaryKey primaryKey, HollowDataset dataModel) {
         String type = primaryKey.getType();
         HollowHistoryTypeKeyIndex typeIndex = typeKeyIndexes.get(type);


### PR DESCRIPTION
Add a helper for Hollow History. When there is a schema change, the type field needs to be indexed on the new state as opposed to current state in history.