### PR TITLE
[DO NOT MERGE] Report per-type added/removed ordinal count in announcement metadata

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -42,6 +42,7 @@ import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.util.HollowWriteStateCreator;
 import com.netflix.hollow.core.write.HollowBlobWriter;
+import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import com.netflix.hollow.core.write.objectmapper.RecordPrimaryKey;
@@ -50,8 +51,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -839,7 +843,12 @@ abstract class AbstractHollowProducer {
                                 "Fail the announcement because current producer is not primary (aka leader)");
                         throw new HollowProducer.NotPrimaryMidCycleException("Announcement failed primary (aka leader) check");
                     }
-                    announcer.announce(readState.getVersion(), readState.getStateEngine().getHeaderTags());
+
+                    Map<String, String> announceTags = new HashMap();
+                    announceTags.putAll(changeCounts(getWriteEngine()));                // change counts
+                    announceTags.putAll(readState.getStateEngine().getHeaderTags());    // blob headers
+
+                    announcer.announce(readState.getVersion(), announceTags);
                 } finally {
                     singleProducerEnforcer.unlock();
                 }
@@ -851,6 +860,35 @@ abstract class AbstractHollowProducer {
                 listeners.fireAnnouncementComplete(status);
             }
         }
+    }
+
+    public Map<String, String> changeCounts(HollowWriteStateEngine writeStateEngine) {
+        OptionalLong totalAdded = OptionalLong.empty();
+        OptionalLong totalRemoved = OptionalLong.empty();
+        Map<String, String> changeCounts = new HashMap();
+
+        for (HollowTypeWriteState typeState : writeStateEngine.getOrderedTypeStates()) {
+            if (typeState.getDeltaAddedOrdinalCount().isPresent()) {
+                int added = typeState.getDeltaAddedOrdinalCount().getAsInt();
+                changeCounts.put("hollow.ordinals.added.type." + typeState.getSchema().getName(),
+                        String.valueOf(added));
+                totalAdded = OptionalLong.of(totalAdded.isPresent()
+                        ? (totalAdded.getAsLong() + added)
+                        : added);
+            }
+            if (typeState.getDeltaRemovedOrdinalCount().isPresent()) {
+                int removed = typeState.getDeltaRemovedOrdinalCount().getAsInt();
+                changeCounts.put("hollow.ordinals.removed.type." + typeState.getSchema().getName(),
+                        String.valueOf(removed));
+                totalRemoved = OptionalLong.of(totalRemoved.isPresent()
+                        ? (totalRemoved.getAsLong() + removed)
+                        : removed);
+            }
+        }
+        totalAdded.ifPresent(v -> changeCounts.put("hollow.ordinals.added.total", String.valueOf(v)));
+        totalRemoved.ifPresent(v -> changeCounts.put("hollow.ordinals.removed.total", String.valueOf(v)));
+
+        return changeCounts;
     }
 
     static final class Artifacts {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -32,6 +32,7 @@ import com.netflix.hollow.core.write.copy.HollowRecordCopier;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.BitSet;
+import java.util.OptionalInt;
 
 /**
  * The {@link HollowTypeWriteState} contains and is the root handle to all of the records of a specific type in
@@ -51,6 +52,18 @@ public abstract class HollowTypeWriteState {
 
     protected ThreadSafeBitSet currentCyclePopulated;
     protected ThreadSafeBitSet previousCyclePopulated;
+
+    /// a modification is counted as 1 ordinal added and 1 ordinal removed
+    protected OptionalInt deltaAddedOrdinalCount = OptionalInt.empty();
+    protected OptionalInt deltaRemovedOrdinalCount = OptionalInt.empty();
+
+    public OptionalInt getDeltaAddedOrdinalCount() {
+        return deltaAddedOrdinalCount;
+    }
+
+    public OptionalInt getDeltaRemovedOrdinalCount() {
+        return deltaRemovedOrdinalCount;
+    }
 
     private final ThreadLocal<ByteDataArray> serializedScratchSpace;
 
@@ -262,6 +275,9 @@ public abstract class HollowTypeWriteState {
         restoredMap = null;
         restoredSchema = null;
         restoredReadState = null;
+
+        deltaAddedOrdinalCount = OptionalInt.empty();
+        deltaRemovedOrdinalCount = OptionalInt.empty();
     }
 
     public void prepareForWrite() {


### PR DESCRIPTION
Seeking feedback on this approach for reporting some measure of entropy from the producer side (applicable for Producer and IncrementalProducer alike) and without incurring much computation overhead (as opposed to adding a listener that iterates over data using DataAccessor to get record change counts). 

This could be useful for-
* powering alerts on too many changes in a rolling time window without having to spin up a consumer or custom producer side computation
* reporting per-type change counts to power some history/diff views solely from metadata (without requiring a consumer for downloading data)

Some design considerations:
* Ordinal added/removed counts are computationally cheap since they are available during delta computation but less useful as compared to record-level add/remove/modify counts which are readily available for IncrementalProducers and can be computed by producers/consumers for types with primary keys using DataAccessor.
* Reporting per-type ordinals added and ordinals removed counts and a writestate-level total additions and total removal count (refer screenshot)
* Reporting on the announcement metadata. This is convenient, since the counts are generated during delta generation and delta blob header has already been written at that point.
* Only reported when delta is computed

Tests yet to be written.

<img width="1058" alt="Screen Shot 2021-09-29 at 8 28 59 AM" src="https://user-images.githubusercontent.com/5712247/135302837-e5e69203-e8b0-4b6b-b4b2-dfa225463d14.png">

