### PR TITLE
Bugfix: Consumer Type Filter unresolved

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -133,6 +133,7 @@ public class HollowBlobReader {
         validateMemoryMode(in.getMemoryMode());
 
         HollowBlobHeader header = readHeader(in, false);
+        filter = filter.resolve(header.getSchemas());
 
         notifyBeginUpdate();
 

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowProducerConsumerTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowProducerConsumerTests.java
@@ -464,16 +464,13 @@ public class HollowProducerConsumerTests {
         /// Showing verbose version of `runCycle(producer, 1);`
         long version = producer.runCycle(state -> state.add(1));
 
-        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
-                .withTypeFilter(new TypeFilter() {
-                    @Override public boolean includes(String type) {
-                        return true;
-                    }
+        TypeFilter filterConfig = TypeFilter.newTypeFilter()
+                .excludeAll()
+                .include("String")
+                .build();
 
-                    @Override public boolean includes(String type, String field) {
-                        return true;
-                    }
-                })
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withTypeFilter(filterConfig)
                 .build();
         consumer.triggerRefreshTo(version);
         Assert.assertEquals(version, consumer.getCurrentVersionId());
@@ -482,15 +479,7 @@ public class HollowProducerConsumerTests {
         try {
             HollowConsumer.withBlobRetriever(blobStore)
                     .withMemoryMode(MemoryMode.SHARED_MEMORY_LAZY)
-                    .withTypeFilter(new TypeFilter() {
-                        @Override public boolean includes(String type) {
-                            return true;
-                        }
-
-                        @Override public boolean includes(String type, String field) {
-                            return true;
-                        }
-                    })
+                    .withTypeFilter(filterConfig)
                     .build();
         } catch (UnsupportedOperationException e) {
             return;


### PR DESCRIPTION
Regression was introduced in Cinder 5.0.0 by a bad manual conflict merge