### PR TITLE
Fixed field traversal in hash index when parent field path is null.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -163,6 +163,10 @@ public class HollowHashIndex implements HollowTypeStateListener {
                     HollowObjectTypeReadState objectAccess = (HollowObjectTypeReadState)readState;
                     readState = objectAccess.getSchema().getReferencedTypeState(fieldPath[j]);
                     hashOrdinal = objectAccess.readOrdinal(hashOrdinal, fieldPath[j]);
+                    // Cannot find nested ordinal for null parent
+                    if(hashOrdinal == -1) {
+                        break;
+                    }
                 }
 
                 HollowObjectTypeReadState objectAccess = (HollowObjectTypeReadState)readState;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.core.index;
 
 import static java.util.Objects.requireNonNull;
 
+import com.netflix.hollow.core.HollowConstants;
 import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
 import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.read.HollowReadFieldUtils;
@@ -164,14 +165,14 @@ public class HollowHashIndex implements HollowTypeStateListener {
                     readState = objectAccess.getSchema().getReferencedTypeState(fieldPath[j]);
                     hashOrdinal = objectAccess.readOrdinal(hashOrdinal, fieldPath[j]);
                     // Cannot find nested ordinal for null parent
-                    if(hashOrdinal == -1) {
+                    if(hashOrdinal == HollowConstants.ORDINAL_NONE) {
                         break;
                     }
                 }
 
                 HollowObjectTypeReadState objectAccess = (HollowObjectTypeReadState)readState;
                 int fieldIdx = fieldPath[fieldPath.length-1];
-                if(hashOrdinal == -1 || !HollowReadFieldUtils.fieldValueEquals(objectAccess, hashOrdinal, fieldIdx, query[i])) {
+                if(hashOrdinal == HollowConstants.ORDINAL_NONE || !HollowReadFieldUtils.fieldValueEquals(objectAccess, hashOrdinal, fieldIdx, query[i])) {
                     return false;
                 }
             }

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexBuilder.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexBuilder.java
@@ -356,8 +356,12 @@ public class HollowHashIndexBuilder {
                 for(int j=0;j<fieldPath.length - 1;j++) {
                     HollowObjectTypeReadState objectAccess = (HollowObjectTypeReadState)readState;
                     readState = objectAccess.getSchema().getReferencedTypeState(fieldPath[j]);
-                    matchOrdinal = objectAccess.readOrdinal(matchOrdinal, fieldPath[j]);
-                    hashOrdinal = objectAccess.readOrdinal(hashOrdinal, fieldPath[j]);
+                    if(matchOrdinal != -1) {
+                        matchOrdinal = objectAccess.readOrdinal(matchOrdinal, fieldPath[j]);
+                    }
+                    if(hashOrdinal != -1) {
+                        hashOrdinal = objectAccess.readOrdinal(hashOrdinal, fieldPath[j]);
+                    }
                 }
 
                 if(matchOrdinal != hashOrdinal) {
@@ -392,6 +396,10 @@ public class HollowHashIndexBuilder {
                     HollowObjectTypeReadState objectAccess = (HollowObjectTypeReadState)readState;
                     readState = objectAccess.getSchema().getReferencedTypeState(fieldPath[j]);
                     ordinal = objectAccess.readOrdinal(ordinal, fieldPath[j]);
+                    // Cannot find nested ordinal for null parent
+                    if(ordinal == -1) {
+                        break;
+                    }
                 }
 
                 int fieldHashCode = ordinal == -1 ? -1 : HollowReadFieldUtils.fieldHashCode((HollowObjectTypeDataAccess) readState, ordinal, fieldPath[fieldPath.length-1]);

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
@@ -20,13 +20,14 @@ import com.netflix.hollow.core.AbstractStateEngineTest;
 import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
 import com.netflix.hollow.core.write.objectmapper.HollowInline;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 
 public class HollowHashIndexTest extends AbstractStateEngineTest {


### PR DESCRIPTION
This change addresses an issue we are encountering where a hash index is defined with a field that is nested several levels deep. Sometimes the root item has a null value for one of the nested types, which breaks the field traversal code.

My fix was to simply check if the last ordinal retrieved was -1 indicating the value is null. In this case, we don't continue to attempt to traverse the field path by looking up any child ordinals.