### PR TITLE
Fix for commons-lang to pick correct version from maven repository.

### DIFF
--- a/hollow-jsonadapter/build.gradle
+++ b/hollow-jsonadapter/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core:2.4.3'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.4.3'
     implementation 'commons-io:commons-io:2.6'
-    implementation 'commons-lang:commons-lang:latest.release'
+    implementation 'commons-lang:commons-lang:2.+'
 
     testImplementation 'junit:junit:4.11'
 }


### PR DESCRIPTION
Maven repository returns a wrong value for commons-lang latest version to Hollow. Fixing it to use 2.+ version. 