### PR TITLE
Adding two new generated API styles

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowAPIFactory.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowAPIFactory.java
@@ -77,7 +77,12 @@ public interface HollowAPIFactory {
                 Constructor<T> constructor = generatedAPIClass.getConstructor(HollowDataAccess.class, Set.class);
                 return constructor.newInstance(dataAccess, cachedTypes);
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                try {
+                    Constructor<T> constructor = generatedAPIClass.getConstructor(HollowDataAccess.class);
+                    return constructor.newInstance(dataAccess);
+                } catch(Exception e2) {
+                    throw new RuntimeException(e2);
+                }
             }
         }
 
@@ -87,7 +92,12 @@ public interface HollowAPIFactory {
                 Constructor<T> constructor = generatedAPIClass.getConstructor(HollowDataAccess.class, Set.class, Map.class, generatedAPIClass);
                 return constructor.newInstance(dataAccess, cachedTypes, Collections.emptyMap(), previousCycleAPI);
             } catch(Exception e) {
-                throw new RuntimeException(e);
+                try {
+                    Constructor<T> constructor = generatedAPIClass.getConstructor(HollowDataAccess.class);
+                    return constructor.newInstance(dataAccess);
+                } catch(Exception e2) {
+                    throw new RuntimeException(e2);
+                }
             }
         }
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowObjectTypePerfAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowObjectTypePerfAPIClassGenerator.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen.perfapi;
+
+import com.netflix.hollow.api.codegen.HollowCodeGenerationUtils;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import java.util.Set;
+
+class HollowObjectTypePerfAPIClassGenerator {
+
+    private final HollowObjectSchema schema;
+    private final String packageName;
+    private final Set<String> checkFieldExistsMethods;
+
+    public HollowObjectTypePerfAPIClassGenerator(HollowObjectSchema schema, String packageName, Set<String> checkFieldExistsMethods) {
+        this.schema = schema;
+        this.packageName = packageName;
+        this.checkFieldExistsMethods = checkFieldExistsMethods;
+    }
+
+    public String generate() {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("package " + packageName + ";\n\n");
+
+        builder.append("import com.netflix.hollow.api.perfapi.HollowObjectTypePerfAPI;\n" +
+                "import com.netflix.hollow.api.perfapi.HollowPerformanceAPI;\n" +
+                "import com.netflix.hollow.api.perfapi.Ref;\n" +
+                "import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;\n\n");
+
+        builder.append("public class " + schema.getName() + "PerfAPI extends HollowObjectTypePerfAPI {\n\n");
+
+        builder.append("    public static final String fieldNames[] = { ");
+        for(int i=0;i<schema.numFields();i++) {
+            if(i > 0)
+                builder.append(", ");
+            builder.append("\"" + schema.getFieldName(i) + "\"");
+        }
+
+        builder.append(" };\n\n");
+
+        builder.append("    public " + schema.getName() + "PerfAPI(HollowDataAccess dataAccess, String typeName, HollowPerformanceAPI api) {\n");
+        builder.append("        super(dataAccess, typeName, api, fieldNames);\n");
+        builder.append("    }\n\n");
+
+        for(int i=0;i<schema.numFields();i++) {
+            FieldType fieldType = schema.getFieldType(i);
+            String fieldName = schema.getFieldName(i);
+            String referencedType = schema.getReferencedType(i);
+            appendFieldMethod(builder, fieldType, fieldName, i, referencedType);
+        }
+
+        builder.append("}");
+
+        return builder.toString();
+    }
+
+    public void appendFieldMethod(StringBuilder builder, FieldType fieldType, String fieldName, int fieldIdx, String referencedType) {
+        String type = fieldType.name();
+        if(fieldType == FieldType.REFERENCE)
+            type += " (" + referencedType + ")";
+
+        builder.append("    /**\n" +
+                "     * <i>"+schema.getName() + "." + fieldName +"</i><br/>\n" +
+                "     * <b>" + type + "</b>\n" +
+                "     */\n");
+
+        switch(fieldType) {
+            case INT:
+                builder.append("    public int get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "(long ref) {\n");
+                builder.append("        return typeAccess.readInt(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("    }\n\n");
+
+                builder.append("    public Integer get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "Boxed(long ref) {\n");
+                builder.append("        int val = typeAccess.readInt(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("        if(val == Integer.MIN_VALUE)\n");
+                builder.append("            return null;\n");
+                builder.append("        return val;\n");
+                builder.append("    }\n\n");
+                break;
+            case LONG:
+                builder.append("    public long get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "(long ref) {\n");
+                builder.append("        return typeAccess.readLong(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("    }\n\n");
+
+                builder.append("    public Long get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "Boxed(long ref) {\n");
+                builder.append("        long val = typeAccess.readLong(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("        if(val == Long.MIN_VALUE)\n");
+                builder.append("            return null;\n");
+                builder.append("        return val;\n");
+                builder.append("    }\n\n");
+                break;
+            case FLOAT:
+                builder.append("    public float get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "(long ref) {\n");
+                builder.append("        return typeAccess.readFloat(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("    }\n\n");
+
+                builder.append("    public Float get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "Boxed(long ref) {\n");
+                builder.append("        float val = typeAccess.readFloat(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("        if(Float.isNaN(val))\n");
+                builder.append("            return null;\n");
+                builder.append("        return val;\n");
+                builder.append("    }\n\n");
+                break;
+            case DOUBLE:
+                builder.append("    public double get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "(long ref) {\n");
+                builder.append("        return typeAccess.readDouble(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("    }\n\n");
+
+                builder.append("    public Double get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "Boxed(long ref) {\n");
+                builder.append("        double val = typeAccess.readDouble(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("        if(Double.isNaN(val))\n");
+                builder.append("            return null;\n");
+                builder.append("        return val;\n");
+                builder.append("    }\n\n");
+                break;
+            case BOOLEAN:
+                builder.append("    public boolean get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "(long ref) {\n");
+                builder.append("        return Boolean.TRUE.equals(typeAccess.readBoolean(ordinal(ref), fieldIdx[" + fieldIdx + "]));\n");
+                builder.append("    }\n\n");
+
+                builder.append("    public Boolean get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "Boxed(long ref) {\n");
+                builder.append("        return typeAccess.readBoolean(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("    }\n\n");
+                break;
+            case STRING:
+                builder.append("    public String get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "(long ref) {\n");
+                builder.append("        return typeAccess.readString(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("    }\n\n");
+
+                builder.append("    public boolean is" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "Equal(long ref, String testValue) {\n");
+                builder.append("        return typeAccess.isStringFieldEqual(ordinal(ref), fieldIdx[" + fieldIdx + "], testValue);\n");
+                builder.append("    }\n\n");
+                break;
+            case BYTES:
+                builder.append("    public byte[] get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "(long ref) {\n");
+                builder.append("        return typeAccess.readBytes(ordinal(ref), fieldIdx[" + fieldIdx + "]);\n");
+                builder.append("    }\n\n");
+                break;
+            case REFERENCE:
+                builder.append("    public long get" + HollowCodeGenerationUtils.upperFirstChar(fieldName) + "Ref(long ref) {\n");
+                builder.append("        return Ref.toRefWithTypeMasked(refMaskedTypeIdx[" + fieldIdx + "], typeAccess.readOrdinal(ordinal(ref), fieldIdx[" + fieldIdx + "]));\n");
+                builder.append("    }\n\n");
+                break;
+        }
+        
+        if(checkFieldExistsMethods.contains(schema.getName() + "." + fieldName)) {
+            builder.append("    public boolean " + fieldName + "FieldExists() {\n");
+            builder.append("        return fieldIdx[" + fieldIdx + "] != -1;\n");
+            builder.append("    }\n\n");
+        }
+
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIClassGenerator.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen.perfapi;
+
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.schema.HollowSchema;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+class HollowPerformanceAPIClassGenerator {
+
+    private final HollowDataset dataset;
+    private final String apiClassName;
+    private final String packageName;
+
+    public HollowPerformanceAPIClassGenerator(HollowDataset dataset, String apiClassName, String packageName) {
+        this.dataset = dataset;
+        this.apiClassName = apiClassName;
+        this.packageName = packageName;
+    }
+
+    public String generate() {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("package " + packageName + ";\n\n");
+
+        builder.append("import com.netflix.hollow.api.perfapi.HollowListTypePerfAPI;\n" +
+                "import com.netflix.hollow.api.perfapi.HollowMapTypePerfAPI;\n" +
+                "import com.netflix.hollow.api.perfapi.HollowPerformanceAPI;\n" +
+                "import com.netflix.hollow.api.perfapi.HollowSetTypePerfAPI;\n" +
+                "import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;\n" +
+                "import com.netflix.hollow.core.read.dataaccess.HollowListTypeDataAccess;\n" +
+                "import com.netflix.hollow.core.read.dataaccess.HollowMapTypeDataAccess;\n" +
+                "import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;\n" +
+                "import com.netflix.hollow.core.read.dataaccess.HollowSetTypeDataAccess;\n" +
+                "import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;\n" +
+                "import java.util.Set;\n" +
+                "\n");
+
+
+        builder.append("public class " + apiClassName + " extends HollowPerformanceAPI {\n\n");
+
+        List<HollowSchema> schemas = new ArrayList<>(dataset.getSchemas());
+        schemas.sort(Comparator.comparing(HollowSchema::getName));
+
+        for(HollowSchema schema : schemas) {
+            String schemaName = schema.getName();
+
+            switch(schema.getSchemaType()) {
+                case OBJECT:
+                    builder.append("    public final " + schemaName + "PerfAPI " + schemaName + ";\n");
+                    break;
+                case LIST:
+                    builder.append("    public final HollowListTypePerfAPI " + schemaName + ";\n");
+                    break;
+                case SET:
+                    builder.append("    public final HollowSetTypePerfAPI " + schemaName + ";\n");
+                    break;
+                case MAP:
+                    builder.append("    public final HollowMapTypePerfAPI " + schemaName + ";\n");
+                    break;
+            }
+        }
+
+        builder.append("\n");
+
+        builder.append("    public " + apiClassName + "(HollowDataAccess dataAccess) {\n");
+        builder.append("        super(dataAccess);\n\n");
+
+        for(HollowSchema schema : schemas) {
+            String schemaName = schema.getName();
+
+            switch (schema.getSchemaType()) {
+                case OBJECT:
+                    builder.append("        this." + schemaName + " = new " + schemaName + "PerfAPI(dataAccess, \"" + schemaName + "\", this);\n");
+                    break;
+                case LIST:
+                    builder.append("        this." + schemaName + " = new HollowListTypePerfAPI(dataAccess, \"" + schemaName + "\", this);\n");
+                    break;
+                case MAP:
+                    builder.append("        this." + schemaName + " = new HollowMapTypePerfAPI(dataAccess, \"" + schemaName + "\",  this);\n");
+                    break;
+                case SET:
+                    builder.append("        this." + schemaName + " = new HollowSetTypePerfAPI(dataAccess, \"" + schemaName + "\",  this);\n");
+                    break;
+            }
+        }
+
+        builder.append("    }\n");
+
+        builder.append("}");
+
+        return builder.toString();
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIGenerator.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen.perfapi;
+
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class HollowPerformanceAPIGenerator {
+
+    private HollowDataset dataset;
+    private String apiClassname;
+    private String packageName;
+    private Path destinationPath;
+    private Set<String> checkFieldExistsMethods = new HashSet<>();
+    
+    public static Builder newBuilder() {
+        HollowPerformanceAPIGenerator gen = new HollowPerformanceAPIGenerator();
+        return gen.theBuilder();
+    }
+    
+    private Builder theBuilder() {
+        return new Builder();
+    }
+
+    public class Builder {
+        public Builder withDataset(HollowDataset dataset) {
+            HollowPerformanceAPIGenerator.this.dataset = dataset;
+            return this;
+        }
+        
+        public Builder withAPIClassname(String apiClassname) {
+            HollowPerformanceAPIGenerator.this.apiClassname = apiClassname;
+            return this;
+        }
+        
+        public Builder withPackageName(String packageName) {
+            HollowPerformanceAPIGenerator.this.packageName = packageName;
+            return this;
+        }
+        
+        public Builder withDestination(String destinationPath) {
+            return withDestination(Paths.get(destinationPath));
+        }
+
+        public Builder withDestination(Path destinationPath) {
+            HollowPerformanceAPIGenerator.this.destinationPath = destinationPath;
+            return this;
+        }
+        
+        public Builder withCheckFieldExistsMethods(Set<String> checkFieldExistsMethods) {
+            HollowPerformanceAPIGenerator.this.checkFieldExistsMethods.addAll(checkFieldExistsMethods);
+            return this;
+        }
+        
+        public Builder withCheckFieldExistsMethods(String... checkFieldExistsMethods) {
+            HollowPerformanceAPIGenerator.this.checkFieldExistsMethods.addAll(Arrays.asList(checkFieldExistsMethods));
+            return this;
+        }
+        
+        public HollowPerformanceAPIGenerator build() {
+            return HollowPerformanceAPIGenerator.this;
+        }
+    }
+    
+    public void generateSourceFiles() throws IOException {
+        generate(dataset, packageName, apiClassname, destinationPath, checkFieldExistsMethods);
+    }
+    
+    private static void generate(HollowDataset dataset, String packageName, String apiClassName, Path destination, Set<String> checkFieldExistsMethods)
+            throws IOException {
+        Path apiClassDestination = destination.resolve(apiClassName + ".java");
+        if (!Files.exists(apiClassDestination)) {
+            Files.createDirectories(destination);
+        }
+
+        String apiClassContent = new HollowPerformanceAPIClassGenerator(dataset, apiClassName, packageName).generate();
+        try (FileWriter writer = new FileWriter(apiClassDestination.toFile())) {
+            writer.write(apiClassContent);
+        }
+
+        for (HollowSchema schema : dataset.getSchemas()) {
+            if (schema.getSchemaType() == SchemaType.OBJECT) {
+                Path objClassDestination = destination.resolve(schema.getName() + "PerfAPI.java");
+                String objClassContent = new HollowObjectTypePerfAPIClassGenerator((HollowObjectSchema) schema, packageName, checkFieldExistsMethods).generate();
+                try (FileWriter writer = new FileWriter(objClassDestination.toFile())) {
+                    writer.write(objClassContent);
+                }
+            }
+        }
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIGenerator.java
@@ -90,8 +90,7 @@ public class HollowPerformanceAPIGenerator {
         generate(dataset, packageName, apiClassname, destinationPath, checkFieldExistsMethods);
     }
     
-    private static void generate(HollowDataset dataset, String packageName, String apiClassName, Path destination, Set<String> checkFieldExistsMethods)
-            throws IOException {
+    private void generate(HollowDataset dataset, String packageName, String apiClassName, Path destination, Set<String> checkFieldExistsMethods) throws IOException {
         Path apiClassDestination = destination.resolve(apiClassName + ".java");
         if (!Files.exists(apiClassDestination)) {
             Files.createDirectories(destination);

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowListTypeTestDataAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowListTypeTestDataAPIClassGenerator.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen.testdata;
+
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.schema.HollowListSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
+
+class HollowListTypeTestDataAPIClassGenerator {
+    
+    private final HollowDataset dataset;
+    private final HollowListSchema schema;
+    private final String packageName;
+    private final String className;
+    private final String elementClassName;
+    
+    public HollowListTypeTestDataAPIClassGenerator(HollowDataset dataset, HollowListSchema schema, String packageName) {
+        this.dataset = dataset;
+        this.schema = schema;
+        this.packageName = packageName;
+        this.className = schema.getName() + "TestData";
+        this.elementClassName = schema.getElementType() + "TestData";
+    }
+    
+    public String generate() {
+        StringBuilder builder = new StringBuilder();
+        
+        builder.append("package " + packageName + ";\n\n");
+        
+        builder.append("import com.netflix.hollow.api.testdata.HollowTestListRecord;\n" + 
+                       "import com.netflix.hollow.core.schema.HollowListSchema;\n\n");
+        
+        builder.append("public class " + className + "<T> extends HollowTestListRecord<T> {\n\n");
+
+        builder.append("    " + className + "(T parent) {\n");
+        builder.append("        super(parent);\n");
+        builder.append("    }\n\n");
+        
+        String elementReturnType = elementClassName + "<" + className + "<T>>";
+        
+        builder.append("    public " + elementReturnType + " " + schema.getElementType() + "() {\n");
+        builder.append("        " + elementReturnType + " __e = new " + elementReturnType + "(this);\n");
+        builder.append("        super.addElement(__e);\n");
+        builder.append("        return __e;\n");
+        builder.append("    }\n\n");
+        
+        HollowSchema elementSchema = dataset.getSchema(schema.getElementType());
+        if(elementSchema.getSchemaType() == SchemaType.OBJECT) {
+            HollowObjectSchema elementObjSchema = (HollowObjectSchema)elementSchema;
+            if(elementObjSchema.numFields() == 1 && elementObjSchema.getFieldType(0) != FieldType.REFERENCE) {
+                switch(elementObjSchema.getFieldType(0)) {
+                case INT:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(Integer value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case LONG:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(Long value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case FLOAT:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(Float value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case DOUBLE:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(Double value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case BOOLEAN:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(Boolean value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case BYTES:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(byte[] value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case STRING:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(String value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
+        builder.append("    private static final HollowListSchema SCHEMA = new HollowListSchema(\"").append(schema.getName()).append("\", \"").append(schema.getElementType()).append("\");\n\n");
+        
+        builder.append("    @Override public HollowListSchema getSchema() { return SCHEMA; }\n\n");
+
+        builder.append("}");
+        
+        return builder.toString();
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowMapTypeTestDataAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowMapTypeTestDataAPIClassGenerator.java
@@ -1,0 +1,182 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen.testdata;
+
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
+
+class HollowMapTypeTestDataAPIClassGenerator {
+    
+    private final HollowDataset dataset;
+    private final HollowMapSchema schema;
+    private final String packageName;
+    private final String className;
+    private final String keyClassName;
+    private final String valueClassName;
+    
+    public HollowMapTypeTestDataAPIClassGenerator(HollowDataset dataset, HollowMapSchema schema, String packageName) {
+        this.dataset = dataset;
+        this.schema = schema;
+        this.packageName = packageName;
+        this.className = schema.getName() + "TestData";
+        this.keyClassName = schema.getKeyType() + "TestData";
+        this.valueClassName = schema.getValueType() + "TestData";
+    }
+    
+    public String generate() {
+        StringBuilder builder = new StringBuilder();
+        
+        builder.append("package " + packageName + ";\n\n");
+        
+        builder.append("import com.netflix.hollow.api.testdata.HollowTestMapRecord;\n" +
+                       "import com.netflix.hollow.core.schema.HollowMapSchema;\n\n");
+        
+        builder.append("public class " + className + "<T> extends HollowTestMapRecord<T> {\n\n");
+        
+        builder.append("    " + className + "(T parent) {\n");
+        builder.append("        super(parent);\n");
+        builder.append("    }\n\n");
+        
+        builder.append("    public Entry entry() {\n");
+        builder.append("        Entry e = new Entry();\n");
+        builder.append("        addEntry(e);\n");
+        builder.append("        return e;\n");
+        builder.append("    }\n\n");
+        
+        if(canErgonomicShortcut(schema.getKeyType()) && canErgonomicShortcut(schema.getValueType())) {
+            String keyType = getErgonomicShortcutType(schema.getKeyType());
+            String valueType = getErgonomicShortcutType(schema.getValueType());
+            
+            builder.append("    public " + className + "<T> entry(" + keyType + " key, " + valueType + " value) {\n");
+            builder.append("        entry().key(key).value(value);\n");
+            builder.append("        return this;\n");
+            builder.append("    }\n\n");
+            
+        } else if(canErgonomicShortcut(schema.getKeyType())) {
+            // TODO
+        }
+
+        builder.append("    private static final HollowMapSchema SCHEMA = new HollowMapSchema(\"" + schema.getName() + "\", \"" + schema.getKeyType() + "\", \"" + schema.getValueType() + "\"");
+        if(schema.getHashKey() != null) {
+            for(String fieldPath : schema.getHashKey().getFieldPaths()) {
+                builder.append(", \"" + fieldPath + "\"");
+            }
+        }
+        builder.append(");\n\n");
+
+        builder.append("    @Override public HollowMapSchema getSchema() { return SCHEMA; }\n\n");
+        
+        
+        builder.append("    public class Entry extends HollowTestMapRecord.Entry<" + className + "<T>> {\n\n");
+        
+        builder.append("        public Entry() {\n");
+        builder.append("            super(" + className + ".this);\n");
+        builder.append("        }\n\n");
+        
+        builder.append("        public " + keyClassName + "<Entry> key() {\n");
+        builder.append("            " + keyClassName + "<Entry> __k = new " + keyClassName + "<>(this);\n");
+        builder.append("            setKey(__k);\n");
+        builder.append("            return __k;\n");
+        builder.append("        }\n\n");
+        
+        builder.append("        public " + valueClassName + "<Entry> value() {\n");
+        builder.append("            " + valueClassName + "<Entry> __v = new " + valueClassName + "<>(this);\n");
+        builder.append("            setValue(__v);\n");
+        builder.append("            return __v;\n");
+        builder.append("        }\n\n");
+        
+        if(canErgonomicShortcut(schema.getKeyType())) {
+            String keyType = getErgonomicShortcutType(schema.getKeyType());
+            String keyFieldName = getErgonomicFieldName(schema.getKeyType());
+            
+            builder.append("        public Entry key(" + keyType + " key) {\n");
+            builder.append("            key()." + keyFieldName + "(key);\n");
+            builder.append("            return this;\n");
+            builder.append("        }\n\n");
+        }
+
+        if(canErgonomicShortcut(schema.getValueType())) {
+            String valueType = getErgonomicShortcutType(schema.getValueType());
+            String valueFieldName = getErgonomicFieldName(schema.getValueType());
+            
+            builder.append("        public Entry value(" + valueType + " value) {\n");
+            builder.append("            value()." + valueFieldName + "(value);\n");
+            builder.append("            return this;\n");
+            builder.append("        }\n\n");
+        }
+        
+        
+        builder.append("    }\n\n");
+        
+        builder.append("}");
+        
+        return builder.toString();
+    }
+    
+    public String className(String type) {
+        return type + "TestData";
+    }
+    
+    private boolean canErgonomicShortcut(String schemaName) {
+        return canErgonomicShortcut(dataset.getSchema(schemaName));
+    }
+    
+    private boolean canErgonomicShortcut(HollowSchema schema) {
+        if(schema.getSchemaType() != SchemaType.OBJECT)
+            return false;
+        
+        HollowObjectSchema objSchema = (HollowObjectSchema)schema;
+        
+        if(objSchema.numFields() != 1)
+            return false;
+        
+        return objSchema.getFieldType(0) != FieldType.REFERENCE;
+    }
+    
+    private String getErgonomicShortcutType(String schemaName) {
+        HollowObjectSchema schema = (HollowObjectSchema)dataset.getSchema(schemaName);
+        
+        switch(schema.getFieldType(0)) {
+        case INT:
+            return "Integer";
+        case LONG:
+            return "Long";
+        case FLOAT:
+            return "Float";
+        case DOUBLE:
+            return "Double";
+        case BOOLEAN:
+            return "Boolean";
+        case BYTES:
+            return "byte[]"; 
+        case STRING:
+            return "String";
+        default:
+            throw new IllegalArgumentException();
+        }
+    }
+    
+    private String getErgonomicFieldName(String schemaName) {
+        HollowObjectSchema schema = (HollowObjectSchema)dataset.getSchema(schemaName);
+        return schema.getFieldName(0);
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowObjectTypeTestDataAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowObjectTypeTestDataAPIClassGenerator.java
@@ -1,0 +1,238 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen.testdata;
+
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+class HollowObjectTypeTestDataAPIClassGenerator {
+    
+    private final HollowDataset dataset;
+    private final HollowObjectSchema schema;
+    private final String packageName;
+    private final String className;
+    
+    public HollowObjectTypeTestDataAPIClassGenerator(HollowDataset dataset, HollowObjectSchema schema, String packageName) {
+        this.dataset = dataset;
+        this.schema = schema;
+        this.packageName = packageName;
+        this.className = schema.getName() + "TestData";
+    }
+    
+    public String generate() {
+        StringBuilder builder = new StringBuilder();
+        
+        
+        StringBuilder importBuilder = new StringBuilder();
+        importBuilder.append("package " + packageName + ";\n\n");
+        
+        importBuilder.append("import com.netflix.hollow.api.testdata.HollowTestObjectRecord;\n"); 
+        if(schema.getPrimaryKey() != null)
+            importBuilder.append("import com.netflix.hollow.core.index.key.PrimaryKey;\n");
+        importBuilder.append("import com.netflix.hollow.core.schema.HollowObjectSchema;\n"); 
+        importBuilder.append("import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;\n\n");
+        
+        Set<String> fieldTypesToImport = new HashSet<>();
+        
+        builder.append("public class " + className + "<T> extends HollowTestObjectRecord<T> {\n\n");
+        
+        builder.append("    " + className + "(T parent){\n");
+        builder.append("        super(parent);\n");
+        builder.append("    }\n\n");
+        
+        for(int i=0;i<schema.numFields();i++) {
+            String fieldName = schema.getFieldName(i);
+            switch(schema.getFieldType(i)) {
+            case INT:
+                builder.append("    public " + className + "<T> " + fieldName + "(Integer " + fieldName + ") {\n");
+                builder.append("        super.addField(\"" + fieldName + "\", " + fieldName + ");\n");
+                builder.append("        return this;\n");
+                builder.append("    }\n\n");
+                break;
+            case LONG:
+                builder.append("    public " + className + "<T> " + fieldName + "(Long " + fieldName + ") {\n");
+                builder.append("        super.addField(\"" + fieldName + "\", " + fieldName + ");\n");
+                builder.append("        return this;\n");
+                builder.append("    }\n\n");
+                break;
+            case FLOAT:
+                builder.append("    public " + className + "<T> " + fieldName + "(Float " + fieldName + ") {\n");
+                builder.append("        super.addField(\"" + fieldName + "\", " + fieldName + ");\n");
+                builder.append("        return this;\n");
+                builder.append("    }\n\n");
+                break;
+            case DOUBLE:
+                builder.append("    public " + className + "<T> " + fieldName + "(Double " + fieldName + ") {\n");
+                builder.append("        super.addField(\"" + fieldName + "\", " + fieldName + ");\n");
+                builder.append("        return this;\n");
+                builder.append("    }\n\n");
+                break;
+            case BOOLEAN:
+                builder.append("    public " + className + "<T> " + fieldName + "(Boolean " + fieldName + ") {\n");
+                builder.append("        super.addField(\"" + fieldName + "\", " + fieldName + ");\n");
+                builder.append("        return this;\n");
+                builder.append("    }\n\n");
+                break;
+            case BYTES:
+                builder.append("    public " + className + "<T> " + fieldName + "(byte[] " + fieldName + ") {\n");
+                builder.append("        super.addField(\"" + fieldName + "\", " + fieldName + ");\n");
+                builder.append("        return this;\n");
+                builder.append("    }\n\n");
+                break;
+            case STRING:
+                builder.append("    public " + className + "<T> " + fieldName + "(String " + fieldName + ") {\n");
+                builder.append("        super.addField(\"" + fieldName + "\", " + fieldName + ");\n");
+                builder.append("        return this;\n");
+                builder.append("    }\n\n");
+                break;
+            case REFERENCE:
+                String refType = schema.getReferencedType(i);
+                String returnType = className(refType) + "<" + className + "<T>>";
+                builder.append("    public " + returnType + " " + fieldName + "() {\n");
+                builder.append("        " + returnType + " __x = new " + returnType + "(this);\n");
+                builder.append("        super.addField(\"" + fieldName + "\", __x);\n");
+                builder.append("        return __x;\n");
+                builder.append("    }\n\n");
+                
+                if(canErgonomicShortcut(i)) {
+                    HollowObjectSchema refSchema = (HollowObjectSchema)dataset.getSchema(refType);
+                    String refField = refSchema.getFieldName(0);
+                    switch(refSchema.getFieldType(0)) {
+                    case INT:
+                        builder.append("    public " + className + "<T> " + fieldName + "(Integer " + fieldName + ") {\n");
+                        builder.append("        " + fieldName + "()." + refField + "(" + fieldName + ");\n");
+                        builder.append("        return this;\n");
+                        builder.append("    }\n\n");
+                        break;
+                    case LONG:
+                        builder.append("    public " + className + "<T> " + fieldName + "(Long " + fieldName + ") {\n");
+                        builder.append("        " + fieldName + "()." + refField + "(" + fieldName + ");\n");
+                        builder.append("        return this;\n");
+                        builder.append("    }\n\n");
+                        break;
+                    case FLOAT:
+                        builder.append("    public " + className + "<T> " + fieldName + "(Float " + fieldName + ") {\n");
+                        builder.append("        " + fieldName + "()." + refField + "(" + fieldName + ");\n");
+                        builder.append("        return this;\n");
+                        builder.append("    }\n\n");
+                        break;
+                    case DOUBLE:
+                        builder.append("    public " + className + "<T> " + fieldName + "(Double " + fieldName + ") {\n");
+                        builder.append("        " + fieldName + "()." + refField + "(" + fieldName + ");\n");
+                        builder.append("        return this;\n");
+                        builder.append("    }\n\n");
+                        break;
+                    case BOOLEAN:
+                        builder.append("    public " + className + "<T> " + fieldName + "(Boolean " + fieldName + ") {\n");
+                        builder.append("        " + fieldName + "()." + refField + "(" + fieldName + ");\n");
+                        builder.append("        return this;\n");
+                        builder.append("    }\n\n");
+                        break;
+                    case BYTES:
+                        builder.append("    public " + className + "<T> " + fieldName + "(byte[] " + fieldName + ") {\n");
+                        builder.append("        " + fieldName + "()." + refField + "(" + fieldName + ");\n");
+                        builder.append("        return this;\n");
+                        builder.append("    }\n\n");
+                        break;
+                    case STRING:
+                        builder.append("    public " + className + "<T> " + fieldName + "(String " + fieldName + ") {\n");
+                        builder.append("        " + fieldName + "()." + refField + "(" + fieldName + ");\n");
+                        builder.append("        return this;\n");
+                        builder.append("    }\n\n");
+                        break;
+                    default:
+                        throw new IllegalStateException("Cannot actually ergonomic shortcut");
+                    }
+
+                }
+            }
+        }
+        
+        builder.append("    public static final HollowObjectSchema SCHEMA = new HollowObjectSchema(\"" + schema.getName() + "\", " + schema.numFields());
+        if(schema.getPrimaryKey() != null) {
+            builder.append(", new PrimaryKey(\"" + schema.getName() + "\"");
+            
+            for(int i=0;i<schema.getPrimaryKey().numFields();i++) {
+                builder.append(", \"" + schema.getPrimaryKey().getFieldPath(i) + "\"");
+            }
+            
+            builder.append(")");
+        }
+        
+        builder.append(");\n\n");
+        
+        
+        builder.append("    static {\n");
+        for(int i=0;i<schema.numFields();i++) {
+            builder.append("        SCHEMA.addField(\"" + schema.getFieldName(i) + "\", FieldType." + schema.getFieldType(i).name());
+            if(schema.getFieldType(i) == FieldType.REFERENCE)
+                builder.append(", \"" + schema.getReferencedType(i) + "\"");
+            builder.append(");\n");
+        }
+        builder.append("    }\n\n");
+        
+        builder.append("    @Override public HollowObjectSchema getSchema() { return SCHEMA; }\n\n");
+        
+        builder.append("}");
+        
+        if(!fieldTypesToImport.isEmpty()) {
+            List<String> fieldTypesList = new ArrayList<>(fieldTypesToImport);
+            Collections.sort(fieldTypesList);
+            for(String fieldType : fieldTypesList) {
+                importBuilder.append("import " + packageName + "." + className(fieldType) + "." + fieldType + "Field;\n");
+            }
+            importBuilder.append("\n");
+        }
+        
+        return importBuilder.toString() + builder.toString();
+    }
+    
+    public String className(String type) {
+        return type + "TestData";
+    }
+    
+    public boolean canErgonomicShortcut(int fieldIdx) {
+        if(schema.getFieldType(fieldIdx) != FieldType.REFERENCE)
+            return false;
+        
+        String refType = schema.getReferencedType(fieldIdx);
+        HollowSchema refSchema = dataset.getSchema(refType);
+
+        return canErgonomicShortcut(refSchema);
+    }
+    
+    public boolean canErgonomicShortcut(HollowSchema schema) {
+        if(schema.getSchemaType() != SchemaType.OBJECT)
+            return false;
+        
+        HollowObjectSchema objSchema = (HollowObjectSchema)schema;
+        
+        if(objSchema.numFields() != 1)
+            return false;
+        
+        return objSchema.getFieldType(0) != FieldType.REFERENCE;
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowSetTypeTestDataAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowSetTypeTestDataAPIClassGenerator.java
@@ -1,0 +1,132 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen.testdata;
+
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
+import com.netflix.hollow.core.schema.HollowSetSchema;
+
+class HollowSetTypeTestDataAPIClassGenerator {
+    
+    private final HollowDataset dataset;
+    private final HollowSetSchema schema;
+    private final String packageName;
+    private final String className;
+    private final String elementClassName;
+    
+    public HollowSetTypeTestDataAPIClassGenerator(HollowDataset dataset, HollowSetSchema schema, String packageName) {
+        this.dataset = dataset;
+        this.schema = schema;
+        this.packageName = packageName;
+        this.className = schema.getName() + "TestData";
+        this.elementClassName = schema.getElementType() + "TestData";
+    }
+    
+    public String generate() {
+        StringBuilder builder = new StringBuilder();
+        
+        builder.append("package " + packageName + ";\n\n");
+        
+        builder.append("import com.netflix.hollow.api.testdata.HollowTestSetRecord;\n" + 
+                       "import com.netflix.hollow.core.schema.HollowSetSchema;\n\n"); 
+        
+        builder.append("public class " + className + "<T> extends HollowTestSetRecord<T> {\n\n");
+
+        builder.append("    " + className + "(T parent) {\n");
+        builder.append("        super(parent);\n");
+        builder.append("    }\n\n");
+        
+        String elementReturnType = elementClassName + "<" + className + "<T>>";
+        
+        builder.append("    public " + elementReturnType + " " + schema.getElementType() + "() {\n");
+        builder.append("        " + elementReturnType + " __e = new " + elementReturnType + "(this);\n");
+        builder.append("        super.addElement(__e);\n");
+        builder.append("        return __e;\n");
+        builder.append("    }\n\n");
+        
+        HollowSchema elementSchema = dataset.getSchema(schema.getElementType());
+        if(elementSchema.getSchemaType() == SchemaType.OBJECT) {
+            HollowObjectSchema elementObjSchema = (HollowObjectSchema)elementSchema;
+            if(elementObjSchema.numFields() == 1 && elementObjSchema.getFieldType(0) != FieldType.REFERENCE) {
+                switch(elementObjSchema.getFieldType(0)) {
+                case INT:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(Integer value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case LONG:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(Long value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case FLOAT:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(Float value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case DOUBLE:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(Double value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case BOOLEAN:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(Boolean value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case BYTES:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(byte[] value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                case STRING:
+                    builder.append("    public " + className + "<T> " + schema.getElementType() + "(String value) {\n");
+                    builder.append("        " + schema.getElementType() + "()." + elementObjSchema.getFieldName(0) + "(value);\n");
+                    builder.append("        return this;\n");
+                    builder.append("    }\n\n");
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+        
+        builder.append("    private static final HollowSetSchema SCHEMA = new HollowSetSchema(\"").append(schema.getName()).append("\", \"").append(schema.getElementType()).append("\"");
+        if(schema.getHashKey() != null) {
+            for(String fieldPath : schema.getHashKey().getFieldPaths()) {
+                builder.append(", \"" + fieldPath + "\"");
+            }
+        }
+        builder.append(");\n\n");
+        
+        builder.append("    @Override public HollowSetSchema getSchema() { return SCHEMA; }\n\n");
+
+        builder.append("}");
+        
+        return builder.toString();
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowTestDataAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowTestDataAPIClassGenerator.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen.testdata;
+
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.schema.HollowSchema;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+class HollowTestDataAPIClassGenerator {
+    
+    private final HollowDataset dataset;
+    private final String apiClassName;
+    private final String packageName;
+    
+    public HollowTestDataAPIClassGenerator(HollowDataset dataset, String apiClassName, String packageName) {
+        this.dataset = dataset;
+        this.apiClassName = apiClassName;
+        this.packageName = packageName;
+    }
+
+    public String generate() {
+        StringBuilder builder = new StringBuilder();
+        
+        builder.append("package " + packageName + ";\n\n");
+        
+        builder.append("import com.netflix.hollow.api.testdata.HollowTestDataset;\n\n");
+        
+        builder.append("public class " + apiClassName + " extends HollowTestDataset {\n\n");
+        
+        List<HollowSchema> schemas = new ArrayList<>(dataset.getSchemas());
+        schemas.sort(Comparator.comparing(HollowSchema::getName));
+
+        for(HollowSchema schema : schemas) {
+            builder.append("    public " + schema.getName() + "TestData<Void> " + schema.getName() + "() {\n");
+            builder.append("        " + schema.getName() + "TestData<Void> rec = new " + schema.getName() + "TestData<>(null);\n");
+            builder.append("        add(rec);\n");
+            builder.append("        return rec;\n");
+            builder.append("    }\n\n");
+        }
+        
+        builder.append("}");
+        
+        return builder.toString();
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowTestDataAPIGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowTestDataAPIGenerator.java
@@ -1,0 +1,118 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen.testdata;
+
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.schema.HollowListSchema;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSetSchema;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class HollowTestDataAPIGenerator {
+    
+    private HollowDataset dataset;
+    private String apiClassname;
+    private String packageName;
+    private Path destinationPath;
+
+    public static Builder newBuilder() {
+        HollowTestDataAPIGenerator gen = new HollowTestDataAPIGenerator();
+        return gen.theBuilder();
+    }
+    
+    private Builder theBuilder() {
+        return new Builder();
+    }
+
+    public class Builder {
+        public Builder withDataset(HollowDataset dataset) {
+            HollowTestDataAPIGenerator.this.dataset = dataset;
+            return this;
+        }
+        
+        public Builder withAPIClassname(String apiClassname) {
+            HollowTestDataAPIGenerator.this.apiClassname = apiClassname;
+            return this;
+        }
+        
+        public Builder withPackageName(String packageName) {
+            HollowTestDataAPIGenerator.this.packageName = packageName;
+            return this;
+        }
+        
+        public Builder withDestination(String destinationPath) {
+            return withDestination(Paths.get(destinationPath));
+        }
+
+        public Builder withDestination(Path destinationPath) {
+            HollowTestDataAPIGenerator.this.destinationPath = destinationPath;
+            return this;
+        }
+        
+        public HollowTestDataAPIGenerator build() {
+            return HollowTestDataAPIGenerator.this;
+        }
+    }
+    
+    public void generateSourceFiles() throws IOException {
+        generate(dataset, packageName, apiClassname, destinationPath);
+    }
+
+    
+    private void generate(HollowDataset dataset, String packageName, String apiClassName, Path destination) throws IOException {
+        Path apiClassDestination = destination.resolve(apiClassName + ".java");
+        Files.createDirectories(destination);
+
+        String apiClassContent = new HollowTestDataAPIClassGenerator(dataset, apiClassName, packageName).generate();
+        try(FileWriter writer = new FileWriter(apiClassDestination.toFile())) {
+            writer.write(apiClassContent);
+        }
+
+        for(HollowSchema schema : dataset.getSchemas()) {
+            File classDestination = destination.resolve(schema.getName() + "TestData.java").toFile();
+            String classContent = null;
+            switch(schema.getSchemaType()) {
+            case OBJECT:
+                classContent = new HollowObjectTypeTestDataAPIClassGenerator(dataset, (HollowObjectSchema) schema, packageName).generate();
+                break;
+            case LIST:
+                classContent = new HollowListTypeTestDataAPIClassGenerator(dataset, (HollowListSchema) schema, packageName).generate();
+                break;
+            case SET:
+                classContent = new HollowSetTypeTestDataAPIClassGenerator(dataset, (HollowSetSchema) schema, packageName).generate();
+                break;
+            case MAP:
+                classContent = new HollowMapTypeTestDataAPIClassGenerator(dataset, (HollowMapSchema) schema, packageName).generate();
+                break;
+            }
+            
+            if(classContent != null)
+            try(FileWriter writer = new FileWriter(classDestination)) {
+                writer.write(classContent);
+            }
+        }
+    }
+    
+        
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HashKeyExtractor.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HashKeyExtractor.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+@FunctionalInterface
+public interface HashKeyExtractor {
+
+    public Object extract(Object extractFrom);
+    
+    public default Object[] extractArray(Object extractFrom) {
+        Object obj = extract(extractFrom);
+        if(obj.getClass().isArray()) {
+            return (Object[])obj;
+        }
+        return new Object[] { obj };
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowListTypePerfAPI.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowListTypePerfAPI.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowListTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.missing.HollowListMissingDataAccess;
+import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+import java.util.List;
+
+public class HollowListTypePerfAPI extends HollowTypePerfAPI {
+    
+    private final HollowListTypeDataAccess typeAccess;
+    final long elementMaskedTypeIdx;
+    
+    public HollowListTypePerfAPI(HollowDataAccess dataAccess, String typeName, HollowPerformanceAPI api) {
+        super(typeName, api);
+        
+        HollowListTypeDataAccess typeAccess = (HollowListTypeDataAccess) dataAccess.getTypeDataAccess(typeName); 
+        
+        int elementTypeIdx = typeAccess == null ? Ref.TYPE_ABSENT : api.types.getIdx(typeAccess.getSchema().getElementType());
+        this.elementMaskedTypeIdx = Ref.toTypeMasked(elementTypeIdx);
+        
+        if(typeAccess == null)
+            typeAccess = new HollowListMissingDataAccess(dataAccess, typeName);
+        this.typeAccess = typeAccess;
+    }
+    
+    public int size(long ref) {
+        return typeAccess.size(ordinal(ref));
+    }
+    
+    public long get(long ref, int idx) {
+        int ordinal = typeAccess.getElementOrdinal(ordinal(ref), idx);
+        return Ref.toRefWithTypeMasked(elementMaskedTypeIdx, ordinal);
+    }
+
+    public HollowPerfReferenceIterator iterator(long ref) {
+        HollowOrdinalIterator iter = typeAccess.ordinalIterator(ordinal(ref));
+        return new HollowPerfReferenceIterator(iter, elementMaskedTypeIdx);
+    }
+    
+    public <T> List<T> backedList(long ref, POJOInstantiator<T> instantiator) {
+        return new HollowPerfBackedList<>(this, ordinal(ref), instantiator);
+    }
+    
+    public HollowListTypeDataAccess typeAccess() {
+        return typeAccess;
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowMapTypePerfAPI.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowMapTypePerfAPI.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowMapTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.missing.HollowMapMissingDataAccess;
+import com.netflix.hollow.core.read.iterator.HollowMapEntryOrdinalIterator;
+import java.util.Map;
+
+public class HollowMapTypePerfAPI extends HollowTypePerfAPI {
+    
+    private final HollowMapTypeDataAccess typeAccess;
+    final long keyMaskedTypeIdx;
+    final long valueMaskedTypeIdx;
+    
+    public HollowMapTypePerfAPI(HollowDataAccess dataAccess, String typeName, HollowPerformanceAPI api) {
+        super(typeName, api);
+        
+        HollowMapTypeDataAccess typeAccess = (HollowMapTypeDataAccess) dataAccess.getTypeDataAccess(typeName);
+        
+        int keyTypeIdx = typeAccess == null ? Ref.TYPE_ABSENT : api.types.getIdx(typeAccess.getSchema().getKeyType());
+        int valueTypeIdx = typeAccess == null ? Ref.TYPE_ABSENT : api.types.getIdx(typeAccess.getSchema().getValueType());
+        
+        this.keyMaskedTypeIdx = Ref.toTypeMasked(keyTypeIdx);
+        this.valueMaskedTypeIdx = Ref.toTypeMasked(valueTypeIdx);
+        
+        if(typeAccess == null)
+            typeAccess = new HollowMapMissingDataAccess(dataAccess, typeName);
+        this.typeAccess = typeAccess;
+    }
+    
+    public int size(long ref) {
+        return typeAccess.size(ordinal(ref));
+    }
+    
+    public HollowPerfMapEntryIterator possibleMatchIter(long ref, int hashCode) {
+        HollowMapEntryOrdinalIterator iter = typeAccess.potentialMatchOrdinalIterator(ordinal(ref), hashCode);
+        return new HollowPerfMapEntryIterator(iter, keyMaskedTypeIdx, valueMaskedTypeIdx); 
+    }
+    
+    public HollowPerfMapEntryIterator iterator(long ref) {
+        HollowMapEntryOrdinalIterator iter = typeAccess.ordinalIterator(ordinal(ref));
+        return new HollowPerfMapEntryIterator(iter, keyMaskedTypeIdx, valueMaskedTypeIdx);
+    }
+    
+    public long findKey(long ref, Object... hashKey) {
+        int ordinal = typeAccess.findKey(ordinal(ref), hashKey);
+        return Ref.toRefWithTypeMasked(keyMaskedTypeIdx, ordinal);
+    }
+
+    public long findValue(long ref, Object... hashKey) {
+        int ordinal = typeAccess.findValue(ordinal(ref), hashKey);
+        return Ref.toRefWithTypeMasked(valueMaskedTypeIdx, ordinal);
+    }
+
+    public <K,V> Map<K,V> backedMap(long ref, POJOInstantiator<K> keyInstantiator, POJOInstantiator<V> valueInstantiator, HashKeyExtractor hashKeyExtractor) {
+        return new HollowPerfBackedMap<K,V>(this, ordinal(ref), keyInstantiator, valueInstantiator, hashKeyExtractor);
+    }
+
+    public HollowMapTypeDataAccess typeAccess() {
+        return typeAccess;
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowObjectTypePerfAPI.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowObjectTypePerfAPI.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.missing.HollowObjectMissingDataAccess;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import java.util.Arrays;
+
+public abstract class HollowObjectTypePerfAPI extends HollowTypePerfAPI {
+    
+    protected final HollowObjectTypeDataAccess typeAccess;
+
+    protected final int[] fieldIdx;
+    protected final long[] refMaskedTypeIdx;
+    
+    public HollowObjectTypePerfAPI(HollowDataAccess dataAccess, String typeName, HollowPerformanceAPI api, String[] fieldNames) {
+        super(typeName, api);
+        
+        HollowObjectTypeDataAccess typeAccess = (HollowObjectTypeDataAccess) dataAccess.getTypeDataAccess(typeName);
+        
+        this.fieldIdx = new int[fieldNames.length];
+        this.refMaskedTypeIdx = new long[fieldNames.length];
+        
+        if(typeAccess != null) {
+            HollowObjectSchema schema = typeAccess.getSchema();
+            for(int i=0;i<fieldNames.length;i++) {
+                fieldIdx[i] = schema.getPosition(fieldNames[i]);
+                if(fieldIdx[i] != -1 && schema.getFieldType(fieldIdx[i]) == FieldType.REFERENCE) {
+                    refMaskedTypeIdx[i] = Ref.toTypeMasked(api.types.getIdx(schema.getReferencedType(fieldIdx[i])));
+                }
+            }
+        } else {
+            Arrays.fill(fieldIdx, -1);
+            Arrays.fill(refMaskedTypeIdx, Ref.toTypeMasked(Ref.TYPE_ABSENT));
+        }
+
+        if(typeAccess == null)
+            typeAccess = new HollowObjectMissingDataAccess(dataAccess, typeName);
+        this.typeAccess = typeAccess;
+    }
+
+    public HollowObjectTypeDataAccess typeAccess() {
+        return typeAccess;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfAPICache.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfAPICache.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
+import java.util.Arrays;
+import java.util.BitSet;
+
+public class HollowPerfAPICache<T> {
+    private static final Object[] EMPTY_CACHE = new Object[0];
+
+    private final HollowTypePerfAPI typeAPI;
+    private final Object[] cachedItems;
+
+    public HollowPerfAPICache(
+            HollowTypePerfAPI typeAPI,
+            POJOInstantiator<T> instantiator,
+            HollowPerfAPICache<T> previous) {
+        assert previous == null || typeAPI.maskedTypeIdx == previous.typeAPI.maskedTypeIdx : "Cache type mismatch";
+
+        this.typeAPI = typeAPI;
+        if(!typeAPI.isMissingType()) {
+            PopulatedOrdinalListener listener = typeAPI.typeAccess().getTypeState()
+                    .getListener(PopulatedOrdinalListener.class);
+            BitSet populatedOrdinals = listener.getPopulatedOrdinals();
+            BitSet previousOrdinals = listener.getPreviousOrdinals();
+
+            int length = Math.max(populatedOrdinals.length(), previousOrdinals.length());
+            // Copy over all previously cached items, resizing the array if necessary.
+            // This is required if removed ordinals are queried in the cache.
+            // For example, see SpecificTypeUpdateNotifier.buildFastlaneUpdateNotificationLists
+            Object[] arr = previous != null
+                    ? Arrays.copyOf(previous.cachedItems, length)
+                    : new Object[length];
+
+            for (int ordinal = 0; ordinal < length; ordinal++) {
+                boolean previouslyPopulated = previous != null && previousOrdinals.get(ordinal);
+                if (!previouslyPopulated) {
+                    // If not previously populated and currently populated then create a new cached instance.
+                    // Otherwise, if not previously populated and not currently populated than null out any
+                    // possibly present old cached value (create a hole)
+                    boolean currentlyPopulated = populatedOrdinals.get(ordinal);
+                    arr[ordinal] = currentlyPopulated
+                            ? instantiator.instantiate(Ref.toRefWithTypeMasked(typeAPI.maskedTypeIdx, ordinal))
+                            : null;
+                }
+                // If previously populated then retain the cached item
+            }
+
+            this.cachedItems = arr;
+        } else {
+            this.cachedItems = EMPTY_CACHE;
+        }
+    }
+
+    public T get(long ref) {
+        @SuppressWarnings("unchecked")
+        T t = (T) cachedItems[typeAPI.ordinal(ref)];
+        return t;
+    }
+    
+    public Object[] getCachedItems() {
+        return Arrays.copyOf(cachedItems, cachedItems.length);
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfAPICache.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfAPICache.java
@@ -30,7 +30,6 @@ public class HollowPerfAPICache<T> {
             HollowTypePerfAPI typeAPI,
             POJOInstantiator<T> instantiator,
             HollowPerfAPICache<T> previous) {
-        assert previous == null || typeAPI.maskedTypeIdx == previous.typeAPI.maskedTypeIdx : "Cache type mismatch";
 
         this.typeAPI = typeAPI;
         if(!typeAPI.isMissingType()) {

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfBackedList.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfBackedList.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.dataaccess.HollowListTypeDataAccess;
+import java.util.AbstractList;
+import java.util.RandomAccess;
+
+public class HollowPerfBackedList<T> extends AbstractList<T> implements RandomAccess {
+    
+    private final int ordinal;
+    private final HollowListTypeDataAccess dataAccess;
+    private final long elementMaskedTypeIdx;
+    private final POJOInstantiator<T> instantiator;
+    
+    public HollowPerfBackedList(HollowListTypePerfAPI typeAPI, int ordinal,
+            POJOInstantiator<T> instantiator) {
+        this.dataAccess = typeAPI.typeAccess();
+        this.ordinal = ordinal;
+        this.instantiator = instantiator;
+        this.elementMaskedTypeIdx = typeAPI.elementMaskedTypeIdx;
+    }
+
+    @Override
+    public T get(int index) {
+        return instantiator.instantiate(elementMaskedTypeIdx | dataAccess.getElementOrdinal(ordinal, index));
+    }
+
+    @Override
+    public int size() {
+        return dataAccess.size(ordinal);
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfBackedMap.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfBackedMap.java
@@ -1,0 +1,190 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.dataaccess.HollowMapTypeDataAccess;
+import com.netflix.hollow.core.read.iterator.HollowMapEntryOrdinalIterator;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+
+public class HollowPerfBackedMap<K, V> extends AbstractMap<K, V> {
+
+    private final int ordinal;
+    private final HollowMapTypeDataAccess dataAccess;
+    private final long keyMaskedTypeIdx;
+    private final long valueMaskedTypeIdx;
+    private final POJOInstantiator<K> keyInstantiator;
+    private final POJOInstantiator<V> valueInstantiator;
+    private final HashKeyExtractor hashKeyExtractor;
+
+    public HollowPerfBackedMap(
+            HollowMapTypePerfAPI typeApi, int ordinal,
+            POJOInstantiator<K> keyInstantiator,
+            POJOInstantiator<V> valueInstantiator,
+            HashKeyExtractor hashKeyExtractor) {
+        this.ordinal = ordinal;
+        this.dataAccess = typeApi.typeAccess();
+        this.keyMaskedTypeIdx = typeApi.keyMaskedTypeIdx;
+        this.valueMaskedTypeIdx = typeApi.valueMaskedTypeIdx;
+        this.keyInstantiator = keyInstantiator;
+        this.valueInstantiator = valueInstantiator;
+        this.hashKeyExtractor = hashKeyExtractor;
+    }
+
+    @Override
+    public boolean containsKey(Object o) {
+        Object[] hashKey = hashKeyExtractor.extractArray(o);
+        
+        return dataAccess.findValue(ordinal, hashKey) != -1;
+    }
+
+    @Override
+    public V get(Object o) {
+        Object[] hashKey = hashKeyExtractor.extractArray(o);
+        
+        int valueOrdinal = dataAccess.findValue(ordinal, hashKey);
+        
+        return valueOrdinal == -1 ? null : valueInstantiator.instantiate(valueMaskedTypeIdx | valueOrdinal);
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return new AbstractSet<Entry<K, V>>() {
+            @Override
+            public Iterator<Entry<K, V>> iterator() {
+                HollowMapEntryOrdinalIterator oi = dataAccess.ordinalIterator(ordinal);
+
+                return new Iterator<Entry<K, V>>() {
+                    boolean next = oi.next();
+
+                    @Override
+                    public boolean hasNext() {
+                        return next;
+                    }
+
+                    @Override
+                    public Entry<K, V> next() {
+                        if (!hasNext()) {
+                            throw new NoSuchElementException();
+                        }
+
+                        long kRef = keyMaskedTypeIdx | oi.getKey();
+                        long vRef = valueMaskedTypeIdx | oi.getValue();
+                        Entry<K, V> e = new BackedEntry(kRef, vRef);
+                        next = oi.next();
+                        return e;
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return HollowPerfBackedMap.this.size();
+            }
+
+            @Override
+            public boolean contains(Object o) {
+                if (!(o instanceof Map.Entry)) {
+                    return false;
+                }
+
+                Entry<?, ?> e = (Entry<?, ?>) o;
+                Object[] hashKey = hashKeyExtractor.extractArray(e.getKey());
+                int valueOrdinal = dataAccess.findValue(ordinal, hashKey);
+                
+                if(valueOrdinal != -1) {
+                    V iV = valueInstantiator.instantiate(valueMaskedTypeIdx | valueOrdinal);
+                    if(Objects.equals(iV, e.getValue()))
+                        return true;
+                }
+                
+                return false;
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return dataAccess.size(ordinal);
+    }
+
+    final class BackedEntry implements Entry<K, V> {
+        final long kRef;
+        final long vRef;
+
+        // Lazily initialized on first access
+        boolean kInstantiated;
+        K k;
+        boolean vInstantiated;
+        V v;
+
+        BackedEntry(long kRef, long vRef) {
+            this.kRef = kRef;
+            this.vRef = vRef;
+        }
+
+        @Override
+        public K getKey() {
+            if (!kInstantiated) {
+                kInstantiated = true;
+                k = keyInstantiator.instantiate(kRef);
+            }
+            return k;
+        }
+
+        @Override
+        public V getValue() {
+            if (!vInstantiated) {
+                vInstantiated = true;
+                v = valueInstantiator.instantiate(vRef);
+            }
+            return v;
+        }
+
+        @Override
+        public V setValue(V value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Map.Entry)) {
+                return false;
+            }
+            Entry<?, ?> e = (Entry<?, ?>) o;
+            return Objects.equals(getKey(), e.getKey()) && Objects.equals(getValue(), e.getValue());
+        }
+
+        @Override
+        public int hashCode() {
+            K key = getKey();
+            V value = getValue();
+            return (key == null ? 0 : key.hashCode()) ^
+                    (value == null ? 0 : value.hashCode());
+        }
+
+        public String toString() {
+            return getKey() + "=" + getValue();
+        }
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfBackedSet.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfBackedSet.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.dataaccess.HollowSetTypeDataAccess;
+import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class HollowPerfBackedSet<T> extends AbstractSet<T> {
+    private final int ordinal;
+    private final HollowSetTypeDataAccess dataAccess;
+    private final long elementMaskedTypeIdx;
+    private final POJOInstantiator<T> instantiator;
+    private final HashKeyExtractor hashKeyExtractor;
+
+    public HollowPerfBackedSet(
+            HollowSetTypePerfAPI typeApi, 
+            long ref,
+            POJOInstantiator<T> instantiator,
+            HashKeyExtractor hashKeyExtractor) {
+        this.dataAccess = typeApi.typeAccess();
+        this.ordinal = typeApi.ordinal(ref);
+        this.instantiator = instantiator;
+        this.elementMaskedTypeIdx = typeApi.elementMaskedTypeIdx;
+        this.hashKeyExtractor = hashKeyExtractor;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        HollowOrdinalIterator oi = dataAccess.ordinalIterator(ordinal);
+
+        return new Iterator<T>() {
+            int eo = oi.next();
+
+            @Override public boolean hasNext() {
+                return eo != HollowOrdinalIterator.NO_MORE_ORDINALS;
+            }
+
+            @Override public T next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                int o = eo;
+                eo = oi.next();
+                return instantiator.instantiate(elementMaskedTypeIdx | o);
+            }
+        };
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        if(hashKeyExtractor == null)
+            throw new UnsupportedOperationException();
+        
+        Object[] key = hashKeyExtractor.extractArray(o);
+        if(key == null)
+            return false;
+        return dataAccess.findElement(ordinal, key) != -1;
+    }
+
+    @Override
+    public int size() {
+        return dataAccess.size(ordinal);
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfMapEntryIterator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfMapEntryIterator.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.iterator.HollowMapEntryOrdinalIterator;
+
+public class HollowPerfMapEntryIterator {
+    
+    private final long keyMaskedTypeIdx;
+    private final long valueMaskedTypeIdx;
+    private final HollowMapEntryOrdinalIterator iter;
+    
+    public HollowPerfMapEntryIterator(HollowMapEntryOrdinalIterator iter, long keyMaskedTypeIdx, long valueMaskedTypeIdx) {
+        this.iter = iter;
+        this.keyMaskedTypeIdx = keyMaskedTypeIdx;
+        this.valueMaskedTypeIdx = valueMaskedTypeIdx;
+    }
+    
+    public boolean next() {
+        return iter.next();
+    }
+    
+    public long getKey() {
+        return Ref.toRefWithTypeMasked(keyMaskedTypeIdx, iter.getKey());
+    }
+    
+    public long getValue() {
+        return Ref.toRefWithTypeMasked(valueMaskedTypeIdx, iter.getValue());
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfReferenceIterator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerfReferenceIterator.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+
+public class HollowPerfReferenceIterator {
+    
+    private final long elementMaskedTypeIdx;
+    private final HollowOrdinalIterator iter;
+
+    private int next;
+    
+    public HollowPerfReferenceIterator(HollowOrdinalIterator iter, long elementMaskedTypeIdx) {
+        this.iter = iter;
+        this.elementMaskedTypeIdx = elementMaskedTypeIdx;
+        this.next = iter.next(); 
+    }
+    
+    public boolean hasNext() {
+        return next != HollowOrdinalIterator.NO_MORE_ORDINALS;
+    }
+    
+    public long next() {
+        long nextRef = Ref.toRefWithTypeMasked(elementMaskedTypeIdx, next);
+        next = iter.next();
+        return nextRef;
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerformanceAPI.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowPerformanceAPI.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.schema.HollowSchema;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HollowPerformanceAPI extends HollowAPI {
+
+    protected final PerfAPITypeIdentifiers types;
+
+    public HollowPerformanceAPI(HollowDataAccess dataAccess) {
+        super(dataAccess);
+
+        this.types = new PerfAPITypeIdentifiers(dataAccess);
+    }
+
+    public PerfAPITypeIdentifiers getTypeIdentifiers() {
+        return types;
+    };
+
+    public static class PerfAPITypeIdentifiers {
+        private final String[] typeNames;
+        private final Map<String, Integer> typeIdxMap;
+
+        public PerfAPITypeIdentifiers(HollowDataset dataset) {
+            List<HollowSchema> schemas = dataset.getSchemas();
+
+            this.typeIdxMap = new HashMap<>();
+            String[] typeNames = new String[schemas.size()];
+            for (int i = 0; i < schemas.size(); i++) {
+                typeNames[i] = schemas.get(i).getName();
+                typeIdxMap.put(typeNames[i], i);
+            }
+
+            this.typeNames = typeNames;
+        }
+
+        public int getIdx(String typeName) {
+            Integer idx = typeIdxMap.get(typeName);
+            if (idx == null) {
+                return Ref.TYPE_ABSENT;
+            }
+
+            return idx;
+        }
+
+        public String getTypeName(int idx) {
+            if (idx >= 0 && idx < typeNames.length) {
+                return typeNames[idx];
+            }
+            return "INVALID (" + idx + ")";
+        }
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowRef.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowRef.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+public abstract class HollowRef {
+    protected final long ref;
+
+    protected HollowRef(long ref) {
+        this.ref = ref;
+    }
+
+    public long ref() {
+        return ref;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HollowRef)) {
+            return false;
+        }
+
+        HollowRef hollowRef = (HollowRef) o;
+        return ref == hollowRef.ref;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(ref);
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowSetTypePerfAPI.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowSetTypePerfAPI.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowSetTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.missing.HollowSetMissingDataAccess;
+import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+import java.util.Set;
+
+public class HollowSetTypePerfAPI extends HollowTypePerfAPI {
+    
+    private final HollowSetTypeDataAccess typeAccess;
+    final long elementMaskedTypeIdx;
+    
+    public HollowSetTypePerfAPI(HollowDataAccess dataAccess, String typeName, HollowPerformanceAPI api) {
+        super(typeName, api);
+        
+        HollowSetTypeDataAccess typeAccess = (HollowSetTypeDataAccess) dataAccess.getTypeDataAccess(typeName);
+        
+        int elementTypeIdx = typeAccess == null ? Ref.TYPE_ABSENT : api.types.getIdx(typeAccess.getSchema().getElementType());
+        this.elementMaskedTypeIdx = Ref.toTypeMasked(elementTypeIdx);
+        
+        if(typeAccess == null)
+            typeAccess = new HollowSetMissingDataAccess(dataAccess, typeName);
+        this.typeAccess = typeAccess;
+    }
+    
+    public int size(long ref) {
+        return typeAccess.size(ordinal(ref));
+    }
+    
+    public HollowPerfReferenceIterator iterator(long ref) {
+        HollowOrdinalIterator iter = typeAccess.ordinalIterator(ordinal(ref));
+        return new HollowPerfReferenceIterator(iter, elementMaskedTypeIdx);
+    }
+    
+    public long findElement(long ref, Object... hashKey) {
+        int ordinal = typeAccess.findElement(ordinal(ref), hashKey);
+        return Ref.toRefWithTypeMasked(elementMaskedTypeIdx, ordinal);
+    }
+    
+    public <T> Set<T> backedSet(long ref, POJOInstantiator<T> instantiator, HashKeyExtractor hashKeyExtractor) {
+        return new HollowPerfBackedSet<>(this, ref, instantiator, hashKeyExtractor);
+    }
+    
+    public HollowSetTypeDataAccess typeAccess() {
+        return typeAccess;
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowTypePerfAPI.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/HollowTypePerfAPI.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
+
+public abstract class HollowTypePerfAPI {
+
+    private final HollowPerformanceAPI api;
+    protected final long maskedTypeIdx;
+
+    public HollowTypePerfAPI(String typeName, HollowPerformanceAPI api) {
+        int typeIdx = api.types.getIdx(typeName);
+        this.maskedTypeIdx = Ref.toTypeMasked(typeIdx);
+        this.api = api;
+    }
+    
+    public long refForOrdinal(int ordinal) {
+        return Ref.toRefWithTypeMasked(maskedTypeIdx, ordinal);
+    }
+
+    public abstract HollowTypeDataAccess typeAccess();
+
+    public HollowPerformanceAPI api() {
+        return api;
+    }
+
+    /**
+     * Gets the ordinal of the reference and checks that the reference is of the correct type.
+     * @param ref the reference
+     * @return the ordinal
+     * @throws IllegalArgumentException if the reference's type differs
+     */
+    public int ordinal(long ref) {
+        if (!Ref.isRefOfTypeMasked(maskedTypeIdx, ref)) {
+            String expectedType = api.types.getTypeName(Ref.type(maskedTypeIdx));
+
+            if (Ref.isNull(ref)) {
+                throw new NullPointerException("Reference is null -- expected type " + expectedType);
+            }
+
+            String foundType = api.types.getTypeName(Ref.type(ref));
+            throw new IllegalArgumentException("Wrong reference type -- expected type " + expectedType + " but ref was of type " + foundType);
+        }
+        return Ref.ordinal(ref);
+    }
+    
+    public boolean isMissingType() {
+        return maskedTypeIdx == Ref.toTypeMasked(Ref.TYPE_ABSENT);
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/POJOInstantiator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/POJOInstantiator.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+@FunctionalInterface
+public interface POJOInstantiator<T> {
+    
+    T instantiate(long ref);
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/perfapi/Ref.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/perfapi/Ref.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.perfapi;
+
+/**
+ * Utility methods on hollow references.
+ * <p>
+ * A hollow reference is a 64 bit pointer comprised of two parts.
+ * One part is an ordinal value.
+ * The other part is a type identifier associated with the ordinal.
+ * A hollow reference provides a degree of type safety such that a hollow reference can only be used to
+ * operate on a hollow object whose type corresponds to the reference's type identifier.
+ */
+public final class Ref {
+    
+    public static final int TYPE_ABSENT = -1;
+
+    private static final long TYPE_MASK = 0x0000FFFF_00000000L;
+
+    public static final long NULL = -1;
+
+    private Ref() {
+    }
+
+    public static boolean isNonNull(long ref) {
+        return ref != -1;
+    }
+
+    public static boolean isNull(long ref) {
+        return ref == -1;
+    }
+
+    public static boolean isRefOfType(int type, long ref) {
+        return isRefOfTypeMasked(toTypeMasked(type), ref);
+    }
+
+    public static boolean isRefOfTypeMasked(long typeMasked, long ref) {
+        return typeMasked(ref) == typeMasked;
+    }
+
+    public static int ordinal(long ref) {
+        return (int) ref;
+    }
+
+    public static int type(long ref) {
+        return (int) (ref >>> 32);
+    }
+
+    public static long typeMasked(long ref) {
+        return ref & TYPE_MASK;
+    }
+
+    public static long toRef(int type, int ordinal) {
+        return toTypeMasked(type) | ordinal;
+    }
+
+    public static long toRefWithTypeMasked(long typeMasked, int ordinal) {
+        // @@@ This erases the type
+        return typeMasked | ordinal;
+    }
+
+    public static long toTypeMasked(int type) {
+        return ((long) type << 32) & TYPE_MASK;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestBlobRetriever.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestBlobRetriever.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.testdata;
+
+import com.netflix.hollow.api.consumer.HollowConsumer.Blob;
+import com.netflix.hollow.api.consumer.HollowConsumer.BlobRetriever;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A simple implementation of a BlobRetriever which allows adding blobs and holds them all in
+ * memory.
+ */
+class HollowTestBlobRetriever implements BlobRetriever {
+    private final Map<Long, Blob> snapshots = new HashMap<>();
+    private final Map<Long, Blob> deltas = new HashMap<>();
+    private final Map<Long, Blob> reverseDeltas = new HashMap<>();
+
+    @Override
+    public Blob retrieveSnapshotBlob(long desiredVersion) {
+        return snapshots.get(desiredVersion);
+    }
+
+    @Override
+    public Blob retrieveDeltaBlob(long currentVersion) {
+        return deltas.get(currentVersion);
+    }
+
+    @Override
+    public Blob retrieveReverseDeltaBlob(long currentVersion) {
+        return reverseDeltas.get(currentVersion);
+    }
+
+    public void addSnapshot(long desiredVersion, Blob transition) {
+        snapshots.put(desiredVersion, transition);
+    }
+
+    public void addDelta(long currentVersion, Blob transition) {
+        deltas.put(currentVersion, transition);
+    }
+
+    public void addReverseDelta(long currentVersion, Blob transition) {
+        reverseDeltas.put(currentVersion, transition);
+    }
+    
+    public static class TestBlob extends Blob {
+    	
+    	private final byte[] data;
+    	
+    	public TestBlob(long snapshotVersion, byte[] data) {
+    		super(snapshotVersion);
+    		this.data = data;
+    	}
+    	
+    	public TestBlob(long fromVersion, long toVersion, byte[] data) {
+    		super(fromVersion, toVersion);
+    		this.data = data;
+    	}
+
+		@Override
+		public InputStream getInputStream() throws IOException {
+			return new ByteArrayInputStream(data);
+		}
+    	
+    }
+
+}
+

--- a/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestDataMapEntry.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestDataMapEntry.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.testdata;
+
+@SuppressWarnings("rawtypes")
+public class HollowTestDataMapEntry<K extends HollowTestRecord, V extends HollowTestRecord> {
+
+    private final K key;
+    private final V value;
+    
+    public HollowTestDataMapEntry(K key, V value) {
+        this.key = key;
+        this.value = value;
+    }
+    
+    public K key() {
+        return key;
+    }
+    
+    public V value() {
+        return value;
+    }
+    
+    public static <K extends HollowTestRecord, V extends HollowTestRecord> HollowTestDataMapEntry<K, V> entry(K key, V value) {
+        return new HollowTestDataMapEntry<>(key, value);
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestDataset.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestDataset.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.testdata;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowBlobWriter;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class HollowTestDataset {
+
+    private final HollowWriteStateEngine writeEngine;
+    private final List<HollowTestRecord<Void>> recsToAdd;
+    
+    private HollowTestBlobRetriever blobRetriever;
+    
+    private long currentState = 0L;
+    
+    
+    public HollowTestDataset() {
+        this.writeEngine = new HollowWriteStateEngine();
+        this.recsToAdd = new ArrayList<>();
+    }
+    
+    public void add(HollowTestRecord<Void> rec) {
+        recsToAdd.add(rec);
+    }
+    
+    public HollowConsumer.Builder<?> newConsumerBuilder() {
+    	blobRetriever = new HollowTestBlobRetriever();
+    	
+    	return HollowConsumer
+    			.newHollowConsumer()
+    			.withBlobRetriever(blobRetriever);
+    }
+    
+    public void buildSnapshot(HollowConsumer consumer) {
+        for(HollowTestRecord<Void> rec : recsToAdd) {
+            rec.addTo(writeEngine);
+        }
+        
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            HollowBlobWriter writer = new HollowBlobWriter(writeEngine);
+            writer.writeSnapshot(baos);
+            writeEngine.prepareForNextCycle();
+            blobRetriever.addSnapshot(currentState, new HollowTestBlobRetriever.TestBlob(currentState, baos.toByteArray()));
+            consumer.triggerRefreshTo(currentState);
+        } catch(IOException rethrow) {
+            throw new RuntimeException(rethrow);
+        }
+    }
+    
+    public void buildDelta(HollowConsumer consumer) {
+        for(HollowTestRecord<Void> rec : recsToAdd) {
+            rec.addTo(writeEngine);
+        }
+        
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            HollowBlobWriter writer = new HollowBlobWriter(writeEngine);
+            writer.writeDelta(baos);
+            writeEngine.prepareForNextCycle();
+            long nextState = currentState + 1;
+            blobRetriever.addDelta(currentState, new HollowTestBlobRetriever.TestBlob(currentState, nextState, baos.toByteArray()));
+            consumer.triggerRefreshTo(nextState);
+            currentState = nextState;
+        } catch(IOException rethrow) {
+            throw new RuntimeException(rethrow);
+        }
+    }
+    
+    public HollowReadStateEngine buildSnapshot() {
+        for(HollowTestRecord<Void> rec : recsToAdd) {
+            rec.addTo(writeEngine);
+        }
+        
+        try {
+            return StateEngineRoundTripper.roundTripSnapshot(writeEngine);
+        } catch(IOException rethrow) {
+            throw new RuntimeException(rethrow);
+        }
+    }
+    
+    public void buildDelta(HollowReadStateEngine readEngine) {
+        for(HollowTestRecord<Void> rec : recsToAdd) {
+            rec.addTo(writeEngine);
+        }
+
+        try {
+            StateEngineRoundTripper.roundTripDelta(writeEngine, readEngine);
+        } catch(IOException rethrow) {
+            throw new RuntimeException(rethrow);
+        }
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestListRecord.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestListRecord.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.testdata;
+
+import com.netflix.hollow.core.write.HollowListWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class HollowTestListRecord<T> extends HollowTestRecord<T> {
+
+    private final List<HollowTestRecord<?>> elements = new ArrayList<>();
+
+    protected HollowTestListRecord(T parent) {
+        super(parent);
+    }
+    
+    protected void addElement(HollowTestRecord<?> element) {
+        elements.add(element);
+    }
+    
+    @SuppressWarnings({ "hiding", "unchecked" })
+    public <T extends HollowTestRecord<?>> T getRecord(int idx) {
+        return (T) elements.get(idx);
+    }
+
+    public HollowWriteRecord toWriteRecord(HollowWriteStateEngine writeEngine) {
+        HollowListWriteRecord rec = new HollowListWriteRecord();
+        for(HollowTestRecord<?> e : elements) {
+            rec.addElement(e.addTo(writeEngine));
+        }
+        return rec;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestMapRecord.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestMapRecord.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.testdata;
+
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.write.HollowMapWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class HollowTestMapRecord<T> extends HollowTestRecord<T> {
+
+    private final List<Entry<?>> entries = new ArrayList<>();
+
+    protected HollowTestMapRecord(T parent) {
+        super(parent);
+    }
+    
+    protected void addEntry(Entry<? extends HollowTestRecord<?>> entry) {
+        entries.add(entry);
+    }
+
+    @SuppressWarnings({ "unchecked", "hiding" })
+    public <T> Entry<T> getEntry(int idx) {
+        return (Entry<T>) entries.get(idx);
+    }
+    
+    public HollowWriteRecord toWriteRecord(HollowWriteStateEngine writeEngine) {
+        HollowMapWriteRecord rec = new HollowMapWriteRecord();
+        for(Entry<?> entry : entries) {
+            int keyOrdinal = entry.key.addTo(writeEngine);
+            int valueOrdinal = entry.value.addTo(writeEngine);
+            rec.addEntry(keyOrdinal, valueOrdinal);
+        }
+        return rec;
+    }
+    
+    public static class Entry<T> extends HollowTestRecord<T> {
+
+        private HollowTestRecord<?> key;
+        private HollowTestRecord<?> value;
+        
+        public Entry(T parent) {
+            super(parent);
+        }
+        
+        protected void setKey(HollowTestRecord<?> key) {
+            this.key = key;
+        }
+        
+        protected void setValue(HollowTestRecord<?> value) {
+            this.value = value;
+        }
+        
+        @SuppressWarnings({ "hiding", "unchecked" })
+        public <T extends HollowTestRecord<?>> T getKey() {
+            return (T)key;
+        }
+
+        @SuppressWarnings({ "hiding", "unchecked" })
+        public <T extends HollowTestRecord<?>> T getValue() {
+            return (T)value;
+        }
+
+        @Override
+        protected HollowSchema getSchema() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected HollowWriteRecord toWriteRecord(HollowWriteStateEngine writeEngine) {
+            throw new UnsupportedOperationException();
+        }
+    }
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestObjectRecord.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestObjectRecord.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.testdata;
+
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class HollowTestObjectRecord<T> extends HollowTestRecord<T> {
+    
+    private final Map<String, Field> fields;
+    
+    protected HollowTestObjectRecord(T parent) {
+        super(parent);
+        this.fields = new HashMap<>();
+    }
+    
+    protected void addField(String fieldName, Object value) {
+        if(value == null) {
+            fields.remove(fieldName);
+        } else {
+            addField(new Field(fieldName, value));
+        }
+    }
+    
+    protected void addField(Field field) {
+        if(field.value == null)
+            this.fields.remove(field.name);
+        else
+            this.fields.put(field.name, field);
+    }
+    
+    protected Field getField(String name) {
+        return fields.get(name);
+    }
+    
+    @SuppressWarnings("rawtypes")
+    @Override
+    protected HollowWriteRecord toWriteRecord(HollowWriteStateEngine writeEngine) {
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord(getSchema());
+        
+        for(Map.Entry<String, Field> entry : fields.entrySet()) {
+            Field field = entry.getValue();
+            if(field.value instanceof Integer) {
+                rec.setInt(field.name, (Integer)field.value);
+            } else if(field.value instanceof Long) {
+                rec.setLong(field.name, (Long)field.value);
+            } else if(field.value instanceof Float) {
+                rec.setFloat(field.name, (Float)field.value);
+            } else if(field.value instanceof Boolean) {
+                rec.setBoolean(field.name, (Boolean)field.value);
+            } else if(field.value instanceof String) {
+                rec.setString(field.name, (String)field.value);
+            } else if(field.value instanceof byte[]) {
+                rec.setBytes(field.name, (byte[])field.value);
+            } else if(field.value instanceof HollowTestRecord) {
+                rec.setReference(field.name, ((HollowTestRecord)field.value).addTo(writeEngine));
+            } else {
+                throw new IllegalStateException("Unknown field type: " + field.value.getClass());
+            }
+        }
+        
+        return rec;
+    }
+    
+    protected abstract HollowObjectSchema getSchema();
+    
+    protected static class Field {
+        public final String name;
+        public final Object value;
+        
+        public Field(String name, Object value) {
+            this.name = name;
+            this.value = value;
+        }
+    }
+
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestRecord.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestRecord.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.testdata;
+
+import com.netflix.hollow.core.schema.HollowListSchema;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSetSchema;
+import com.netflix.hollow.core.write.HollowListTypeWriteState;
+import com.netflix.hollow.core.write.HollowMapTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowSetTypeWriteState;
+import com.netflix.hollow.core.write.HollowTypeWriteState;
+import com.netflix.hollow.core.write.HollowWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+
+public abstract class HollowTestRecord<T> {
+    
+    private final T parent;
+    private int assignedOrdinal = -1;
+    
+    protected HollowTestRecord(T parent) {
+        this.parent = parent;
+    }
+    
+    public T up() {
+        return parent;
+    }
+    
+    @SuppressWarnings({ "hiding", "unchecked" })
+    public <T> T upTop() {
+        HollowTestRecord<?> root = this;
+        while(root.up() != null) {
+            root = (HollowTestRecord<?>) root.up();
+        }
+        return (T)root;
+    }
+    
+    int addTo(HollowWriteStateEngine writeEngine) {
+        HollowSchema schema = getSchema();
+        HollowTypeWriteState typeState = writeEngine.getTypeState(schema.getName());
+        if(typeState == null) {
+            switch(schema.getSchemaType()) {
+            case OBJECT:
+                typeState = new HollowObjectTypeWriteState((HollowObjectSchema)schema);
+                break;
+            case LIST:
+                typeState = new HollowListTypeWriteState((HollowListSchema)schema);
+                break;
+            case SET:
+                typeState = new HollowSetTypeWriteState((HollowSetSchema)schema);
+                break;
+            case MAP:
+                typeState = new HollowMapTypeWriteState((HollowMapSchema)schema);
+                break;
+            }
+            writeEngine.addTypeState(typeState);
+        }
+        
+        assignedOrdinal = typeState.add(toWriteRecord(writeEngine));
+        return assignedOrdinal;
+    }
+    
+    public int getOrdinal() {
+        return assignedOrdinal;
+    }
+    
+    protected abstract HollowSchema getSchema();
+
+    protected abstract HollowWriteRecord toWriteRecord(HollowWriteStateEngine writeEngine);
+    
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestSetRecord.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/testdata/HollowTestSetRecord.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.testdata;
+
+import com.netflix.hollow.core.write.HollowSetWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class HollowTestSetRecord<T> extends HollowTestRecord<T> {
+
+    private final Set<HollowTestRecord<?>> elements = new HashSet<>();
+
+    protected HollowTestSetRecord(T parent) {
+        super(parent);
+    }
+
+    protected void addElement(HollowTestRecord<?> element) {
+        elements.add(element);
+    }
+
+    public HollowWriteRecord toWriteRecord(HollowWriteStateEngine writeEngine) {
+        HollowSetWriteRecord rec = new HollowSetWriteRecord();
+        for(HollowTestRecord<?> e : elements) {
+            rec.addElement(e.addTo(writeEngine));
+        }
+        return rec;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/SimpleHollowDataset.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/SimpleHollowDataset.java
@@ -18,6 +18,8 @@ package com.netflix.hollow.core.schema;
 
 import com.netflix.hollow.api.error.SchemaNotFoundException;
 import com.netflix.hollow.core.HollowDataset;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -60,6 +62,15 @@ public class SimpleHollowDataset implements HollowDataset {
         if(schema == null)
             throw new SchemaNotFoundException(typeName, schemas.keySet());
         return schema;
+    }
+
+    public static SimpleHollowDataset fromClassDefinitions(Class<?>... classes) {
+        HollowWriteStateEngine stateEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(stateEngine);
+        for(Class<?> clazz : classes) {
+            mapper.initializeTypeState(clazz);
+        }
+        return new SimpleHollowDataset(stateEngine.getSchemas());
     }
 
 }


### PR DESCRIPTION
* **Performance API**: A consumer API which allows for traversal of a dataset without ever creating POJOs.  Instead, record handles are `long`s (called `Ref`s).  The high bits of a `Ref` contain a type identifier, and the low bits contain the record's ordinal.
* **Unit testing API**: A typed producer API which allows for quick creation of data states within unit tests.