### PR TITLE
Add null check for when type didn't exist in a historic state

### DIFF
--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/model/HistoryStateQueryMatches.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/model/HistoryStateQueryMatches.java
@@ -76,6 +76,9 @@ public class HistoryStateQueryMatches {
 
             
             HollowHistoricalStateTypeKeyOrdinalMapping typeKeyMapping = historicalState.getKeyOrdinalMapping().getTypeMapping(type);
+            if (typeKeyMapping == null) {
+                return;
+            }
             HollowObjectTypeDataAccess typeDataAccess = (HollowObjectTypeDataAccess) historicalState.getDataAccess().getTypeDataAccess(type);
 
             for(int i=0;i<queryMatchingKeys.size();i++) {


### PR DESCRIPTION
To fix NPE when searching across a type that was recently added