### PR TITLE
Bugfix for HOLLOW-536 Infinite CPU-consuming Loop in VarInt.readVLong/readVInt on truncated InputStream

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/VarInt.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/VarInt.java
@@ -19,6 +19,7 @@ package com.netflix.hollow.core.memory.encoding;
 import com.netflix.hollow.core.memory.ByteData;
 import com.netflix.hollow.core.memory.ByteDataArray;
 import com.netflix.hollow.core.read.HollowBlobInput;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -173,14 +174,14 @@ public class VarInt {
      * @throws IOException if the value cannot be read from the input
      */
     public static int readVInt(InputStream in) throws IOException {
-        byte b = (byte)in.read();
+        byte b = readByteSafely(in);
 
         if(b == (byte) 0x80)
             throw new RuntimeException("Attempting to read null value as int");
 
         int value = b & 0x7F;
         while ((b & 0x80) != 0) {
-            b = (byte)in.read();
+            b = readByteSafely(in);
             value <<= 7;
             value |= (b & 0x7F);
         }
@@ -195,14 +196,14 @@ public class VarInt {
      * @throws IOException if the value cannot be read from the input
      */
     public static int readVInt(HollowBlobInput in) throws IOException {
-        byte b = (byte)in.read();
+        byte b = readByteSafely(in);
 
         if(b == (byte) 0x80)
             throw new RuntimeException("Attempting to read null value as int");
 
         int value = b & 0x7F;
         while ((b & 0x80) != 0) {
-            b = (byte)in.read();
+            b = readByteSafely(in);
             value <<= 7;
             value |= (b & 0x7F);
         }
@@ -261,14 +262,14 @@ public class VarInt {
      * @throws IOException if the value cannot be read from the input stream
      */
     public static long readVLong(InputStream in) throws IOException {
-        byte b = (byte)in.read();
+        byte b = readByteSafely(in);
 
         if(b == (byte) 0x80)
             throw new RuntimeException("Attempting to read null value as long");
 
         long value = b & 0x7F;
         while ((b & 0x80) != 0) {
-            b = (byte)in.read();
+            b = readByteSafely(in);
             value <<= 7;
             value |= (b & 0x7F);
         }
@@ -283,14 +284,14 @@ public class VarInt {
      * @throws IOException if the value cannot be read from the input
      */
     public static long readVLong(HollowBlobInput in) throws IOException {
-        byte b = (byte)in.read();
+        byte b = readByteSafely(in);
 
         if(b == (byte) 0x80)
             throw new RuntimeException("Attempting to read null value as long");
 
         long value = b & 0x7F;
         while ((b & 0x80) != 0) {
-            b = (byte)in.read();
+            b = readByteSafely(in);
             value <<= 7;
             value |= (b & 0x7F);
         }
@@ -373,4 +374,19 @@ public class VarInt {
         return numInts;
     }
 
+    public static byte readByteSafely(InputStream is) throws IOException {
+        int i = is.read();
+        if(i == -1) {
+            throw new EOFException("Unexpected end of VarInt record");
+        }
+        return (byte)i;
+    }
+
+    public static byte readByteSafely(HollowBlobInput in) throws IOException {
+        int i = in.read();
+        if(i == -1) {
+            throw new EOFException("Unexpected end of VarInt record");
+        }
+        return (byte)i;
+    }
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/encoding/VarIntTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/encoding/VarIntTest.java
@@ -1,0 +1,99 @@
+package com.netflix.hollow.core.memory.encoding;
+
+import com.netflix.hollow.core.read.HollowBlobInput;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VarIntTest {
+    private final static byte[] BYTES_EMPTY = new byte[]{};
+    private final static byte[] BYTES_TRUNCATED = new byte[]{(byte) 0x81};
+    private final static byte[] BYTES_VALUE_129 = new byte[]{(byte) 0x81, (byte) 0x01};
+
+    @Test
+    public void testReadVLongInputStream() throws IOException {
+        InputStream is = new ByteArrayInputStream(BYTES_VALUE_129);
+
+        Assert.assertEquals(129, VarInt.readVLong(is));
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadVLongEmptyInputStream() throws IOException {
+        InputStream is = new ByteArrayInputStream(BYTES_EMPTY);
+
+        VarInt.readVLong(is);
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadVLongTruncatedInputStream() throws IOException {
+        InputStream is = new ByteArrayInputStream(BYTES_TRUNCATED);
+
+        VarInt.readVLong(is);
+    }
+
+    @Test
+    public void testReadVIntInputStream() throws IOException {
+        InputStream is = new ByteArrayInputStream(BYTES_VALUE_129);
+
+        Assert.assertEquals(129, VarInt.readVInt(is));
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadVIntEmptyInputStream() throws IOException {
+        InputStream is = new ByteArrayInputStream(BYTES_EMPTY);
+
+        VarInt.readVInt(is);
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadVIntTruncatedInputStream() throws IOException {
+        InputStream is = new ByteArrayInputStream(BYTES_TRUNCATED);
+
+        VarInt.readVInt(is);
+    }
+
+    @Test
+    public void testReadVLongHollowBlobInput() throws IOException {
+        HollowBlobInput hbi = HollowBlobInput.serial(BYTES_VALUE_129);
+
+        Assert.assertEquals(129l, VarInt.readVLong(hbi));
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadVLongEmptyHollowBlobInput() throws IOException {
+        HollowBlobInput hbi = HollowBlobInput.serial(BYTES_EMPTY);
+
+        VarInt.readVLong(hbi);
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadVLongTruncatedHollowBlobInput() throws IOException {
+        HollowBlobInput hbi = HollowBlobInput.serial(BYTES_TRUNCATED);
+
+        VarInt.readVLong(hbi);
+    }
+
+    @Test
+    public void testReadVIntHollowBlobInput() throws IOException {
+        HollowBlobInput hbi = HollowBlobInput.serial(BYTES_VALUE_129);
+
+        Assert.assertEquals(129l, VarInt.readVInt(hbi));
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadVIntEmptyHollowBlobInput() throws IOException {
+        HollowBlobInput hbi = HollowBlobInput.serial(BYTES_EMPTY);
+
+        VarInt.readVInt(hbi);
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadVIntTruncatedHollowBlobInput() throws IOException {
+        HollowBlobInput hbi = HollowBlobInput.serial(BYTES_TRUNCATED);
+
+        VarInt.readVInt(hbi);
+    }
+}


### PR DESCRIPTION
If ```InputStream/HollowBlobInput``` ends abruptly, in the middle for the VarInt record, throw EOFException, instead of going into the infinite loop. 

See https://github.com/Netflix/hollow/issues/536