### PR TITLE
Prevent load failure when missing types are defined in hash keys.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/FieldPaths.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/FieldPaths.java
@@ -227,7 +227,7 @@ public final class FieldPaths {
     /**
      * An exception contain structured information when a field path cannot be bound.
      */
-    static final class FieldPathException extends IllegalArgumentException {
+    public static final class FieldPathException extends IllegalArgumentException {
         enum ErrorKind {
             NOT_BINDABLE,
             NOT_FOUND,

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -22,6 +22,7 @@ import com.netflix.hollow.api.sampling.DisabledSamplingDirector;
 import com.netflix.hollow.api.sampling.HollowMapSampler;
 import com.netflix.hollow.api.sampling.HollowSampler;
 import com.netflix.hollow.api.sampling.HollowSamplingDirector;
+import com.netflix.hollow.core.index.FieldPaths.FieldPathException;
 import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
 import com.netflix.hollow.core.memory.MemoryMode;
 import com.netflix.hollow.core.memory.encoding.VarInt;
@@ -300,8 +301,13 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     }
     
     public void buildKeyDeriver() {
-        if(getSchema().getHashKey() != null)
-            this.keyDeriver = new HollowPrimaryKeyValueDeriver(getSchema().getHashKey(), getStateEngine());
+        if(getSchema().getHashKey() != null) {
+            try {
+                this.keyDeriver = new HollowPrimaryKeyValueDeriver(getSchema().getHashKey(), getStateEngine());
+            } catch(FieldPathException ex) {
+                ex.printStackTrace();
+            }
+        }
         
         for(int i=0; i<shards.length; i++)
             shards[i].setKeyDeriver(keyDeriver);

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -22,6 +22,7 @@ import com.netflix.hollow.api.sampling.DisabledSamplingDirector;
 import com.netflix.hollow.api.sampling.HollowSampler;
 import com.netflix.hollow.api.sampling.HollowSamplingDirector;
 import com.netflix.hollow.api.sampling.HollowSetSampler;
+import com.netflix.hollow.core.index.FieldPaths.FieldPathException;
 import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
 import com.netflix.hollow.core.memory.MemoryMode;
 import com.netflix.hollow.core.memory.encoding.VarInt;
@@ -278,8 +279,13 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
 	}
 	
 	public void buildKeyDeriver() {
-	    if(getSchema().getHashKey() != null)
-	        this.keyDeriver = new HollowPrimaryKeyValueDeriver(getSchema().getHashKey(), getStateEngine());
+	    if(getSchema().getHashKey() != null) {
+	        try {
+	            this.keyDeriver = new HollowPrimaryKeyValueDeriver(getSchema().getHashKey(), getStateEngine());
+	        } catch(FieldPathException ex) {
+	            ex.printStackTrace();
+	        }
+	    }
 	    
 	    for(int i=0;i<shards.length;i++)
 	        shards[i].setKeyDeriver(keyDeriver);


### PR DESCRIPTION
This is potentially relevant for either 1) client-side type filters or 2) optional blob parts.