### PR TITLE
BUGFIX: Fix object schema equality

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowObjectSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowObjectSchema.java
@@ -280,6 +280,8 @@ public class HollowObjectSchema extends HollowSchema {
         for(int i=0;i<numFields();i++) {
             if(getFieldType(i) != otherSchema.getFieldType(i))
                 return false;
+            if(getFieldType(i) == FieldType.REFERENCE && !getReferencedType(i).equals(otherSchema.getReferencedType(i)))
+                return false;
             if(!getFieldName(i).equals(otherSchema.getFieldName(i)))
                 return false;
         }


### PR DESCRIPTION
If two REFERENCE fields have the same name, we must check that the referenced type is also equal.