### PR TITLE
Optional blob parts: configure specific types into blob 'parts'

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowDataHolder.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowDataHolder.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016-2019 Netflix, Inc.
+ *  Copyright 2016-2021 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -158,17 +158,16 @@ class HollowDataHolder {
         }
     }
 
-
     private void applyStateEngineTransition(HollowBlobInput in, HollowConsumer.Blob transition, HollowConsumer.RefreshListener[] refreshListeners) throws IOException {
         if(transition.isSnapshot()) {
             if(filter == null) {
-                reader.readSnapshot(in);
+                reader.readSnapshot(in, transition.getOptionalBlobPartInputs());
             }
             else {
-                reader.readSnapshot(in, filter);
+                reader.readSnapshot(in, transition.getOptionalBlobPartInputs(), filter);
             }
         } else {
-            reader.applyDelta(in);
+            reader.applyDelta(in, transition.getOptionalBlobPartInputs());
         }
 
         setVersion(transition.getToVersion());

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016-2019 Netflix, Inc.
+ *  Copyright 2016-2021 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import com.netflix.hollow.api.metrics.HollowConsumerMetrics;
 import com.netflix.hollow.api.metrics.HollowMetricsCollector;
 import com.netflix.hollow.core.HollowConstants;
 import com.netflix.hollow.core.memory.MemoryMode;
+import com.netflix.hollow.core.read.OptionalBlobPartInput;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.filter.HollowFilterConfig;
 import com.netflix.hollow.core.read.filter.TypeFilter;
@@ -44,6 +45,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
@@ -462,6 +464,11 @@ public class HollowConsumer {
          * @return the blob of the reverse delta
          */
         HollowConsumer.Blob retrieveReverseDeltaBlob(long currentVersion);
+
+        default Set<String> configuredOptionalBlobParts() {
+            return null;
+        }
+
     }
 
     /**
@@ -521,6 +528,19 @@ public class HollowConsumer {
          * @throws IOException if the input stream to the blob cannot be obtained
          */
         public abstract InputStream getInputStream() throws IOException;
+
+        /**
+         * Implementations may define how to retrieve the optional blob part data for this specific transition from a data store.
+         * <p>
+         * It is expected that none of the returned InputStreams will be interrupted.  For this reason, it is a good idea to
+         * retrieve the entire blob part data (e.g. to disk) from a remote datastore prior to returning these streams.
+         * 
+         * @return
+         * @throws IOException
+         */
+        public OptionalBlobPartInput getOptionalBlobPartInputs() throws IOException {
+            return null;
+        }
 
         public File getFile() throws IOException {
             throw new UnsupportedOperationException();

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemBlobRetriever.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemBlobRetriever.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016-2019 Netflix, Inc.
+ *  Copyright 2016-2021 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -19,7 +19,10 @@ package com.netflix.hollow.api.consumer.fs;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.HollowConsumer.Blob.BlobType;
 import com.netflix.hollow.core.HollowConstants;
+import com.netflix.hollow.core.read.HollowBlobInput;
+import com.netflix.hollow.core.read.OptionalBlobPartInput;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -28,12 +31,16 @@ import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriever {
     private final Path blobStorePath;
     private final HollowConsumer.BlobRetriever fallbackBlobRetriever;
     private final boolean useExistingStaleSnapshot;
+    private final Set<String> optionalBlobParts;
 
     /**
      * A new HollowFilesystemBlobRetriever which is not backed by a remote store.
@@ -43,7 +50,7 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
      */
     @SuppressWarnings("unused")
     public HollowFilesystemBlobRetriever(Path blobStorePath) {
-        this(blobStorePath, null);
+        this(blobStorePath, null, false);
     }
 
     /**
@@ -72,12 +79,33 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
      *                               blob present for the desired version then that snapshot blob is returned and
      *                               the fallback blob retriever (if present) is not queried.
      */
-    public HollowFilesystemBlobRetriever(Path blobStorePath, HollowConsumer.BlobRetriever fallbackBlobRetriever,
-            boolean useExistingStaleSnapshot) {
+    public HollowFilesystemBlobRetriever(Path blobStorePath, HollowConsumer.BlobRetriever fallbackBlobRetriever, boolean useExistingStaleSnapshot) {
         this.blobStorePath = blobStorePath;
         this.fallbackBlobRetriever = fallbackBlobRetriever;
         this.useExistingStaleSnapshot = useExistingStaleSnapshot;
+        this.optionalBlobParts = fallbackBlobRetriever.configuredOptionalBlobParts();
 
+        ensurePathExists(blobStorePath);
+    }
+
+    /**
+     * A new HollowFilesystemBlobRetriever which is not backed by a remote store.
+     * 
+     * Uses the configured optional blob parts
+     *
+     * @param blobStorePath The directory from which to retrieve blobs
+     * @since 2.12.0
+     */
+    public HollowFilesystemBlobRetriever(Path blobStorePath, Set<String> optionalBlobParts) {
+        this.blobStorePath = blobStorePath;
+        this.optionalBlobParts = optionalBlobParts;
+        this.useExistingStaleSnapshot = true;
+        this.fallbackBlobRetriever = null;
+
+        ensurePathExists(blobStorePath);
+    }
+
+    private void ensurePathExists(Path blobStorePath) {
         try {
             if(!Files.exists(this.blobStorePath)){
                 Files.createDirectories(this.blobStorePath);
@@ -92,10 +120,9 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
         Path exactPath = blobStorePath.resolve("snapshot-" + desiredVersion);
 
         if(Files.exists(exactPath))
-            return new FilesystemBlob(exactPath, desiredVersion);
+            return filesystemBlob(BlobType.SNAPSHOT, -1L, desiredVersion);
         
         long maxVersionBeforeDesired = HollowConstants.VERSION_NONE;
-        String maxVersionBeforeDesiredFilename = null;
 
         try(DirectoryStream<Path> directoryStream = Files.newDirectoryStream(blobStorePath)) {
             for (Path path : directoryStream) {
@@ -104,7 +131,6 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
                     long version = Long.parseLong(filename.substring(filename.lastIndexOf("-") + 1));
                     if(version < desiredVersion && version > maxVersionBeforeDesired) {
                         maxVersionBeforeDesired = version;
-                        maxVersionBeforeDesiredFilename = filename;
                     }
                 }
             }
@@ -114,13 +140,12 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
 
         HollowConsumer.Blob filesystemBlob = null;
         if (maxVersionBeforeDesired != HollowConstants.VERSION_NONE) {
-            filesystemBlob = new FilesystemBlob(blobStorePath.resolve(maxVersionBeforeDesiredFilename),
-                    maxVersionBeforeDesired);
+            filesystemBlob = filesystemBlob(BlobType.SNAPSHOT, -1L, maxVersionBeforeDesired);
             if (useExistingStaleSnapshot) {
                 return filesystemBlob;
             }
         }
-
+        
         if(fallbackBlobRetriever != null) {
             HollowConsumer.Blob remoteBlob = fallbackBlobRetriever.retrieveSnapshotBlob(desiredVersion);
             if(remoteBlob != null && (filesystemBlob == null || remoteBlob.getToVersion() != filesystemBlob.getToVersion()))
@@ -128,6 +153,45 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
         }
         
         return filesystemBlob;
+    }
+
+    private HollowConsumer.Blob filesystemBlob(HollowConsumer.Blob.BlobType type, long currentVersion, long destinationVersion) {
+        Path path;
+        Map<String, Path> optionalPartPaths = null;
+        switch(type) {
+        case SNAPSHOT:
+            path = blobStorePath.resolve("snapshot-" + destinationVersion);
+            if(optionalBlobParts != null && !optionalBlobParts.isEmpty()) {
+                optionalPartPaths = new HashMap<>(optionalBlobParts.size());
+                for(String part : optionalBlobParts) {
+                    optionalPartPaths.put(part, blobStorePath.resolve("snapshot_"+part+"-"+destinationVersion));
+                }
+            }
+            
+            return new FilesystemBlob(path, destinationVersion, optionalPartPaths);
+        case DELTA:
+            path = blobStorePath.resolve("delta-" + currentVersion + "-" + destinationVersion);
+            if(optionalBlobParts != null && !optionalBlobParts.isEmpty()) {
+                optionalPartPaths = new HashMap<>(optionalBlobParts.size());
+                for(String part : optionalBlobParts) {
+                    optionalPartPaths.put(part, blobStorePath.resolve("delta_"+part+"-"+currentVersion+"-"+destinationVersion));
+                }
+            }
+            
+            return new FilesystemBlob(path, destinationVersion, optionalPartPaths);
+        case REVERSE_DELTA:
+            path = blobStorePath.resolve("reversedelta-" + currentVersion + "-" + destinationVersion);
+            if(optionalBlobParts != null && !optionalBlobParts.isEmpty()) {
+                optionalPartPaths = new HashMap<>(optionalBlobParts.size());
+                for(String part : optionalBlobParts) {
+                    optionalPartPaths.put(part, blobStorePath.resolve("reversedelta_"+part+"-"+currentVersion+"-"+destinationVersion));
+                }
+            }
+            
+            return new FilesystemBlob(path, destinationVersion, optionalPartPaths);
+        default:
+            throw new IllegalArgumentException("Unknown BlobType: " + type.toString());
+        }
     }
 
     @Override
@@ -138,7 +202,7 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
                 String filename = path.getFileName().toString();
                 if(filename.startsWith("delta-" + currentVersion)) {
                     long destinationVersion = Long.parseLong(filename.substring(filename.lastIndexOf("-") + 1));
-                    return new FilesystemBlob(blobStorePath.resolve(filename), currentVersion, destinationVersion);
+                    return filesystemBlob(BlobType.DELTA, currentVersion, destinationVersion);
                 }
             }
         } catch(IOException ex) {
@@ -161,7 +225,7 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
                 String filename = path.getFileName().toString();
                 if(filename.startsWith("reversedelta-" + currentVersion)) {
                     long destinationVersion = Long.parseLong(filename.substring(filename.lastIndexOf("-") + 1));
-                    return new FilesystemBlob(blobStorePath.resolve(filename), currentVersion, destinationVersion);
+                    return filesystemBlob(BlobType.REVERSE_DELTA, currentVersion, destinationVersion);
                 }
             }
         } catch(IOException ex) {
@@ -180,6 +244,7 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
     private static class FilesystemBlob extends HollowConsumer.Blob {
 
         private final Path path;
+        private final Map<String, Path> optionalPartPaths;
 
         @Deprecated
         FilesystemBlob(File snapshotFile, long toVersion) {
@@ -190,16 +255,26 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
          * @since 2.12.0
          */
         FilesystemBlob(Path snapshotPath, long toVersion) {
-            super(toVersion);
-            this.path = snapshotPath;
+            this(snapshotPath, toVersion, null);
         }
 
         /**
          * @since 2.12.0
          */
         FilesystemBlob(Path deltaPath, long fromVersion, long toVersion) {
+            this(deltaPath, fromVersion, toVersion, null);
+        }
+
+        FilesystemBlob(Path snapshotPath, long toVersion, Map<String, Path> optionalPartPaths) {
+            super(toVersion);
+            this.path = snapshotPath;
+            this.optionalPartPaths = optionalPartPaths;
+        }
+
+        FilesystemBlob(Path deltaPath, long fromVersion, long toVersion, Map<String, Path> optionalPartPaths) {
             super(fromVersion, toVersion);
             this.path = deltaPath;
+            this.optionalPartPaths = optionalPartPaths;
         }
 
         @Override
@@ -208,12 +283,24 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
         }
 
         @Override
+        public OptionalBlobPartInput getOptionalBlobPartInputs() throws IOException {
+            if(optionalPartPaths == null || optionalPartPaths.isEmpty())
+                return null;
+            
+            OptionalBlobPartInput input = new OptionalBlobPartInput();
+            for(Map.Entry<String, Path> pathEntry : optionalPartPaths.entrySet()) {
+                input.addInput(pathEntry.getKey(), new BufferedInputStream(Files.newInputStream(pathEntry.getValue())));
+            }
+            return input;
+        }
+
+        @Override
         public File getFile() throws IOException {
             return path.toFile();
         }
         
     }
-    
+
     private static class BlobForBackupToFilesystem extends HollowConsumer.Blob {
         
         private final HollowConsumer.Blob remoteBlob;
@@ -260,5 +347,37 @@ public class HollowFilesystemBlobRetriever implements HollowConsumer.BlobRetriev
 
             return path.toFile();
         }
+
+        @Override
+        public OptionalBlobPartInput getOptionalBlobPartInputs() throws IOException {
+            OptionalBlobPartInput remoteOptionalParts = remoteBlob.getOptionalBlobPartInputs();
+            if(remoteOptionalParts == null)
+                return null;
+
+            OptionalBlobPartInput localOptionalParts = new OptionalBlobPartInput();
+
+
+            for(Map.Entry<String, HollowBlobInput> entry : remoteOptionalParts.getInputsByPartName().entrySet()) {
+                Path tempPath = path.resolveSibling(path.getName(path.getNameCount()-1) + "_" + entry.getKey() + "-" + UUID.randomUUID().toString());
+                Path destPath = getBlobType() == BlobType.SNAPSHOT ?
+                        path.resolveSibling(getBlobType().getType() + "_" + entry.getKey() + "-" + getToVersion())
+                            : path.resolveSibling(getBlobType().getType() + "_" + entry.getKey() + "-" + getFromVersion() + "-" + getToVersion());
+                try(
+                        HollowBlobInput is = entry.getValue();
+                        OutputStream os = Files.newOutputStream(tempPath)
+                ) {
+                    byte buf[] = new byte[4096];
+                    int n;
+                    while (-1 != (n = is.read(buf, 0, buf.length)))
+                        os.write(buf, 0, n);
+                }
+                Files.move(tempPath, destPath, REPLACE_EXISTING);
+                
+                localOptionalParts.addInput(entry.getKey(), new BufferedInputStream(Files.newInputStream(destPath)));
+            }
+
+            return localOptionalParts;
+        }
+
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ProducerOptionalBlobPartConfig.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ProducerOptionalBlobPartConfig.java
@@ -1,0 +1,169 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * A blob may be configured to produce optional "parts".  Parts will contain the data one or more types.
+ * 
+ * A type may be assigned to one and only one section -- by default a type will be serialized to the main "part".
+ * 
+ * The optional blob parts are intended to be stored as separate files in the blob store, so that they may be 
+ * retrieved by consumers only when required. Details of how this is accomplished will be dependent upon individual
+ * implementations of {@link HollowProducer.Publisher} and {@link HollowConsumer.BlobRetriever}.
+ */
+public class ProducerOptionalBlobPartConfig {
+
+    private final Map<String, Set<String>> parts;
+    
+    public ProducerOptionalBlobPartConfig() {
+        this.parts = new HashMap<>();
+    }
+    
+    public void addTypesToPart(String partName, String... types) {
+        if(types.length == 0)
+            return;
+        
+        Set<String> typeSet = parts.computeIfAbsent(partName, n -> new HashSet<>());
+        
+        for(String type : types) {
+            typeSet.add(type);
+        }
+    }
+    
+    public Set<String> getParts() {
+        return parts.keySet();
+    }
+    
+    public OptionalBlobPartOutputStreams newStreams() {
+        return new OptionalBlobPartOutputStreams();
+    }
+    
+    public OptionalBlobPartOutputStreams newStreams(Function<String, OutputStream> streamCreator) {
+        OptionalBlobPartOutputStreams s = newStreams();
+        for(String part : getParts()) {
+            s.addOutputStream(part, streamCreator.apply(part));
+        }
+        return s;
+    }
+
+    public class OptionalBlobPartOutputStreams {
+        
+        private final Map<String, ConfiguredOutputStream> partStreams;
+        
+        private OptionalBlobPartOutputStreams() {
+            this.partStreams = new HashMap<>();
+        }
+        
+        public void addOutputStream(String partName, OutputStream os) {
+            Set<String> types = parts.get(partName);
+            
+            if(types == null)
+                throw new IllegalArgumentException("There is no blob part named " + partName + " in this configuration");
+            
+            partStreams.put(partName, new ConfiguredOutputStream(partName, types, new DataOutputStream(os)));
+        }
+        
+        public Map<String, DataOutputStream> getStreamsByType() {
+            if(!allPartsHaveStreams())
+                throw new IllegalStateException("Not all configured parts have streams!");
+            
+            Map<String, DataOutputStream> streamsByType = new HashMap<>();
+            
+            for(Map.Entry<String, ConfiguredOutputStream> entry : partStreams.entrySet()) {
+                ConfiguredOutputStream cos = entry.getValue();
+                
+                for(String type : cos.getTypes()) {
+                    streamsByType.put(type, cos.getStream());
+                }
+            }
+            
+            return streamsByType;
+        }
+        
+        public Map<String, String> getPartNameByType() {
+            if(!allPartsHaveStreams())
+                throw new IllegalStateException("Not all configured parts have streams!");
+            
+            Map<String, String> streamsByType = new HashMap<>();
+            
+            for(Map.Entry<String, ConfiguredOutputStream> entry : partStreams.entrySet()) {
+                ConfiguredOutputStream cos = entry.getValue();
+                
+                for(String type : cos.getTypes()) {
+                    streamsByType.put(type, cos.getPartName());
+                }
+            }
+            
+            return streamsByType;
+        }
+        
+        public Map<String, ConfiguredOutputStream> getPartStreams() {
+            return Collections.unmodifiableMap(partStreams);
+        }
+        
+        public void flush() throws IOException {
+            for(Map.Entry<String, ConfiguredOutputStream> entry : partStreams.entrySet()) {
+                entry.getValue().getStream().flush();
+            }
+        }
+        
+        public void close() throws IOException {
+            for(Map.Entry<String, ConfiguredOutputStream> entry : partStreams.entrySet()) {
+                entry.getValue().getStream().close();
+            }
+        }
+        
+        private boolean allPartsHaveStreams() {
+            return parts.keySet().equals(partStreams.keySet());
+        }
+    }
+    
+    public static class ConfiguredOutputStream {
+        private final String partName;
+        private final Set<String> types;
+        private final DataOutputStream stream;
+        
+        public ConfiguredOutputStream(String partName, Set<String> types, DataOutputStream stream) {
+            this.partName = partName;
+            this.types = Collections.unmodifiableSet(types);
+            this.stream = stream;
+        }
+        
+        public String getPartName() {
+            return partName;
+        }
+        
+        public Set<String> getTypes() {
+            return types;
+        }
+        
+        public DataOutputStream getStream() {
+            return stream;
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/HollowBlobHeader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowBlobHeader.java
@@ -39,8 +39,6 @@ import java.util.Objects;
  *      
  * </dl>
  * 
- * @author dkoszewnik
- *
  */
 public class HollowBlobHeader {
 

--- a/hollow/src/main/java/com/netflix/hollow/core/HollowBlobOptionalPartHeader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowBlobOptionalPartHeader.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core;
+
+import com.netflix.hollow.core.schema.HollowSchema;
+import java.util.Collections;
+import java.util.List;
+
+public class HollowBlobOptionalPartHeader {
+
+    public static final int HOLLOW_BLOB_PART_VERSION_HEADER = 1031;
+    
+    private final String partName;
+    private List<HollowSchema> schemas = Collections.emptyList();
+    private long originRandomizedTag;
+    private long destinationRandomizedTag;
+
+    public HollowBlobOptionalPartHeader(String partName) {
+        this.partName = partName;
+    }
+
+    public List<HollowSchema> getSchemas() {
+        return schemas;
+    }
+
+    public void setSchemas(List<HollowSchema> schemas) {
+        this.schemas = schemas;
+    }
+
+    public long getOriginRandomizedTag() {
+        return originRandomizedTag;
+    }
+
+    public void setOriginRandomizedTag(long originRandomizedTag) {
+        this.originRandomizedTag = originRandomizedTag;
+    }
+
+    public long getDestinationRandomizedTag() {
+        return destinationRandomizedTag;
+    }
+
+    public void setDestinationRandomizedTag(long destinationRandomizedTag) {
+        this.destinationRandomizedTag = destinationRandomizedTag;
+    }
+
+    public String getPartName() {
+        return partName;
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/read/HollowBlobInput.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/HollowBlobInput.java
@@ -54,6 +54,26 @@ public class HollowBlobInput implements Closeable {
     }
 
     /**
+     * Initialize the Hollow Blob Input object from the Hollow Consumer blob's Input Stream or Random Access File,
+     * depending on the configured memory mode. The returned HollowBlobInput object must be closed to free up resources.
+     *
+     * @param mode Configured memory mode
+     * @param blob Hollow Consumer blob
+     * @param partName the name of the optional part
+     * @return the initialized Hollow Blob Input
+     * @throws IOException if the Hollow Blob Input couldn't be initialized
+     */
+    public static HollowBlobInput modeBasedSelector(MemoryMode mode, OptionalBlobPartInput input, String partName) throws IOException {
+        if (mode.equals(ON_HEAP)) {
+            return serial(input.getInputStream(partName));
+        } else if (mode.equals(SHARED_MEMORY_LAZY)) {
+            return randomAccess(input.getFile(partName));
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
      * Initialize a random access Hollow Blob input object from a file. The returned HollowBlobInput object must be
      * closed to free up resources.
      *

--- a/hollow/src/main/java/com/netflix/hollow/core/read/OptionalBlobPartInput.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/OptionalBlobPartInput.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.read;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OptionalBlobPartInput {
+
+    private final Map<String, HollowBlobInput> inputsByPartName;
+
+    public OptionalBlobPartInput() {
+        this.inputsByPartName = new HashMap<>();
+    }
+
+    public void addInput(String partName, InputStream in) {
+        addInput(partName, HollowBlobInput.serial(in));
+    }
+
+    public void addInput(String partName, HollowBlobInput in) {
+        inputsByPartName.put(partName, in);
+    }
+
+    public Map<String, HollowBlobInput> getInputsByPartName() {
+        return Collections.unmodifiableMap(inputsByPartName);
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016-2019 Netflix, Inc.
+ *  Copyright 2016-2021 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@
 package com.netflix.hollow.core.read.engine;
 
 import com.netflix.hollow.core.HollowBlobHeader;
+import com.netflix.hollow.core.HollowBlobOptionalPartHeader;
 import com.netflix.hollow.core.memory.MemoryMode;
 import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.read.HollowBlobInput;
+import com.netflix.hollow.core.read.OptionalBlobPartInput;
 import com.netflix.hollow.core.read.engine.list.HollowListTypeReadState;
 import com.netflix.hollow.core.read.engine.map.HollowMapTypeReadState;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
@@ -34,7 +36,11 @@ import com.netflix.hollow.core.schema.HollowSetSchema;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.TreeSet;
 import java.util.logging.Logger;
 
@@ -130,10 +136,22 @@ public class HollowBlobReader {
      * @throws IOException if the snapshot could not be read
      */
     public void readSnapshot(HollowBlobInput in, TypeFilter filter) throws IOException {
+        readSnapshot(in, null, filter);
+    }
+
+    public void readSnapshot(HollowBlobInput in, OptionalBlobPartInput optionalParts) throws IOException {
+        readSnapshot(in, optionalParts, new HollowFilterConfig(true));
+    }
+
+    public void readSnapshot(HollowBlobInput in, OptionalBlobPartInput optionalParts, TypeFilter filter) throws IOException {
         validateMemoryMode(in.getMemoryMode());
+        validateMemoryMode(optionalParts);
 
         HollowBlobHeader header = readHeader(in, false);
-        filter = filter.resolve(header.getSchemas());
+        List<HollowBlobOptionalPartHeader> partHeaders = readPartHeaders(header, optionalParts);
+        List<HollowSchema> allSchemas = combineSchemas(header, partHeaders);
+
+        filter = filter.resolve(allSchemas);
 
         notifyBeginUpdate();
 
@@ -145,6 +163,17 @@ public class HollowBlobReader {
         for(int i=0;i<numStates;i++) {
             String typeName = readTypeStateSnapshot(in, filter);
             typeNames.add(typeName);
+        }
+
+        if(optionalParts != null) {
+            for(Map.Entry<String, HollowBlobInput> optionalPartEntry : optionalParts.getInputsByPartName().entrySet()) {
+                numStates = VarInt.readVInt(optionalPartEntry.getValue());
+
+                for(int i=0;i<numStates;i++) {
+                    String typeName = readTypeStateSnapshot(optionalPartEntry.getValue(), filter);
+                    typeNames.add(typeName);
+                }
+            }
         }
 
         stateEngine.wireTypeStatesToSchemas();
@@ -183,9 +212,15 @@ public class HollowBlobReader {
      * @throws IOException if the delta could not be applied
      */
     public void applyDelta(HollowBlobInput in) throws IOException {
+        applyDelta(in, null);
+    }
+
+    public void applyDelta(HollowBlobInput in, OptionalBlobPartInput optionalParts) throws IOException {
         validateMemoryMode(in.getMemoryMode());
+        validateMemoryMode(optionalParts);
 
         HollowBlobHeader header = readHeader(in, true);
+        List<HollowBlobOptionalPartHeader> partHeaders = readPartHeaders(header, optionalParts);
         notifyBeginUpdate();
 
         long startTime = System.currentTimeMillis();
@@ -199,13 +234,24 @@ public class HollowBlobReader {
             stateEngine.getMemoryRecycler().swap();
         }
 
+        if(optionalParts != null) {
+            for(Map.Entry<String, HollowBlobInput> optionalPartEntry : optionalParts.getInputsByPartName().entrySet()) {
+                numStates = VarInt.readVInt(optionalPartEntry.getValue());
+
+                for(int i=0;i<numStates;i++) {
+                    String typeName = readTypeStateDelta(optionalPartEntry.getValue());
+                    typeNames.add(typeName);
+                    stateEngine.getMemoryRecycler().swap();
+                }
+            }
+        }
+
         long endTime = System.currentTimeMillis();
 
         log.info("DELTA COMPLETED IN " + (endTime - startTime) + "ms");
         log.info("TYPES: " + typeNames);
 
         notifyEndUpdate();
-
     }
 
     private HollowBlobHeader readHeader(HollowBlobInput in, boolean isDelta) throws IOException {
@@ -217,6 +263,39 @@ public class HollowBlobReader {
         stateEngine.setCurrentRandomizedTag(header.getDestinationRandomizedTag());
         stateEngine.setHeaderTags(header.getHeaderTags());
         return header;
+    }
+
+    private List<HollowBlobOptionalPartHeader> readPartHeaders(HollowBlobHeader header, OptionalBlobPartInput in) throws IOException {
+        if(in == null)
+            return Collections.emptyList();
+
+        Map<String, HollowBlobInput> inputsByPartName = in.getInputsByPartName();
+        List<HollowBlobOptionalPartHeader> list = new ArrayList<>(inputsByPartName.size());
+        for(Map.Entry<String, HollowBlobInput> entry : inputsByPartName.entrySet()) {
+            HollowBlobOptionalPartHeader partHeader = headerReader.readPartHeader(entry.getValue());
+            if(!partHeader.getPartName().equals(entry.getKey()))
+                throw new IllegalArgumentException("Optional blob part expected name " + entry.getKey() + " but was " + partHeader.getPartName());
+            if(partHeader.getOriginRandomizedTag() != header.getOriginRandomizedTag()
+                    || partHeader.getDestinationRandomizedTag() != header.getDestinationRandomizedTag())
+                throw new IllegalArgumentException("Optional blob part " + entry.getKey() + " does not appear to be matched with the main input");
+
+            list.add(partHeader);
+        }
+
+        return list;
+    }
+
+    private List<HollowSchema> combineSchemas(HollowBlobHeader header, List<HollowBlobOptionalPartHeader> partHeaders) throws IOException {
+        if(partHeaders.isEmpty())
+            return header.getSchemas();
+
+        List<HollowSchema> schemas = new ArrayList<>(header.getSchemas());
+
+        for(HollowBlobOptionalPartHeader partHeader : partHeaders) {
+            schemas.addAll(partHeader.getSchemas());
+        }
+
+        return schemas;
     }
 
     private void notifyBeginUpdate() {
@@ -324,6 +403,13 @@ public class HollowBlobReader {
             HollowSetTypeReadState.discardDelta(in, numShards);
         else if(schema instanceof HollowMapSchema)
             HollowMapTypeReadState.discardDelta(in, numShards);
+    }
+
+    private void validateMemoryMode(OptionalBlobPartInput partInput) {
+        if(partInput != null) {
+            for(Map.Entry<String, HollowBlobInput> partEntry : partInput.getInputsByPartName().entrySet())
+                validateMemoryMode(partEntry.getValue().getMemoryMode());
+        }
     }
 
     private void validateMemoryMode(MemoryMode inputMode) {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobHeaderWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobHeaderWriter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016-2019 Netflix, Inc.
+ *  Copyright 2016-2021 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.netflix.hollow.core.write;
 
 import com.netflix.hollow.core.HollowBlobHeader;
+import com.netflix.hollow.core.HollowBlobOptionalPartHeader;
 import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.schema.HollowSchema;
 import java.io.ByteArrayOutputStream;
@@ -63,4 +64,20 @@ public class HollowBlobHeaderWriter {
         }
     }
     
+    public void writePartHeader(HollowBlobOptionalPartHeader header, DataOutputStream dos) throws IOException {
+        dos.writeInt(HollowBlobOptionalPartHeader.HOLLOW_BLOB_PART_VERSION_HEADER);
+
+        dos.writeUTF(header.getPartName());
+
+        dos.writeLong(header.getOriginRandomizedTag());
+        dos.writeLong(header.getDestinationRandomizedTag());
+
+        VarInt.writeVInt(dos, header.getSchemas().size());
+        for(HollowSchema schema : header.getSchemas())
+            schema.writeTo(dos);
+
+        ///backwards compatibility -- new data can be added here by first indicating number of bytes used, will be skipped by existing readers.
+        VarInt.writeVInt(dos, 0);
+    }
+
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/InMemoryBlobStore.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/InMemoryBlobStore.java
@@ -95,7 +95,7 @@ public class InMemoryBlobStore implements BlobRetriever, Publisher {
                         parts.addInput(part, blob.newOptionalPartInputStream(part));
                 }
 
-                if(parts.getInputsByPartName().isEmpty())
+                if(parts.getPartNames().isEmpty())
                     return null;
 
                 return parts;

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/LocalBlobStoreTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/LocalBlobStoreTest.java
@@ -1,10 +1,12 @@
 package com.netflix.hollow.api.consumer;
 
 import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.ProducerOptionalBlobPartConfig;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,25 +31,31 @@ public class LocalBlobStoreTest {
         assertNSnapshots(1, localDir);
 
         long v2 = producer.runCycle(ws -> {
-            ws.add(1);
+            ws.add(2);
         });
 
+        consumer = HollowConsumer.withBlobRetriever(bs)
+                .withLocalBlobStore(localDir).build();
+        
         consumer.triggerRefreshTo(v2);
+        
         Assert.assertEquals(v2, consumer.getCurrentVersionId());
         assertNSnapshots(2, localDir);
+        assertNDeltas(0, localDir);
     }
 
     @Test
     public void testBlobStoreOverride() throws Exception {
         File localDir = createLocalDir();
-        InMemoryBlobStore bs = new InMemoryBlobStore();
+        InMemoryBlobStore bs = new InMemoryBlobStore(Collections.singleton("LONG"));
 
         HollowProducer producer = HollowProducer.withPublisher(bs)
-                .withBlobStager(new HollowInMemoryBlobStager())
+                .withBlobStager(new HollowInMemoryBlobStager(optionalPartConfig()))
                 .build();
 
         long v1 = producer.runCycle(ws -> {
             ws.add(1);
+            ws.add(1L);
         });
 
         HollowConsumer consumer = HollowConsumer.withBlobRetriever(bs)
@@ -57,13 +65,61 @@ public class LocalBlobStoreTest {
         assertNSnapshots(1, localDir);
 
         long v2 = producer.runCycle(ws -> {
-            ws.add(1);
+            ws.add(2);
+            ws.add(2L);
         });
 
+        consumer = HollowConsumer.withBlobRetriever(bs)
+                .withLocalBlobStore(localDir, true).build();
         consumer.triggerRefreshTo(v2);
-        // v2 is not loaded from fallback since v1 exists in local cache
+
+        Assert.assertEquals(v2, consumer.getCurrentVersionId());
+        assertNSnapshots(1, localDir);
+        assertNSnapshots(1, "LONG", localDir);
+        assertNDeltas(1, localDir);
+        assertNDeltas(1, "LONG", localDir);
+    }
+    
+    @Test
+    public void testBlobStoreOverrideOptionalPartNotLoaded() throws Exception {
+        File localDir = createLocalDir();
+        InMemoryBlobStore bs = new InMemoryBlobStore(Collections.emptySet());
+
+        HollowProducer producer = HollowProducer.withPublisher(bs)
+                .withBlobStager(new HollowInMemoryBlobStager(optionalPartConfig()))
+                .build();
+
+        long v1 = producer.runCycle(ws -> {
+            ws.add(1);
+            ws.add(1L);
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(bs)
+                .withLocalBlobStore(localDir, true).build();
+        consumer.triggerRefreshTo(v1);
         Assert.assertEquals(v1, consumer.getCurrentVersionId());
         assertNSnapshots(1, localDir);
+
+        long v2 = producer.runCycle(ws -> {
+            ws.add(2);
+            ws.add(2L);
+        });
+
+        consumer = HollowConsumer.withBlobRetriever(bs)
+                .withLocalBlobStore(localDir, true).build();
+        consumer.triggerRefreshTo(v2);
+
+        Assert.assertEquals(v2, consumer.getCurrentVersionId());
+        assertNSnapshots(1, localDir);
+        assertNSnapshots(0, "LONG", localDir);
+        assertNDeltas(1, localDir);
+        assertNDeltas(0, "LONG", localDir);
+    }    
+    
+    static ProducerOptionalBlobPartConfig optionalPartConfig() throws IOException {
+        ProducerOptionalBlobPartConfig optionalPartConfig = new ProducerOptionalBlobPartConfig();
+        optionalPartConfig.addTypesToPart("LONG", "Long");
+        return optionalPartConfig;
     }
 
     static File createLocalDir() throws IOException {
@@ -73,8 +129,26 @@ public class LocalBlobStoreTest {
     }
 
     static void assertNSnapshots(int n, File localDir) throws IOException {
-        long nSnapshots = Files.list(localDir.toPath()).filter(p -> p.getFileName().toString().startsWith("snapshot"))
+        long nSnapshots = Files.list(localDir.toPath()).filter(p -> p.getFileName().toString().startsWith("snapshot-"))
                 .count();
-        Assert.assertEquals(1, nSnapshots);
+        Assert.assertEquals(n, nSnapshots);
     }
+
+    static void assertNDeltas(int n, File localDir) throws IOException {
+        long nDeltas = Files.list(localDir.toPath()).filter(p -> p.getFileName().toString().startsWith("delta-"))
+                .count();
+        Assert.assertEquals(n, nDeltas);
+    }
+
+    static void assertNSnapshots(int n, String optionalPart, File localDir) throws IOException {
+        long nSnapshots = Files.list(localDir.toPath()).filter(p -> p.getFileName().toString().startsWith("snapshot_" + optionalPart + "-"))
+                .count();
+        Assert.assertEquals(n, nSnapshots);
+    }
+    
+    static void assertNDeltas(int n, String optionalPart, File localDir) throws IOException {
+        long nDeltas = Files.list(localDir.toPath()).filter(p -> p.getFileName().toString().startsWith("delta_" + optionalPart + "-"))
+                .count();
+        Assert.assertEquals(n, nDeltas);
+    }    
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/read/HollowBlobOptionalPartTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/HollowBlobOptionalPartTest.java
@@ -1,0 +1,283 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.read;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.ProducerOptionalBlobPartConfig;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.read.engine.HollowBlobReader;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.filter.TypeFilter;
+import com.netflix.hollow.core.write.HollowBlobWriter;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import com.netflix.hollow.core.write.objectmapper.TypeA;
+import com.netflix.hollow.core.write.objectmapper.TypeB;
+import com.netflix.hollow.core.write.objectmapper.TypeC;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HollowBlobOptionalPartTest {
+
+    @Test
+    public void optionalPartsAreAvailableInLowLevelAPI() throws IOException {
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
+        mapper.initializeTypeState(TypeA.class);
+
+        mapper.add(new TypeA("1", 1, new TypeB((short)1, 1L, 1f, new char[] {'1'}, new byte[] { 1 }), Collections.singleton(new TypeC('1', null))));
+        mapper.add(new TypeA("2", 2, new TypeB((short)2, 2L, 2f, new char[] {'2'}, new byte[] { 2 }), Collections.singleton(new TypeC('2', null))));
+        mapper.add(new TypeA("3", 3, new TypeB((short)3, 3L, 3f, new char[] {'3'}, new byte[] { 3 }), Collections.singleton(new TypeC('3', null))));
+
+        ByteArrayOutputStream mainPart = new ByteArrayOutputStream();
+        ByteArrayOutputStream bPart = new ByteArrayOutputStream();
+        ByteArrayOutputStream cPart = new ByteArrayOutputStream();
+
+        ProducerOptionalBlobPartConfig partConfig = newPartConfig();
+
+        ProducerOptionalBlobPartConfig.OptionalBlobPartOutputStreams partStreams = partConfig.newStreams();
+        partStreams.addOutputStream("B", bPart);
+        partStreams.addOutputStream("C", cPart);
+
+        HollowBlobWriter writer = new HollowBlobWriter(writeEngine);
+        writer.writeSnapshot(mainPart, partStreams);
+
+        HollowReadStateEngine readEngine = new HollowReadStateEngine();
+        HollowBlobReader reader = new HollowBlobReader(readEngine);
+
+        HollowBlobInput mainPartInput = HollowBlobInput.serial(new ByteArrayInputStream(mainPart.toByteArray()));
+        HollowBlobInput bPartInput = HollowBlobInput.serial(new ByteArrayInputStream(bPart.toByteArray()));
+        // HollowBlobInput cPartInput = HollowBlobInput.serial(new ByteArrayInputStream(cPart.toByteArray()));
+
+        OptionalBlobPartInput optionalPartInput = new OptionalBlobPartInput();
+        optionalPartInput.addInput("B", bPartInput);
+
+        reader.readSnapshot(mainPartInput, optionalPartInput, TypeFilter.newTypeFilter().build());
+
+        GenericHollowObject obj = new GenericHollowObject(readEngine, "TypeA", 1);
+
+        Assert.assertEquals("2", obj.getObject("a1").getString("value"));
+        Assert.assertEquals(2, obj.getInt("a2"));
+        Assert.assertEquals(2L, obj.getObject("b").getLong("b2"));
+
+        Assert.assertNull(readEngine.getTypeState("TypeC"));
+    }
+
+    @Test
+    public void optionalPartsAreAvailableInHighLevelAPI() throws IOException {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore(Collections.singleton("B"));
+        HollowInMemoryBlobStager stager = new HollowInMemoryBlobStager(newPartConfig());
+
+        HollowProducer producer = HollowProducer
+                .withPublisher(blobStore)
+                .withNumStatesBetweenSnapshots(2)
+                .withBlobStager(stager)
+                .build();
+
+        producer.initializeDataModel(TypeA.class);
+
+        producer.runCycle(state -> {
+            state.add(new TypeA("1", 1, new TypeB((short)1, 1L, 1f, new char[] {'1'}, new byte[] { 1 }), Collections.singleton(new TypeC('1', null))));
+            state.add(new TypeA("2", 2, new TypeB((short)2, 2L, 2f, new char[] {'2'}, new byte[] { 2 }), Collections.singleton(new TypeC('2', null))));
+            state.add(new TypeA("3", 3, new TypeB((short)3, 3L, 3f, new char[] {'3'}, new byte[] { 3 }), Collections.singleton(new TypeC('3', null))));
+        });
+
+        producer.runCycle(state -> {
+            state.add(new TypeA("1", 1, new TypeB((short)1, 1L, 1f, new char[] {'1'}, new byte[] { 1 }), Collections.singleton(new TypeC('1', null))));
+            // state.add(new TypeA("2", 2, new TypeB((short)2, 2L, 2f, new char[] {'2'}, new byte[] { 2 }), Collections.singleton(new TypeC('2', null))));
+            state.add(new TypeA("3", 3, new TypeB((short)3, 3L, 3f, new char[] {'3'}, new byte[] { 3 }), Collections.singleton(new TypeC('3', null))));
+            state.add(new TypeA("4", 4, new TypeB((short)4, 4L, 4f, new char[] {'4'}, new byte[] { 4 }), Collections.singleton(new TypeC('4', null))));
+        });
+
+        HollowConsumer consumer = HollowConsumer.newHollowConsumer()
+                .withBlobRetriever(blobStore)
+                .build();
+        
+        consumer.triggerRefresh();
+
+        GenericHollowObject obj = new GenericHollowObject(consumer.getStateEngine(), "TypeA", 3);
+
+        Assert.assertEquals("4", obj.getObject("a1").getString("value"));
+        Assert.assertEquals(4, obj.getInt("a2"));
+        Assert.assertEquals(4L, obj.getObject("b").getLong("b2"));
+
+        Assert.assertFalse(consumer.getStateEngine().getTypeState("TypeB").getPopulatedOrdinals().get(1));
+        Assert.assertNull(consumer.getStateEngine().getTypeState("TypeC"));
+    }
+    
+    @Test
+    public void refusesToApplyIncorrectPartSnapshot() throws IOException {
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
+        mapper.initializeTypeState(TypeA.class);
+
+        mapper.add(new TypeA("1", 1, new TypeB((short)1, 1L, 1f, new char[] {'1'}, new byte[] { 1 }), Collections.singleton(new TypeC('1', null))));
+        mapper.add(new TypeA("2", 2, new TypeB((short)2, 2L, 2f, new char[] {'2'}, new byte[] { 2 }), Collections.singleton(new TypeC('2', null))));
+        mapper.add(new TypeA("3", 3, new TypeB((short)3, 3L, 3f, new char[] {'3'}, new byte[] { 3 }), Collections.singleton(new TypeC('3', null))));
+
+        ByteArrayOutputStream mainPart = new ByteArrayOutputStream();
+        ByteArrayOutputStream bPart = new ByteArrayOutputStream();
+        ByteArrayOutputStream cPart = new ByteArrayOutputStream();
+
+        ProducerOptionalBlobPartConfig partConfig = newPartConfig();
+
+        ProducerOptionalBlobPartConfig.OptionalBlobPartOutputStreams partStreams = partConfig.newStreams();
+        partStreams.addOutputStream("B", bPart);
+        partStreams.addOutputStream("C", cPart);
+
+        HollowBlobWriter writer = new HollowBlobWriter(writeEngine);
+        writer.writeSnapshot(mainPart, partStreams);
+        
+        writeEngine.prepareForNextCycle();
+
+        mapper.add(new TypeA("1", 1, new TypeB((short)1, 1L, 1f, new char[] {'1'}, new byte[] { 1 }), Collections.singleton(new TypeC('1', null))));
+        mapper.add(new TypeA("3", 3, new TypeB((short)3, 3L, 3f, new char[] {'3'}, new byte[] { 3 }), Collections.singleton(new TypeC('3', null))));
+        mapper.add(new TypeA("4", 4, new TypeB((short)2, 2L, 2f, new char[] {'2'}, new byte[] { 2 }), Collections.singleton(new TypeC('2', null))));
+
+        ByteArrayOutputStream mainPart2 = new ByteArrayOutputStream();
+        ByteArrayOutputStream bPart2 = new ByteArrayOutputStream();
+        ByteArrayOutputStream cPart2 = new ByteArrayOutputStream();
+
+        partStreams = partConfig.newStreams();
+        partStreams.addOutputStream("B", bPart2);
+        partStreams.addOutputStream("C", cPart2);
+
+        writer = new HollowBlobWriter(writeEngine);
+        writer.writeSnapshot(mainPart2, partStreams);
+
+        HollowReadStateEngine readEngine = new HollowReadStateEngine();
+        HollowBlobReader reader = new HollowBlobReader(readEngine);
+
+        HollowBlobInput mainPartInput = HollowBlobInput.serial(new ByteArrayInputStream(mainPart.toByteArray()));
+        HollowBlobInput bPartInput = HollowBlobInput.serial(new ByteArrayInputStream(bPart.toByteArray()));
+        HollowBlobInput cPartInput = HollowBlobInput.serial(new ByteArrayInputStream(cPart2.toByteArray())); /// wrong part state
+
+        OptionalBlobPartInput optionalPartInput = new OptionalBlobPartInput();
+        optionalPartInput.addInput("B", bPartInput);
+        optionalPartInput.addInput("C", cPartInput);
+
+        try {
+            reader.readSnapshot(mainPartInput, optionalPartInput, TypeFilter.newTypeFilter().build());
+            Assert.fail("Should have thrown Exception");
+        } catch(IllegalArgumentException ex) {
+            Assert.assertEquals("Optional blob part C does not appear to be matched with the main input", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void refusesToApplyIncorrectPartDelta() throws IOException {
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
+        mapper.initializeTypeState(TypeA.class);
+
+        mapper.add(new TypeA("1", 1, new TypeB((short)1, 1L, 1f, new char[] {'1'}, new byte[] { 1 }), Collections.singleton(new TypeC('1', null))));
+        mapper.add(new TypeA("2", 2, new TypeB((short)2, 2L, 2f, new char[] {'2'}, new byte[] { 2 }), Collections.singleton(new TypeC('2', null))));
+        mapper.add(new TypeA("3", 3, new TypeB((short)3, 3L, 3f, new char[] {'3'}, new byte[] { 3 }), Collections.singleton(new TypeC('3', null))));
+
+        ByteArrayOutputStream mainPart = new ByteArrayOutputStream();
+        ByteArrayOutputStream bPart = new ByteArrayOutputStream();
+        ByteArrayOutputStream cPart = new ByteArrayOutputStream();
+
+        ProducerOptionalBlobPartConfig partConfig = newPartConfig();
+
+        ProducerOptionalBlobPartConfig.OptionalBlobPartOutputStreams partStreams = partConfig.newStreams();
+        partStreams.addOutputStream("B", bPart);
+        partStreams.addOutputStream("C", cPart);
+
+        HollowBlobWriter writer = new HollowBlobWriter(writeEngine);
+        writer.writeSnapshot(mainPart, partStreams);
+        
+        writeEngine.prepareForNextCycle();
+
+        mapper.add(new TypeA("1", 1, new TypeB((short)1, 1L, 1f, new char[] {'1'}, new byte[] { 1 }), Collections.singleton(new TypeC('1', null))));
+        mapper.add(new TypeA("3", 3, new TypeB((short)3, 3L, 3f, new char[] {'3'}, new byte[] { 3 }), Collections.singleton(new TypeC('3', null))));
+        mapper.add(new TypeA("4", 4, new TypeB((short)2, 2L, 2f, new char[] {'2'}, new byte[] { 2 }), Collections.singleton(new TypeC('2', null))));
+
+        ByteArrayOutputStream mainPart2 = new ByteArrayOutputStream();
+        ByteArrayOutputStream bPart2 = new ByteArrayOutputStream();
+        ByteArrayOutputStream cPart2 = new ByteArrayOutputStream();
+
+        partStreams = partConfig.newStreams();
+        partStreams.addOutputStream("B", bPart2);
+        partStreams.addOutputStream("C", cPart2);
+
+        writer = new HollowBlobWriter(writeEngine);
+        writer.writeDelta(mainPart2, partStreams);
+        
+        writeEngine.prepareForNextCycle();
+
+        mapper.add(new TypeA("3", 3, new TypeB((short)3, 3L, 3f, new char[] {'3'}, new byte[] { 3 }), Collections.singleton(new TypeC('3', null))));
+        mapper.add(new TypeA("4", 4, new TypeB((short)2, 2L, 2f, new char[] {'2'}, new byte[] { 2 }), Collections.singleton(new TypeC('2', null))));
+        mapper.add(new TypeA("5", 5, new TypeB((short)5, 5L, 5f, new char[] {'1'}, new byte[] { 1 }), Collections.singleton(new TypeC('5', null))));
+
+        ByteArrayOutputStream mainPart3 = new ByteArrayOutputStream();
+        ByteArrayOutputStream bPart3 = new ByteArrayOutputStream();
+        ByteArrayOutputStream cPart3 = new ByteArrayOutputStream();
+        
+        partStreams = partConfig.newStreams();
+        partStreams.addOutputStream("B", bPart3);
+        partStreams.addOutputStream("C", cPart3);
+
+        writer = new HollowBlobWriter(writeEngine);
+        writer.writeDelta(mainPart3, partStreams);
+
+        /// read snapshot
+        HollowReadStateEngine readEngine = new HollowReadStateEngine();
+        HollowBlobReader reader = new HollowBlobReader(readEngine);
+
+        HollowBlobInput mainPartInput = HollowBlobInput.serial(new ByteArrayInputStream(mainPart.toByteArray()));
+        HollowBlobInput bPartInput = HollowBlobInput.serial(new ByteArrayInputStream(bPart.toByteArray()));
+        HollowBlobInput cPartInput = HollowBlobInput.serial(new ByteArrayInputStream(cPart.toByteArray()));
+
+        OptionalBlobPartInput optionalPartInput = new OptionalBlobPartInput();
+        optionalPartInput.addInput("B", bPartInput);
+        optionalPartInput.addInput("C", cPartInput);
+
+        reader.readSnapshot(mainPartInput, optionalPartInput, TypeFilter.newTypeFilter().build());
+
+        /// apply delta
+        mainPartInput = HollowBlobInput.serial(new ByteArrayInputStream(mainPart2.toByteArray()));
+        bPartInput = HollowBlobInput.serial(new ByteArrayInputStream(bPart3.toByteArray())); /// wrong part state
+        cPartInput = HollowBlobInput.serial(new ByteArrayInputStream(cPart2.toByteArray()));
+        
+        optionalPartInput = new OptionalBlobPartInput();
+        optionalPartInput.addInput("B", bPartInput);
+        optionalPartInput.addInput("C", cPartInput);
+        
+        try {
+            reader.applyDelta(mainPartInput, optionalPartInput);
+            Assert.fail("Should have thrown Exception");
+        } catch(IllegalArgumentException ex) {
+            Assert.assertEquals("Optional blob part B does not appear to be matched with the main input", ex.getMessage());
+        }
+    }
+
+
+    private ProducerOptionalBlobPartConfig newPartConfig() {
+        ProducerOptionalBlobPartConfig partConfig = new ProducerOptionalBlobPartConfig();
+        partConfig.addTypesToPart("B", "TypeB");
+        partConfig.addTypesToPart("C", "SetOfTypeC", "TypeC", "MapOfStringToListOfInteger", "ListOfInteger", "Integer");
+        return partConfig;
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/HollowBlobOptionalPartTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/HollowBlobOptionalPartTest.java
@@ -18,10 +18,13 @@ package com.netflix.hollow.core.read;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.consumer.fs.HollowFilesystemBlobRetriever;
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
 import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.api.producer.ProducerOptionalBlobPartConfig;
+import com.netflix.hollow.api.producer.fs.HollowFilesystemPublisher;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.memory.MemoryMode;
 import com.netflix.hollow.core.read.engine.HollowBlobReader;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.filter.TypeFilter;
@@ -33,7 +36,10 @@ import com.netflix.hollow.core.write.objectmapper.TypeB;
 import com.netflix.hollow.core.write.objectmapper.TypeC;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
@@ -67,7 +73,7 @@ public class HollowBlobOptionalPartTest {
         HollowBlobReader reader = new HollowBlobReader(readEngine);
 
         HollowBlobInput mainPartInput = HollowBlobInput.serial(new ByteArrayInputStream(mainPart.toByteArray()));
-        HollowBlobInput bPartInput = HollowBlobInput.serial(new ByteArrayInputStream(bPart.toByteArray()));
+        InputStream bPartInput = new ByteArrayInputStream(bPart.toByteArray());
         // HollowBlobInput cPartInput = HollowBlobInput.serial(new ByteArrayInputStream(cPart.toByteArray()));
 
         OptionalBlobPartInput optionalPartInput = new OptionalBlobPartInput();
@@ -170,8 +176,8 @@ public class HollowBlobOptionalPartTest {
         HollowBlobReader reader = new HollowBlobReader(readEngine);
 
         HollowBlobInput mainPartInput = HollowBlobInput.serial(new ByteArrayInputStream(mainPart.toByteArray()));
-        HollowBlobInput bPartInput = HollowBlobInput.serial(new ByteArrayInputStream(bPart.toByteArray()));
-        HollowBlobInput cPartInput = HollowBlobInput.serial(new ByteArrayInputStream(cPart2.toByteArray())); /// wrong part state
+        InputStream bPartInput = new ByteArrayInputStream(bPart.toByteArray());
+        InputStream cPartInput = new ByteArrayInputStream(cPart2.toByteArray()); /// wrong part state
 
         OptionalBlobPartInput optionalPartInput = new OptionalBlobPartInput();
         optionalPartInput.addInput("B", bPartInput);
@@ -247,8 +253,8 @@ public class HollowBlobOptionalPartTest {
         HollowBlobReader reader = new HollowBlobReader(readEngine);
 
         HollowBlobInput mainPartInput = HollowBlobInput.serial(new ByteArrayInputStream(mainPart.toByteArray()));
-        HollowBlobInput bPartInput = HollowBlobInput.serial(new ByteArrayInputStream(bPart.toByteArray()));
-        HollowBlobInput cPartInput = HollowBlobInput.serial(new ByteArrayInputStream(cPart.toByteArray()));
+        InputStream bPartInput = new ByteArrayInputStream(bPart.toByteArray());
+        InputStream cPartInput = new ByteArrayInputStream(cPart.toByteArray());
 
         OptionalBlobPartInput optionalPartInput = new OptionalBlobPartInput();
         optionalPartInput.addInput("B", bPartInput);
@@ -258,8 +264,8 @@ public class HollowBlobOptionalPartTest {
 
         /// apply delta
         mainPartInput = HollowBlobInput.serial(new ByteArrayInputStream(mainPart2.toByteArray()));
-        bPartInput = HollowBlobInput.serial(new ByteArrayInputStream(bPart3.toByteArray())); /// wrong part state
-        cPartInput = HollowBlobInput.serial(new ByteArrayInputStream(cPart2.toByteArray()));
+        bPartInput = new ByteArrayInputStream(bPart3.toByteArray()); /// wrong part state
+        cPartInput = new ByteArrayInputStream(cPart2.toByteArray());
         
         optionalPartInput = new OptionalBlobPartInput();
         optionalPartInput.addInput("B", bPartInput);
@@ -272,6 +278,43 @@ public class HollowBlobOptionalPartTest {
             Assert.assertEquals("Optional blob part B does not appear to be matched with the main input", ex.getMessage());
         }
     }
+    
+    @Test
+    public void optionalPartsWithSharedMemoryLazy() throws IOException {
+        File localBlobStore = createLocalDir();
+        HollowFilesystemPublisher publisher = new HollowFilesystemPublisher(localBlobStore.toPath());
+        HollowInMemoryBlobStager stager = new HollowInMemoryBlobStager(newPartConfig());
+
+        HollowProducer producer = HollowProducer
+                .withPublisher(publisher)
+                .withNumStatesBetweenSnapshots(2)
+                .withBlobStager(stager)
+                .build();
+
+        producer.initializeDataModel(TypeA.class);
+
+        producer.runCycle(state -> {
+            state.add(new TypeA("1", 1, new TypeB((short)1, 1L, 1f, new char[] {'1'}, new byte[] { 1 }), Collections.singleton(new TypeC('1', null))));
+            state.add(new TypeA("2", 2, new TypeB((short)2, 2L, 2f, new char[] {'2'}, new byte[] { 2 }), Collections.singleton(new TypeC('2', null))));
+            state.add(new TypeA("3", 3, new TypeB((short)3, 3L, 3f, new char[] {'3'}, new byte[] { 3 }), Collections.singleton(new TypeC('3', null))));
+        });
+
+        HollowConsumer consumer = HollowConsumer.newHollowConsumer()
+                .withBlobRetriever(new HollowFilesystemBlobRetriever(localBlobStore.toPath(), Collections.singleton("B")))
+                .withMemoryMode(MemoryMode.SHARED_MEMORY_LAZY)
+                .build();
+        
+        consumer.triggerRefresh();
+
+        GenericHollowObject obj = new GenericHollowObject(consumer.getStateEngine(), "TypeA", 1);
+
+        Assert.assertEquals("2", obj.getObject("a1").getString("value"));
+        Assert.assertEquals(2, obj.getInt("a2"));
+        Assert.assertEquals(2L, obj.getObject("b").getLong("b2"));
+
+        Assert.assertNull(consumer.getStateEngine().getTypeState("TypeC"));
+    }
+
 
 
     private ProducerOptionalBlobPartConfig newPartConfig() {
@@ -280,4 +323,11 @@ public class HollowBlobOptionalPartTest {
         partConfig.addTypesToPart("C", "SetOfTypeC", "TypeC", "MapOfStringToListOfInteger", "ListOfInteger", "Integer");
         return partConfig;
     }
+    
+    static File createLocalDir() throws IOException {
+        File localDir = Files.createTempDirectory("hollow").toFile();
+        localDir.deleteOnExit();
+        return localDir;
+    }
+    
 }


### PR DESCRIPTION
Blob 'parts' are published and retrieved as separate files.  Clients can download and load only the 'parts' they are interested in.