### PR TITLE
DataAccessor tweaks

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/api/HollowDataAccessorGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/api/HollowDataAccessorGenerator.java
@@ -46,7 +46,7 @@ public class HollowDataAccessorGenerator extends HollowConsumerJavaFileGenerator
         super(packageName, SUB_PACKAGE_NAME, dataset, config);
         this.className = getClassName(schema);
         this.apiclassName = apiclassName;
-        this.type =  hollowImplClassname(schema.getName());
+        this.type = schema.getName();
         this.schema = schema;
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/api/HollowDataAccessorGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/api/HollowDataAccessorGenerator.java
@@ -46,7 +46,7 @@ public class HollowDataAccessorGenerator extends HollowConsumerJavaFileGenerator
         super(packageName, SUB_PACKAGE_NAME, dataset, config);
         this.className = getClassName(schema);
         this.apiclassName = apiclassName;
-        this.type = schema.getName();
+        this.type =  hollowImplClassname(schema.getName());
         this.schema = schema;
     }
 
@@ -68,7 +68,7 @@ public class HollowDataAccessorGenerator extends HollowConsumerJavaFileGenerator
         builder.append("@SuppressWarnings(\"all\")\n");
         builder.append("public class " + className + " extends " + AbstractHollowDataAccessor.class.getSimpleName() + "<" + type  +"> {\n\n");
 
-        builder.append("    public static final String TYPE = \"" + type + "\";\n");
+        builder.append("    public static final String TYPE = \"" + schema.getName() + "\";\n");
         builder.append("    private " + apiclassName + " api;\n\n");
 
         genConstructors(builder);

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/data/AbstractHollowDataAccessor.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/data/AbstractHollowDataAccessor.java
@@ -40,6 +40,7 @@ public abstract class AbstractHollowDataAccessor<T> {
     protected final String type;
     protected final PrimaryKey primaryKey;
     protected final HollowReadStateEngine rStateEngine;
+    protected final HollowTypeReadState typeState;
 
     private BitSet removedOrdinals = new BitSet();
     private BitSet addedOrdinals = new BitSet();
@@ -61,7 +62,7 @@ public abstract class AbstractHollowDataAccessor<T> {
 
     public AbstractHollowDataAccessor(HollowReadStateEngine rStateEngine, String type, PrimaryKey primaryKey) {
         this.rStateEngine = requireNonNull(rStateEngine, "read state required");
-        HollowTypeReadState typeState = requireNonNull(rStateEngine.getTypeState(type),
+        this.typeState = requireNonNull(rStateEngine.getTypeState(type),
                 "type not loaded or does not exist in dataset; type=" + type);
         HollowSchema schema = typeState.getSchema();
         if (schema instanceof HollowObjectSchema) {
@@ -79,6 +80,17 @@ public abstract class AbstractHollowDataAccessor<T> {
         } else {
             throw new RuntimeException(String.format("Unsupported DataType=%s with SchemaType=%s : %s", type, schema.getSchemaType(), "Only supported type=" + SchemaType.OBJECT));
         }
+    }
+
+    /**
+     * Indicate whether Data Accessor contains prior state
+     *
+     * NOTE: This is critical since loading a Snapshot will not contain any information about changes from prior state
+     *
+     * @return true indicate it contains prior state
+     */
+    public boolean hasPriorState() {
+        return !typeState.getPreviousOrdinals().isEmpty();
     }
 
     /**


### PR DESCRIPTION
- Fix Generator to use schema name for data type instead of implClass since classname does not always match schema type (e.g. when using PostFix for classname)

- Also introduce DataAccessor.hasPriorState() since it is important data point when using DataAccessor.  Loading Snapshot does not contain prior state info so can't computeChange.