### PR TITLE
Expose getPrimaryKeys() API at HollowStateEngine

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
@@ -65,6 +65,16 @@ public interface HollowStateEngine extends HollowDataset {
 
     String getHeaderTag(String name);
 
+    default PrimaryKey getPrimaryKey(String typeName) {
+        PrimaryKey pk=null;
+        HollowSchema schema = getSchema(typeName);
+        if (schema.getSchemaType() == HollowSchema.SchemaType.OBJECT) {
+            pk = ((HollowObjectSchema) schema).getPrimaryKey();
+        }
+
+        return pk;
+    }
+
     default List<PrimaryKey> getPrimaryKeys() {
         List<HollowSchema> schemas = getSchemas();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
@@ -17,9 +17,14 @@
 package com.netflix.hollow.core;
 
 import com.netflix.hollow.api.error.SchemaNotFoundException;
+import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.util.StateEngineUtil;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -59,4 +64,19 @@ public interface HollowStateEngine extends HollowDataset {
     Map<String, String> getHeaderTags();
 
     String getHeaderTag(String name);
+
+    default List<PrimaryKey> getPrimaryKeys() {
+        List<HollowSchema> schemas = getSchemas();
+
+        List<PrimaryKey> primaryKeys = new ArrayList<>();
+        for (HollowSchema schema : schemas) {
+            if (schema.getSchemaType() == HollowSchema.SchemaType.OBJECT) {
+                PrimaryKey pk = ((HollowObjectSchema) schema).getPrimaryKey();
+                if (pk != null)
+                    primaryKeys.add(pk);
+            }
+        }
+
+        return StateEngineUtil.sortPrimaryKeys(primaryKeys, this);
+    }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
@@ -68,7 +68,7 @@ public interface HollowStateEngine extends HollowDataset {
     default PrimaryKey getPrimaryKey(String typeName) {
         PrimaryKey pk=null;
         HollowSchema schema = getSchema(typeName);
-        if (schema.getSchemaType() == HollowSchema.SchemaType.OBJECT) {
+        if (schema!=null && schema.getSchemaType() == HollowSchema.SchemaType.OBJECT) {
             pk = ((HollowObjectSchema) schema).getPrimaryKey();
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/util/StateEngineUtil.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/StateEngineUtil.java
@@ -1,0 +1,36 @@
+package com.netflix.hollow.core.util;
+
+import com.netflix.hollow.core.HollowStateEngine;
+import com.netflix.hollow.core.index.key.PrimaryKey;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchemaSorter;
+
+import java.util.Comparator;
+import java.util.List;
+
+public final class StateEngineUtil {
+
+    /**
+     * Sort Primary Key based on the schemas of specified HollowStateEngine
+     */
+    public static List<PrimaryKey> sortPrimaryKeys(List<PrimaryKey> primaryKeys, HollowStateEngine stateEngine) {
+        if (primaryKeys.isEmpty()) return primaryKeys;
+
+        final List<HollowSchema> dependencyOrderedSchemas = HollowSchemaSorter.dependencyOrderedSchemaList(stateEngine.getSchemas());
+        primaryKeys.sort(new Comparator<PrimaryKey>() {
+            public int compare(PrimaryKey o1, PrimaryKey o2) {
+                return schemaDependencyIdx(o1) - schemaDependencyIdx(o2);
+            }
+
+            private int schemaDependencyIdx(PrimaryKey key) {
+                for (int i = 0; i < dependencyOrderedSchemas.size(); i++) {
+                    if (dependencyOrderedSchemas.get(i).getName().equals(key.getType()))
+                        return i;
+                }
+                throw new IllegalArgumentException("Primary key defined for non-existent type: " + key.getType());
+            }
+        });
+
+        return primaryKeys;
+    }
+}


### PR DESCRIPTION
There are many use cases of HollowStateEngine's Primary Keys so instead of having many projects copy/paste code, it would be great to have it part of HollowStateEngine itself.  