### PR TITLE
Remove noisy log lines which also cause NPE if primary key null

### DIFF
--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
@@ -40,13 +40,10 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.velocity.VelocityContext;
 
 public class BrowseSelectedTypePage extends HollowExplorerPage {
-    private static final Logger LOG = Logger.getLogger(BrowseSelectedTypePage.class.getName());
     private static final String SESSION_ATTR_QUERY_RESULT = "query-result";
 
     public BrowseSelectedTypePage(HollowExplorerUI ui) {
@@ -101,7 +98,6 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
         try {
             parsedKey = parseKey(ui.getStateEngine(), primaryKey, key);
         } catch(Exception e) {
-            LOG.log(Level.WARNING, String.format("Failed to parse query=%s into %s", key, primaryKey.toString()), e);
             key = "";
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -39,12 +39,8 @@ import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class HollowHistoryTypeKeyIndex {
-
-    private static final Logger LOG = Logger.getLogger(HollowHistoryTypeKeyIndex.class.getName());
 
     private final PrimaryKey primaryKey;
     private final String[][] keyFieldParts;
@@ -234,7 +230,6 @@ public class HollowHistoryTypeKeyIndex {
             try {
                 parsedKey = parseKey(readStateEngine, primaryKey, query);
             } catch(Exception e) {
-                LOG.log(Level.WARNING, String.format("Failed to parse query=%s into %s", query, primaryKey.toString()), e);
                 return matchingKeys;
             }
 


### PR DESCRIPTION
They're noisy because we try to match the entered primary key to each type, and we expect there to be a parsing error in most cases