### PR TITLE
Throw a more specific NotAPrimaryProducerException for failures due t…

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -607,7 +607,7 @@ abstract class AbstractHollowProducer {
             if (!blob.type.equals(HollowProducer.Blob.Type.SNAPSHOT)) {
                 // Don't allow producer to enable/disable between validating primary status and publishing for delta
                 // or reverse delta blobs. No need to check for primary status when publishing snapshots because a
-                // snapshot publishby a non-primary producer would be harmless, and the wasted effort is justified
+                // snapshot publish by a non-primary producer would be harmless, and the wasted effort is justified
                 // by the shorter wait for a call to release the primary status when artifacts are being published.
                 try {
                     singleProducerEnforcer.lock();
@@ -617,7 +617,7 @@ abstract class AbstractHollowProducer {
                         // producer instance could have been running concurrently as primary and that could break the delta chain.
                         log.log(Level.INFO,
                                 "Publish failed because current producer is not primary (aka leader)");
-                        throw new IllegalStateException("Publish failed primary (aka leader) check");
+                        throw new HollowProducer.NotPrimaryMidCycleException("Publish failed primary (aka leader) check");
                     }
                     publishBlob(blob);
                 } finally {
@@ -837,7 +837,7 @@ abstract class AbstractHollowProducer {
                         // have been running concurrently as primary and that would break the delta chain.
                         log.log(Level.INFO,
                                 "Fail the announcement because current producer is not primary (aka leader)");
-                        throw new IllegalStateException("Announcement failed primary (aka leader) check");
+                        throw new HollowProducer.NotPrimaryMidCycleException("Announcement failed primary (aka leader) check");
                     }
                     announcer.announce(readState.getVersion(), readState.getStateEngine().getHeaderTags());
                 } finally {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -333,6 +333,15 @@ public class HollowProducer extends AbstractHollowProducer {
             super(type.name() + " checksum invalid");
         }
     }
+    /**
+     * This exception is thrown when a publishing producer for the current cycle is not primary.
+     * */
+    public static final class NotPrimaryMidCycleException extends IllegalStateException {
+
+        NotPrimaryMidCycleException(String message) {
+            super(message);
+        }
+    }
 
     public interface VersionMinter {
         /**

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
@@ -160,6 +160,7 @@ public class HollowProducerTest {
                 ws.add(2);
             });
         } catch (IllegalStateException e) {
+            Assert.assertTrue(e instanceof HollowProducer.NotPrimaryMidCycleException);
             Assert.assertEquals("Publish failed primary (aka leader) check", e.getMessage());
             return;
         }
@@ -179,7 +180,7 @@ public class HollowProducerTest {
             producer.runCycle(ws -> {
                 ws.add(1);
             });
-        } catch (IllegalStateException e) {
+        } catch (HollowProducer.NotPrimaryMidCycleException e) {
             Assert.assertEquals("Announcement failed primary (aka leader) check", e.getMessage());
             return;
         }


### PR DESCRIPTION
…o producer failing primary producer check. Under majority of cases, primary producer check failures are transient and do not require any action by App teams. This will be helpful in setting more relevant alerts.