### PR TITLE
Augment RecordCountVarianceValidator to support optional behavior to only fail the publish if the record count goes down by the specified percentage

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/RecordCountVarianceValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/RecordCountVarianceValidator.java
@@ -111,7 +111,7 @@ public class RecordCountVarianceValidator implements ValidatorListener {
         vrb.detail(ACTUAL_CHANGE_PERCENT_NAME, actualChangePercent);
 
         if (Float.compare(actualChangePercent, allowableVariancePercent) > 0) {
-            if(!onlyValidateDropsInCardinality || latestCardinality < previousCardinality) {
+            if (!onlyValidateDropsInCardinality || latestCardinality < previousCardinality) {
                 String message = String.format(FAILED_RECORD_COUNT_VALIDATION, typeName, actualChangePercent,
                         allowableVariancePercent);
 

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/RecordCountVarianceValidatorTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/RecordCountVarianceValidatorTests.java
@@ -100,6 +100,36 @@ public class RecordCountVarianceValidatorTests {
     }
 
     @Test
+    public void failTestTooManyRemoved_onlyValidateDropsInCardinality() {
+        try {
+            HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                    .withBlobStager(new HollowInMemoryBlobStager())
+                    .withListener(new RecordCountVarianceValidator("TypeWithPrimaryKey", 1f, true)).build();
+
+            producer.runCycle(new Populator() {
+                public void populate(WriteState newState) throws Exception {
+                    newState.add(new TypeWithPrimaryKey(1, "Brad Pitt", "klsdjfla;sdjkf"));
+                    newState.add(new TypeWithPrimaryKey(1, "Angelina Jolie", "as;dlkfjasd;l"));
+                    newState.add(new TypeWithPrimaryKey(1, "Bruce Willis", "as;dlkfjasd;l"));
+                }
+            });
+
+            producer.runCycle(new Populator() {
+                public void populate(WriteState newState) throws Exception {
+                    newState.add(new TypeWithPrimaryKey(1, "Brad Pitt", "klsdjfla;sdjkf"));
+                    newState.add(new TypeWithPrimaryKey(1, "Angelina Jolie", "as;dlkfjasd;l"));
+                }
+            });
+            Assert.fail();
+        } catch (ValidationStatusException expected) {
+            //System.out.println("Message:"+expected.getIndividualFailures().get(0).getMessage());
+            Assert.assertEquals(1, expected.getValidationStatus().getResults().size());
+            Assert.assertTrue(expected.getValidationStatus().getResults().get(0).getMessage()
+                    .startsWith("Record count validation for type"));
+        }
+    }
+
+    @Test
     public void passTestNoMoreChangeThanExpected() {
         HollowProducer producer = HollowProducer.withPublisher(blobStore).withBlobStager(new HollowInMemoryBlobStager())
                 .withListener(new RecordCountVarianceValidator("TypeWithPrimaryKey", 50f)).build();
@@ -124,6 +154,36 @@ public class RecordCountVarianceValidatorTests {
         HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
         consumer.triggerRefresh();
         Assert.assertEquals(3, consumer.getStateEngine().getTypeState("TypeWithPrimaryKey").getPopulatedOrdinals()
+                .cardinality());
+    }
+
+    @Test
+    public void passTestNoMoreChangeThanExpected_onlyValidateDropsInCardinality() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore).withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new RecordCountVarianceValidator("TypeWithPrimaryKey", 1f, true)).build();
+
+        // runCycle(producer, 1);
+        producer.runCycle(new Populator() {
+
+            public void populate(WriteState newState) throws Exception {
+                newState.add(new TypeWithPrimaryKey(1, "Brad Pitt", "klsdjfla;sdjkf"));
+                newState.add(new TypeWithPrimaryKey(1, "Angelina Jolie", "as;dlkfjasd;l"));
+            }
+        });
+
+        producer.runCycle(new Populator() {
+
+            public void populate(WriteState newState) throws Exception {
+                newState.add(new TypeWithPrimaryKey(1, "Brad Pitt", "klsdjfla;sdjkf"));
+                newState.add(new TypeWithPrimaryKey(2, "Angelina Jolie", "as;dlkfjasd;l"));
+                newState.add(new TypeWithPrimaryKey(7, "Bruce Willis", "as;dlkfjasd;l"));
+                newState.add(new TypeWithPrimaryKey(9, "Tom Hardy", "as;dlkfjasd;l"));
+                newState.add(new TypeWithPrimaryKey(10, "Tom Cruise", "as;dlkfjasd;l"));
+            }
+        });
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefresh();
+        Assert.assertEquals(5, consumer.getStateEngine().getTypeState("TypeWithPrimaryKey").getPopulatedOrdinals()
                 .cardinality());
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/RecordCountVarianceValidatorTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/RecordCountVarianceValidatorTests.java
@@ -63,7 +63,6 @@ public class RecordCountVarianceValidatorTests {
             Assert.fail();
         } catch (ValidationStatusException expected) {
             Assert.assertEquals(1, expected.getValidationStatus().getResults().size());
-            //System.out.println("Message:"+expected.getIndividualFailures().get(0).getMessage());
             Assert.assertTrue(expected.getValidationStatus().getResults().get(0).getMessage()
                     .startsWith("Record count validation for type"));
         }
@@ -92,7 +91,6 @@ public class RecordCountVarianceValidatorTests {
             });
             Assert.fail();
         } catch (ValidationStatusException expected) {
-            //System.out.println("Message:"+expected.getIndividualFailures().get(0).getMessage());
             Assert.assertEquals(1, expected.getValidationStatus().getResults().size());
             Assert.assertTrue(expected.getValidationStatus().getResults().get(0).getMessage()
                     .startsWith("Record count validation for type"));
@@ -122,7 +120,6 @@ public class RecordCountVarianceValidatorTests {
             });
             Assert.fail();
         } catch (ValidationStatusException expected) {
-            //System.out.println("Message:"+expected.getIndividualFailures().get(0).getMessage());
             Assert.assertEquals(1, expected.getValidationStatus().getResults().size());
             Assert.assertTrue(expected.getValidationStatus().getResults().get(0).getMessage()
                     .startsWith("Record count validation for type"));
@@ -134,7 +131,6 @@ public class RecordCountVarianceValidatorTests {
         HollowProducer producer = HollowProducer.withPublisher(blobStore).withBlobStager(new HollowInMemoryBlobStager())
                 .withListener(new RecordCountVarianceValidator("TypeWithPrimaryKey", 50f)).build();
 
-        // runCycle(producer, 1);
         producer.runCycle(new Populator() {
 
             public void populate(WriteState newState) throws Exception {
@@ -162,7 +158,6 @@ public class RecordCountVarianceValidatorTests {
         HollowProducer producer = HollowProducer.withPublisher(blobStore).withBlobStager(new HollowInMemoryBlobStager())
                 .withListener(new RecordCountVarianceValidator("TypeWithPrimaryKey", 1f, true)).build();
 
-        // runCycle(producer, 1);
         producer.runCycle(new Populator() {
 
             public void populate(WriteState newState) throws Exception {


### PR DESCRIPTION
This will allow clients to allow as many additions for a given type as needed by the business, but will prevent sudden loss of data beyond the specified threshold.