### PR TITLE
Add metric for last announced version in producer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.parallel=true

--- a/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowProducerMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/metrics/HollowProducerMetrics.java
@@ -23,6 +23,8 @@ import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class HollowProducerMetrics extends HollowMetrics {
+    private long lastAnnouncedVersion = 0;
+
     private int cyclesCompleted = 0;
     private int cyclesSucceeded = 0;
     private int cycleFailed = 0;
@@ -65,7 +67,7 @@ public class HollowProducerMetrics extends HollowMetrics {
 
         if(readState != null) {
             HollowReadStateEngine hollowReadStateEngine = readState.getStateEngine();
-            super.update(hollowReadStateEngine, version);
+            update(hollowReadStateEngine, version);
         } else {
             super.update(version);
         }
@@ -137,5 +139,14 @@ public class HollowProducerMetrics extends HollowMetrics {
 
     public int getReverseDeltasFailed() {
         return reverseDeltasFailed;
+    }
+
+    public long getLastAnnouncedVersion() {
+        return lastAnnouncedVersion;
+    }
+
+    protected void update(HollowReadStateEngine hollowReadStateEngine, long version) {
+        lastAnnouncedVersion = version;
+        super.update(hollowReadStateEngine, version);
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/metrics/HollowProducerMetricsTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/metrics/HollowProducerMetricsTests.java
@@ -38,18 +38,38 @@ public class HollowProducerMetricsTests {
     }
 
     @Test
+    public void metricsWhenNothingToPublish() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+            .withBlobStager(new HollowInMemoryBlobStager())
+            .build();
+
+        producer.runCycle(new HollowProducer.Populator() {
+            public void populate(HollowProducer.WriteState state) throws Exception {
+            }
+        });
+
+        HollowProducerMetrics hollowProducerMetrics = producer.getMetrics();
+        Assert.assertEquals(hollowProducerMetrics.getLastAnnouncedVersion(), 0);
+        Assert.assertEquals(hollowProducerMetrics.getCyclesSucceeded(), 1);
+        Assert.assertEquals(hollowProducerMetrics.getCyclesCompleted(), 1);
+        Assert.assertEquals(hollowProducerMetrics.getTotalPopulatedOrdinals(), 0);
+        Assert.assertEquals(hollowProducerMetrics.getSnapshotsCompleted(), 0);
+    }
+
+    @Test
     public void metricsWhenPublishingSnapshot() {
         HollowProducer producer = HollowProducer.withPublisher(blobStore)
                 .withBlobStager(new HollowInMemoryBlobStager())
                 .build();
 
-        producer.runCycle(new HollowProducer.Populator() {
+        long version = producer.runCycle(new HollowProducer.Populator() {
             public void populate(HollowProducer.WriteState state) throws Exception {
                 state.add(Integer.valueOf(1));
             }
         });
 
         HollowProducerMetrics hollowProducerMetrics = producer.getMetrics();
+        Assert.assertEquals(hollowProducerMetrics.getLastAnnouncedVersion(), version);
         Assert.assertEquals(hollowProducerMetrics.getCyclesSucceeded(), 1);
         Assert.assertEquals(hollowProducerMetrics.getCyclesCompleted(), 1);
         Assert.assertEquals(hollowProducerMetrics.getTotalPopulatedOrdinals(), 1);


### PR DESCRIPTION
The `currentVersion` of the producer is changed on each cycle regardless of state changes.

I've added a `lastAnnouncedVersion` metric that should change only when there are changes in state and should report the last published version. This can be useful in alerting when you want to check whether you have consumers that are out of sync. The check can be made on the consumer's `currentVersion` and the producer's `lastAnnouncedVersion`.