### PR TITLE
Data Corruption Fix: overflow when reading values from arrays

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/memory/FixedLengthData.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/FixedLengthData.java
@@ -16,7 +16,7 @@ import java.io.IOException;
  * the value 100100 in binary, or 36 in base 10, would be returned. </p>
  * <p>
  *     As a result there two ways to obtain an element value from the bit string at a given bit index.  The first,
- * using {@link #getElementValue} for values less than 61 bits in length and the second, using
+ * using {@link #getElementValue} for values less than 59 bits in length and the second, using
  * {@link #getLargeElementValue} that is recommended for values of upto 64 bits in length.
  * </p>
  */
@@ -24,10 +24,10 @@ public interface FixedLengthData {
 
     /**
      * Gets an element value, comprising of {@code bitsPerElement} bits, at the given
-     * bit {@code index}. {@code bitsPerElement} should be less than 61 bits.
+     * bit {@code index}. {@code bitsPerElement} should be less than 59 bits.
      *
      * @param index the bit index
-     * @param bitsPerElement bits per element, must be less than 61 otherwise
+     * @param bitsPerElement bits per element, must be less than 59 otherwise
      * the result is undefined
      * @return the element value
      */
@@ -38,7 +38,7 @@ public interface FixedLengthData {
      * bit {@code index}.
      *
      * @param index the bit index
-     * @param bitsPerElement bits per element, must be less than 61 otherwise
+     * @param bitsPerElement bits per element, must be less than 59 otherwise
      * the result is undefined
      * @param mask the mask to apply to an element value before it is returned.
      * The mask should be less than or equal to {@code (1L << bitsPerElement) - 1} to
@@ -52,11 +52,11 @@ public interface FixedLengthData {
      * Gets a large element value, comprising of {@code bitsPerElement} bits, at the given
      * bit {@code index}.
      * <p>
-     * This method should be utilized if the {@code bitsPerElement} may exceed {@code 60} bits,
+     * This method should be utilized if the {@code bitsPerElement} may exceed {@code 58} bits,
      * otherwise the method {@link #getLargeElementValue(long, int)} can be utilized instead.
      *
      * @param index the bit index
-     * @param bitsPerElement bits per element, may be greater than 60
+     * @param bitsPerElement bits per element, may be greater than 58
      * @return the large element value
      */
     long getLargeElementValue(long index, int bitsPerElement);
@@ -65,11 +65,11 @@ public interface FixedLengthData {
      * Gets a masked large element value, comprising of {@code bitsPerElement} bits, at the given
      * bit {@code index}.
      * <p>
-     * This method should be utilized if the {@code bitsPerElement} may exceed {@code 60} bits,
+     * This method should be utilized if the {@code bitsPerElement} may exceed {@code 58} bits,
      * otherwise the method {@link #getLargeElementValue(long, int, long)} can be utilized instead.
      *
      * @param index the bit index
-     * @param bitsPerElement bits per element, may be greater than 60
+     * @param bitsPerElement bits per element, may be greater than 58
      * @param mask the mask to apply to an element value before it is returned.
      * The mask should be less than or equal to {@code (1L << bitsPerElement) - 1} to
      * guarantee that one or more (possibly) partial element values occurring

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/EncodedLongBuffer.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/EncodedLongBuffer.java
@@ -23,22 +23,24 @@ import com.netflix.hollow.core.read.HollowBlobInput;
 import java.io.IOException;
 
 /**
- * This class allows for storage and retrieval of fixed-length data in ByteBuffers.
- *
- * As a result there two ways to obtain an element value from the bit string at a given bit index.  The first,
- * using {@link #getElementValue(long, int)} or {@link #getElementValue(long, int, long)}, at byte index offsets within
- * the buffers. The second, using {@link #getLargeElementValue(long, int)} or
- * {@link #getLargeElementValue(long, int, long)}, by reading two long values and then composing an element value
- * from bits that cover the two.
- *
+ * This class allows for storage and retrieval of fixed-length data in ByteBuffers. As a result there two ways to obtain
+ * an element value from the bit string at a given bit index.
+ * <br><br>
+ * {@link #getElementValue(long, int)} or {@link #getElementValue(long, int, long)}: at byte index offsets within
+ * the buffers.
+ * <br><br>
+ * {@link #getLargeElementValue(long, int)} or {@link #getLargeElementValue(long, int, long)}: by reading two long
+ * values and then composing an element value from bits that cover the two.
+ * <br><br>
  * In the counterpart {@link FixedLengthElementArray} implementation a long read into the last 8 bytes of data was safe
  * because of a padding of 1 long at the end. Instead, this implementation returns a zero byte if the 8 byte range past
  * the buffer capacity is queried.
- *
- * {@link #getElementValue} can only support element values of 60-bits or less since two 60-bit values in sequence can
- * be represented exactly in 15 bytes.  Two 61-bit values in sequence require 16 bytes.  For such a bit string
- * performing an unaligned read at byte index 7 to obtain the second 61-bit value will result in missing the 2 most
- * significant bits located at byte index 15.
+ * <br><br>
+ * {@link #getElementValue} can only support element values of 58 bits or less. This is because reading values that are
+ * unaligned with byte boundaries requires shifting by the number of bits the address is offset by within a byte. For
+ * 58 bit values, the offset from a byte boundary can be as high as 6 bits. 58 bits can be shifted 6 bits and still fit
+ * within the 64 bit space. For 59 bit values the offset from a byte boundary can be as high as 7 bits. Shifting a
+ * 59 bit value by 6 or 7 bits will both overflow the 64 bit space, resulting in an invalid value when reading.
  */
 @SuppressWarnings("restriction")
 public class EncodedLongBuffer implements FixedLengthData {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateShard.java
@@ -31,21 +31,22 @@ class HollowListTypeReadStateShard {
         int elementOrdinal;
 
         do {
-            long startAndEndElement;
+            long startElement;
+            long endElement;
 
             do {
                 currentData = this.currentDataVolatile;
 
-                long fixedLengthOffset = (long)ordinal * currentData.bitsPerListPointer;
-
-                startAndEndElement = ordinal == 0 ?
-                        currentData.listPointerData.getElementValue(fixedLengthOffset, currentData.bitsPerListPointer) << currentData.bitsPerListPointer :
-                            currentData.listPointerData.getElementValue(fixedLengthOffset - currentData.bitsPerListPointer, currentData.bitsPerListPointer * 2);
-
+                if (ordinal == 0) {
+                    startElement = 0;
+                    endElement = currentData.listPointerData.getElementValue(0, currentData.bitsPerListPointer);
+                } else {
+                    long endFixedLengthOffset = (long)ordinal * currentData.bitsPerListPointer;
+                    long startFixedLengthOffset = endFixedLengthOffset - currentData.bitsPerListPointer;
+                    startElement = currentData.listPointerData.getElementValue(startFixedLengthOffset, currentData.bitsPerListPointer);
+                    endElement = currentData.listPointerData.getElementValue(endFixedLengthOffset, currentData.bitsPerListPointer);
+                }
             } while(readWasUnsafe(currentData));
-
-            long endElement = startAndEndElement >> currentData.bitsPerListPointer;
-            long startElement = startAndEndElement &  ((1 << currentData.bitsPerListPointer) - 1);
 
             long elementIndex = startElement + listIndex;
 
@@ -65,14 +66,17 @@ class HollowListTypeReadStateShard {
         do {
             currentData = this.currentDataVolatile;
 
-            long fixedLengthOffset = (long)ordinal * currentData.bitsPerListPointer;
-
-            long startAndEndElement = ordinal == 0 ?
-                    currentData.listPointerData.getElementValue(fixedLengthOffset, currentData.bitsPerListPointer) << currentData.bitsPerListPointer :
-                        currentData.listPointerData.getElementValue(fixedLengthOffset - currentData.bitsPerListPointer, currentData.bitsPerListPointer * 2);
-
-            long endElement = startAndEndElement >> currentData.bitsPerListPointer;
-            long startElement = startAndEndElement &  ((1 << currentData.bitsPerListPointer) - 1);
+            long startElement;
+            long endElement;
+            if (ordinal == 0) {
+                startElement = 0;
+                endElement = currentData.listPointerData.getElementValue(0, currentData.bitsPerListPointer);
+            } else {
+                long endFixedLengthOffset = (long)ordinal * currentData.bitsPerListPointer;
+                long startFixedLengthOffset = endFixedLengthOffset - currentData.bitsPerListPointer;
+                startElement = currentData.listPointerData.getElementValue(startFixedLengthOffset, currentData.bitsPerListPointer);
+                endElement = currentData.listPointerData.getElementValue(endFixedLengthOffset, currentData.bitsPerListPointer);
+            }
 
             size = (int)(endElement - startElement);
         } while(readWasUnsafe(currentData));


### PR DESCRIPTION
My company runs many Hollow based apps in production and we noticed data corruption with a couple datasets that used a large number of array elements. After debugging we found that the failure occurs when the dataset consists of more than 2^29 array elements. It does not matter how many elements are in any individual array. Cumulatively there must be less than 2^29 array elements across all arrays.

The problem was happening because HollowListTypeReadStateShard tries to read 2 values at once, which results in a 58 bit read. However the 29 bit value can be offset by 7 bits from a byte boundary, causing the result of a 58 bit read to overflow the 64 bit space and an invalid value to be returned.

The fix was to modify HollowListTypeReadStateShard to read the values individually.

Unit tests are provided demonstrating the situations described above. In addition, we found that FixedLengthData values are actually limited to 58 bits in length, contrary to the comments in code which claim it can support 60 bit wide values. This is because a 59 bit wide value will overflow when offset by 6 bits from a byte boundary. There are also unit tests included to demonstrate this.

Issue: #513 