### PR TITLE
Refresh successful after metrics updated

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -175,14 +175,14 @@ public class HollowClientUpdater {
                 hollowDataHolderVolatile.update(updatePlan, localListeners, () -> {});
             }
 
-            for(HollowConsumer.RefreshListener refreshListener : localListeners)
-                refreshListener.refreshSuccessful(beforeVersion, getCurrentVersionId(), requestedVersion);
-
             metrics.updateTypeStateMetrics(getStateEngine(), requestedVersion);
             if(metricsCollector != null)
                 metricsCollector.collect(metrics);
 
             initialLoad.complete(getCurrentVersionId()); // only set the first time
+            for(HollowConsumer.RefreshListener refreshListener : localListeners)
+                refreshListener.refreshSuccessful(beforeVersion, getCurrentVersionId(), requestedVersion);
+
             return getCurrentVersionId() == requestedVersion;
         } catch(Throwable th) {
             forceDoubleSnapshotNextUpdate();

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
@@ -148,15 +148,17 @@ public class HollowClientUpdaterTest {
         when(retriever.retrieveSnapshotBlob(anyLong()))
                 .thenReturn(blob);
 
-        AtomicBoolean listenerCalled=new AtomicBoolean(false);
-        subject.addRefreshListener(new AbstractRefreshListener(){
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        subject.addRefreshListener(new AbstractRefreshListener() {
             @Override
-            public void refreshSuccessful(long beforeVersion, long afterVersion, long requestedVersion) {
+            public void refreshSuccessful(long beforeVersion, long afterVersion,
+                long requestedVersion) {
                 listenerCalled.set(true);
                 // verify metrics are correct when calling the callback
-                verify(metrics).updateTypeStateMetrics(any(HollowReadStateEngine.class), eq(requestedVersion));
+                verify(metrics)
+                    .updateTypeStateMetrics(any(HollowReadStateEngine.class), eq(requestedVersion));
             }
-        },null);
+        }, null);
 
         // such act
         subject.updateTo(VERSION_LATEST);
@@ -165,7 +167,8 @@ public class HollowClientUpdaterTest {
         assertTrue(subject.getInitialLoad().isDone());
 
         // verify metrics were updated
-        verify(metrics).updateTypeStateMetrics(any(HollowReadStateEngine.class), eq(VERSION_LATEST));
+        verify(metrics)
+            .updateTypeStateMetrics(any(HollowReadStateEngine.class), eq(VERSION_LATEST));
         assertTrue(listenerCalled.get());
 
         // test exception msg when subsequent update fails to fetch qualifying versions

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
@@ -23,11 +23,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.HollowConsumer.AbstractRefreshListener;
 import com.netflix.hollow.api.metrics.HollowConsumerMetrics;
 import com.netflix.hollow.core.memory.MemoryMode;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
@@ -37,6 +41,7 @@ import com.netflix.hollow.test.HollowWriteStateEngineBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -143,11 +148,25 @@ public class HollowClientUpdaterTest {
         when(retriever.retrieveSnapshotBlob(anyLong()))
                 .thenReturn(blob);
 
+        AtomicBoolean listenerCalled=new AtomicBoolean(false);
+        subject.addRefreshListener(new AbstractRefreshListener(){
+            @Override
+            public void refreshSuccessful(long beforeVersion, long afterVersion, long requestedVersion) {
+                listenerCalled.set(true);
+                // verify metrics are correct when calling the callback
+                verify(metrics).updateTypeStateMetrics(any(HollowReadStateEngine.class), eq(requestedVersion));
+            }
+        },null);
+
         // such act
         subject.updateTo(VERSION_LATEST);
 
         // amaze!
         assertTrue(subject.getInitialLoad().isDone());
+
+        // verify metrics were updated
+        verify(metrics).updateTypeStateMetrics(any(HollowReadStateEngine.class), eq(VERSION_LATEST));
+        assertTrue(listenerCalled.get());
 
         // test exception msg when subsequent update fails to fetch qualifying versions
         long v = Long.MAX_VALUE - 1;


### PR DESCRIPTION
Right now, if someone will try to log the latest metrics using `RefreshListener`, they will get wrong results, because the event is emitted before the metrics are updated. If this is the first refresh, it will show 0 entities and 0 kb used. 

This is particularly annoying when trying to build a tool around Hollow that will integrate with existing corporate monitoring systems.