### PR TITLE
Bug fix for firing announcement with read state in producer listener

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ProducerListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ProducerListenerSupport.java
@@ -286,6 +286,8 @@ final class ProducerListenerSupport extends ListenerSupport {
             long version = readState.getVersion();
             fire(AnnouncementListener.class,
                     l -> l.onAnnouncementStart(version));
+            fire(AnnouncementListener.class,
+                    l -> l.onAnnouncementStart(readState));
 
             return new Status.StageWithStateBuilder().readState(readState);
         }

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerListenerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerListenerTest.java
@@ -297,8 +297,10 @@ public class HollowProducerListenerTest {
 
         producer.runCycle(ws -> ws.add(new Top(1)));
 
-        Assert.assertTrue(ls.callCount.values().stream().allMatch(c -> c == 1));
+        Assert.assertTrue(ls.callCount.entrySet().stream().filter(c -> !c.getKey().equals("onAnnouncementStart")).allMatch(c -> c.getValue() == 1));
+        Assert.assertEquals(ls.callCount.get("onAnnouncementStart").intValue(), 2);
         Assert.assertEquals(16, ls.callCount.size());
+
     }
 
 

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/ProducerListenerSupportTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/ProducerListenerSupportTest.java
@@ -306,5 +306,7 @@ public class ProducerListenerSupportTest {
         Mockito.doThrow(RuntimeException.class).when(listener).onAnnouncementStart(version);
         listenerSupport.listeners().fireAnnouncementStart(readState);
         Mockito.verify(listener).onAnnouncementStart(version);
+        Mockito.verify(listener).onAnnouncementStart(readState);
     }
+    
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/ProducerListenerSupportTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/ProducerListenerSupportTest.java
@@ -297,7 +297,6 @@ public class ProducerListenerSupportTest {
         Mockito.verify(listener).onIntegrityCheckStart(version);
     }
 
-
     @Test
     public void fireAnnouncementStartDontStopWhenOneFails() {
         long version = 31337;
@@ -308,5 +307,4 @@ public class ProducerListenerSupportTest {
         Mockito.verify(listener).onAnnouncementStart(version);
         Mockito.verify(listener).onAnnouncementStart(readState);
     }
-    
 }


### PR DESCRIPTION
Used a debugger to check if the "listener.onAnnouncementStart(readState))" call is getting fired.