### PR TITLE
Fix producer metric reporting non-published version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.parallel=true

--- a/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowProducerMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowProducerMetrics.java
@@ -66,8 +66,6 @@ public class HollowProducerMetrics extends HollowMetrics {
         if(readState != null) {
             HollowReadStateEngine hollowReadStateEngine = readState.getStateEngine();
             super.update(hollowReadStateEngine, version);
-        } else {
-            super.update(version);
         }
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/api/metrics/HollowProducerMetricsTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/metrics/HollowProducerMetricsTests.java
@@ -38,18 +38,38 @@ public class HollowProducerMetricsTests {
     }
 
     @Test
+    public void metricsWhenNothingToPublish() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+            .withBlobStager(new HollowInMemoryBlobStager())
+            .build();
+
+        producer.runCycle(new HollowProducer.Populator() {
+            public void populate(HollowProducer.WriteState state) throws Exception {
+            }
+        });
+
+        HollowProducerMetrics hollowProducerMetrics = producer.getMetrics();
+        Assert.assertEquals(hollowProducerMetrics.getCurrentVersion(), 0);
+        Assert.assertEquals(hollowProducerMetrics.getCyclesSucceeded(), 1);
+        Assert.assertEquals(hollowProducerMetrics.getCyclesCompleted(), 1);
+        Assert.assertEquals(hollowProducerMetrics.getTotalPopulatedOrdinals(), 0);
+        Assert.assertEquals(hollowProducerMetrics.getSnapshotsCompleted(), 0);
+    }
+
+    @Test
     public void metricsWhenPublishingSnapshot() {
         HollowProducer producer = HollowProducer.withPublisher(blobStore)
                 .withBlobStager(new HollowInMemoryBlobStager())
                 .build();
 
-        producer.runCycle(new HollowProducer.Populator() {
+        long version = producer.runCycle(new HollowProducer.Populator() {
             public void populate(HollowProducer.WriteState state) throws Exception {
                 state.add(Integer.valueOf(1));
             }
         });
 
         HollowProducerMetrics hollowProducerMetrics = producer.getMetrics();
+        Assert.assertEquals(hollowProducerMetrics.getCurrentVersion(), version);
         Assert.assertEquals(hollowProducerMetrics.getCyclesSucceeded(), 1);
         Assert.assertEquals(hollowProducerMetrics.getCyclesCompleted(), 1);
         Assert.assertEquals(hollowProducerMetrics.getTotalPopulatedOrdinals(), 1);


### PR DESCRIPTION
On each cycle that is run, a `toVersion` is computed.
The `currentVersion` metric of the producer is updated on each cycle to the above version. I find that misleading because when there is NO state change, there will be no new version published but the metric will still be updated, pointing to a non-existent version.

If I understood correctly, the producer's `readState` will be null when there is no state change so I removed the else branch in which the version update happened.

Also added a gradle setting to build the subprojects in parallel.

**Use-case for this metric**: we want to add an alert for consumers that are out-of-sync with the producer for a given amount of time. For that we look at the consumer's reported version and at the producer's version.