### PR TITLE
Fix: Track current and previous cycle start times to set the right value in blob header

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -358,9 +358,6 @@ abstract class AbstractHollowProducer {
             // 1a. Prepare the write state
             writeEngine.prepareForNextCycle();
 
-            // save timestamp in ms of when cycle starts
-            writeEngine.addHeaderTag(HollowStateEngine.HEADER_TAG_METRIC_CYCLE_START, String.valueOf(System.currentTimeMillis()));
-
             // 2. Populate the state
             populate(listeners, incrementalPopulator, populator, toVersion);
 

--- a/hollow/src/main/java/com/netflix/hollow/core/HollowBlobHeader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowBlobHeader.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 /**
  * Represents the header of a serialized blob.  A blob header contains the following elements:  
@@ -44,11 +45,12 @@ public class HollowBlobHeader {
 
     public static final int HOLLOW_BLOB_VERSION_HEADER = 1030;
 
-    private Map<String, String> headerTags = new HashMap<String, String>();
-    private List<HollowSchema> schemas = new ArrayList<HollowSchema>();
+    private Map<String, String> headerTags = new HashMap<>();
+    private List<HollowSchema> schemas = new ArrayList<>();
     private long originRandomizedTag;
     private long destinationRandomizedTag;
     private int blobFormatVersion = HOLLOW_BLOB_VERSION_HEADER;
+    private OptionalLong cycleStartTsTag = OptionalLong.empty();
 
     public Map<String, String> getHeaderTags() {
         return headerTags;
@@ -88,6 +90,14 @@ public class HollowBlobHeader {
 
     public int getBlobFormatVersion() {
         return blobFormatVersion;
+    }
+
+    public void setCycleStartTsTag(long cycleStartTs) {
+        this.cycleStartTsTag = OptionalLong.of(cycleStartTs);
+    }
+
+    public OptionalLong getCycleStartTsTag() {
+        return cycleStartTsTag;
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
@@ -193,10 +193,16 @@ public class HollowWriteStateCreator {
         
         writeEngine.addHeaderTags(readEngine.getHeaderTags());
         writeEngine.overrideNextStateRandomizedTag(readEngine.getCurrentRandomizedTag());
-        if (readEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START) != null) {
-            writeEngine.overrideCycleStartTs(Long.valueOf(
-                    readEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START)));
+
+        // override current cycle start time
+        writeEngine.overrideCycleStartTs(System.currentTimeMillis());
+
+        // set previousCycleStartTs to the restored read state's cycle time
+        String readStateCycleStartTs = readEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START);
+        if (readStateCycleStartTs != null) {
+            writeEngine.overridePreviousCycleStartTs(Long.valueOf(readStateCycleStartTs));
         }
+
         writeEngine.prepareForWrite();
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
@@ -16,6 +16,8 @@
  */
 package com.netflix.hollow.core.util;
 
+import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_METRIC_CYCLE_START;
+
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
@@ -191,6 +193,10 @@ public class HollowWriteStateCreator {
         
         writeEngine.addHeaderTags(readEngine.getHeaderTags());
         writeEngine.overrideNextStateRandomizedTag(readEngine.getCurrentRandomizedTag());
+        if (readEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START) != null) {
+            writeEngine.overrideCycleStartTs(Long.valueOf(
+                    readEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START)));
+        }
         writeEngine.prepareForWrite();
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobHeaderWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobHeaderWriter.java
@@ -16,6 +16,8 @@
  */
 package com.netflix.hollow.core.write;
 
+import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_METRIC_CYCLE_START;
+
 import com.netflix.hollow.core.HollowBlobHeader;
 import com.netflix.hollow.core.HollowBlobOptionalPartHeader;
 import com.netflix.hollow.core.memory.encoding.VarInt;
@@ -55,7 +57,10 @@ public class HollowBlobHeaderWriter {
         ///backwards compatibility -- new data can be added here by first indicating number of bytes used, will be skipped by existing readers.
         VarInt.writeVInt(dos, 0);
 
-        /// write the header tags -- intended to include input source data versions
+        // add header tag for cycle start timestamp
+        header.getCycleStartTsTag().ifPresent(t -> header.getHeaderTags().put(HEADER_TAG_METRIC_CYCLE_START, String.valueOf(t)));
+
+        /// write the header tags -- for eg. custom tags indicating input source data versions
         dos.writeShort(header.getHeaderTags().size());
 
         for (Map.Entry<String, String> headerTag : header.getHeaderTags().entrySet()) {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
@@ -280,13 +280,17 @@ public class HollowBlobWriter {
 
         /// write main header
         HollowBlobHeader header = new HollowBlobHeader();
-        header.setHeaderTags(stateEngine.getHeaderTags());
+        header.getHeaderTags().putAll(stateEngine.getHeaderTags());
         if(isReverseDelta) {
             header.setOriginRandomizedTag(stateEngine.getNextStateRandomizedTag());
             header.setDestinationRandomizedTag(stateEngine.getPreviousStateRandomizedTag());
+            // cycle start time on reverse delta from v1 to v0 is the cycle start time of v0
+            stateEngine.getPreviousCycleStartTs().ifPresent(t -> header.setCycleStartTsTag(t));
         } else {
             header.setOriginRandomizedTag(stateEngine.getPreviousStateRandomizedTag());
             header.setDestinationRandomizedTag(stateEngine.getNextStateRandomizedTag());
+            // cycle start time on delta from v0 to v1 is the cycle start time of v1
+            stateEngine.getCycleStartTs().ifPresent(t -> header.setCycleStartTsTag(t));
         }
         header.setSchemas(mainSchemas);
         headerWriter.writeHeader(header, os);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
@@ -280,7 +280,7 @@ public class HollowBlobWriter {
 
         /// write main header
         HollowBlobHeader header = new HollowBlobHeader();
-        header.getHeaderTags().putAll(stateEngine.getHeaderTags());
+        header.getHeaderTags().putAll(stateEngine.getHeaderTags()); // make a deep copy
         if(isReverseDelta) {
             header.setOriginRandomizedTag(stateEngine.getNextStateRandomizedTag());
             header.setDestinationRandomizedTag(stateEngine.getPreviousStateRandomizedTag());

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
@@ -65,7 +65,7 @@ public class HollowWriteStateEngine implements HollowStateEngine {
     private final Map<String, HollowTypeWriteState> writeStates;
     private final Map<String, HollowSchema> hollowSchemas;
     private final List<HollowTypeWriteState> orderedTypeStates;
-    private final Map<String,String> headerTags = new ConcurrentHashMap<String, String>();
+    private final Map<String,String> headerTags = new ConcurrentHashMap<>();
     private final HollowObjectHashCodeFinder hashCodeFinder;
     
     //// target a maximum shard size to reduce excess memory pool requirement 
@@ -284,8 +284,11 @@ public class HollowWriteStateEngine implements HollowStateEngine {
         
         /// recreate a new randomized tag, to avoid any potential conflict with aborted versions
         nextStateRandomizedTag = mintNewRandomizedStateTag();
+
+        /// re-assign cycle start time but preserve previousCycleStartTs
+        cycleStartTs = OptionalLong.of(System.currentTimeMillis());
+
         preparedForNextCycle = true;
-        
     }
 
     /**

--- a/hollow/src/main/java/com/netflix/hollow/tools/patch/delta/HollowStateDeltaPatcher.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/patch/delta/HollowStateDeltaPatcher.java
@@ -107,8 +107,7 @@ public class HollowStateDeltaPatcher {
     public void prepareInitialTransition() {
         writeEngine.overridePreviousStateRandomizedTag(from.getCurrentRandomizedTag());
         if (from.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START) != null) {
-            writeEngine.overridePreviousCycleStartTs(Long.valueOf(
-                    from.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START)));
+            writeEngine.overridePreviousCycleStartTs(Long.valueOf(from.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START)));
         }
         copyUnchangedDataToIntermediateState();
         remapTheChangedDataToUnusedOrdinals();

--- a/hollow/src/main/java/com/netflix/hollow/tools/patch/delta/HollowStateDeltaPatcher.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/patch/delta/HollowStateDeltaPatcher.java
@@ -16,6 +16,8 @@
  */
 package com.netflix.hollow.tools.patch.delta;
 
+import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_METRIC_CYCLE_START;
+
 import com.netflix.hollow.core.memory.ThreadSafeBitSet;
 import com.netflix.hollow.core.read.HollowReadFieldUtils;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
@@ -104,6 +106,10 @@ public class HollowStateDeltaPatcher {
      */
     public void prepareInitialTransition() {
         writeEngine.overridePreviousStateRandomizedTag(from.getCurrentRandomizedTag());
+        if (from.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START) != null) {
+            writeEngine.overridePreviousCycleStartTs(Long.valueOf(
+                    from.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START)));
+        }
         copyUnchangedDataToIntermediateState();
         remapTheChangedDataToUnusedOrdinals();
     }

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListenerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListenerTest.java
@@ -1,5 +1,6 @@
 package com.netflix.hollow.api.producer.metrics;
 
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import com.netflix.hollow.api.producer.HollowProducer;
@@ -45,7 +46,7 @@ public class AbstractProducerMetricsListenerTest {
         final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
             @Override
             public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
-                Assert.assertNotNull(cycleMetrics);
+                assertNotNull(cycleMetrics);
                 Assert.assertEquals(0l, cycleMetrics.getConsecutiveFailures());
                 Assert.assertEquals(Optional.empty(), cycleMetrics.getIsCycleSuccess());
                 Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getCycleDurationMillis());
@@ -61,7 +62,7 @@ public class AbstractProducerMetricsListenerTest {
         final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
             @Override
             public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
-                Assert.assertNotNull(cycleMetrics);
+                assertNotNull(cycleMetrics);
                 Assert.assertEquals(0l, cycleMetrics.getConsecutiveFailures());
                 Assert.assertEquals(Optional.empty(), cycleMetrics.getIsCycleSuccess());
                 Assert.assertEquals(OptionalLong.empty(), cycleMetrics.getCycleDurationMillis());
@@ -78,7 +79,7 @@ public class AbstractProducerMetricsListenerTest {
         final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
             @Override
             public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
-                Assert.assertNotNull(cycleMetrics);
+                assertNotNull(cycleMetrics);
                 Assert.assertEquals(0l, cycleMetrics.getConsecutiveFailures());
                 Assert.assertEquals(Optional.of(true), cycleMetrics.getIsCycleSuccess());
                 Assert.assertEquals(OptionalLong.of(TEST_CYCLE_DURATION_MILLIS.toMillis()), cycleMetrics.getCycleDurationMillis());
@@ -98,7 +99,7 @@ public class AbstractProducerMetricsListenerTest {
         final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
             @Override
             public void cycleMetricsReporting(CycleMetrics cycleMetrics) {
-                Assert.assertNotNull(cycleMetrics);
+                assertNotNull(cycleMetrics);
                 Assert.assertEquals(1l, cycleMetrics.getConsecutiveFailures());
                 Assert.assertEquals(Optional.of(false), cycleMetrics.getIsCycleSuccess());
                 Assert.assertEquals(OptionalLong.of(TEST_CYCLE_DURATION_MILLIS.toMillis()), cycleMetrics.getCycleDurationMillis());
@@ -117,7 +118,7 @@ public class AbstractProducerMetricsListenerTest {
         final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
             @Override
             public void announcementMetricsReporting(AnnouncementMetrics announcementMetrics) {
-                Assert.assertNotNull(announcementMetrics);
+                assertNotNull(announcementMetrics);
                 Assert.assertEquals(TEST_DATA_SIZE, announcementMetrics.getDataSizeBytes());
                 Assert.assertEquals(true, announcementMetrics.getIsAnnouncementSuccess());
                 Assert.assertEquals(TEST_ANNOUNCEMENT_DURATION_MILLIS,
@@ -139,7 +140,7 @@ public class AbstractProducerMetricsListenerTest {
         final class TestProducerMetricsListener extends AbstractProducerMetricsListener {
             @Override
             public void announcementMetricsReporting(AnnouncementMetrics announcementMetrics) {
-                Assert.assertNotNull(announcementMetrics);
+                assertNotNull(announcementMetrics);
                 Assert.assertEquals(TEST_DATA_SIZE, announcementMetrics.getDataSizeBytes());
                 Assert.assertFalse(announcementMetrics.getIsAnnouncementSuccess());
                 Assert.assertEquals(TEST_ANNOUNCEMENT_DURATION_MILLIS,

--- a/hollow/src/test/java/com/netflix/hollow/core/util/HollowWriteStateCreatorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/util/HollowWriteStateCreatorTest.java
@@ -16,6 +16,11 @@
  */
 package com.netflix.hollow.core.util;
 
+import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_METRIC_CYCLE_START;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
@@ -38,14 +43,33 @@ public class HollowWriteStateCreatorTest {
         HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
         mapper.add(new Integer(1));
         writeEngine.addHeaderTag("CopyTag", "copied");
-        
+
         HollowReadStateEngine readEngine = StateEngineRoundTripper.roundTripSnapshot(writeEngine);
+        String cycleStartTime = readEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START);
+
         HollowWriteStateEngine recreatedWriteEngine = HollowWriteStateCreator.recreateAndPopulateUsingReadEngine(readEngine);
         HollowReadStateEngine recreatedReadEngine = StateEngineRoundTripper.roundTripSnapshot(recreatedWriteEngine);
         
-        Assert.assertEquals(HollowChecksum.forStateEngine(readEngine), HollowChecksum.forStateEngine(recreatedReadEngine));
-        Assert.assertEquals("copied", recreatedReadEngine.getHeaderTag("CopyTag"));
-        Assert.assertEquals(readEngine.getCurrentRandomizedTag(), recreatedReadEngine.getCurrentRandomizedTag());
+        assertEquals(HollowChecksum.forStateEngine(readEngine), HollowChecksum.forStateEngine(recreatedReadEngine));
+        assertEquals("copied", recreatedReadEngine.getHeaderTag("CopyTag"));
+        assertEquals(readEngine.getCurrentRandomizedTag(), recreatedReadEngine.getCurrentRandomizedTag());
+        assertEquals(cycleStartTime, recreatedReadEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START));
+
+    }
+
+    @Test
+    public void recreatesUsingReadEngine_backwardsCompatible_cycleStartTimeNotSet() throws IOException {
+        // cycle start time header was not set on original read state
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+
+        HollowReadStateEngine readEngine = StateEngineRoundTripper.roundTripSnapshot(writeEngine);
+        readEngine.getHeaderTags().remove(HEADER_TAG_METRIC_CYCLE_START);
+
+        HollowWriteStateEngine recreatedWriteEngine = HollowWriteStateCreator.recreateAndPopulateUsingReadEngine(readEngine);
+        HollowReadStateEngine recreatedReadEngine = StateEngineRoundTripper.roundTripSnapshot(recreatedWriteEngine);
+
+        assertNotNull(recreatedReadEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START));
+
     }
     
     @Test
@@ -84,16 +108,16 @@ public class HollowWriteStateCreatorTest {
         HollowReadStateEngine recreatedReadEngine = StateEngineRoundTripper.roundTripSnapshot(repopulatedWriteStateEngine);
         
         GenericHollowObject one = new GenericHollowObject(recreatedReadEngine, "Integer", 0);
-        Assert.assertEquals(1, one.getInt("value"));
-        Assert.assertNull(one.getString("anotherValue"));
+        assertEquals(1, one.getInt("value"));
+        assertNull(one.getString("anotherValue"));
         
         GenericHollowObject two = new GenericHollowObject(recreatedReadEngine, "Integer", 1);
-        Assert.assertEquals(2, two.getInt("value"));
-        Assert.assertNull(two.getString("anotherValue"));
+        assertEquals(2, two.getInt("value"));
+        assertNull(two.getString("anotherValue"));
         
         GenericHollowObject three = new GenericHollowObject(recreatedReadEngine, "Integer", 2);
-        Assert.assertEquals(3, three.getInt("value"));
-        Assert.assertEquals("3", three.getString("anotherValue"));
+        assertEquals(3, three.getInt("value"));
+        assertEquals("3", three.getString("anotherValue"));
     }
     
     @Test
@@ -118,17 +142,17 @@ public class HollowWriteStateCreatorTest {
 
         HollowObjectSchema schema = (HollowObjectSchema)recreatedReadEngine.getSchema("Integer");
         
-        Assert.assertEquals(1, schema.numFields());
-        Assert.assertEquals("value", schema.getFieldName(0));
+        assertEquals(1, schema.numFields());
+        assertEquals("value", schema.getFieldName(0));
         
         GenericHollowObject one = new GenericHollowObject(recreatedReadEngine, "Integer", 0);
-        Assert.assertEquals(1, one.getInt("value"));
+        assertEquals(1, one.getInt("value"));
         
         GenericHollowObject two = new GenericHollowObject(recreatedReadEngine, "Integer", 1);
-        Assert.assertEquals(2, two.getInt("value"));
+        assertEquals(2, two.getInt("value"));
         
         GenericHollowObject three = new GenericHollowObject(recreatedReadEngine, "Integer", 2);
-        Assert.assertEquals(3, three.getInt("value"));
+        assertEquals(3, three.getInt("value"));
     }
     
     @Test
@@ -153,9 +177,9 @@ public class HollowWriteStateCreatorTest {
     @Test
     public void testReadSchemaFileIntoWriteState() throws Exception {
         HollowWriteStateEngine engine = new HollowWriteStateEngine();
-        Assert.assertEquals("Should have no type states", 0, engine.getOrderedTypeStates().size());
+        assertEquals("Should have no type states", 0, engine.getOrderedTypeStates().size());
         HollowWriteStateCreator.readSchemaFileIntoWriteState("schema1.txt", engine);
-        Assert.assertEquals("Should now have types", 2, engine.getOrderedTypeStates().size());
+        assertEquals("Should now have types", 2, engine.getOrderedTypeStates().size());
     }
     
     @SuppressWarnings("unused")

--- a/hollow/src/test/java/com/netflix/hollow/core/util/HollowWriteStateCreatorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/util/HollowWriteStateCreatorTest.java
@@ -31,6 +31,7 @@ import com.netflix.hollow.core.write.objectmapper.HollowShardLargeType;
 import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
 import com.netflix.hollow.tools.checksum.HollowChecksum;
 import java.io.IOException;
+import java.util.OptionalLong;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -48,12 +49,14 @@ public class HollowWriteStateCreatorTest {
         String cycleStartTime = readEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START);
 
         HollowWriteStateEngine recreatedWriteEngine = HollowWriteStateCreator.recreateAndPopulateUsingReadEngine(readEngine);
+        // use cycle start time of read state to initialize previous cycle time of new write state
+        assertEquals(OptionalLong.of(Long.valueOf(cycleStartTime)), recreatedWriteEngine.getPreviousCycleStartTs());
+
         HollowReadStateEngine recreatedReadEngine = StateEngineRoundTripper.roundTripSnapshot(recreatedWriteEngine);
         
         assertEquals(HollowChecksum.forStateEngine(readEngine), HollowChecksum.forStateEngine(recreatedReadEngine));
         assertEquals("copied", recreatedReadEngine.getHeaderTag("CopyTag"));
         assertEquals(readEngine.getCurrentRandomizedTag(), recreatedReadEngine.getCurrentRandomizedTag());
-        assertEquals(cycleStartTime, recreatedReadEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START));
 
     }
 


### PR DESCRIPTION
Cycle start time is set by the producer in the blob headers, using local time in milliseconds, corresponding to the write state creation. Consumers rely on this value to compute a metric for measuring data staleness- time elapsed since cycle started on the producer.

The earlier implementation always injected the start time of the current runCycle into the blob header. This was problematic for reverse deltas since the reverse delta from v1 to v0 is created in runcycle corresponding to v1 and thus contained the start time for v1 runcycle. Instead, the reverse detla header should contain the start time corresponding to v0 cycle, so that consumers can accurately compute staleness when they transition to v0 state by following reverse delta from v1 to v0.

In the reworked implementation, previous cycle start time is tracked in the write state engine and thats set on the reverse delta.