### PR TITLE
Remove usages of jcenter()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  repositories { jcenter() }
+  repositories { mavenCentral() }
 }
 
 plugins {
@@ -31,6 +31,6 @@ subprojects {
   }
 
   repositories {
-    jcenter()
+    mavenCentral()
   }
 }


### PR DESCRIPTION
Hi folks,

As you might be aware, JFrog is sunsetting Bintray and JCenter: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

This is to use maven central instead of jcenter