### PR TITLE
Replace all calls to putOrderedLong with putLong

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthElementArray.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthElementArray.java
@@ -192,7 +192,6 @@ public class FixedLengthElementArray extends SegmentedLongArray implements Fixed
         long l = unsafe.getLong(segment, elementByteOffset);
 
         unsafe.putLong(segment, elementByteOffset, l + (increment << whichBit));
-        unsafe.storeFence();
 
         /// update the fencepost longs
         if((whichByte & byteBitmask) > bitmask * 8 && (whichSegment + 1) < segments.length) {

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthElementArray.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthElementArray.java
@@ -197,11 +197,9 @@ public class FixedLengthElementArray extends SegmentedLongArray implements Fixed
         /// update the fencepost longs
         if((whichByte & byteBitmask) > bitmask * 8 && (whichSegment + 1) < segments.length) {
             unsafe.putLong(segments[whichSegment + 1], (long) Unsafe.ARRAY_LONG_BASE_OFFSET, segments[whichSegment][bitmask + 1]);
-            unsafe.storeFence();
         }
         if((whichByte & byteBitmask) < 8 && whichSegment > 0) {
             unsafe.putLong(segments[whichSegment - 1], (long) Unsafe.ARRAY_LONG_BASE_OFFSET + (8 * (bitmask + 1)), segments[whichSegment][0]);
-            unsafe.storeFence();
         }
     }
 


### PR DESCRIPTION
An alternative approach to #518 

It seems like the culprit wasn't the unaligned write, but rather the memory fence that putOrderedLong creates. 

This is a much cleaner solution that still provides all the safety of putOrderedLong through the calls to storeFence().