### PR TITLE
Bugfix: Dont close streams that we didn't open

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -75,9 +75,8 @@ public class HollowBlobReader {
      * @throws IOException if the snapshot could not be read
      */
     public void readSnapshot(InputStream is) throws IOException {
-        try (HollowBlobInput hbi = HollowBlobInput.serial(is)) {
-            readSnapshot(hbi);
-        }
+        HollowBlobInput hbi = HollowBlobInput.serial(is);
+        readSnapshot(hbi);
     }
 
     /**
@@ -103,9 +102,8 @@ public class HollowBlobReader {
      */
     @Deprecated
     public void readSnapshot(InputStream is, HollowFilterConfig filter) throws IOException {
-        try (HollowBlobInput hbi = HollowBlobInput.serial(is)) {
-            readSnapshot(hbi, (TypeFilter) filter);
-        }
+        HollowBlobInput hbi = HollowBlobInput.serial(is);
+        readSnapshot(hbi, (TypeFilter) filter);
     }
 
     /**
@@ -118,9 +116,8 @@ public class HollowBlobReader {
      * @throws IOException if the snapshot could not be read
      */
     public void readSnapshot(InputStream is, TypeFilter filter) throws IOException {
-        try (HollowBlobInput hbi = HollowBlobInput.serial(is)) {
-            readSnapshot(hbi, filter);
-        }
+        HollowBlobInput hbi = HollowBlobInput.serial(is);
+        readSnapshot(hbi, filter);
     }
 
     /**
@@ -153,8 +150,8 @@ public class HollowBlobReader {
 
         long endTime = System.currentTimeMillis();
 
-        log.info("mmap'ed SNAPSHOT COMPLETED IN " + (endTime - startTime) + "ms");
-        log.info("mmap'ed TYPES: " + typeNames);
+        log.info("SNAPSHOT COMPLETED IN " + (endTime - startTime) + "ms");
+        log.info("TYPES: " + typeNames);
 
         notifyEndUpdate();
 
@@ -171,9 +168,8 @@ public class HollowBlobReader {
      * @throws IOException if the delta could not be applied
      */
     public void applyDelta(InputStream in) throws IOException {
-        try (HollowBlobInput hbi = HollowBlobInput.serial(in)) {
-            applyDelta(hbi);
-        }
+        HollowBlobInput hbi = HollowBlobInput.serial(in);
+        applyDelta(hbi);
     }
 
     /**

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchema.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchema.java
@@ -78,10 +78,10 @@ public abstract class HollowSchema {
     }
 
     public static HollowSchema readFrom(InputStream is) throws IOException {
-        try (HollowBlobInput hbi = HollowBlobInput.serial(is)) {
-            return readFrom(hbi);
-        }
+        HollowBlobInput hbi = HollowBlobInput.serial(is);
+        return readFrom(hbi);
     }
+
     public static HollowSchema readFrom(HollowBlobInput in) throws IOException {
         int schemaTypeId = in.read();
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistoricalStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistoricalStateCreator.java
@@ -346,9 +346,8 @@ public class HollowHistoricalStateCreator {
                 }
             });
 
-            try (HollowBlobInput hbi = HollowBlobInput.serial(in)) {
-                reader.readSnapshot(hbi);
-            }
+            HollowBlobInput hbi = HollowBlobInput.serial(in);
+            reader.readSnapshot(hbi);
         } catch (Exception e) {
             pipeException = e;
         }

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryKeyIndex.java
@@ -182,13 +182,13 @@ public class HollowHistoryKeyIndex {
                 }
             });
 
-            try (HollowBlobInput in = HollowBlobInput.serial(new BufferedInputStream(is))) {
-                if (isInitialUpdate || isSnapshot) {
-                    reader.readSnapshot(in);
-                } else {
-                    reader.applyDelta(in);
-                }
+            HollowBlobInput in = HollowBlobInput.serial(new BufferedInputStream(is));
+            if (isInitialUpdate || isSnapshot) {
+                reader.readSnapshot(in);
+            } else {
+                reader.applyDelta(in);
             }
+
         } catch (Exception e) {
             pipeException = e;
         }


### PR DESCRIPTION
InputStream closing has a cascading effect for nested streams, and recent refactoring to adapt to HollowBlobInput closed streams that are in use beyond the usage of HollowBlobInput. If a parent stream isn't closed but a nested stream was, that's fine, the parent stream doesn't hold any resources and will eventually be GC'ed. 

So now we don't close any streams that we didn't open.