### PR TITLE
Overflow fix

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
@@ -160,7 +160,7 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
 
         ByteData data = ordinalMap.getByteData().getUnderlyingArray();
 
-        int elementCounter[] = new int[numShards];
+        long elementCounter[] = new long[numShards];
         int shardMask = numShards - 1;
 
         for(int ordinal=0;ordinal<=maxOrdinal;ordinal++) {


### PR DESCRIPTION
Addresses issue #515 by converting array to hold longs instead of ints.

I tried to write a test for this but found that it took very long to run, and required more memory than was available on my laptop (16GiB). I've pasted it below in case it's of any use:

```
package com.netflix.hollow.core.write;

import com.netflix.hollow.core.schema.HollowListSchema;
import org.junit.Before;
import org.junit.Test;

public class HollowListTypeWriteStateTest {
    HollowListSchema schema;

    @Before
    public void setUp() {
        schema = new HollowListSchema("Test", "String");
    }

    @Test
    public void testCalculateSnapshot() {
        HollowListTypeWriteState state = new HollowListTypeWriteState(schema, 1);
        for(int i=0; i<Integer.MAX_VALUE/1_000_000; i++) {
            HollowListWriteRecord rec = new HollowListWriteRecord();
            // Add 1,000,001 elements to each list, ensuring every list is unique by offsetting by list ordinal
            for(int j=0; j<1_000_001; j++) {
                rec.addElement(j+i);
            }
            state.add(rec);
        }

        state.prepareForWrite();

	// This will fail if elementCounter is of type int[], should pass if it is changed to long[]
        state.calculateSnapshot();
    }
}
```