### PR TITLE
Focus shard updates to reduce delta resource requirements.

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -55,6 +55,8 @@ public class HollowClientUpdater {
     private final HollowConsumerMetrics metrics;
     private final HollowMetricsCollector<HollowConsumerMetrics> metricsCollector;
 
+    private boolean skipTypeShardUpdateWithNoAdditions;
+
     private TypeFilter filter;
 
     public HollowClientUpdater(HollowConsumer.BlobRetriever transitionCreator,
@@ -82,6 +84,13 @@ public class HollowClientUpdater {
         this.metrics = metrics;
         this.metricsCollector = metricsCollector;
         this.initialLoad = new CompletableFuture<>();
+    }
+
+    public void setSkipShardUpdateWithNoAdditions(boolean skipTypeShardUpdateWithNoAdditions) {
+        this.skipTypeShardUpdateWithNoAdditions = skipTypeShardUpdateWithNoAdditions;
+        HollowDataHolder dataHolder = hollowDataHolderVolatile;
+        if(dataHolder != null)
+            dataHolder.getStateEngine().setSkipTypeShardUpdateWithNoAdditions(skipTypeShardUpdateWithNoAdditions);
     }
 
     /**
@@ -242,7 +251,8 @@ public class HollowClientUpdater {
         return new HollowDataHolder(newStateEngine(), apiFactory, memoryMode,
                 doubleSnapshotConfig, failedTransitionTracker,
                 staleReferenceDetector, objectLongevityConfig)
-                .setFilter(filter);
+                .setFilter(filter)
+                .setSkipTypeShardUpdateWithNoAdditions(skipTypeShardUpdateWithNoAdditions);
     }
 
     private HollowReadStateEngine newStateEngine() {

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowDataHolder.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowDataHolder.java
@@ -100,6 +100,11 @@ class HollowDataHolder {
         return this;
     }
 
+    HollowDataHolder setSkipTypeShardUpdateWithNoAdditions(boolean skipTypeShardUpdateWithNoAdditions) {
+        this.stateEngine.setSkipTypeShardUpdateWithNoAdditions(skipTypeShardUpdateWithNoAdditions);
+        return this;
+    }
+
     void update(HollowUpdatePlan updatePlan, HollowConsumer.RefreshListener[] refreshListeners,
             Runnable apiInitCallback) throws Throwable {
         // Only fail if double snapshot is configured.

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -197,6 +197,8 @@ public class HollowConsumer {
                 metrics,
                 builder.metricsCollector);
         updater.setFilter(builder.typeFilter);
+        if(builder.skipTypeShardUpdateWithNoAdditions)
+            updater.setSkipShardUpdateWithNoAdditions(true);
         this.announcementWatcher = builder.announcementWatcher;
         this.refreshExecutor = builder.refreshExecutor;
         this.refreshLock = new ReentrantReadWriteLock();
@@ -996,6 +998,7 @@ public class HollowConsumer {
         protected Executor refreshExecutor = null;
         protected MemoryMode memoryMode = MemoryMode.ON_HEAP;
         protected HollowMetricsCollector<HollowConsumerMetrics> metricsCollector;
+        protected boolean skipTypeShardUpdateWithNoAdditions = false;
 
         public B withBlobRetriever(HollowConsumer.BlobRetriever blobRetriever) {
             this.blobRetriever = blobRetriever;
@@ -1179,6 +1182,14 @@ public class HollowConsumer {
 
         public B withMetricsCollector(HollowMetricsCollector<HollowConsumerMetrics> metricsCollector) {
             this.metricsCollector = metricsCollector;
+            return (B)this;
+        }
+        
+        /**
+         * Experimental: When there are no updates for a type shard in a delta, skip updating that type shard.
+         */
+        public B withSkipTypeShardUpdateWithNoAdditions() {
+            this.skipTypeShardUpdateWithNoAdditions = true;
             return (B)this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -91,7 +91,7 @@ abstract class AbstractHollowProducer {
         this(new HollowFilesystemBlobStager(), publisher, announcer,
                 Collections.emptyList(),
                 new VersionMinterWithCounter(), null, 0,
-                DEFAULT_TARGET_MAX_TYPE_SHARD_SIZE, null,
+                DEFAULT_TARGET_MAX_TYPE_SHARD_SIZE, false, null,
                 new DummyBlobStorageCleaner(), new BasicSingleProducerEnforcer(),
                 null, true);
     }
@@ -103,7 +103,7 @@ abstract class AbstractHollowProducer {
         this(b.stager, b.publisher, b.announcer,
                 b.eventListeners,
                 b.versionMinter, b.snapshotPublishExecutor,
-                b.numStatesBetweenSnapshots, b.targetMaxTypeShardSize,
+                b.numStatesBetweenSnapshots, b.targetMaxTypeShardSize, b.focusHoleFillInFewestShards,
                 b.metricsCollector, b.blobStorageCleaner, b.singleProducerEnforcer,
                 b.hashCodeFinder, b.doIntegrityCheck);
     }
@@ -117,6 +117,7 @@ abstract class AbstractHollowProducer {
             Executor snapshotPublishExecutor,
             int numStatesBetweenSnapshots,
             long targetMaxTypeShardSize,
+            boolean focusHoleFillInFewestShards,
             HollowMetricsCollector<HollowProducerMetrics> metricsCollector,
             HollowProducer.BlobStorageCleaner blobStorageCleaner,
             SingleProducerEnforcer singleProducerEnforcer,
@@ -136,6 +137,7 @@ abstract class AbstractHollowProducer {
                 ? new HollowWriteStateEngine()
                 : new HollowWriteStateEngine(hashCodeFinder);
         writeEngine.setTargetMaxTypeShardSize(targetMaxTypeShardSize);
+        writeEngine.setFocusHoleFillInFewestShards(focusHoleFillInFewestShards);
 
         this.objectMapper = new HollowObjectMapper(writeEngine);
         if (hashCodeFinder != null) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -678,6 +678,7 @@ public class HollowProducer extends AbstractHollowProducer {
         VersionMinter versionMinter = new VersionMinterWithCounter();
         Executor snapshotPublishExecutor = null;
         int numStatesBetweenSnapshots = 0;
+        boolean focusHoleFillInFewestShards = false;
         long targetMaxTypeShardSize = DEFAULT_TARGET_MAX_TYPE_SHARD_SIZE;
         HollowMetricsCollector<HollowProducerMetrics> metricsCollector;
         BlobStorageCleaner blobStorageCleaner = new DummyBlobStorageCleaner();
@@ -805,6 +806,11 @@ public class HollowProducer extends AbstractHollowProducer {
 
         public B withTargetMaxTypeShardSize(long targetMaxTypeShardSize) {
             this.targetMaxTypeShardSize = targetMaxTypeShardSize;
+            return (B) this;
+        }
+
+        public B withFocusHoleFillInFewestShards(boolean focusHoleFillInFewestShards) {
+            this.focusHoleFillInFewestShards = focusHoleFillInFewestShards;
             return (B) this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016-2019 Netflix, Inc.
+ *  Copyright 2016-2021 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -358,7 +358,7 @@ public class ByteArrayOrdinalMap {
      *
      * @param usedOrdinals a bit set representing the ordinals which are currently referenced by any image.
      */
-    public void compact(ThreadSafeBitSet usedOrdinals) {
+    public void compact(ThreadSafeBitSet usedOrdinals, int numShards, boolean focusHoleFillInFewestShards) {
         long[] populatedReverseKeys = new long[size];
 
         int counter = 0;
@@ -398,7 +398,11 @@ public class ByteArrayOrdinalMap {
         }
 
         byteData.setPosition(currentCopyPointer);
-        freeOrdinalTracker.sort();
+
+        if(focusHoleFillInFewestShards && numShards > 1)
+            freeOrdinalTracker.sort(numShards);
+        else
+            freeOrdinalTracker.sort();
 
         // Reset the array then fill with compacted values
         // Volatile store not required, could use plain store

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
@@ -55,6 +55,7 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
     private final Map<String, List<HollowTypeStateListener>> listeners;
     private final HollowObjectHashCodeFinder hashCodeFinder;
     private final boolean listenToAllPopulatedOrdinals;
+    private boolean skipTypeShardUpdateWithNoAdditions;
     private ArraySegmentRecycler memoryRecycler;
     private Map<String,String> headerTags;
     private Set<String> typesWithDefinedHashCodes = new HashSet<String>();
@@ -203,6 +204,17 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
 
     public boolean isListenToAllPopulatedOrdinals() {
         return listenToAllPopulatedOrdinals;
+    }
+
+    /**
+     * Experimental: When there are no updates for a type shard in a delta, skip updating that type shard.
+     */
+    public void setSkipTypeShardUpdateWithNoAdditions(boolean skipTypeShardUpdateWithNoAdditions) {
+        this.skipTypeShardUpdateWithNoAdditions = skipTypeShardUpdateWithNoAdditions;
+    }
+
+    public boolean isSkipTypeShardUpdateWithNoAdditions() {
+        return skipTypeShardUpdateWithNoAdditions;
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -21,6 +21,7 @@ import com.netflix.hollow.api.sampling.HollowListSampler;
 import com.netflix.hollow.api.sampling.HollowSampler;
 import com.netflix.hollow.api.sampling.HollowSamplingDirector;
 import com.netflix.hollow.core.memory.MemoryMode;
+import com.netflix.hollow.core.memory.encoding.GapEncodedVariableLengthIntegerReader;
 import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.core.read.HollowBlobInput;
@@ -96,14 +97,35 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
 
         for(int i=0; i<shards.length; i++) {
             HollowListTypeDataElements deltaData = new HollowListTypeDataElements(memoryMode, memoryRecycler);
-            HollowListTypeDataElements nextData = new HollowListTypeDataElements(memoryMode, memoryRecycler);
             deltaData.readDelta(in);
-            HollowListTypeDataElements oldData = shards[i].currentDataElements();
-            nextData.applyDelta(oldData, deltaData);
-            shards[i].setCurrentData(nextData);
-            notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
-            deltaData.destroy();
-            oldData.destroy();
+            if(stateEngine.isSkipTypeShardUpdateWithNoAdditions() && deltaData.encodedAdditions.isEmpty()) {
+
+                if(!deltaData.encodedRemovals.isEmpty())
+                    notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+
+                HollowListTypeDataElements currentData = shards[i].currentDataElements();
+                GapEncodedVariableLengthIntegerReader oldRemovals = currentData.encodedRemovals == null ? GapEncodedVariableLengthIntegerReader.EMPTY_READER : currentData.encodedRemovals;
+                if(oldRemovals.isEmpty()) {
+                    currentData.encodedRemovals = deltaData.encodedRemovals;
+                    oldRemovals.destroy();
+                } else {
+                    if(!deltaData.encodedRemovals.isEmpty()) {
+                        currentData.encodedRemovals = GapEncodedVariableLengthIntegerReader.combine(oldRemovals, deltaData.encodedRemovals, memoryRecycler);
+                        oldRemovals.destroy();
+                    }
+                    deltaData.encodedRemovals.destroy();
+                }
+
+                deltaData.encodedAdditions.destroy();
+            } else {
+                HollowListTypeDataElements nextData = new HollowListTypeDataElements(memoryMode, memoryRecycler);
+                HollowListTypeDataElements oldData = shards[i].currentDataElements();
+                nextData.applyDelta(oldData, deltaData);
+                shards[i].setCurrentData(nextData);
+                notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+                deltaData.destroy();
+                oldData.destroy();
+            }
             stateEngine.getMemoryRecycler().swap();
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -123,9 +123,9 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
                 nextData.applyDelta(oldData, deltaData);
                 shards[i].setCurrentData(nextData);
                 notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
-                deltaData.destroy();
                 oldData.destroy();
             }
+            deltaData.destroy();
             stateEngine.getMemoryRecycler().swap();
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -130,9 +130,9 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
                 nextData.applyDelta(oldData, deltaData);
                 shards[i].setCurrentData(nextData);
                 notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
-                deltaData.destroy();
                 oldData.destroy();
             }
+            deltaData.destroy();
             stateEngine.getMemoryRecycler().swap();
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -24,6 +24,7 @@ import com.netflix.hollow.api.sampling.HollowSampler;
 import com.netflix.hollow.api.sampling.HollowSamplingDirector;
 import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
 import com.netflix.hollow.core.memory.MemoryMode;
+import com.netflix.hollow.core.memory.encoding.GapEncodedVariableLengthIntegerReader;
 import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.core.read.HollowBlobInput;
@@ -103,14 +104,35 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
 
         for(int i=0; i<shards.length; i++) {
             HollowMapTypeDataElements deltaData = new HollowMapTypeDataElements(memoryMode, memoryRecycler);
-            HollowMapTypeDataElements nextData = new HollowMapTypeDataElements(memoryMode, memoryRecycler);
             deltaData.readDelta(in);
-            HollowMapTypeDataElements oldData = shards[i].currentDataElements();
-            nextData.applyDelta(oldData, deltaData);
-            shards[i].setCurrentData(nextData);
-            notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
-            deltaData.destroy();
-            oldData.destroy();
+            if(stateEngine.isSkipTypeShardUpdateWithNoAdditions() && deltaData.encodedAdditions.isEmpty()) {
+
+                if(!deltaData.encodedRemovals.isEmpty())
+                    notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+
+                HollowMapTypeDataElements currentData = shards[i].currentDataElements();
+                GapEncodedVariableLengthIntegerReader oldRemovals = currentData.encodedRemovals == null ? GapEncodedVariableLengthIntegerReader.EMPTY_READER : currentData.encodedRemovals;
+                if(oldRemovals.isEmpty()) {
+                    currentData.encodedRemovals = deltaData.encodedRemovals;
+                    oldRemovals.destroy();
+                } else {
+                    if(!deltaData.encodedRemovals.isEmpty()) {
+                        currentData.encodedRemovals = GapEncodedVariableLengthIntegerReader.combine(oldRemovals, deltaData.encodedRemovals, memoryRecycler);
+                        oldRemovals.destroy();
+                    }
+                    deltaData.encodedRemovals.destroy();
+                }
+
+                deltaData.encodedAdditions.destroy();
+            } else {
+                HollowMapTypeDataElements nextData = new HollowMapTypeDataElements(memoryMode, memoryRecycler);
+                HollowMapTypeDataElements oldData = shards[i].currentDataElements();
+                nextData.applyDelta(oldData, deltaData);
+                shards[i].setCurrentData(nextData);
+                notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+                deltaData.destroy();
+                oldData.destroy();
+            }
             stateEngine.getMemoryRecycler().swap();
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -131,9 +131,9 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
                 nextData.applyDelta(oldData, deltaData);
                 shards[i].setCurrentData(nextData);
                 notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
-                deltaData.destroy();
                 oldData.destroy();
             }
+            deltaData.destroy();
             stateEngine.getMemoryRecycler().swap();
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -131,9 +131,9 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
                 nextData.applyDelta(oldData, deltaData);
                 shards[i].setCurrentData(nextData);
                 notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
-                deltaData.destroy();
                 oldData.destroy();
             }
+            deltaData.destroy();
             stateEngine.getMemoryRecycler().swap();
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -24,6 +24,7 @@ import com.netflix.hollow.api.sampling.HollowSamplingDirector;
 import com.netflix.hollow.api.sampling.HollowSetSampler;
 import com.netflix.hollow.core.index.key.HollowPrimaryKeyValueDeriver;
 import com.netflix.hollow.core.memory.MemoryMode;
+import com.netflix.hollow.core.memory.encoding.GapEncodedVariableLengthIntegerReader;
 import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.core.read.HollowBlobInput;
@@ -104,14 +105,35 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
 
         for(int i=0;i<shards.length;i++) {
             HollowSetTypeDataElements deltaData = new HollowSetTypeDataElements(memoryMode, memoryRecycler);
-            HollowSetTypeDataElements nextData = new HollowSetTypeDataElements(memoryMode, memoryRecycler);
             deltaData.readDelta(in);
-            HollowSetTypeDataElements oldData = shards[i].currentDataElements();
-            nextData.applyDelta(oldData, deltaData);
-            shards[i].setCurrentData(nextData);
-            notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
-            deltaData.destroy();
-            oldData.destroy();
+            if(stateEngine.isSkipTypeShardUpdateWithNoAdditions() && deltaData.encodedAdditions.isEmpty()) {
+
+                if(!deltaData.encodedRemovals.isEmpty())
+                    notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+
+                HollowSetTypeDataElements currentData = shards[i].currentDataElements();
+                GapEncodedVariableLengthIntegerReader oldRemovals = currentData.encodedRemovals == null ? GapEncodedVariableLengthIntegerReader.EMPTY_READER : currentData.encodedRemovals;
+                if(oldRemovals.isEmpty()) {
+                    currentData.encodedRemovals = deltaData.encodedRemovals;
+                    oldRemovals.destroy();
+                } else {
+                    if(!deltaData.encodedRemovals.isEmpty()) {
+                        currentData.encodedRemovals = GapEncodedVariableLengthIntegerReader.combine(oldRemovals, deltaData.encodedRemovals, memoryRecycler);
+                        oldRemovals.destroy();
+                    }
+                    deltaData.encodedRemovals.destroy();
+                }
+
+                deltaData.encodedAdditions.destroy();
+            } else {
+                HollowSetTypeDataElements nextData = new HollowSetTypeDataElements(memoryMode, memoryRecycler);
+                HollowSetTypeDataElements oldData = shards[i].currentDataElements();
+                nextData.applyDelta(oldData, deltaData);
+                shards[i].setCurrentData(nextData);
+                notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+                deltaData.destroy();
+                oldData.destroy();
+            }
             stateEngine.getMemoryRecycler().swap();
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016-2019 Netflix, Inc.
+ *  Copyright 2016-2021 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -138,12 +138,12 @@ public abstract class HollowTypeWriteState {
     public void resetToLastPrepareForNextCycle() {
         if(restoredReadState == null) {
             currentCyclePopulated.clearAll();
-            ordinalMap.compact(previousCyclePopulated);
+            ordinalMap.compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards());
         } else {
             /// this state engine began the cycle as a restored state engine
             currentCyclePopulated.clearAll();
             previousCyclePopulated.clearAll();
-            ordinalMap.compact(previousCyclePopulated);
+            ordinalMap.compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards());
             restoreFrom(restoredReadState);
             wroteData = false;
         }
@@ -251,7 +251,7 @@ public abstract class HollowTypeWriteState {
      * Postcondition: We are ready to add objects to this state engine for the next server cycle.
      */
     public void prepareForNextCycle() {
-        ordinalMap.compact(currentCyclePopulated);
+        ordinalMap.compact(currentCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards());
 
         ThreadSafeBitSet temp = previousCyclePopulated;
         previousCyclePopulated = currentCyclePopulated;

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/FocusedShardHoleFillTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/FocusedShardHoleFillTest.java
@@ -1,0 +1,226 @@
+package com.netflix.hollow.api.consumer;
+
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.HollowProducer.WriteState;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.read.engine.list.HollowListTypeReadState;
+import com.netflix.hollow.core.read.engine.map.HollowMapTypeReadState;
+import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
+import com.netflix.hollow.core.read.engine.set.HollowSetTypeReadState;
+import com.netflix.hollow.core.read.iterator.HollowMapEntryOrdinalIterator;
+import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+import com.netflix.hollow.core.write.objectmapper.HollowInline;
+import com.netflix.hollow.core.write.objectmapper.HollowShardLargeType;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FocusedShardHoleFillTest {
+    
+    @Test
+    public void focusChanges() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowProducer producer = HollowProducer.withPublisher(blobStore).withBlobStager(new HollowInMemoryBlobStager()).withFocusHoleFillInFewestShards(true).build();
+        long v1 = producer.runCycle(state -> {
+            for(int i=1;i<=36;i++) {
+                add(state, "val" + i, i);
+            }
+        });
+        
+        HollowConsumer consumer = HollowConsumer.newHollowConsumer().withBlobRetriever(blobStore).withSkipTypeShardUpdateWithNoAdditions().build();
+        consumer.triggerRefreshTo(v1);
+        
+        Assert.assertEquals(4, consumer.getStateEngine().getTypeState("TestRec").numShards());
+        Assert.assertEquals(4, consumer.getStateEngine().getTypeState("ListOfTestRec").numShards());
+        Assert.assertEquals(4, consumer.getStateEngine().getTypeState("SetOfTestRec").numShards());
+        Assert.assertEquals(4, consumer.getStateEngine().getTypeState("MapOfTestRecToTestRec").numShards());
+        
+        /// remove 4 from S0: 13, 21, 25, 29
+        /// remove 5 from S1:  6, 14, 18, 26, 30
+        /// remove 2 from S2: 11, 19
+        /// remove 1 from S3: 24
+        Set<Integer> removeSet = new HashSet<>(Arrays.asList(13, 21, 25, 29, 6, 14, 18, 26, 30, 11, 19, 24));
+        
+        long v2 = producer.runCycle(state -> {
+            for(int i=1;i<=36;i++) {
+                if(!removeSet.contains(i))
+                    add(state, "val" + i, i);
+            }
+            
+            add(state, "newval37", 37);
+        });
+        
+        consumer.triggerRefreshTo(v2);
+        
+        removeSet.add(5);
+       
+        long v3 = producer.runCycle(state -> {
+            for(int i=1;i<=36;i++) {
+                if(!removeSet.contains(i))
+                    add(state, "val" + i, i);
+            }
+
+            add(state, "newval37", 37);
+
+            for(int i=1000;i<1005;i++) {
+                add(state, "bigval"+i, i);
+            }
+        });
+        
+        consumer.triggerRefreshTo(v3);
+        
+        /// all changes focused in shard 1
+        assertRecordOrdinal(consumer,  5, "bigval1000", 1000);
+        assertRecordOrdinal(consumer, 13, "bigval1001", 1001);
+        assertRecordOrdinal(consumer, 17, "bigval1002", 1002);
+        assertRecordOrdinal(consumer, 25, "bigval1003", 1003);
+        assertRecordOrdinal(consumer, 29, "bigval1004", 1004);
+        
+        assertRecordOrdinal(consumer, 32, "val33", 33); // shard1
+        assertRecordOrdinal(consumer,  9, "val10", 10); // shard2
+        assertRecordOrdinal(consumer, 14, "val15", 15);
+        assertRecordOrdinal(consumer, 11, "val12", 12);
+        
+        long v4 = producer.runCycle(state -> {
+            for(int i=1;i<=36;i++) {
+                if(!removeSet.contains(i))
+                    add(state, "val" + i, i);
+            }
+
+            add(state, "newval37", 37);
+
+            for(int i=1000;i<1010;i++) {
+                add(state, "bigval"+i, i);
+            }
+        });
+        
+        consumer.triggerRefreshTo(v4);
+        
+        /// all changes focused in shard 0
+        assertRecordOrdinal(consumer,  4, "bigval1005", 1005);
+        assertRecordOrdinal(consumer, 12, "bigval1006", 1006);
+        assertRecordOrdinal(consumer, 20, "bigval1007", 1007);
+        assertRecordOrdinal(consumer, 24, "bigval1008", 1008);
+        assertRecordOrdinal(consumer, 28, "bigval1009", 1009);
+        
+        assertRecordOrdinal(consumer, 32, "val33", 33); // shard1
+        assertRecordOrdinal(consumer,  9, "val10", 10); // shard2
+        assertRecordOrdinal(consumer, 14, "val15", 15);
+        assertRecordOrdinal(consumer, 11, "val12", 12);
+        
+        long v5 = producer.runCycle(state -> {
+            for(int i=1;i<=36;i++) {
+                if(!removeSet.contains(i))
+                    add(state, "val" + i, i);
+            }
+
+            add(state, "newval37", 37);
+
+            for(int i=1000;i<1013;i++) {
+                add(state, "bigval"+i, i);
+            }
+        });
+
+        consumer.triggerRefreshTo(v5);
+
+        /// all changes focused in shards 2 and 3
+        assertRecordOrdinal(consumer, 10, "bigval1010", 1010);
+        assertRecordOrdinal(consumer, 18, "bigval1011", 1011);
+        assertRecordOrdinal(consumer, 23, "bigval1012", 1012);
+        
+        assertRecordOrdinal(consumer, 32, "val33", 33); // shard1
+        assertRecordOrdinal(consumer,  9, "val10", 10); // shard2
+        assertRecordOrdinal(consumer, 14, "val15", 15);
+        assertRecordOrdinal(consumer, 11, "val12", 12);
+        
+        consumer.triggerRefreshTo(v1);
+        
+        BitSet ordinals = consumer.getStateEngine().getTypeState("TestRec").getPopulatedOrdinals();
+        
+        for(int i=0;i<36;i++) {
+            Assert.assertTrue(ordinals.get(i));
+            assertRecordOrdinal(consumer, i, "val"+(i+1), i+1);
+        }
+        
+        Assert.assertEquals(36, ordinals.cardinality());
+    }
+    
+    private void add(WriteState state, String sVal, int iVal) {
+        TestRec rec = new TestRec(sVal, iVal);
+        state.add(rec);
+        state.add(new ListRec(rec));
+        state.add(new SetRec(rec));
+        state.add(new MapRec(rec));
+    }
+    
+    private void assertRecordOrdinal(HollowConsumer consumer, int ordinal, String sVal, int iVal) {
+        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState)consumer.getStateEngine().getTypeState("TestRec");
+        
+        Assert.assertEquals(iVal, typeState.readInt(ordinal, typeState.getSchema().getPosition("intVal")));
+        Assert.assertEquals(sVal, typeState.readString(ordinal, typeState.getSchema().getPosition("strVal")));
+
+        HollowListTypeReadState listState = (HollowListTypeReadState)consumer.getStateEngine().getTypeState("ListOfTestRec");
+        HollowOrdinalIterator iter = listState.ordinalIterator(ordinal);
+        Assert.assertEquals(ordinal, iter.next());
+        Assert.assertEquals(HollowOrdinalIterator.NO_MORE_ORDINALS, iter.next());
+
+        HollowSetTypeReadState setState = (HollowSetTypeReadState)consumer.getStateEngine().getTypeState("SetOfTestRec");
+        iter = setState.ordinalIterator(ordinal);
+        Assert.assertEquals(ordinal, iter.next());
+        Assert.assertEquals(HollowOrdinalIterator.NO_MORE_ORDINALS, iter.next());
+        
+        HollowMapTypeReadState mapState = (HollowMapTypeReadState)consumer.getStateEngine().getTypeState("MapOfTestRecToTestRec");
+        HollowMapEntryOrdinalIterator mapIter = mapState.ordinalIterator(ordinal);
+        Assert.assertTrue(mapIter.next());
+        Assert.assertEquals(ordinal, mapIter.getKey());
+        Assert.assertEquals(ordinal, mapIter.getValue());
+        Assert.assertEquals(HollowOrdinalIterator.NO_MORE_ORDINALS, iter.next());
+
+    }
+    
+    private static class ListRec {
+        @HollowShardLargeType(numShards = 4)
+        private final List<TestRec> list;
+        
+        public ListRec(TestRec rec) {
+            this.list = Collections.singletonList(rec);
+        }
+    }
+    
+    private static class SetRec {
+        @HollowShardLargeType(numShards = 4)
+        private final Set<TestRec> set;
+        
+        public SetRec(TestRec rec) {
+            this.set = Collections.singleton(rec);
+        }
+    }
+    
+    private static class MapRec {
+        @HollowShardLargeType(numShards = 4)
+        private final Map<TestRec, TestRec> map;
+        
+        public MapRec(TestRec rec) {
+            this.map = Collections.singletonMap(rec, rec);
+        }
+    }
+    
+    @HollowShardLargeType(numShards = 4)
+    private static class TestRec {
+        @HollowInline
+        private final String strVal;
+        private final int intVal;
+        
+        public TestRec(String strVal, int intVal) {
+            this.strVal = strVal;
+            this.intVal = intVal;
+        }
+    }
+    
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/FreeOrdinalTrackerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/FreeOrdinalTrackerTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.memory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FreeOrdinalTrackerTest {
+
+    @Test
+    public void minimizeNumberOfUpdatedShards() {
+        FreeOrdinalTracker tracker = new FreeOrdinalTracker();
+        for(int i=0;i<100;i++)
+            tracker.getFreeOrdinal();
+
+        // shard 3
+        tracker.returnOrdinalToPool(15);
+
+        // shard 1
+        tracker.returnOrdinalToPool(13);
+        tracker.returnOrdinalToPool(9);
+        tracker.returnOrdinalToPool(17);
+        tracker.returnOrdinalToPool(5);
+        tracker.returnOrdinalToPool(1);
+        tracker.returnOrdinalToPool(21);
+
+        // shard 2
+        tracker.returnOrdinalToPool(2);
+        tracker.returnOrdinalToPool(10);
+        tracker.returnOrdinalToPool(14);
+
+        /// sort for 4 shards
+        tracker.sort(4);
+
+        Assert.assertEquals(1, tracker.getFreeOrdinal());
+        Assert.assertEquals(5, tracker.getFreeOrdinal());
+        Assert.assertEquals(9, tracker.getFreeOrdinal());
+        Assert.assertEquals(13, tracker.getFreeOrdinal());
+        Assert.assertEquals(17, tracker.getFreeOrdinal());
+        Assert.assertEquals(21, tracker.getFreeOrdinal());
+        Assert.assertEquals(2, tracker.getFreeOrdinal());
+        Assert.assertEquals(10, tracker.getFreeOrdinal());
+        Assert.assertEquals(14, tracker.getFreeOrdinal());
+        Assert.assertEquals(15, tracker.getFreeOrdinal());
+        Assert.assertEquals(100, tracker.getFreeOrdinal());
+        Assert.assertEquals(101, tracker.getFreeOrdinal());
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/encoding/GapEncodedVariableLengthIntegerReaderTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/encoding/GapEncodedVariableLengthIntegerReaderTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.memory.encoding;
+
+import com.netflix.hollow.core.memory.ByteDataArray;
+import com.netflix.hollow.core.memory.pool.WastefulRecycler;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GapEncodedVariableLengthIntegerReaderTest {
+
+    @Test
+    public void returnsValues() {
+        GapEncodedVariableLengthIntegerReader reader = reader(1, 10, 100, 105, 107, 200);
+
+        assertValues(reader, 1, 10, 100, 105, 107, 200);
+        reader.reset();
+        assertValues(reader, 1, 10, 100, 105, 107, 200);
+    }
+
+    @Test
+    public void testEmpty() {
+        GapEncodedVariableLengthIntegerReader reader = reader(20);
+        Assert.assertFalse(reader.isEmpty());
+
+        reader = reader();
+        Assert.assertTrue(reader.isEmpty());
+
+        Assert.assertTrue(GapEncodedVariableLengthIntegerReader.EMPTY_READER.isEmpty());
+    }
+
+    @Test
+    public void testCombine() {
+        GapEncodedVariableLengthIntegerReader reader1 = reader(1, 10, 100, 105, 107, 200);
+        GapEncodedVariableLengthIntegerReader reader2 = reader(5, 76, 100, 102, 109, 197, 198, 199, 200, 201);
+
+        GapEncodedVariableLengthIntegerReader combined = GapEncodedVariableLengthIntegerReader.combine(reader1, reader2, WastefulRecycler.SMALL_ARRAY_RECYCLER);
+
+        assertValues(combined, 1, 5, 10, 76, 100, 102, 105, 107, 109, 197, 198, 199, 200, 201);
+    }
+
+    private GapEncodedVariableLengthIntegerReader reader(int... values) {
+        ByteDataArray arr = new ByteDataArray(WastefulRecycler.SMALL_ARRAY_RECYCLER);
+
+        int cur = 0;
+        for(int i=0;i<values.length;i++) {
+            VarInt.writeVInt(arr, values[i] - cur);
+            cur = values[i];
+        }
+
+        return new GapEncodedVariableLengthIntegerReader(arr.getUnderlyingArray(), (int) arr.length());
+    }
+
+    private void assertValues(GapEncodedVariableLengthIntegerReader reader, int... expectedValues) {
+        for(int i=0;i<expectedValues.length;i++) {
+            Assert.assertEquals(expectedValues[i], reader.nextElement());
+            reader.advance();
+        }
+
+        Assert.assertEquals(Integer.MAX_VALUE, reader.nextElement());
+    }
+
+}


### PR DESCRIPTION
Currently, the effort required to process a type's delta is directly correlated with the size of the dataset, not the size of the delta.  For small updates on large types, this is suboptimal.  With this change, the effort required to process a delta of sharded types can be brought closer to being correlated with the size of the delta.

There are two changes here:
* The `HollowProducer` can be instructed to focus changes within a type to as few shards as possible where enough ordinal holes are available to fill.
* The `HollowConsumer` can be instructed to defer processing updates of shards where no additions are present in a delta.