### PR TITLE
Fix reverse delta header tags

### DIFF
--- a/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestHollowConsumer.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestHollowConsumer.java
@@ -145,7 +145,6 @@ public class TestHollowConsumer extends HollowConsumer {
         // create a new write state for delta application, restore from current state
         HollowWriteStateEngine deltaState = HollowWriteStateCreator.createWithSchemas(getStateEngine().getSchemas());
         deltaState.restoreFrom(getStateEngine());
-        deltaState.overridePreviousStateRandomizedTag(this.getStateEngine().getCurrentRandomizedTag());
 
         // add all records from passed in {@code state} to delta write state
         HollowCombiner combiner = new HollowCombiner(HollowCombinerCopyDirector.DEFAULT_DIRECTOR,

--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
@@ -188,7 +188,8 @@ public class HollowWriteStateCreator {
         } catch(Exception e) {
             throw new RuntimeException(e);
         }
-        
+
+        writeEngine.overridePreviousHeaderTags(readEngine.getHeaderTags());
         writeEngine.addHeaderTags(readEngine.getHeaderTags());
         writeEngine.overrideNextStateRandomizedTag(readEngine.getCurrentRandomizedTag());
         writeEngine.prepareForWrite();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
@@ -293,11 +293,12 @@ public class HollowBlobWriter {
             }
         }
         /// write main header
-        header.setHeaderTags(stateEngine.getHeaderTags());
         if(isReverseDelta) {
+            header.setHeaderTags(stateEngine.getPreviousHeaderTags());  // header tags corresponding to destination state
             header.setOriginRandomizedTag(stateEngine.getNextStateRandomizedTag());
             header.setDestinationRandomizedTag(stateEngine.getPreviousStateRandomizedTag());
         } else {
+            header.setHeaderTags(stateEngine.getHeaderTags());
             header.setOriginRandomizedTag(stateEngine.getPreviousStateRandomizedTag());
             header.setDestinationRandomizedTag(stateEngine.getNextStateRandomizedTag());
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
@@ -64,7 +64,8 @@ public class HollowWriteStateEngine implements HollowStateEngine {
     private final Map<String, HollowTypeWriteState> writeStates;
     private final Map<String, HollowSchema> hollowSchemas;
     private final List<HollowTypeWriteState> orderedTypeStates;
-    private final Map<String,String> headerTags = new ConcurrentHashMap<String, String>();
+    private final Map<String,String> headerTags = new ConcurrentHashMap<>();
+    private final Map<String,String> previousHeaderTags = new ConcurrentHashMap<>();
     private final HollowObjectHashCodeFinder hashCodeFinder;
     
     //// target a maximum shard size to reduce excess memory pool requirement 
@@ -170,6 +171,7 @@ public class HollowWriteStateEngine implements HollowStateEngine {
 
         previousStateRandomizedTag = readStateEngine.getCurrentRandomizedTag();
         nextStateRandomizedTag = mintNewRandomizedStateTag();
+        overridePreviousHeaderTags(readStateEngine.getHeaderTags());
 
         try {
             executor.awaitSuccessfulCompletion();
@@ -216,6 +218,7 @@ public class HollowWriteStateEngine implements HollowStateEngine {
 
         previousStateRandomizedTag = nextStateRandomizedTag;
         nextStateRandomizedTag = mintNewRandomizedStateTag();
+        overridePreviousHeaderTags(headerTags);
 
         try {
             SimultaneousExecutor executor = new SimultaneousExecutor(getClass(), "prepare-for-next-cycle");
@@ -369,6 +372,10 @@ public class HollowWriteStateEngine implements HollowStateEngine {
         this.headerTags.putAll(headerTags);
     }
 
+    public Map<String, String> getPreviousHeaderTags() {
+        return previousHeaderTags;
+    }
+
     @Override
     public String getHeaderTag(String name) {
         return headerTags.get(name);
@@ -385,6 +392,11 @@ public class HollowWriteStateEngine implements HollowStateEngine {
     
     public void overridePreviousStateRandomizedTag(long previousStateRandomizedTag) {
         this.previousStateRandomizedTag = previousStateRandomizedTag;
+    }
+
+    public void overridePreviousHeaderTags(Map<String, String> previousHeaderTags) {
+        this.previousHeaderTags.clear();
+        this.previousHeaderTags.putAll(previousHeaderTags);
     }
     
     public long getNextStateRandomizedTag() {

--- a/hollow/src/main/java/com/netflix/hollow/tools/patch/delta/HollowStateDeltaPatcher.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/patch/delta/HollowStateDeltaPatcher.java
@@ -104,6 +104,7 @@ public class HollowStateDeltaPatcher {
      */
     public void prepareInitialTransition() {
         writeEngine.overridePreviousStateRandomizedTag(from.getCurrentRandomizedTag());
+        writeEngine.overridePreviousHeaderTags(from.getHeaderTags());
         copyUnchangedDataToIntermediateState();
         remapTheChangedDataToUnusedOrdinals();
     }
@@ -114,6 +115,7 @@ public class HollowStateDeltaPatcher {
     public void prepareFinalTransition() {
         writeEngine.prepareForNextCycle();
         writeEngine.overrideNextStateRandomizedTag(to.getCurrentRandomizedTag());
+        writeEngine.addHeaderTags(to.getHeaderTags());
         copyUnchangedDataToDestinationState();
         remapTheChangedDataToDestinationOrdinals();
     }

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/metrics/AbstractRefreshMetricsListenerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/metrics/AbstractRefreshMetricsListenerTest.java
@@ -2,9 +2,14 @@ package com.netflix.hollow.api.consumer.metrics;
 
 import static com.netflix.hollow.core.HollowConstants.VERSION_NONE;
 import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_METRIC_CYCLE_START;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,7 +36,7 @@ public class AbstractRefreshMetricsListenerTest {
     class TestRefreshMetricsListener extends AbstractRefreshMetricsListener {
         @Override
         public void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
-            Assert.assertNotNull(refreshMetrics);
+            assertNotNull(refreshMetrics);
         }
     }
 
@@ -47,8 +52,8 @@ public class AbstractRefreshMetricsListenerTest {
     public void testRefreshStartedWithInitialLoad() {
         concreteRefreshMetricsListener.refreshStarted(VERSION_NONE, TEST_VERSION_HIGH);
         ConsumerRefreshMetrics refreshMetrics = concreteRefreshMetricsListener.refreshMetricsBuilder.build();
-        Assert.assertEquals(true, refreshMetrics.getIsInitialLoad());
-        Assert.assertNotNull(refreshMetrics.getUpdatePlanDetails());
+        assertEquals(true, refreshMetrics.getIsInitialLoad());
+        assertNotNull(refreshMetrics.getUpdatePlanDetails());
     }
 
     @Test
@@ -56,7 +61,7 @@ public class AbstractRefreshMetricsListenerTest {
         concreteRefreshMetricsListener.refreshStarted(TEST_VERSION_LOW, TEST_VERSION_HIGH);
         ConsumerRefreshMetrics refreshMetrics = concreteRefreshMetricsListener.refreshMetricsBuilder.build();
         Assert.assertFalse(refreshMetrics.getIsInitialLoad());
-        Assert.assertNotNull(refreshMetrics.getUpdatePlanDetails());
+        assertNotNull(refreshMetrics.getUpdatePlanDetails());
     }
 
     @Test
@@ -70,10 +75,10 @@ public class AbstractRefreshMetricsListenerTest {
         concreteRefreshMetricsListener.transitionsPlanned(TEST_VERSION_LOW, TEST_VERSION_HIGH, true, testTransitionSequence);
         ConsumerRefreshMetrics refreshMetrics = concreteRefreshMetricsListener.refreshMetricsBuilder.build();
 
-        Assert.assertEquals(HollowConsumer.Blob.BlobType.SNAPSHOT, refreshMetrics.getOverallRefreshType());
-        Assert.assertEquals(TEST_VERSION_HIGH, refreshMetrics.getUpdatePlanDetails().getDesiredVersion());
-        Assert.assertEquals(TEST_VERSION_LOW, refreshMetrics.getUpdatePlanDetails().getBeforeVersion());
-        Assert.assertEquals(testTransitionSequence, refreshMetrics.getUpdatePlanDetails().getTransitionSequence());
+        assertEquals(HollowConsumer.Blob.BlobType.SNAPSHOT, refreshMetrics.getOverallRefreshType());
+        assertEquals(TEST_VERSION_HIGH, refreshMetrics.getUpdatePlanDetails().getDesiredVersion());
+        assertEquals(TEST_VERSION_LOW, refreshMetrics.getUpdatePlanDetails().getBeforeVersion());
+        assertEquals(testTransitionSequence, refreshMetrics.getUpdatePlanDetails().getTransitionSequence());
     }
 
     @Test
@@ -87,10 +92,10 @@ public class AbstractRefreshMetricsListenerTest {
         concreteRefreshMetricsListener.transitionsPlanned(TEST_VERSION_LOW, TEST_VERSION_HIGH, false, testTransitionSequence);
         ConsumerRefreshMetrics refreshMetrics = concreteRefreshMetricsListener.refreshMetricsBuilder.build();
 
-        Assert.assertEquals(HollowConsumer.Blob.BlobType.DELTA, refreshMetrics.getOverallRefreshType());
-        Assert.assertEquals(TEST_VERSION_HIGH, refreshMetrics.getUpdatePlanDetails().getDesiredVersion());
-        Assert.assertEquals(TEST_VERSION_LOW, refreshMetrics.getUpdatePlanDetails().getBeforeVersion());
-        Assert.assertEquals(testTransitionSequence, refreshMetrics.getUpdatePlanDetails().getTransitionSequence());
+        assertEquals(HollowConsumer.Blob.BlobType.DELTA, refreshMetrics.getOverallRefreshType());
+        assertEquals(TEST_VERSION_HIGH, refreshMetrics.getUpdatePlanDetails().getDesiredVersion());
+        assertEquals(TEST_VERSION_LOW, refreshMetrics.getUpdatePlanDetails().getBeforeVersion());
+        assertEquals(testTransitionSequence, refreshMetrics.getUpdatePlanDetails().getTransitionSequence());
     }
 
     @Test
@@ -104,10 +109,10 @@ public class AbstractRefreshMetricsListenerTest {
         concreteRefreshMetricsListener.transitionsPlanned(TEST_VERSION_HIGH, TEST_VERSION_LOW, false, testTransitionSequence);
         ConsumerRefreshMetrics refreshMetrics = concreteRefreshMetricsListener.refreshMetricsBuilder.build();
 
-        Assert.assertEquals(HollowConsumer.Blob.BlobType.REVERSE_DELTA, refreshMetrics.getOverallRefreshType());
-        Assert.assertEquals(TEST_VERSION_LOW, refreshMetrics.getUpdatePlanDetails().getDesiredVersion());
-        Assert.assertEquals(TEST_VERSION_HIGH, refreshMetrics.getUpdatePlanDetails().getBeforeVersion());
-        Assert.assertEquals(testTransitionSequence, refreshMetrics.getUpdatePlanDetails().getTransitionSequence());
+        assertEquals(HollowConsumer.Blob.BlobType.REVERSE_DELTA, refreshMetrics.getOverallRefreshType());
+        assertEquals(TEST_VERSION_LOW, refreshMetrics.getUpdatePlanDetails().getDesiredVersion());
+        assertEquals(TEST_VERSION_HIGH, refreshMetrics.getUpdatePlanDetails().getBeforeVersion());
+        assertEquals(testTransitionSequence, refreshMetrics.getUpdatePlanDetails().getTransitionSequence());
     }
 
     @Test
@@ -115,11 +120,11 @@ public class AbstractRefreshMetricsListenerTest {
         class SuccessTestRefreshMetricsListener extends AbstractRefreshMetricsListener {
             @Override
             public void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
-                Assert.assertEquals(0l, refreshMetrics.getConsecutiveFailures());
-                Assert.assertEquals(true, refreshMetrics.getIsRefreshSuccess());
-                Assert.assertEquals(0l, refreshMetrics.getRefreshSuccessAgeMillisOptional().getAsLong());
+                assertEquals(0l, refreshMetrics.getConsecutiveFailures());
+                assertEquals(true, refreshMetrics.getIsRefreshSuccess());
+                assertEquals(0l, refreshMetrics.getRefreshSuccessAgeMillisOptional().getAsLong());
                 Assert.assertNotEquals(0l, refreshMetrics.getRefreshEndTimeNano());
-                Assert.assertEquals(TEST_CYCLE_START_TIMESTAMP, refreshMetrics.getCycleStartTimestamp().getAsLong());
+                assertEquals(TEST_CYCLE_START_TIMESTAMP, refreshMetrics.getCycleStartTimestamp().getAsLong());
             }
         }
         SuccessTestRefreshMetricsListener successTestRefreshMetricsListener = new SuccessTestRefreshMetricsListener();
@@ -154,8 +159,8 @@ public class AbstractRefreshMetricsListenerTest {
         class SuccessTestRefreshMetricsListener extends AbstractRefreshMetricsListener {
             @Override
             public void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
-                Assert.assertEquals(3, refreshMetrics.getUpdatePlanDetails().getNumSuccessfulTransitions());
-                Assert.assertEquals(TEST_CYCLE_START_TIMESTAMP, refreshMetrics.getCycleStartTimestamp().getAsLong());
+                assertEquals(3, refreshMetrics.getUpdatePlanDetails().getNumSuccessfulTransitions());
+                assertEquals(TEST_CYCLE_START_TIMESTAMP, refreshMetrics.getCycleStartTimestamp().getAsLong());
             }
         }
         List<HollowConsumer.Blob.BlobType> testTransitionSequence = new ArrayList<HollowConsumer.Blob.BlobType>() {{
@@ -188,8 +193,8 @@ public class AbstractRefreshMetricsListenerTest {
         class FailureTestRefreshMetricsListener extends AbstractRefreshMetricsListener {
             @Override
             public void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
-                Assert.assertEquals(1, refreshMetrics.getUpdatePlanDetails().getNumSuccessfulTransitions());
-                Assert.assertEquals(TEST_CYCLE_START_TIMESTAMP, refreshMetrics.getCycleStartTimestamp().getAsLong());
+                assertEquals(1, refreshMetrics.getUpdatePlanDetails().getNumSuccessfulTransitions());
+                assertEquals(TEST_CYCLE_START_TIMESTAMP, refreshMetrics.getCycleStartTimestamp().getAsLong());
             }
         }
         List<HollowConsumer.Blob.BlobType> testTransitionSequence = new ArrayList<HollowConsumer.Blob.BlobType>() {{
@@ -208,5 +213,78 @@ public class AbstractRefreshMetricsListenerTest {
 
         failureTestRefreshMetricsListener.refreshFailed(TEST_VERSION_LOW-1, TEST_VERSION_LOW, TEST_VERSION_HIGH, null);
 
+    }
+
+    @Test
+    public void testCycleStart() {  // also exercises reverse delta transition
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+        HollowProducer p = HollowProducer
+                .withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .build();
+        p.initializeDataModel(String.class);
+
+        long version1 = p.runCycle(ws -> {
+            // override cycle start time with a strictly incrementing count to prevent potential
+            // clock skew issue from use of System.currentTimeMillis() that would make test brittle
+            ws.getStateEngine().addHeaderTag(HEADER_TAG_METRIC_CYCLE_START, "1");
+            ws.add("A");
+        });
+
+        class TestRefreshMetricsListener extends AbstractRefreshMetricsListener {
+            int run = 0;
+
+            @Override
+            public void refreshEndMetricsReporting(ConsumerRefreshMetrics refreshMetrics) {
+                run ++;
+                assertNotNull(refreshMetrics.getCycleStartTimestamp());
+                switch (run) {
+                    case 1:
+                        assertEquals(1L, refreshMetrics.getCycleStartTimestamp().getAsLong());
+                        break;
+                    case 2:
+                    case 5:
+                        assertEquals(2L, refreshMetrics.getCycleStartTimestamp().getAsLong());
+                        break;
+                    case 3:
+                        assertEquals(1L, refreshMetrics.getCycleStartTimestamp().getAsLong());
+                        break;
+                    case 4:
+                        assertEquals(3L, refreshMetrics.getCycleStartTimestamp().getAsLong());
+                        break;
+                }
+            }
+        }
+        TestRefreshMetricsListener testMetricsListener = new TestRefreshMetricsListener();
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withRefreshListener(testMetricsListener)
+                .build();
+        consumer.triggerRefreshTo(version1);    // snapshot load
+
+        long version2 = p.runCycle(ws -> {
+            ws.getStateEngine().addHeaderTag(HEADER_TAG_METRIC_CYCLE_START, "2");
+            ws.add("B");
+        });
+
+        consumer.triggerRefreshTo(version2);    // delta transition
+        consumer.triggerRefreshTo(version1);    // reverse delta transition
+
+        // now restore from v2 and continue delta chain
+        HollowProducer p2 = HollowProducer
+                .withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .build();
+        p2.initializeDataModel(String.class);
+        p2.restore(version2, blobStore);
+
+        long version3 = p2.runCycle(ws -> {
+            ws.getStateEngine().addHeaderTag(HEADER_TAG_METRIC_CYCLE_START, "3");
+            ws.add("C");
+        });
+
+        consumer.triggerRefreshTo(version3);    // delta transition
+        consumer.triggerRefreshTo(version2);    // reverse delta transition
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/util/HollowWriteStateCreatorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/util/HollowWriteStateCreatorTest.java
@@ -16,6 +16,9 @@
  */
 package com.netflix.hollow.core.util;
 
+import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_METRIC_CYCLE_START;
+import static org.junit.Assert.assertEquals;
+
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
@@ -38,14 +41,18 @@ public class HollowWriteStateCreatorTest {
         HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
         mapper.add(new Integer(1));
         writeEngine.addHeaderTag("CopyTag", "copied");
+        writeEngine.addHeaderTag(HEADER_TAG_METRIC_CYCLE_START, String.valueOf(System.currentTimeMillis()));
         
         HollowReadStateEngine readEngine = StateEngineRoundTripper.roundTripSnapshot(writeEngine);
+        String cycleStartTime = readEngine.getHeaderTag(HEADER_TAG_METRIC_CYCLE_START);
         HollowWriteStateEngine recreatedWriteEngine = HollowWriteStateCreator.recreateAndPopulateUsingReadEngine(readEngine);
+        assertEquals(cycleStartTime, recreatedWriteEngine.getPreviousHeaderTags().get(HEADER_TAG_METRIC_CYCLE_START));
+
         HollowReadStateEngine recreatedReadEngine = StateEngineRoundTripper.roundTripSnapshot(recreatedWriteEngine);
         
-        Assert.assertEquals(HollowChecksum.forStateEngine(readEngine), HollowChecksum.forStateEngine(recreatedReadEngine));
-        Assert.assertEquals("copied", recreatedReadEngine.getHeaderTag("CopyTag"));
-        Assert.assertEquals(readEngine.getCurrentRandomizedTag(), recreatedReadEngine.getCurrentRandomizedTag());
+        assertEquals(HollowChecksum.forStateEngine(readEngine), HollowChecksum.forStateEngine(recreatedReadEngine));
+        assertEquals("copied", recreatedReadEngine.getHeaderTag("CopyTag"));
+        assertEquals(readEngine.getCurrentRandomizedTag(), recreatedReadEngine.getCurrentRandomizedTag());
     }
     
     @Test
@@ -84,16 +91,16 @@ public class HollowWriteStateCreatorTest {
         HollowReadStateEngine recreatedReadEngine = StateEngineRoundTripper.roundTripSnapshot(repopulatedWriteStateEngine);
         
         GenericHollowObject one = new GenericHollowObject(recreatedReadEngine, "Integer", 0);
-        Assert.assertEquals(1, one.getInt("value"));
+        assertEquals(1, one.getInt("value"));
         Assert.assertNull(one.getString("anotherValue"));
         
         GenericHollowObject two = new GenericHollowObject(recreatedReadEngine, "Integer", 1);
-        Assert.assertEquals(2, two.getInt("value"));
+        assertEquals(2, two.getInt("value"));
         Assert.assertNull(two.getString("anotherValue"));
         
         GenericHollowObject three = new GenericHollowObject(recreatedReadEngine, "Integer", 2);
-        Assert.assertEquals(3, three.getInt("value"));
-        Assert.assertEquals("3", three.getString("anotherValue"));
+        assertEquals(3, three.getInt("value"));
+        assertEquals("3", three.getString("anotherValue"));
     }
     
     @Test
@@ -118,17 +125,17 @@ public class HollowWriteStateCreatorTest {
 
         HollowObjectSchema schema = (HollowObjectSchema)recreatedReadEngine.getSchema("Integer");
         
-        Assert.assertEquals(1, schema.numFields());
-        Assert.assertEquals("value", schema.getFieldName(0));
+        assertEquals(1, schema.numFields());
+        assertEquals("value", schema.getFieldName(0));
         
         GenericHollowObject one = new GenericHollowObject(recreatedReadEngine, "Integer", 0);
-        Assert.assertEquals(1, one.getInt("value"));
+        assertEquals(1, one.getInt("value"));
         
         GenericHollowObject two = new GenericHollowObject(recreatedReadEngine, "Integer", 1);
-        Assert.assertEquals(2, two.getInt("value"));
+        assertEquals(2, two.getInt("value"));
         
         GenericHollowObject three = new GenericHollowObject(recreatedReadEngine, "Integer", 2);
-        Assert.assertEquals(3, three.getInt("value"));
+        assertEquals(3, three.getInt("value"));
     }
     
     @Test
@@ -153,9 +160,9 @@ public class HollowWriteStateCreatorTest {
     @Test
     public void testReadSchemaFileIntoWriteState() throws Exception {
         HollowWriteStateEngine engine = new HollowWriteStateEngine();
-        Assert.assertEquals("Should have no type states", 0, engine.getOrderedTypeStates().size());
+        assertEquals("Should have no type states", 0, engine.getOrderedTypeStates().size());
         HollowWriteStateCreator.readSchemaFileIntoWriteState("schema1.txt", engine);
-        Assert.assertEquals("Should now have types", 2, engine.getOrderedTypeStates().size());
+        assertEquals("Should now have types", 2, engine.getOrderedTypeStates().size());
     }
     
     @SuppressWarnings("unused")

--- a/hollow/src/test/java/com/netflix/hollow/core/write/HollowWriteStateEngineTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/HollowWriteStateEngineTest.java
@@ -1,0 +1,64 @@
+package com.netflix.hollow.core.write;
+
+import static org.junit.Assert.assertEquals;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import org.junit.Test;
+
+public class HollowWriteStateEngineTest {
+
+    private static final String TEST_TAG = "test";
+    @Test
+    public void testHeaderTagsOnDeltaAndReverseDelta() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+        HollowProducer p = HollowProducer
+                .withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .build();
+        p.initializeDataModel(String.class);
+
+        long version1 = p.runCycle(ws -> {
+            // override cycle start time with a strictly incrementing count to work around clock skew
+            ws.getStateEngine().addHeaderTag(TEST_TAG, "1");
+            ws.add("A");
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .build();
+        consumer.triggerRefreshTo(version1);    // snapshot load
+
+        long version2 = p.runCycle(ws -> {
+            ws.getStateEngine().addHeaderTag(TEST_TAG, "2");
+            ws.add("B");
+        });
+
+        consumer.triggerRefreshTo(version2);    // delta transition
+        assertEquals("2", consumer.getStateEngine().getHeaderTag(TEST_TAG));
+
+        consumer.triggerRefreshTo(version1);    // reverse delta transition
+        assertEquals("1", consumer.getStateEngine().getHeaderTag(TEST_TAG));
+
+        // now test the RESTORE case
+        HollowProducer p2 = HollowProducer
+                .withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .build();
+        p2.initializeDataModel(String.class);
+        p2.restore(version2, blobStore);
+
+        long version3 = p2.runCycle(ws -> {
+            ws.getStateEngine().addHeaderTag(TEST_TAG, "3");
+            ws.add("C");
+        });
+
+        consumer.triggerRefreshTo(version3);    // delta transition
+        assertEquals("3", consumer.getStateEngine().getHeaderTag(TEST_TAG));
+
+        consumer.triggerRefreshTo(version2);    // reverse delta transition
+        assertEquals("2", consumer.getStateEngine().getHeaderTag(TEST_TAG));
+    }
+}


### PR DESCRIPTION
Header tags set on reverse delta should be the same as those on the snapshot corresponding to the destination version (not those of source version). The old behavior caused issues when-
* pinning back to an older version, the header tags at the destination version weren't what you'd expect. Once place this caused an issue was in reporting the cycle start time metric which relies on a header tag- after traversing a reverse delta the value of the metric would reflect the origin state instead of the destination
* building history using reverse deltas- going from v2 to v1 we wouldn't have header tags set on the snapshot/delta to arrive at v1
