### PR TITLE
Hollow Diff Support Diffing Type that does not have primary key

### DIFF
--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/model/HollowDiffOverviewTypeEntry.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/model/HollowDiffOverviewTypeEntry.java
@@ -21,6 +21,7 @@ import static com.netflix.hollow.ui.HollowDiffUtil.formatBytes;
 public class HollowDiffOverviewTypeEntry {
 
     private final String typeName;
+    private final boolean hasUniqueKey;
     private final long totalDiffScore;
     private final int unmatchedInFrom;
     private final int unmatchedInTo;
@@ -32,12 +33,19 @@ public class HollowDiffOverviewTypeEntry {
     private final long holeInTo;
 
     public HollowDiffOverviewTypeEntry(String typeName, long totalDiffScore, int unmatchedInFrom, int unmatchedInTo, int totalInFrom, int totalInTo) {
-        this(typeName, totalDiffScore, unmatchedInFrom, unmatchedInTo, totalInFrom, totalInTo, 0, 0, 0, 0);
+        this(typeName, false, totalDiffScore, unmatchedInFrom, unmatchedInTo, totalInFrom, totalInTo, 0, 0, 0, 0);
     }
 
     public HollowDiffOverviewTypeEntry(String typeName, long totalDiffScore, int unmatchedInFrom, int unmatchedInTo, int totalInFrom, int totalInTo,
                                        long heapInFrom, long heapInTo, long holeInFrom, long holeInTo) {
+        this(typeName, false, totalDiffScore, unmatchedInFrom, unmatchedInTo, totalInFrom, totalInTo, heapInFrom, heapInTo, holeInFrom, holeInTo);
+
+    }
+
+    public HollowDiffOverviewTypeEntry(String typeName, boolean hasUniqueKey, long totalDiffScore, int unmatchedInFrom, int unmatchedInTo, int totalInFrom, int totalInTo,
+                                       long heapInFrom, long heapInTo, long holeInFrom, long holeInTo) {
         this.typeName = typeName;
+        this.hasUniqueKey = hasUniqueKey;
         this.totalDiffScore = totalDiffScore;
         this.unmatchedInFrom = unmatchedInFrom;
         this.unmatchedInTo = unmatchedInTo;
@@ -52,6 +60,9 @@ public class HollowDiffOverviewTypeEntry {
     public String getTypeName() {
         return typeName;
     }
+
+    public boolean hasUniqueKey() { return hasUniqueKey;}
+
     public long getTotalDiffScore() {
         return totalDiffScore;
     }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/model/HollowDiffOverviewTypeEntry.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/model/HollowDiffOverviewTypeEntry.java
@@ -62,6 +62,8 @@ public class HollowDiffOverviewTypeEntry {
     }
 
     public boolean hasUniqueKey() { return hasUniqueKey;}
+    public boolean hasUnmatched() { return unmatchedInFrom > 0 || unmatchedInTo > 0; }
+    public boolean hasData() { return totalInFrom!=0 || totalInTo!=0; }
 
     public long getTotalDiffScore() {
         return totalDiffScore;
@@ -78,6 +80,9 @@ public class HollowDiffOverviewTypeEntry {
     public int getTotalInTo() {
         return totalInTo;
     }
+
+    public int getDeltaSize() { return Math.abs(totalInFrom - totalInTo); }
+
     public long getHeapInFrom() { return heapInFrom; }
     public long getHeapInTo() { return heapInTo; }
     public long getHoleInFrom() { return holeInFrom; }
@@ -89,12 +94,13 @@ public class HollowDiffOverviewTypeEntry {
     public String getHoleInToFormatted() { return formatBytes(holeInTo); }
 
     public String getBgColor() {
-        if (!hasUniqueKey)
-            return "#FFFBDB"; // No Unique Key
-        else if  (totalDiffScore > 0 || unmatchedInFrom > 0 || unmatchedInTo > 0)
-            return "#FFCC99"; // Has Diff
-        else if (totalInFrom == 0 && totalInTo == 0)
+        if (totalInFrom == 0 && totalInTo == 0)
             return "#D0D0D0"; // No Data
+        else if (!hasUniqueKey) {
+            if (totalInFrom!=totalInTo) return "#F0E592";
+            return "#FFFBDB"; // No Unique Key
+        } else if  (totalDiffScore > 0 || unmatchedInFrom > 0 || unmatchedInTo > 0)
+            return "#FFCC99"; // Has Diff
         return "";
     }
 }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/model/HollowDiffOverviewTypeEntry.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/model/HollowDiffOverviewTypeEntry.java
@@ -89,10 +89,12 @@ public class HollowDiffOverviewTypeEntry {
     public String getHoleInToFormatted() { return formatBytes(holeInTo); }
 
     public String getBgColor() {
-        if  (totalDiffScore > 0 || unmatchedInFrom > 0 || unmatchedInTo > 0)
-            return "#FFCC99";
+        if (!hasUniqueKey)
+            return "#FFFBDB"; // No Unique Key
+        else if  (totalDiffScore > 0 || unmatchedInFrom > 0 || unmatchedInTo > 0)
+            return "#FFCC99"; // Has Diff
         else if (totalInFrom == 0 && totalInTo == 0)
-            return "#D0D0D0";
+            return "#D0D0D0"; // No Data
         return "";
     }
 }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/pages/DiffOverviewPage.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/pages/DiffOverviewPage.java
@@ -65,7 +65,7 @@ public class DiffOverviewPage extends DiffPage {
             HollowTypeReadState fromTypeState = diff.getFromTypeState();
             HollowTypeReadState toTypeState = diff.getToTypeState();
 
-            overviewEntries.add(new HollowDiffOverviewTypeEntry(diff.getTypeName(), totalDiffScore, unmatchedInFrom, unmatchedInTo, fromCount, toCount,
+            overviewEntries.add(new HollowDiffOverviewTypeEntry(diff.getTypeName(), diff.hasMatchPaths(), totalDiffScore, unmatchedInFrom, unmatchedInTo, fromCount, toCount,
                     fromTypeState==null ? 0:fromTypeState.getApproximateHeapFootprintInBytes(), toTypeState==null ? 0:toTypeState.getApproximateHeapFootprintInBytes(),
                     fromTypeState==null ? 0:fromTypeState.getApproximateHoleCostInBytes(), toTypeState==null ? 0:toTypeState.getApproximateHoleCostInBytes()));
         }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/pages/DiffOverviewPage.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/pages/DiffOverviewPage.java
@@ -22,6 +22,7 @@ import com.netflix.hollow.diff.ui.model.HollowDiffOverviewTypeEntry;
 import com.netflix.hollow.tools.diff.HollowTypeDiff;
 import com.netflix.hollow.ui.HollowUISession;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.velocity.VelocityContext;
@@ -72,9 +73,20 @@ public class DiffOverviewPage extends DiffPage {
 
         if(sortBy == null || "diffs".equals(sortBy)) {
             overviewEntries.sort((o1, o2) -> {
-                long o1Diff = o1.getTotalDiffScore();
-                long o2Diff = o2.getTotalDiffScore();
-                return Long.compare(o2Diff, o1Diff);
+                int result = Comparator
+                        .comparing(HollowDiffOverviewTypeEntry::getTotalDiffScore)
+                        .thenComparing(HollowDiffOverviewTypeEntry::getDeltaSize)
+                        .thenComparing(HollowDiffOverviewTypeEntry::hasData)
+                        .thenComparing(HollowDiffOverviewTypeEntry::hasUnmatched)
+                        .thenComparing(HollowDiffOverviewTypeEntry::hasUniqueKey)
+                        .compare(o2, o1);
+
+                // Fallback to Type Name Ordering
+                if (result==0) {
+                    return o1.getTypeName().compareTo(o2.getTypeName());
+                }
+
+                return result;
             });
         } else if("unmatchedFrom".equals(sortBy)) {
             overviewEntries.sort((o1, o2) -> o2.getUnmatchedInFrom() - o1.getUnmatchedInFrom());

--- a/hollow-diff-ui/src/main/resources/diff-overview.vm
+++ b/hollow-diff-ui/src/main/resources/diff-overview.vm
@@ -23,9 +23,9 @@
     </tr>
     <tr style="background-color:#9EBFF9">
         <th>Type</th>
-        <th><a href="$path/?sortBy=diffs"># Total Diffs</a></th>
-        <th><a href="$path/?sortBy=unmatchedFrom"># FROM - Extra</a></th>
-        <th><a href="$path/?sortBy=unmatchedTo"># TO - Extra</a></th>
+        <th><a href="$path/?sortBy=diffs">Diff Score</a></th>
+        <th><a href="$path/?sortBy=unmatchedFrom"># FROM - Unmatched</a></th>
+        <th><a href="$path/?sortBy=unmatchedTo"># TO - Unmatched</a></th>
         <th><a href="$path/?sortBy=fromCount">FROM - Item Count</a></th>
         <th><a href="$path/?sortBy=toCount">TO - Item Count</a></th>
         <th><a href="$path/?sortBy=fromHeap">FROM - Heap Footprint</a></th>

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiff.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiff.java
@@ -19,11 +19,13 @@ package com.netflix.hollow.tools.diff;
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.util.SimultaneousExecutor;
 import com.netflix.hollow.tools.diff.exact.DiffEqualityMapping;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +44,7 @@ import java.util.logging.Logger;
  *
  */
 public class HollowDiff {
+    private final EnumSet<FieldType> SINGLE_FIELD_SUPPORTED_TYPES = EnumSet.of(FieldType.INT, FieldType.LONG, FieldType.DOUBLE, FieldType.STRING, FieldType.FLOAT, FieldType.BOOLEAN);
 
     private final Logger log = Logger.getLogger(HollowDiff.class.getName());
     private final HollowReadStateEngine fromStateEngine;
@@ -87,8 +90,8 @@ public class HollowDiff {
                     HollowObjectSchema objectSchema = ((HollowObjectSchema) schema);
                     PrimaryKey pKey = objectSchema.getPrimaryKey();
 
-                    // Handle diffing of type with single field
-                    if (pKey==null && objectSchema.numFields()==1) {
+                    // Support basic Single Field Types
+                    if (pKey==null && objectSchema.numFields()==1 && SINGLE_FIELD_SUPPORTED_TYPES.contains(objectSchema.getFieldType(0))) {
                         pKey = new PrimaryKey(schema.getName(), objectSchema.getFieldName(0));
                     }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiff.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiff.java
@@ -22,6 +22,7 @@ import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.util.SimultaneousExecutor;
 import com.netflix.hollow.tools.diff.exact.DiffEqualityMapping;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -83,10 +84,15 @@ public class HollowDiff {
             schemas.addAll(toStateEngine.getSchemas());
             for (HollowSchema schema : schemas) {
                 if (schema instanceof HollowObjectSchema) {
-                    PrimaryKey pKey = ((HollowObjectSchema) schema).getPrimaryKey();
-                    if (pKey == null) continue;
+                    HollowObjectSchema objectSchema = ((HollowObjectSchema) schema);
+                    PrimaryKey pKey = objectSchema.getPrimaryKey();
 
-                    addTypeDiff(schema.getName(), pKey.getFieldPaths());
+                    // Handle diffing of type with single field
+                    if (pKey==null && objectSchema.numFields()==1) {
+                        pKey = new PrimaryKey(schema.getName(), objectSchema.getFieldName(0));
+                    }
+
+                    addTypeDiff(schema.getName(), pKey==null? null : pKey.getFieldPaths());
                 }
             }
         }

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiff.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiff.java
@@ -64,7 +64,7 @@ public class HollowDiff {
      * @param to the "to" state
      */
     public HollowDiff(HollowReadStateEngine from, HollowReadStateEngine to) {
-        this(from, to, true);
+        this(from, to, true, false);
     }
 
     /**
@@ -77,6 +77,20 @@ public class HollowDiff {
      * @param isAutoDiscoverTypeDiff If true, all OBJECT types with a defined PrimaryKey will be configured to be diffed.
      */
     public HollowDiff(HollowReadStateEngine from, HollowReadStateEngine to, boolean isAutoDiscoverTypeDiff) {
+        this(from, to, isAutoDiscoverTypeDiff, false);
+    }
+
+    /**
+     * Instantiate a HollowDiff.
+     * <p>
+     * To calculate the diff, call calculateDiff().
+     *
+     * @param from the "from" state
+     * @param to the "to" state
+     * @param isAutoDiscoverTypeDiff If true, all OBJECT types with a defined PrimaryKey will be configured to be diffed.
+     * @param isIncludeNonPrimaryKeyTypes If true, all OBJECT types without PrimaryKey will also be configured to be diffed.
+     */
+    public HollowDiff(HollowReadStateEngine from, HollowReadStateEngine to, boolean isAutoDiscoverTypeDiff, boolean isIncludeNonPrimaryKeyTypes) {
         this.fromStateEngine = from;
         this.toStateEngine = to;
         this.equalityMapping = new DiffEqualityMapping(from, to);
@@ -89,6 +103,7 @@ public class HollowDiff {
                 if (schema instanceof HollowObjectSchema) {
                     HollowObjectSchema objectSchema = ((HollowObjectSchema) schema);
                     PrimaryKey pKey = objectSchema.getPrimaryKey();
+                    if (pKey==null && !isIncludeNonPrimaryKeyTypes) continue;
 
                     // Support basic Single Field Types
                     if (pKey==null && objectSchema.numFields()==1 && SINGLE_FIELD_SUPPORTED_TYPES.contains(objectSchema.getFieldType(0))) {

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiffMatcher.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiffMatcher.java
@@ -21,6 +21,7 @@ import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.util.IntList;
 import com.netflix.hollow.core.util.LongList;
+
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
@@ -45,7 +46,7 @@ public class HollowDiffMatcher {
     private HollowPrimaryKeyIndex toIdx;
 
     public HollowDiffMatcher(HollowObjectTypeReadState fromTypeState, HollowObjectTypeReadState toTypeState) {
-        this.matchPaths = new ArrayList<String>();
+        this.matchPaths = new ArrayList<>();
         this.fromTypeState = fromTypeState;
         this.toTypeState = toTypeState;
         this.matchedOrdinals = new LongList();
@@ -68,6 +69,13 @@ public class HollowDiffMatcher {
         }
 
         if (toTypeState==null) {
+            fromTypeState.getPopulatedOrdinals().stream().forEach(i -> extraInFrom.add(i));
+            return;
+        }
+
+        // No Primary Key so no matching will be done
+        if (matchPaths==null || matchPaths.isEmpty()) {
+            toTypeState.getPopulatedOrdinals().stream().forEach(i -> extraInTo.add(i));
             fromTypeState.getPopulatedOrdinals().stream().forEach(i -> extraInFrom.add(i));
             return;
         }
@@ -118,14 +126,15 @@ public class HollowDiffMatcher {
     public String getKeyDisplayString(HollowObjectTypeReadState state, int ordinal) {
         Object[] key = null;
 
-        if(state == fromTypeState) {
+        if(state == fromTypeState && fromIdx!=null) {
             key = fromIdx.getRecordKey(ordinal);
-        } else if(state == toTypeState) {
+        } else if(state == toTypeState && toIdx!=null) {
             key = toIdx.getRecordKey(ordinal);
         }
 
+        // Show Display similar to Hollow Explorer when there is no primary key
         if(key == null)
-            return null;
+            return "ORDINAL:" + ordinal;
 
         return keyDisplayString(key);
     }

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowTypeDiff.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowTypeDiff.java
@@ -25,6 +25,7 @@ import com.netflix.hollow.tools.diff.count.HollowDiffObjectCountingNode;
 import com.netflix.hollow.tools.diff.count.HollowFieldDiff;
 import com.netflix.hollow.tools.diff.exact.DiffEqualOrdinalMap;
 import com.netflix.hollow.tools.diff.exact.DiffEqualityMapping;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,7 +45,6 @@ public class HollowTypeDiff {
     private final HollowDiffMatcher matcher;
     private final String type;
     private final Set<String> shortcutTypes;
-    private boolean hasMatchPaths;
 
     private List<HollowFieldDiff> calculatedFieldDiffs;
 
@@ -57,8 +57,7 @@ public class HollowTypeDiff {
         this.shortcutTypes = new HashSet<>();
 
         // Allow Basic diffing of Type that do not have PrimaryKey/MatchPaths
-        this.hasMatchPaths = matchPaths!=null && matchPaths.length>0;
-        if (hasMatchPaths) {
+        if (matchPaths!=null && matchPaths.length>0) {
             for (String matchPath : matchPaths) {
                 addMatchPath(matchPath);
             }

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowTypeDiff.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowTypeDiff.java
@@ -44,6 +44,7 @@ public class HollowTypeDiff {
     private final HollowDiffMatcher matcher;
     private final String type;
     private final Set<String> shortcutTypes;
+    private boolean hasMatchPaths;
 
     private List<HollowFieldDiff> calculatedFieldDiffs;
 
@@ -53,10 +54,14 @@ public class HollowTypeDiff {
         this.from = (HollowObjectTypeReadState) rootDiff.getFromStateEngine().getTypeState(type);
         this.to = (HollowObjectTypeReadState) rootDiff.getToStateEngine().getTypeState(type);
         this.matcher = new HollowDiffMatcher(this.from, this.to);
-        this.shortcutTypes = new HashSet<String>();
+        this.shortcutTypes = new HashSet<>();
 
-        for(String matchPath : matchPaths) {
-            addMatchPath(matchPath);
+        // Allow Basic diffing of Type that do not have PrimaryKey/MatchPaths
+        this.hasMatchPaths = matchPaths!=null && matchPaths.length>0;
+        if (hasMatchPaths) {
+            for (String matchPath : matchPaths) {
+                addMatchPath(matchPath);
+            }
         }
     }
 
@@ -65,6 +70,14 @@ public class HollowTypeDiff {
      */
     public String getTypeName() {
         return type;
+    }
+
+    /**
+     * Indicate whether Match Paths are defined
+     * @return true to indicate there is
+     */
+    public boolean hasMatchPaths() {
+        return !matcher.getMatchPaths().isEmpty();
     }
 
     /**

--- a/hollow/src/test/java/com/netflix/hollow/tools/diff/HollowDiffTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/diff/HollowDiffTest.java
@@ -217,7 +217,7 @@ public class HollowDiffTest {
         HollowWriteStateEngine toStateEngine = newWriteStateEngine();
         HollowDiff diff = new HollowDiff(readEngine(fromStateEngine), readEngine(toStateEngine));
 
-        Assert.assertEquals(4, diff.getTypeDiffs().size());
+        Assert.assertEquals(1, diff.getTypeDiffs().size());
 
         HollowTypeDiff typeDDiff = diff.getTypeDiff("TypeD");
         Assert.assertNotNull(typeDDiff);
@@ -241,7 +241,7 @@ public class HollowDiffTest {
         HollowDiff diff = new HollowDiff(readEngine(fromStateEngine), readEngine(toStateEngine));
         diff.calculateDiffs();
 
-        Assert.assertEquals(5, diff.getTypeDiffs().size());
+        Assert.assertEquals(2, diff.getTypeDiffs().size());
         {
             HollowTypeDiff typeEDiff = diff.getTypeDiff("TypeE");
             Assert.assertNotNull(typeEDiff);
@@ -272,7 +272,7 @@ public class HollowDiffTest {
         addFRec(toStateEngine, f(3));
         addFRec(toStateEngine, f(4));
 
-        HollowDiff diff = new HollowDiff(readEngine(fromStateEngine), readEngine(toStateEngine));
+        HollowDiff diff = new HollowDiff(readEngine(fromStateEngine), readEngine(toStateEngine), true, true);
         diff.calculateDiffs();
 
         Assert.assertEquals(5, diff.getTypeDiffs().size());


### PR DESCRIPTION
- Single Field Type : Use Single Field as match Path
- Multi Field Type : Just add all data as unmatched since there is no key to match on (diff basic information)