### PR TITLE
Optimization to delay creation of Hollow Objects only when needed.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/data/AbstractHollowDataAccessor.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/data/AbstractHollowDataAccessor.java
@@ -27,19 +27,22 @@ import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
 import com.netflix.hollow.core.util.AllHollowRecordCollection;
+import com.netflix.hollow.core.util.HollowRecordCollection;
+
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public abstract class AbstractHollowDataAccessor<T> {
     protected final String type;
     protected final PrimaryKey primaryKey;
     protected final HollowReadStateEngine rStateEngine;
 
-    private List<T> removedRecords = Collections.emptyList();
-    private List<T> addedRecords = Collections.emptyList();
+    private BitSet removedOrdinals = new BitSet();
+    private BitSet addedOrdinals = new BitSet();
     private List<UpdatedRecord<T>> updatedRecords = Collections.emptyList();
 
     private boolean isDataChangeComputed = false;
@@ -99,59 +102,33 @@ public abstract class AbstractHollowDataAccessor<T> {
         HollowTypeReadState typeState = stateEngine.getTypeDataAccess(type).getTypeState();
 
         // track removed ordinals
-        BitSet removedOrdinals = new BitSet();
+        removedOrdinals = new BitSet();
         removedOrdinals.or(typeState.getPreviousOrdinals());
         removedOrdinals.andNot(typeState.getPopulatedOrdinals());
 
         // track added ordinals
-        BitSet addedOrdinals = new BitSet();
+        addedOrdinals = new BitSet();
         addedOrdinals.or(typeState.getPopulatedOrdinals());
         addedOrdinals.andNot(typeState.getPreviousOrdinals());
 
+        // track updated ordinals
+        updatedRecords = new ArrayList<>();
         HollowPrimaryKeyValueDeriver keyDeriver = new HollowPrimaryKeyValueDeriver(primaryKey, stateEngine);
         HollowPrimaryKeyIndex removalsIndex = new HollowPrimaryKeyIndex(stateEngine, primaryKey, stateEngine.getMemoryRecycler(), removedOrdinals);
 
-        List<T> addedRecords = new ArrayList<>();
-        List<T> removedRecords = new ArrayList<>();
-        List<UpdatedRecord<T>> updatedRecords = new ArrayList<>();
-
-        BitSet updatedRecordOrdinals = new BitSet();
-
-        { // Determine added / updated records (removed records and added back with different value)
+        { // Determine updated records (removed records and added back with different value)
             int addedOrdinal = addedOrdinals.nextSetBit(0);
             while (addedOrdinal != -1) {
                 Object[] key = keyDeriver.getRecordKey(addedOrdinal);
                 int removedOrdinal = removalsIndex.getMatchingOrdinal(key);
 
-                T addedRecord = getRecord(addedOrdinal);
                 if (removedOrdinal != -1) { // record was re-added after being removed = update
-                    updatedRecordOrdinals.set(removedOrdinal);
-                    T removedRecord = getRecord(removedOrdinal);
-                    updatedRecords.add(new UpdatedRecord<T>(removedRecord, addedRecord));
-                } else {
-                    addedRecords.add(addedRecord);
+                    updatedRecords.add(new UpdatedRecordOrdinal(removedOrdinal, addedOrdinal));
                 }
 
                 addedOrdinal = addedOrdinals.nextSetBit(addedOrdinal + 1);
             }
         }
-
-        { // determine removed records
-            int removedOrdinal = removedOrdinals.nextSetBit(0);
-            while (removedOrdinal != -1) {
-                // exclude records that was removed but re-added with different ordinal since that is considered as updated record
-                if (!updatedRecordOrdinals.get(removedOrdinal)) {
-                    T removedRecord = getRecord(removedOrdinal);
-                    removedRecords.add(removedRecord);
-                }
-
-                removedOrdinal = removedOrdinals.nextSetBit(removedOrdinal + 1);
-            }
-        }
-
-        this.removedRecords = Collections.unmodifiableList(removedRecords);
-        this.addedRecords = Collections.unmodifiableList(addedRecords);
-        this.updatedRecords = Collections.unmodifiableList(updatedRecords);
     }
 
     /**
@@ -192,7 +169,10 @@ public abstract class AbstractHollowDataAccessor<T> {
      */
     public Collection<T> getAddedRecords() {
         if (!isDataChangeComputed) computeDataChange();
-        return addedRecords;
+
+        return new HollowRecordCollection<T>(addedOrdinals) { @Override protected T getForOrdinal(int ordinal) {
+                return getRecord(ordinal);
+            }};
     }
 
     /**
@@ -201,7 +181,9 @@ public abstract class AbstractHollowDataAccessor<T> {
      */
     public Collection<T> getRemovedRecords() {
         if (!isDataChangeComputed) computeDataChange();
-        return removedRecords;
+        return new HollowRecordCollection<T>(removedOrdinals) { @Override protected T getForOrdinal(int ordinal) {
+            return getRecord(ordinal);
+        }};
     }
 
     /**
@@ -211,6 +193,38 @@ public abstract class AbstractHollowDataAccessor<T> {
     public Collection<UpdatedRecord<T>> getUpdatedRecords() {
         if (!isDataChangeComputed) computeDataChange();
         return updatedRecords;
+    }
+
+    private class UpdatedRecordOrdinal extends UpdatedRecord<T>{
+        private final int before;
+        private final int after;
+
+        private UpdatedRecordOrdinal(int before, int after) {
+            super(null, null);
+            this.before = before;
+            this.after = after;
+        }
+
+        public T getBefore() {
+            return getRecord(before);
+        }
+
+        public T getAfter() { return getRecord(after);}
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            UpdatedRecordOrdinal that = (UpdatedRecordOrdinal) o;
+            return before == that.before &&
+                    after == that.after;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), before, after);
+        }
     }
 
     /**
@@ -268,9 +282,9 @@ public abstract class AbstractHollowDataAccessor<T> {
         public String toString() {
             StringBuilder builder = new StringBuilder();
             builder.append("UpdatedRecord [before=");
-            builder.append(before);
+            builder.append(getBefore());
             builder.append(", after=");
-            builder.append(after);
+            builder.append(getAfter());
             builder.append("]");
             return builder.toString();
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/util/AllHollowRecordCollection.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/AllHollowRecordCollection.java
@@ -18,46 +18,10 @@ package com.netflix.hollow.core.util;
 
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
-import java.util.AbstractCollection;
-import java.util.BitSet;
-import java.util.Iterator;
 
-public abstract class AllHollowRecordCollection<T> extends AbstractCollection<T> {
-    
-    private final BitSet populatedOrdinals;
-    
+public abstract class AllHollowRecordCollection<T> extends HollowRecordCollection<T> {
+
     public AllHollowRecordCollection(HollowTypeReadState typeState) {
-        this.populatedOrdinals = typeState.getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
+        super(typeState.getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals());
     }
-
-    @Override
-    public Iterator<T> iterator() {
-        return new Iterator<T>() {
-            private int ordinal = populatedOrdinals.nextSetBit(0);
-
-            public boolean hasNext() {
-                return ordinal != -1;
-            }
-
-            @Override
-            public T next() {
-                T t = getForOrdinal(ordinal);
-                ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
-                return t;
-            }
-
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
-        };
-    }
-
-    @Override
-    public int size() {
-        return populatedOrdinals.cardinality();
-    }
-    
-    protected abstract T getForOrdinal(int ordinal);
-
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowRecordCollection.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowRecordCollection.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.util;
+
+import java.util.AbstractCollection;
+import java.util.BitSet;
+import java.util.Iterator;
+
+public abstract class HollowRecordCollection<T> extends AbstractCollection<T> {
+
+    private final BitSet populatedOrdinals;
+
+    public HollowRecordCollection(BitSet populatedOrdinals) {
+        this.populatedOrdinals = populatedOrdinals;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new Iterator<T>() {
+            private int ordinal = populatedOrdinals.nextSetBit(0);
+
+            public boolean hasNext() {
+                return ordinal != -1;
+            }
+
+            @Override
+            public T next() {
+                T t = getForOrdinal(ordinal);
+                ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
+                return t;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return populatedOrdinals.cardinality();
+    }
+    
+    protected abstract T getForOrdinal(int ordinal);
+
+}


### PR DESCRIPTION
- Enhance computeDataChange to capture ordinals only and not create Hollow Objects
- Benefits will be significant for large state changes