### PR TITLE
Feature: search in history by composite primary key

### DIFF
--- a/hollow-diff-ui/build.gradle
+++ b/hollow-diff-ui/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api project(':hollow-ui-tools')
     implementation 'com.google.code.gson:gson:2.8.0'
 
-    compileOnly 'org.eclipse.jetty:jetty-server:9.4.3.v20170317'
+    compile 'org.eclipse.jetty:jetty-server:9.4.3.v20170317'
 
     testImplementation 'junit:junit:4.11'
 }

--- a/hollow-diff-ui/build.gradle
+++ b/hollow-diff-ui/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api project(':hollow-ui-tools')
     implementation 'com.google.code.gson:gson:2.8.0'
 
-    compile 'org.eclipse.jetty:jetty-server:9.4.3.v20170317'
+    compileOnly 'org.eclipse.jetty:jetty-server:9.4.3.v20170317'
 
     testImplementation 'junit:junit:4.11'
 }

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
@@ -16,6 +16,8 @@
  */
 package com.netflix.hollow.explorer.ui.pages;
 
+import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
+import static com.netflix.hollow.tools.util.SearchUtils.MULTI_FIELD_KEY_DELIMITER;
 import static com.netflix.hollow.tools.util.SearchUtils.getFieldPathIndexes;
 import static com.netflix.hollow.tools.util.SearchUtils.getOrdinalToDisplay;
 import static com.netflix.hollow.tools.util.SearchUtils.getPrimaryKey;
@@ -85,9 +87,9 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
         
         List<TypeKey> keys = new ArrayList<>(pageSize);
         
-        for(int i=0;i<pageSize && currentOrdinal != -1;i++) {
+        for(int i = 0; i < pageSize && currentOrdinal != ORDINAL_NONE; i ++) {
             keys.add(getKey(startRec + i, typeState, currentOrdinal, fieldPathIndexes));
-            currentOrdinal = selectedOrdinals.nextSetBit(currentOrdinal+1);
+            currentOrdinal = selectedOrdinals.nextSetBit(currentOrdinal + 1);
         }
 
         
@@ -100,12 +102,12 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
         }
 
         HollowTypeReadState readTypeState = getTypeState(req);
-        int ordinal = req.getParameter("ordinal") == null ? -1 : Integer.parseInt(req.getParameter("ordinal"));
+        int ordinal = req.getParameter("ordinal") == null ? ORDINAL_NONE : Integer.parseInt(req.getParameter("ordinal"));
         ordinal = getOrdinalToDisplay(ui.getStateEngine(), key, parsedKey, ordinal, selectedOrdinals, fieldPathIndexes, readTypeState);
-        if (ordinal != -1 && "".equals(key)
+        if (ordinal != ORDINAL_NONE && "".equals(key)
                 && fieldPathIndexes != null) {
             // set key for the case where it was unset previously
-            key = getKey(-1, typeState, ordinal, fieldPathIndexes).getKey();
+            key = getKey(ORDINAL_NONE, typeState, ordinal, fieldPathIndexes).getKey();
         }
 
         int numRecords = selectedOrdinals.cardinality();
@@ -128,9 +130,9 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
         ui.getVelocityEngine().getTemplate("browse-selected-type-top.vm").merge(ctx, writer);
         try {
             Writer htmlEscapingWriter = new HtmlEscapingWriter(writer);
-            if (!"".equals(key) && ordinal != null && ordinal.equals(-1)) {
+            if (!"".equals(key) && ordinal != null && ordinal.equals(ORDINAL_NONE)) {
                 htmlEscapingWriter.append("ERROR: Key " + key + " was not found!");
-            } else if (ordinal != null && !ordinal.equals(-1)) {
+            } else if (ordinal != null && !ordinal.equals(ORDINAL_NONE)) {
                 HollowStringifier stringifier = "json".equals(req.getParameter("display"))
                     ? new HollowRecordJsonStringifier() : new HollowRecordStringifier();
                 stringifier.stringify(htmlEscapingWriter, ui.getStateEngine(),
@@ -158,9 +160,9 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
                 }
 
                 if(i > 0)
-                    keyBuilder.append(":");
+                    keyBuilder.append(MULTI_FIELD_KEY_DELIMITER);
 
-                keyBuilder.append(HollowReadFieldUtils.fieldValueObject(curState, curOrdinal, fieldPathIndexes[i][fieldPathIndexes[i].length-1]));
+                keyBuilder.append(HollowReadFieldUtils.fieldValueObject(curState, curOrdinal, fieldPathIndexes[i][fieldPathIndexes[i].length - 1]));
             }
 
             return new TypeKey(recordIdx, ordinal, keyBuilder.toString());

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
@@ -100,8 +100,9 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
         }
 
         HollowTypeReadState readTypeState = getTypeState(req);
-        Integer ordinal = getOrdinalToDisplay(ui.getStateEngine(), key, parsedKey, selectedOrdinals, fieldPathIndexes, readTypeState);
-        if (ordinal != null && !ordinal.equals(-1) && "".equals(key)
+        int ordinal = req.getParameter("ordinal") == null ? -1 : Integer.parseInt(req.getParameter("ordinal"));
+        ordinal = getOrdinalToDisplay(ui.getStateEngine(), key, parsedKey, ordinal, selectedOrdinals, fieldPathIndexes, readTypeState);
+        if (ordinal != -1 && "".equals(key)
                 && fieldPathIndexes != null) {
             // set key for the case where it was unset previously
             key = getKey(-1, typeState, ordinal, fieldPathIndexes).getKey();

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
@@ -40,10 +40,13 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.velocity.VelocityContext;
 
 public class BrowseSelectedTypePage extends HollowExplorerPage {
+    private static final Logger LOG = Logger.getLogger(BrowseSelectedTypePage.class.getName());
     private static final String SESSION_ATTR_QUERY_RESULT = "query-result";
 
     public BrowseSelectedTypePage(HollowExplorerUI ui) {
@@ -98,6 +101,7 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
         try {
             parsedKey = parseKey(ui.getStateEngine(), primaryKey, key);
         } catch(Exception e) {
+            LOG.log(Level.WARNING, String.format("Failed to parse query=%s into %s", key, primaryKey.toString()), e);
             key = "";
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -39,8 +39,12 @@ import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class HollowHistoryTypeKeyIndex {
+
+    private static final Logger LOG = Logger.getLogger(HollowHistoryTypeKeyIndex.class.getName());
 
     private final PrimaryKey primaryKey;
     private final String[][] keyFieldParts;
@@ -230,6 +234,7 @@ public class HollowHistoryTypeKeyIndex {
             try {
                 parsedKey = parseKey(readStateEngine, primaryKey, query);
             } catch(Exception e) {
+                LOG.log(Level.WARNING, String.format("Failed to parse query=%s into %s", query, primaryKey.toString()), e);
                 return matchingKeys;
             }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -218,7 +218,7 @@ public class HollowHistoryTypeKeyIndex {
         }
 
         String[] parts;
-        if (query.contains(":")) {  // composite field query, won't work if a value contains ':'
+        if (query.contains(":")) {  // composite field query, uses ':' as separator
             parts = query.split(":");
             if (parts.length != primaryKey.numFields()) {
                 return matchingKeys;

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -233,7 +233,7 @@ public class HollowHistoryTypeKeyIndex {
 
             BitSet selectedOrdinals = keyTypeState.getPopulatedOrdinals();
             int fieldPathIndexes[][] = getFieldPathIndexes(readStateEngine, primaryKey);
-            Integer ordinal = getOrdinalToDisplay(readStateEngine, query, parsedKey, selectedOrdinals, fieldPathIndexes, keyTypeState);
+            int ordinal = getOrdinalToDisplay(readStateEngine, query, parsedKey, -1, selectedOrdinals, fieldPathIndexes, keyTypeState);
             matchingKeys.add(ordinal);
             return matchingKeys;
         }

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -16,18 +16,18 @@
  */
 package com.netflix.hollow.tools.history.keyindex;
 
+import static com.netflix.hollow.tools.util.SearchUtils.getFieldPathIndexes;
+import static com.netflix.hollow.tools.util.SearchUtils.getOrdinalToDisplay;
+import static com.netflix.hollow.tools.util.SearchUtils.parseKey;
+
 import com.netflix.hollow.core.HollowDataset;
-import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.read.HollowReadFieldUtils;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
-import com.netflix.hollow.core.read.engine.HollowTypeReadState;
-import com.netflix.hollow.core.read.engine.HollowTypeStateListener;
 import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.util.IntList;
 import com.netflix.hollow.core.util.LongList;
 import com.netflix.hollow.core.util.RemovedOrdinalIterator;
@@ -210,125 +210,6 @@ public class HollowHistoryTypeKeyIndex {
         return HashCodes.hashInt(hashCode);
     }
 
-    private Object[] parseKey(PrimaryKey primaryKey, String keyString) {
-        // Split by the number of fields of the primary key
-        // This ensures correct extraction of an empty value for the last field
-        String fields[] = keyString.split(":", primaryKey.numFields());
-
-        Object key[] = new Object[fields.length];
-
-        for(int i=0;i<fields.length;i++) {
-            switch(primaryKey.getFieldType(readStateEngine, i)) {
-                case BOOLEAN:
-                    key[i] = Boolean.parseBoolean(fields[i]);
-                    break;
-                case STRING:
-                    key[i] = fields[i];
-                    break;
-                case INT:
-                case REFERENCE:
-                    key[i] = Integer.parseInt(fields[i]);
-                    break;
-                case LONG:
-                    key[i] = Long.parseLong(fields[i]);
-                    break;
-                case DOUBLE:
-                    key[i] = Double.parseDouble(fields[i]);
-                    break;
-                case FLOAT:
-                    key[i] = Float.parseFloat(fields[i]);
-                    break;
-                case BYTES:
-                    key[i] = null; //TODO
-            }
-        }
-        return key;
-    }
-
-    private HollowPrimaryKeyIndex findPrimaryKeyIndex(HollowTypeReadState typeState) {
-        if(getPrimaryKey(typeState.getSchema()) == null)
-            return null;
-
-        for(HollowTypeStateListener listener : typeState.getListeners()) {
-            if(listener instanceof HollowPrimaryKeyIndex) {
-                if(((HollowPrimaryKeyIndex) listener).getPrimaryKey().equals(getPrimaryKey(typeState.getSchema())))
-                    return (HollowPrimaryKeyIndex)listener;
-            }
-        }
-
-        return null;
-    }
-
-    private PrimaryKey getPrimaryKey(HollowSchema schema) {
-        if(schema.getSchemaType() == HollowSchema.SchemaType.OBJECT)
-            return ((HollowObjectSchema)schema).getPrimaryKey();
-        return null;
-    }
-
-    private Integer getOrdinalToDisplay(String query, Object[] parsedKey, BitSet selectedOrdinals, int[][] fieldPathIndexes, HollowObjectTypeReadState keyTypeState) {
-
-        int ordinal = -1;
-
-        // verify ordinal key matches parsed key
-        if (ordinal != -1 && selectedOrdinals.get(ordinal)
-                && recordKeyEquals(keyTypeState, ordinal, parsedKey, fieldPathIndexes)) {
-            return ordinal;
-        } else {
-            HollowPrimaryKeyIndex idx = findPrimaryKeyIndex(keyTypeState);
-            if (idx != null) {
-                // N.B. - findOrdinal can return -1, the caller deals with it
-                return findOrdinal(idx, query);
-            } else {
-                // no index, scan through records
-                ordinal = selectedOrdinals.nextSetBit(0);
-                while (ordinal != -1) {
-                    if (recordKeyEquals(keyTypeState, ordinal, parsedKey, fieldPathIndexes)) {
-                        return ordinal;
-                    }
-                    ordinal = selectedOrdinals.nextSetBit(ordinal + 1);
-                }
-            }
-        }
-
-        return -1;
-    }
-
-    private boolean recordKeyEquals(HollowTypeReadState typeState, int ordinal, Object[] key, int[][] fieldPathIndexes) {
-        HollowObjectTypeReadState objState = (HollowObjectTypeReadState)typeState;
-
-        for(int i=0;i<fieldPathIndexes.length;i++) {
-            int curOrdinal = ordinal;
-            HollowObjectTypeReadState curState = objState;
-
-            for(int j=0;j<fieldPathIndexes[i].length - 1;j++) {
-                curOrdinal = curState.readOrdinal(curOrdinal, fieldPathIndexes[i][j]);
-                curState = (HollowObjectTypeReadState) curState.getSchema().getReferencedTypeState(fieldPathIndexes[i][j]);
-            }
-
-            if(!HollowReadFieldUtils.fieldValueEquals(curState, curOrdinal, fieldPathIndexes[i][fieldPathIndexes[i].length-1], key[i]))
-                return false;
-        }
-
-        return true;
-    }
-
-    private int findOrdinal(HollowPrimaryKeyIndex idx, String keyString) {
-        Object[] key = parseKey(idx.getPrimaryKey(), keyString);
-
-        return idx.getMatchingOrdinal(key);
-    }
-
-    private int[][] getFieldPathIndexes(PrimaryKey primaryKey) {
-        if(primaryKey != null) {
-            int fieldPathIndexes[][] = new int[primaryKey.numFields()][];
-            for(int i=0;i<primaryKey.numFields();i++) {
-                fieldPathIndexes[i] = primaryKey.getFieldPathIndex(readStateEngine, i);
-            }
-            return fieldPathIndexes;
-        }
-
-        return null;
-    }
     public IntList queryIndexedFields(final String query) {
         final HollowObjectTypeReadState keyTypeState = (HollowObjectTypeReadState) readStateEngine.getTypeState(primaryKey.getType());
         IntList matchingKeys = new IntList();
@@ -337,7 +218,7 @@ public class HollowHistoryTypeKeyIndex {
         }
 
         String[] parts;
-        if (query.contains(":")) {  // composite field query
+        if (query.contains(":")) {  // composite field query, won't work if a value contains ':'
             parts = query.split(":");
             if (parts.length != primaryKey.numFields()) {
                 return matchingKeys;
@@ -345,14 +226,14 @@ public class HollowHistoryTypeKeyIndex {
 
             Object[] parsedKey;
             try {
-                parsedKey = parseKey(primaryKey, query);
+                parsedKey = parseKey(readStateEngine, primaryKey, query);
             } catch(Exception e) {
                 return matchingKeys;
             }
 
             BitSet selectedOrdinals = keyTypeState.getPopulatedOrdinals();
-            int fieldPathIndexes[][] = getFieldPathIndexes(primaryKey);
-            Integer ordinal = getOrdinalToDisplay(query, parsedKey, selectedOrdinals, fieldPathIndexes, keyTypeState);
+            int fieldPathIndexes[][] = getFieldPathIndexes(readStateEngine, primaryKey);
+            Integer ordinal = getOrdinalToDisplay(readStateEngine, query, parsedKey, selectedOrdinals, fieldPathIndexes, keyTypeState);
             matchingKeys.add(ordinal);
             return matchingKeys;
         }

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/SearchUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/SearchUtils.java
@@ -1,6 +1,7 @@
 package com.netflix.hollow.tools.util;
 
 import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
+import static com.netflix.hollow.core.schema.HollowObjectSchema.FieldType.BYTES;
 
 import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
 import com.netflix.hollow.core.index.key.PrimaryKey;
@@ -51,7 +52,7 @@ public class SearchUtils {
                     key[i] = Float.parseFloat(fields[i]);
                     break;
                 case BYTES:
-                    key[i] = null;
+                    throw new IllegalArgumentException("Primary key contains a field of type BYTES");
             }
         }
         return key;
@@ -76,13 +77,14 @@ public class SearchUtils {
      * Returns primary key index for a given type if it exists.
      */
     public static HollowPrimaryKeyIndex findPrimaryKeyIndex(HollowTypeReadState typeState) {
-        if(getPrimaryKey(typeState.getSchema()) == null)
+        PrimaryKey pkey = getPrimaryKey(typeState.getSchema());
+        if(pkey == null)
             return null;
 
         for(HollowTypeStateListener listener : typeState.getListeners()) {
             if(listener instanceof HollowPrimaryKeyIndex) {
-                if(((HollowPrimaryKeyIndex) listener).getPrimaryKey().equals(getPrimaryKey(typeState.getSchema())))
-                    return (HollowPrimaryKeyIndex)listener;
+                if(((HollowPrimaryKeyIndex) listener).getPrimaryKey().equals(pkey))
+                    return (HollowPrimaryKeyIndex) listener;
             }
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/SearchUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/SearchUtils.java
@@ -1,0 +1,153 @@
+package com.netflix.hollow.tools.util;
+
+import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
+import com.netflix.hollow.core.index.key.PrimaryKey;
+import com.netflix.hollow.core.read.HollowReadFieldUtils;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.engine.HollowTypeReadState;
+import com.netflix.hollow.core.read.engine.HollowTypeStateListener;
+import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import java.util.BitSet;
+
+public class SearchUtils {
+
+    /**
+     * Parse a colon-separated string into a primary key, throw exception if format exception for eg. if primary key was
+     * expecting an integer but keyString didn't contain a parseable integer at the right spot
+     */
+    public static Object[] parseKey(HollowReadStateEngine readStateEngine, PrimaryKey primaryKey, String keyString) {
+        // Split by the number of fields of the primary key
+        // This ensures correct extraction of an empty value for the last field
+        String fields[] = keyString.split(":", primaryKey.numFields());
+
+        Object key[] = new Object[fields.length];
+
+        for(int i=0;i<fields.length;i++) {
+            switch(primaryKey.getFieldType(readStateEngine, i)) {
+                case BOOLEAN:
+                    key[i] = Boolean.parseBoolean(fields[i]);
+                    break;
+                case STRING:
+                    key[i] = fields[i];
+                    break;
+                case INT:
+                case REFERENCE:
+                    key[i] = Integer.parseInt(fields[i]);
+                    break;
+                case LONG:
+                    key[i] = Long.parseLong(fields[i]);
+                    break;
+                case DOUBLE:
+                    key[i] = Double.parseDouble(fields[i]);
+                    break;
+                case FLOAT:
+                    key[i] = Float.parseFloat(fields[i]);
+                    break;
+                case BYTES:
+                    key[i] = null; //TODO
+            }
+        }
+        return key;
+    }
+
+    /**
+     * Return field index in object schema for each field comprising primary key
+     */
+    public static int[][] getFieldPathIndexes(HollowReadStateEngine readStateEngine, PrimaryKey primaryKey) {
+        if(primaryKey != null) {
+            int fieldPathIndexes[][] = new int[primaryKey.numFields()][];
+            for(int i=0;i<primaryKey.numFields();i++) {
+                fieldPathIndexes[i] = primaryKey.getFieldPathIndex(readStateEngine, i);
+            }
+            return fieldPathIndexes;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns primary key index for a given type if it exists
+     */
+    public static HollowPrimaryKeyIndex findPrimaryKeyIndex(HollowTypeReadState typeState) {
+        if(getPrimaryKey(typeState.getSchema()) == null)
+            return null;
+
+        for(HollowTypeStateListener listener : typeState.getListeners()) {
+            if(listener instanceof HollowPrimaryKeyIndex) {
+                if(((HollowPrimaryKeyIndex) listener).getPrimaryKey().equals(getPrimaryKey(typeState.getSchema())))
+                    return (HollowPrimaryKeyIndex)listener;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the primary key for an object schema
+     */
+    public static PrimaryKey getPrimaryKey(HollowSchema schema) {
+        if(schema.getSchemaType() == HollowSchema.SchemaType.OBJECT)
+            return ((HollowObjectSchema)schema).getPrimaryKey();
+        return null;
+    }
+
+    /**
+     * Returns the ordinal corresponding to the search result of searching by primary key
+     */
+    public static Integer getOrdinalToDisplay(HollowReadStateEngine readStateEngine, String query, Object[] parsedKey,
+            BitSet selectedOrdinals, int[][] fieldPathIndexes, HollowTypeReadState keyTypeState) {
+
+        int ordinal = -1;
+
+        // verify ordinal key matches parsed key
+        if (ordinal != -1 && selectedOrdinals.get(ordinal)
+                && recordKeyEquals(keyTypeState, ordinal, parsedKey, fieldPathIndexes)) {
+            return ordinal;
+        } else {
+            HollowPrimaryKeyIndex idx = findPrimaryKeyIndex(keyTypeState);
+            if (idx != null) {
+                // N.B. - findOrdinal can return -1, the caller deals with it
+                return findOrdinal(readStateEngine, idx, query);
+            } else {
+                // no index, scan through records
+                ordinal = selectedOrdinals.nextSetBit(0);
+                while (ordinal != -1) {
+                    if (recordKeyEquals(keyTypeState, ordinal, parsedKey, fieldPathIndexes)) {
+                        return ordinal;
+                    }
+                    ordinal = selectedOrdinals.nextSetBit(ordinal + 1);
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    private static boolean recordKeyEquals(HollowTypeReadState typeState, int ordinal, Object[] key, int[][] fieldPathIndexes) {
+        HollowObjectTypeReadState objState = (HollowObjectTypeReadState)typeState;
+
+        for(int i=0;i<fieldPathIndexes.length;i++) {
+            int curOrdinal = ordinal;
+            HollowObjectTypeReadState curState = objState;
+
+            for(int j=0;j<fieldPathIndexes[i].length - 1;j++) {
+                curOrdinal = curState.readOrdinal(curOrdinal, fieldPathIndexes[i][j]);
+                curState = (HollowObjectTypeReadState) curState.getSchema().getReferencedTypeState(fieldPathIndexes[i][j]);
+            }
+
+            if(!HollowReadFieldUtils.fieldValueEquals(curState, curOrdinal, fieldPathIndexes[i][fieldPathIndexes[i].length-1], key[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static int findOrdinal(HollowReadStateEngine readStateEngine, HollowPrimaryKeyIndex idx, String keyString) {
+        Object[] key = parseKey(readStateEngine, idx.getPrimaryKey(), keyString);
+
+        return idx.getMatchingOrdinal(key);
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/SearchUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/SearchUtils.java
@@ -15,11 +15,13 @@ public class SearchUtils {
 
     /**
      * Parse a colon-separated string into a primary key, throw exception if format exception for eg. if primary key was
-     * expecting an integer but keyString didn't contain a parseable integer at the right spot
+     * expecting an integer but keyString didn't contain a parse-able integer at the right spot.
      */
     public static Object[] parseKey(HollowReadStateEngine readStateEngine, PrimaryKey primaryKey, String keyString) {
-        // Split by the number of fields of the primary key
-        // This ensures correct extraction of an empty value for the last field
+        /**
+         * Split by the number of fields of the primary key.
+         * This ensures correct extraction of an empty value for the last field.
+         */
         String fields[] = keyString.split(":", primaryKey.numFields());
 
         Object key[] = new Object[fields.length];
@@ -46,14 +48,14 @@ public class SearchUtils {
                     key[i] = Float.parseFloat(fields[i]);
                     break;
                 case BYTES:
-                    key[i] = null; //TODO
+                    key[i] = null;
             }
         }
         return key;
     }
 
     /**
-     * Return field index in object schema for each field comprising primary key
+     * Return field index in object schema for each field comprising primary key.
      */
     public static int[][] getFieldPathIndexes(HollowReadStateEngine readStateEngine, PrimaryKey primaryKey) {
         if(primaryKey != null) {
@@ -68,7 +70,7 @@ public class SearchUtils {
     }
 
     /**
-     * Returns primary key index for a given type if it exists
+     * Returns primary key index for a given type if it exists.
      */
     public static HollowPrimaryKeyIndex findPrimaryKeyIndex(HollowTypeReadState typeState) {
         if(getPrimaryKey(typeState.getSchema()) == null)
@@ -85,7 +87,7 @@ public class SearchUtils {
     }
 
     /**
-     * Get the primary key for an object schema
+     * Get the primary key for an object schema.
      */
     public static PrimaryKey getPrimaryKey(HollowSchema schema) {
         if(schema.getSchemaType() == HollowSchema.SchemaType.OBJECT)
@@ -94,7 +96,7 @@ public class SearchUtils {
     }
 
     /**
-     * Returns the ordinal corresponding to the search result of searching by primary key
+     * Returns the ordinal corresponding to the search result of searching by primary key.
      */
     public static Integer getOrdinalToDisplay(HollowReadStateEngine readStateEngine, String query, Object[] parsedKey,
             int ordinal, BitSet selectedOrdinals, int[][] fieldPathIndexes, HollowTypeReadState keyTypeState) {
@@ -110,7 +112,7 @@ public class SearchUtils {
                 HollowPrimaryKeyIndex idx = findPrimaryKeyIndex(keyTypeState);
                 if (idx != null) {
                     // N.B. - findOrdinal can return -1, the caller deals with it
-                    return findOrdinal(readStateEngine, idx, query);
+                    return idx.getMatchingOrdinal(parsedKey);
                 } else {
                     // no index, scan through records
                     ordinal = selectedOrdinals.nextSetBit(0);
@@ -125,7 +127,6 @@ public class SearchUtils {
         }
         return -1;
     }
-
 
     private static boolean recordKeyEquals(HollowTypeReadState typeState, int ordinal, Object[] key, int[][] fieldPathIndexes) {
         HollowObjectTypeReadState objState = (HollowObjectTypeReadState)typeState;
@@ -145,11 +146,4 @@ public class SearchUtils {
 
         return true;
     }
-
-    private static int findOrdinal(HollowReadStateEngine readStateEngine, HollowPrimaryKeyIndex idx, String keyString) {
-        Object[] key = parseKey(readStateEngine, idx.getPrimaryKey(), keyString);
-
-        return idx.getMatchingOrdinal(key);
-    }
-
 }


### PR DESCRIPTION
Status quo: History UI's search can accept a single field- so one can search based on any indexed field, and by default all fields comprising a primary key are indexed.

New: If a primary key is composed of multiple fields, one can search using primary key by colon delimiting the values, for eg. "1234:US"