### PR TITLE
Support ARM64/AWS Graviton Instances by not performing unaligned accesses

### DIFF
--- a/hollow-perf/src/main/java/hollow/FixedLengthElementArrayPlainPut.java
+++ b/hollow-perf/src/main/java/hollow/FixedLengthElementArrayPlainPut.java
@@ -41,7 +41,7 @@ import sun.misc.Unsafe;
 @SuppressWarnings("restriction")
 public class FixedLengthElementArrayPlainPut extends SegmentedLongArrayPlainPut {
 
-    private static final Unsafe unsafe = HollowUnsafeHandle.getUnsafe();
+    private static final HollowUnsafeHandle unsafe = HollowUnsafeHandle.getUnsafe();
 
     private final int log2OfSegmentSizeInBytes;
     private final int byteBitmask;

--- a/hollow-perf/src/main/java/hollow/SegmentedLongArrayPlainPut.java
+++ b/hollow-perf/src/main/java/hollow/SegmentedLongArrayPlainPut.java
@@ -39,7 +39,7 @@ import sun.misc.Unsafe;
 @SuppressWarnings("restriction")
 public class SegmentedLongArrayPlainPut {
 
-    private static final Unsafe unsafe = HollowUnsafeHandle.getUnsafe();
+    private static final HollowUnsafeHandle unsafe = HollowUnsafeHandle.getUnsafe();
 
     protected final long[][] segments;
     protected final int log2OfSegmentSize;

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
@@ -51,19 +51,29 @@ public class HollowUnsafeHandle {
         return singleton;
     }
 
-    public void putOrderedLong(Object o, long l, long l1) {
-        if (UNALIGNED_ALLOWED) {
-            unsafe.putOrderedLong(o, l, l1);
+    public void putOrderedLong(Object o, long offset, long value) {
+        if (UNALIGNED_ALLOWED || (offset & 7) == 0) {
+            unsafe.putOrderedLong(o, offset, value);
+        } else if ((offset & 3) == 0) {
+            // 4 byte aligned, little endian
+            unsafe.putOrderedInt(o, offset, (int)(value));
+            unsafe.putOrderedInt(o, offset + 4, (int)(value >>> 32));
+        } else if ((offset & 1) == 0) {
+            // 2 byte aligned, little endian
+            unsafe.putShortVolatile(o, offset, (short)(value));
+            unsafe.putShortVolatile(o, offset + 2, (short)(value >>> 16));
+            unsafe.putShortVolatile(o, offset + 4, (short)(value >>> 32));
+            unsafe.putShortVolatile(o, offset + 6, (short)(value >>> 48));
         } else {
-            // Assume little endian
-            unsafe.putByteVolatile(o, l, (byte) (l1));
-            unsafe.putByteVolatile(o, l + 1, (byte) (l1 >>> 8));
-            unsafe.putByteVolatile(o, l + 2, (byte) (l1 >>> 16));
-            unsafe.putByteVolatile(o, l + 3, (byte) (l1 >>> 24));
-            unsafe.putByteVolatile(o, l + 4, (byte) (l1 >>> 32));
-            unsafe.putByteVolatile(o, l + 5, (byte) (l1 >>> 40));
-            unsafe.putByteVolatile(o, l + 6, (byte) (l1 >>> 48));
-            unsafe.putByteVolatile(o, l + 7, (byte) (l1 >>> 56));
+            // 1 byte aligned, little endian
+            unsafe.putByteVolatile(o, offset, (byte) (value));
+            unsafe.putByteVolatile(o, offset + 1, (byte) (value >>> 8));
+            unsafe.putByteVolatile(o, offset + 2, (byte) (value >>> 16));
+            unsafe.putByteVolatile(o, offset + 3, (byte) (value >>> 24));
+            unsafe.putByteVolatile(o, offset + 4, (byte) (value >>> 32));
+            unsafe.putByteVolatile(o, offset + 5, (byte) (value >>> 40));
+            unsafe.putByteVolatile(o, offset + 6, (byte) (value >>> 48));
+            unsafe.putByteVolatile(o, offset + 7, (byte) (value >>> 56));
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
@@ -26,6 +26,12 @@ import sun.misc.Unsafe;
 public class HollowUnsafeHandle {
     private static final Logger log = Logger.getLogger(HollowUnsafeHandle.class.getName());
     private static final Unsafe unsafe;
+    private static final HollowUnsafeHandle singleton;
+
+    // TODO: figure this out somehow
+    private static final boolean UNALIGNED_ALLOWED = false;
+
+    private HollowUnsafeHandle() {}
 
     static {
         Field theUnsafe;
@@ -38,10 +44,105 @@ public class HollowUnsafeHandle {
             log.log(Level.SEVERE, "Unsafe access failed", e);
         }
         unsafe = u;
+        singleton = new HollowUnsafeHandle();
     }
 
-    public static Unsafe getUnsafe() {
-        return unsafe;
+    public static HollowUnsafeHandle getUnsafe() {
+        return singleton;
     }
 
+    public void putOrderedLong(Object o, long l, long l1) {
+        if (UNALIGNED_ALLOWED) {
+            unsafe.putOrderedLong(o, l, l1);
+        } else {
+            // Assume little endian
+            // TODO: detect if the address is 64, 32, 16, or 8 bit aligned and run different code?
+            unsafe.putByteVolatile(o, l, (byte) (l1));
+            unsafe.putByteVolatile(o, l + 1, (byte) (l1 >>> 8));
+            unsafe.putByteVolatile(o, l + 2, (byte) (l1 >>> 16));
+            unsafe.putByteVolatile(o, l + 3, (byte) (l1 >>> 24));
+            unsafe.putByteVolatile(o, l + 4, (byte) (l1 >>> 32));
+            unsafe.putByteVolatile(o, l + 5, (byte) (l1 >>> 40));
+            unsafe.putByteVolatile(o, l + 6, (byte) (l1 >>> 48));
+            unsafe.putByteVolatile(o, l + 7, (byte) (l1 >>> 56));
+        }
+    }
+
+    public long getLong(Object o, long l) {
+        if (UNALIGNED_ALLOWED) {
+            return unsafe.getLong(o, l);
+        } else {
+            // Assume little endian
+            // TODO: detect if the address is 64, 32, 16, or 8 bit aligned and run different code?
+            return ((long) unsafe.getByte(o, l) & 0xFF)
+                    | (((long) unsafe.getByte(o, l + 1) & 0xFF) << 8)
+                    | (((long) unsafe.getByte(o, l + 2) & 0xFF) << 16)
+                    | (((long) unsafe.getByte(o, l + 3) & 0xFF) << 24)
+                    | (((long) unsafe.getByte(o, l + 4) & 0xFF) << 32)
+                    | (((long) unsafe.getByte(o, l + 5) & 0xFF) << 40)
+                    | (((long) unsafe.getByte(o, l + 6) & 0xFF) << 48)
+                    | (((long) unsafe.getByte(o, l + 7) & 0xFF) << 56);
+        }
+    }
+
+    public void putByteVolatile(Object o, long l, byte b) {
+        unsafe.putByteVolatile(o, l, b);
+    }
+
+    public void loadFence() {
+        unsafe.loadFence();
+    }
+
+    public long objectFieldOffset(Field field) {
+        return unsafe.objectFieldOffset(field);
+    }
+
+    public Object getObject(Object o, long l) {
+        return unsafe.getObject(o, l);
+    }
+
+    public float getFloat(Object o, long l) {
+        return unsafe.getFloat(o, l);
+    }
+
+    public double getDouble(Object o, long l) {
+        return unsafe.getDouble(o, l);
+    }
+
+    public void putLong(Object o, long l, long l1) {
+        if (UNALIGNED_ALLOWED) {
+            unsafe.putLong(o, l, l1);
+        } else {
+            // Assume little endian
+            // TODO: detect if the address is 64, 32, 16, or 8 bit aligned and run different code?
+            unsafe.putByte(o, l, (byte) (l1));
+            unsafe.putByte(o, l + 1, (byte) (l1 >>> 8));
+            unsafe.putByte(o, l + 2, (byte) (l1 >>> 16));
+            unsafe.putByte(o, l + 3, (byte) (l1 >>> 24));
+            unsafe.putByte(o, l + 4, (byte) (l1 >>> 32));
+            unsafe.putByte(o, l + 5, (byte) (l1 >>> 40));
+            unsafe.putByte(o, l + 6, (byte) (l1 >>> 48));
+            unsafe.putByte(o, l + 7, (byte) (l1 >>> 56));
+        }
+    }
+
+    public boolean getBoolean(Object o, long l) {
+        return unsafe.getBoolean(o, l);
+    }
+
+    public int getInt(Object o, long l) {
+        return unsafe.getInt(o, l);
+    }
+
+    public short getShort(Object o, long l) {
+        return unsafe.getShort(o, l);
+    }
+
+    public byte getByte(Object o, long l) {
+        return unsafe.getByte(o, l);
+    }
+
+    public char getChar(Object o, long l) {
+        return unsafe.getChar(o, l);
+    }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
@@ -77,19 +77,27 @@ public class HollowUnsafeHandle {
         }
     }
 
-    public long getLong(Object o, long l) {
-        if (UNALIGNED_ALLOWED) {
-            return unsafe.getLong(o, l);
+    public long getLong(Object o, long offset) {
+        if (UNALIGNED_ALLOWED || (offset & 7) == 0) {
+            return unsafe.getLong(o, offset);
+        } else if ((offset & 3) == 0) {
+            return ((long) unsafe.getInt(o, offset) & 0xFFFFFFFFL)
+                    | (((long) unsafe.getInt(o, offset + 4) & 0xFFFFFFFFL) << 32);
+        } else if ((offset & 1) == 0) {
+            return ((long) unsafe.getShort(o, offset) & 0xFFFF)
+                    | (((long) unsafe.getShort(o, offset + 2) & 0xFFFF) << 16)
+                    | (((long) unsafe.getShort(o, offset + 4) & 0xFFFF) << 32)
+                    | (((long) unsafe.getShort(o, offset + 6) & 0xFFFF) << 48);
         } else {
             // Assume little endian
-            return ((long) unsafe.getByte(o, l) & 0xFF)
-                    | (((long) unsafe.getByte(o, l + 1) & 0xFF) << 8)
-                    | (((long) unsafe.getByte(o, l + 2) & 0xFF) << 16)
-                    | (((long) unsafe.getByte(o, l + 3) & 0xFF) << 24)
-                    | (((long) unsafe.getByte(o, l + 4) & 0xFF) << 32)
-                    | (((long) unsafe.getByte(o, l + 5) & 0xFF) << 40)
-                    | (((long) unsafe.getByte(o, l + 6) & 0xFF) << 48)
-                    | (((long) unsafe.getByte(o, l + 7) & 0xFF) << 56);
+            return ((long) unsafe.getByte(o, offset) & 0xFF)
+                    | (((long) unsafe.getByte(o, offset + 1) & 0xFF) << 8)
+                    | (((long) unsafe.getByte(o, offset + 2) & 0xFF) << 16)
+                    | (((long) unsafe.getByte(o, offset + 3) & 0xFF) << 24)
+                    | (((long) unsafe.getByte(o, offset + 4) & 0xFF) << 32)
+                    | (((long) unsafe.getByte(o, offset + 5) & 0xFF) << 40)
+                    | (((long) unsafe.getByte(o, offset + 6) & 0xFF) << 48)
+                    | (((long) unsafe.getByte(o, offset + 7) & 0xFF) << 56);
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/HollowUnsafeHandle.java
@@ -56,7 +56,6 @@ public class HollowUnsafeHandle {
             unsafe.putOrderedLong(o, l, l1);
         } else {
             // Assume little endian
-            // TODO: detect if the address is 64, 32, 16, or 8 bit aligned and run different code?
             unsafe.putByteVolatile(o, l, (byte) (l1));
             unsafe.putByteVolatile(o, l + 1, (byte) (l1 >>> 8));
             unsafe.putByteVolatile(o, l + 2, (byte) (l1 >>> 16));
@@ -73,7 +72,6 @@ public class HollowUnsafeHandle {
             return unsafe.getLong(o, l);
         } else {
             // Assume little endian
-            // TODO: detect if the address is 64, 32, 16, or 8 bit aligned and run different code?
             return ((long) unsafe.getByte(o, l) & 0xFF)
                     | (((long) unsafe.getByte(o, l + 1) & 0xFF) << 8)
                     | (((long) unsafe.getByte(o, l + 2) & 0xFF) << 16)
@@ -114,7 +112,6 @@ public class HollowUnsafeHandle {
             unsafe.putLong(o, l, l1);
         } else {
             // Assume little endian
-            // TODO: detect if the address is 64, 32, 16, or 8 bit aligned and run different code?
             unsafe.putByte(o, l, (byte) (l1));
             unsafe.putByte(o, l + 1, (byte) (l1 >>> 8));
             unsafe.putByte(o, l + 2, (byte) (l1 >>> 16));

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/SegmentedByteArray.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/SegmentedByteArray.java
@@ -42,7 +42,7 @@ import sun.misc.Unsafe;
 @SuppressWarnings("restriction")
 public class SegmentedByteArray implements VariableLengthData {
 
-    private static final Unsafe unsafe = HollowUnsafeHandle.getUnsafe();
+    private static final HollowUnsafeHandle unsafe = HollowUnsafeHandle.getUnsafe();
 
     private byte[][] segments;
     private final int log2OfSegmentSize;

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/SegmentedLongArray.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/SegmentedLongArray.java
@@ -38,7 +38,7 @@ import sun.misc.Unsafe;
 @SuppressWarnings("restriction")
 public class SegmentedLongArray {
 
-    private static final Unsafe unsafe = HollowUnsafeHandle.getUnsafe();
+    private static final HollowUnsafeHandle unsafe = HollowUnsafeHandle.getUnsafe();
 
     protected final long[][] segments;
     protected final int log2OfSegmentSize;

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthElementArray.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthElementArray.java
@@ -58,7 +58,7 @@ import sun.misc.Unsafe;
 @SuppressWarnings("restriction")
 public class FixedLengthElementArray extends SegmentedLongArray implements FixedLengthData {
 
-    private static final Unsafe unsafe = HollowUnsafeHandle.getUnsafe();
+    private static final HollowUnsafeHandle unsafe = HollowUnsafeHandle.getUnsafe();
 
     private final int log2OfSegmentSizeInBytes;
     private final int byteBitmask;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -33,12 +33,11 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import sun.misc.Unsafe;
 
 @SuppressWarnings("restriction")
 public class HollowObjectTypeMapper extends HollowTypeMapper {
     
-    private static final Unsafe unsafe = HollowUnsafeHandle.getUnsafe();
+    private static final HollowUnsafeHandle unsafe = HollowUnsafeHandle.getUnsafe();
     private final HollowObjectMapper parentMapper;
 
     private final String typeName;


### PR DESCRIPTION
Resolves https://github.com/Netflix/hollow/issues/517 and allows Hollow to be used on ARM based machines such as AWS Graviton instances.

There are a few things left to finish up, but I wanted to get this in front of people sooner rather than later to get some feedback on the design here.

What I've done is swapped HollowUnsafeHandle from being simply a way to get an instance of sun.misc.Unsafe to a singleton class wrapping sun.misc.Unsafe. It seems the only classes that perform unaligned accesses are the FixedLengthElementArray and SegmentedLongArray families, so it might also make sense to have only those classes call an unaligned helper method on HollowUnsafeHandle, rather than having all unsafe calls go through this class. Let me know if this would be preferred.

I've tested this (but only the consumer side) on an r6g.4xlarge instance on AWS, and performance is very good. Also, the kernel doesn't kill it with a SIGBUS :slightly_smiling_face: 

I'm new to the sun.misc.Unsafe API, so there are a few things I haven't been able to figure out how to do yet:

- How do we detect whether the host platform supports unaligned accesses?

OpenJDK 8 does it like [this internally](https://github.com/openjdk/jdk/blob/9a9add8825a040565051a09010b29b099c2e7d49/jdk/src/share/classes/java/nio/Bits.java#L606-L615), but there seems to not be a public-facing API version of this, at least in JDK8. Maybe a configuration setting would be most appropriate if there's no reliable way to auto detect it.

- Improve efficiency by checking the alignment of the address

I'd like to check if the address is aligned, and use the faster putOrderedLong/getLong calls directly if possible. Since all the accesses use the object + offset form instead of raw addresses, there doesn't seem to be a way to do this unless we can retrieve the address of the base object, which doesn't seem to be possible through sun.misc.Unsafe.

Thanks for your time.