### PR TITLE
feature: HollowHistory can build history using reverse deltas to allow building history in both directions simultaneously

### DIFF
--- a/hollow-diff-ui/build.gradle
+++ b/hollow-diff-ui/build.gradle
@@ -10,9 +10,10 @@ facets {
 dependencies {
     api project(':hollow')
     api project(':hollow-ui-tools')
+    implementation project(':hollow-test')
     implementation 'com.google.code.gson:gson:2.8.0'
 
-    compileOnly 'org.eclipse.jetty:jetty-server:9.4.3.v20170317'
+    implementation 'org.eclipse.jetty:jetty-server:9.4.3.v20170317'
 
     testImplementation 'junit:junit:4.11'
 }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diffview/effigy/HollowEffigy.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diffview/effigy/HollowEffigy.java
@@ -134,4 +134,22 @@ public class HollowEffigy {
         COLLECTION
     }
 
+    @Override
+    public int hashCode() {
+        int hashcode = 31 + getFields().hashCode();
+        return hashcode;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if(this == other)
+            return true;
+
+        if(other instanceof HollowEffigy) {
+            HollowEffigy otherEffigy = (HollowEffigy) other;
+            return this.getFields().equals(otherEffigy.getFields());
+        }
+
+        return false;
+    }
 }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/jetty/HollowHistoryUIServer.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/jetty/HollowHistoryUIServer.java
@@ -27,13 +27,33 @@ public class HollowHistoryUIServer {
 
     private final UIServer server;
     private final HollowHistoryUI ui;
-    
+
+    /**
+     * HollowHistoryUIServer that builds history using a consumer that transitions forwards i.e. in increasing version 
+     * order (v1, v2, v3...). This constructor defaults time zone to PST.
+     *
+     * @param consumer HollowConsumer (already initialized with data) that will be traversing forward deltas
+     * @param port server port
+     */
+    public HollowHistoryUIServer(HollowConsumer consumer, int port) {
+        this(new HollowHistoryUI("", consumer), port);
+    }
+
     public HollowHistoryUIServer(HollowConsumer consumer, int port, TimeZone timeZone) {
         this(new HollowHistoryUI("", consumer, timeZone), port);
     }
 
-    public HollowHistoryUIServer(HollowConsumer consumer, int port) {
-        this(new HollowHistoryUI("", consumer), port);
+    /**
+     * Serves HollowHistoryUI that supports building history in both directions simultaneously.
+     * Fwd and rev consumers should be initialized to the same version before calling this constructor.
+     * Attempting double snapshots or forward version transitions on consumerRev will have unintended consequences on history.
+     *
+     * @param consumerFwd HollowConsumer (already initialized with data) that will be traversing forward deltas
+     * @param consumerRev HollowConsumer (also initialized to the same version as consumerFwd) that will be traversing reverse deltas
+     * @param port server port
+     */
+    public HollowHistoryUIServer(HollowConsumer consumerFwd, HollowConsumer consumerRev, int port) {
+        this(new HollowHistoryUI("", consumerFwd, consumerRev), port);
     }
 
     public HollowHistoryUIServer(HollowConsumer consumer, int numStatesToTrack, int port, TimeZone timeZone) {

--- a/hollow-diff-ui/src/test/java/com/netflix/hollow/diffview/FakeHollowHistoryUtil.java
+++ b/hollow-diff-ui/src/test/java/com/netflix/hollow/diffview/FakeHollowHistoryUtil.java
@@ -1,0 +1,299 @@
+package com.netflix.hollow.diffview;
+
+import static org.junit.Assert.assertEquals;
+
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.write.HollowBlobWriter;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.diffview.effigy.HollowEffigy;
+import com.netflix.hollow.diffview.effigy.HollowEffigyFactory;
+import com.netflix.hollow.history.ui.HollowHistoryUI;
+import com.netflix.hollow.history.ui.model.HistoryStateTypeChanges;
+import com.netflix.hollow.history.ui.model.RecordDiff;
+import com.netflix.hollow.history.ui.naming.HollowHistoryRecordNamer;
+import com.netflix.hollow.test.consumer.TestBlob;
+import com.netflix.hollow.test.consumer.TestBlobRetriever;
+import com.netflix.hollow.tools.history.HollowHistoricalState;
+import com.netflix.hollow.tools.history.HollowHistory;
+import com.netflix.hollow.tools.history.keyindex.HollowHistoricalStateTypeKeyOrdinalMapping;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Utility to help create a delta chain (with reverse deltas) containing some history UI friendly fake data,
+ * and utilities to help compare outputs of HollowHistoryUIs for parity.
+ */
+public class FakeHollowHistoryUtil {
+    private static final String CUSTOM_VERSION_TAG = "myVersion";
+
+    public static void createDeltaChain(TestBlobRetriever testBlobRetriever) throws IOException {
+
+        HollowObjectSchema movieSchema = new HollowObjectSchema("Movie", 2, "id");
+        movieSchema.addField("id", HollowObjectSchema.FieldType.INT);
+        movieSchema.addField("name", HollowObjectSchema.FieldType.STRING);
+
+        HollowWriteStateEngine stateEngine = new HollowWriteStateEngine();
+        stateEngine.addTypeState(new HollowObjectTypeWriteState(movieSchema));
+
+        // v1
+        stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v1");
+        addMovie(stateEngine, 1, "movie1-added-in-v1");
+        addMovie(stateEngine, 2, "movie2-added-in-v1");
+        addMovie(stateEngine, 3, "movie3-added-in-v1-removed-in-v2");
+        stateEngine.prepareForWrite();
+        ByteArrayOutputStream baos_v1 = new ByteArrayOutputStream();
+        HollowBlobWriter writer = new HollowBlobWriter(stateEngine);
+        writer.writeSnapshot(baos_v1);
+        testBlobRetriever.addSnapshot(1, new TestBlob(1,new ByteArrayInputStream(baos_v1.toByteArray())));
+
+        // v2
+        stateEngine.prepareForNextCycle();
+        stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v2");
+        addMovie(stateEngine, 1, "movie1-added-in-v1");
+        addMovie(stateEngine, 2, "movie2-added-in-v1-modified-in-v2-removed-in-v5");
+        addMovie(stateEngine, 4, "movie4-added-in-v2");
+        stateEngine.prepareForWrite();
+        ByteArrayOutputStream baos_v1_to_v2 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v2_to_v1 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v2 = new ByteArrayOutputStream();
+        writer.writeSnapshot(baos_v2);
+        writer.writeDelta(baos_v1_to_v2);
+        writer.writeReverseDelta(baos_v2_to_v1);
+        testBlobRetriever.addSnapshot(2, new TestBlob(2,new ByteArrayInputStream(baos_v2.toByteArray())));
+        testBlobRetriever.addDelta(1, new TestBlob(1, 2, new ByteArrayInputStream(baos_v1_to_v2.toByteArray())));
+        testBlobRetriever.addReverseDelta(2, new TestBlob(2, 1, new ByteArrayInputStream(baos_v2_to_v1.toByteArray())));
+
+        // v3
+        stateEngine.prepareForNextCycle();
+        stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v3");
+        addMovie(stateEngine, 1, "movie1-added-in-v1-modified-in-v3-removed-in-v4");
+        addMovie(stateEngine, 2, "movie2-added-in-v1-modified-in-v2-removed-in-v5");
+        addMovie(stateEngine, 4, "movie4-added-in-v2");
+        addMovie(stateEngine, 5, "movie5-added-in-v3-removed-in-v5");
+        stateEngine.prepareForWrite();
+        ByteArrayOutputStream baos_v2_to_v3 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v3_to_v2 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v3 = new ByteArrayOutputStream();
+        writer.writeSnapshot(baos_v3);
+        writer.writeDelta(baos_v2_to_v3);
+        writer.writeReverseDelta(baos_v3_to_v2);
+        testBlobRetriever.addSnapshot(3, new TestBlob(3,new ByteArrayInputStream(baos_v3.toByteArray())));
+        testBlobRetriever.addDelta(2, new TestBlob(2, 2, new ByteArrayInputStream(baos_v2_to_v3.toByteArray())));
+        testBlobRetriever.addReverseDelta(3, new TestBlob(3, 2, new ByteArrayInputStream(baos_v3_to_v2.toByteArray())));
+
+        // v4
+        stateEngine.prepareForNextCycle();
+        stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v4");
+        addMovie(stateEngine, 2, "movie2-added-in-v1-modified-in-v2-removed-in-v5");
+        addMovie(stateEngine, 4, "movie4-added-in-v2-modified-in-v4");
+        addMovie(stateEngine, 5, "movie5-added-in-v3-removed-in-v5");
+        addMovie(stateEngine, 6, "movie6-added-in-v4");
+
+        stateEngine.prepareForWrite();
+        ByteArrayOutputStream baos_v4 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v3_to_v4 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v4_to_v3 = new ByteArrayOutputStream();
+        writer.writeSnapshot(baos_v4);
+        writer.writeDelta(baos_v3_to_v4);
+        writer.writeReverseDelta(baos_v4_to_v3);
+        testBlobRetriever.addSnapshot(4, new TestBlob(4,new ByteArrayInputStream(baos_v4.toByteArray())));
+        testBlobRetriever.addDelta(3, new TestBlob(3, 4, new ByteArrayInputStream(baos_v3_to_v4.toByteArray())));
+        testBlobRetriever.addReverseDelta(4, new TestBlob(4, 3, new ByteArrayInputStream(baos_v4_to_v3.toByteArray())));
+
+        // v5
+        stateEngine.prepareForNextCycle();
+        stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v5");
+        addMovie(stateEngine, 4, "movie4-added-in-v2-modified-in-v4");
+        addMovie(stateEngine, 6, "movie6-added-in-v4-modified-in-v5");
+        addMovie(stateEngine, 7, "movie7-added-in-v5-removed-in-v6");
+        stateEngine.prepareForWrite();
+        ByteArrayOutputStream baos_v5 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v4_to_v5 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v5_to_v4 = new ByteArrayOutputStream();
+        writer.writeSnapshot(baos_v5);
+        writer.writeDelta(baos_v4_to_v5);
+        writer.writeReverseDelta(baos_v5_to_v4);
+        testBlobRetriever.addSnapshot(5, new TestBlob(5,new ByteArrayInputStream(baos_v5.toByteArray())));
+        testBlobRetriever.addDelta(4, new TestBlob(4, 5, new ByteArrayInputStream(baos_v4_to_v5.toByteArray())));
+        testBlobRetriever.addReverseDelta(5, new TestBlob(5, 4, new ByteArrayInputStream(baos_v5_to_v4.toByteArray())));
+
+        // v6 - only snapshot artifact, also contains new type in schema- to test double snapshots
+        stateEngine.prepareForNextCycle();
+        stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v6");
+        addMovie(stateEngine, 4, "movie4-added-in-v2-modified-in-v4-also-modified-in-v6");
+        addMovie(stateEngine, 8, "movie8-added-in-v6");
+        stateEngine.prepareForWrite();
+        ByteArrayOutputStream baos_v6 = new ByteArrayOutputStream();
+        writer.writeSnapshot(baos_v6);
+        testBlobRetriever.addSnapshot(6, new TestBlob(6,new ByteArrayInputStream(baos_v6.toByteArray())));
+
+
+        // v7 - introduces schema change
+        stateEngine.prepareForNextCycle();
+        HollowObjectSchema actorSchema = new HollowObjectSchema("Actor", 1, "id");
+        actorSchema.addField("id", HollowObjectSchema.FieldType.INT);
+        stateEngine.addTypeState(new HollowObjectTypeWriteState(actorSchema));
+        stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v7");
+        addMovie(stateEngine, 4, "movie4-added-in-v2-modified-in-v4-also-modified-in-v6");
+        addActor(stateEngine, 1);
+        stateEngine.prepareForWrite();
+        ByteArrayOutputStream baos_v7 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v6_to_v7 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v7_to_v6 = new ByteArrayOutputStream();
+        writer.writeSnapshot(baos_v7);
+        writer.writeDelta(baos_v6_to_v7);
+        writer.writeReverseDelta(baos_v7_to_v6);
+        testBlobRetriever.addSnapshot(7, new TestBlob(7, new ByteArrayInputStream(baos_v7.toByteArray())));
+        testBlobRetriever.addDelta(6, new TestBlob(6, 7, new ByteArrayInputStream(baos_v6_to_v7.toByteArray())));
+        testBlobRetriever.addReverseDelta(7, new TestBlob(7, 6, new ByteArrayInputStream(baos_v7_to_v6.toByteArray())));
+
+        // v0 - snapshot only - just to test that double snapshot can not be applied in reverse direction
+        HollowWriteStateEngine stateEngineV0 = new HollowWriteStateEngine();
+        stateEngineV0.addTypeState(new HollowObjectTypeWriteState(movieSchema));
+        addMovie(stateEngineV0, 0, "movie0-never-shows-up-in-ui");
+        stateEngineV0.prepareForWrite();
+        ByteArrayOutputStream baos_v0 = new ByteArrayOutputStream();
+        writer.writeSnapshot(baos_v0);
+        testBlobRetriever.addSnapshot(0, new TestBlob(0,new ByteArrayInputStream(baos_v0.toByteArray())));
+    }
+
+    public static void assertUiParity(HollowHistoryUI hui1, HollowHistoryUI hui2) {
+        HollowHistory h1 = hui1.getHistory();
+        HollowHistory h2 = hui2.getHistory();
+        List<RecordDiff> addedDiffs1, addedDiffs2, removedDiffs1, removedDiffs2, modifiedDiffs1, modifiedDiffs2;
+        HollowHistoricalState state1, state2;
+
+        //OverviewPage
+        assertEquals("Should have same number of Historical States", h1.getHistoricalStates().length, h2.getHistoricalStates().length);
+        for (int j = 0; j < h1.getHistoricalStates().length; j++) {
+            state1 = h1.getHistoricalStates()[j];
+            state2 = h2.getHistoricalStates()[j];
+
+            // make sure traversal is in the right order
+            assertEquals("Prev state should be the same", getPreviousStateVersion(state1, h1), getPreviousStateVersion(state2, h2));
+            assertEquals("Next state should be the same", getNextStateVersion(state1), getNextStateVersion(state2));
+            assertEquals("Same size of type mappings for historical state", state1.getKeyOrdinalMapping().getTypeMappings().size(), state2.getKeyOrdinalMapping().getTypeMappings().size());
+            assertEquals("Not same key set of type mappings for historical state", state1.getKeyOrdinalMapping().getTypeMappings().keySet(), state2.getKeyOrdinalMapping().getTypeMappings().keySet());
+
+            Map<String, String> headerTags1 = state1.getHeaderEntries();
+            Map<String, String> headerTags2 = state2.getHeaderEntries();
+            assertEquals(headerTags1, headerTags2);
+
+            for (String key : state2.getKeyOrdinalMapping().getTypeMappings().keySet()) {
+
+                HollowHistoricalStateTypeKeyOrdinalMapping typeKeyMapping1 = state1.getKeyOrdinalMapping().getTypeMappings().get(key);
+                HollowHistoricalStateTypeKeyOrdinalMapping typeKeyMapping2 = state2.getKeyOrdinalMapping().getTypeMappings().get(key);
+
+                assertEquals("No. of added records", typeKeyMapping1.getNumberOfNewRecords(), typeKeyMapping2.getNumberOfNewRecords());
+                assertEquals("No. of removed records", typeKeyMapping1.getNumberOfRemovedRecords(), typeKeyMapping2.getNumberOfRemovedRecords());
+                assertEquals("No. of modified records", typeKeyMapping1.getNumberOfModifiedRecords(), typeKeyMapping2.getNumberOfModifiedRecords());
+
+                HistoryStateTypeChanges typeChanges1 = new HistoryStateTypeChanges(state1, key, HollowHistoryRecordNamer.DEFAULT_RECORD_NAMER, new String[0]);
+                HistoryStateTypeChanges typeChanges2 = new HistoryStateTypeChanges(state2, key, HollowHistoryRecordNamer.DEFAULT_RECORD_NAMER, new String[0]);
+
+                addedDiffs1 = typeChanges1.getAddedRecords().getRecordDiffs();
+                addedDiffs2 = typeChanges2.getAddedRecords().getRecordDiffs();
+                removedDiffs1 = typeChanges1.getRemovedRecords().getRecordDiffs();
+                removedDiffs2 = typeChanges2.getRemovedRecords().getRecordDiffs();
+                modifiedDiffs1 = typeChanges1.getModifiedRecords().getRecordDiffs();
+                modifiedDiffs2 = typeChanges2.getModifiedRecords().getRecordDiffs();
+
+                assertEquals("Add Diffs size", addedDiffs1.size(), addedDiffs2.size());
+                assertEquals("Remove Diffs size", removedDiffs1.size(), removedDiffs2.size());
+                assertEquals("Modified Diffs size", modifiedDiffs1.size(), modifiedDiffs2.size());
+
+                assertEquals("Added subgroups (if any)", typeChanges1.getAddedRecords().hasSubGroups(), typeChanges2.getAddedRecords().hasSubGroups());
+                assertEquals("Removed subgroups (if any)", typeChanges1.getRemovedRecords().hasSubGroups(), typeChanges2.getRemovedRecords().hasSubGroups());
+                assertEquals("Added subgroups (if any)", typeChanges1.getModifiedRecords().hasSubGroups(), typeChanges2.getModifiedRecords().hasSubGroups());
+                HollowEffigyFactory effigyFactory = new HollowEffigyFactory();
+
+                Set<HollowEffigy> addedEffigies1 = new HashSet<>();
+                Set<HollowEffigy> addedEffigies2 = new HashSet<>();
+                if (!typeChanges1.getAddedRecords().isEmpty()) {
+                    addedEffigies1 = toEffigies(addedDiffs1, effigyFactory, state1);
+                    addedEffigies2 = toEffigies(addedDiffs2, effigyFactory, state2);
+                }
+                assertEquals(addedEffigies1, addedEffigies2);
+
+                Set<HollowEffigy> modifiedFromEffigies1 = new HashSet<>();
+                Set<HollowEffigy> modifiedToEffigies1 = new HashSet<>();
+                Set<HollowEffigy> modifiedFromEffigies2 = new HashSet<>();
+                Set<HollowEffigy> modifiedToEffigies2 = new HashSet<>();
+                if (!typeChanges1.getModifiedRecords().isEmpty()) {
+                    modifiedFromEffigies1 = fromEffigies(modifiedDiffs1, effigyFactory, state1);
+                    modifiedFromEffigies2 = fromEffigies(modifiedDiffs2, effigyFactory, state2);
+
+                    modifiedToEffigies1 = toEffigies(modifiedDiffs1, effigyFactory, state1);
+                    modifiedToEffigies2 = toEffigies(modifiedDiffs2, effigyFactory, state2);
+                }
+                assertEquals(modifiedFromEffigies1, modifiedFromEffigies2);
+                assertEquals(modifiedToEffigies1, modifiedToEffigies2);
+
+                Set<HollowEffigy> removedEffigies1 = new HashSet<>();
+                Set<HollowEffigy> removedEffigies2 = new HashSet<>();
+                if (!typeChanges1.getRemovedRecords().isEmpty()) {
+                    removedEffigies1 = fromEffigies(removedDiffs1, effigyFactory, state1);
+                    removedEffigies2 = fromEffigies(removedDiffs2, effigyFactory, state2);
+                }
+                assertEquals(removedEffigies1, removedEffigies2);
+            }
+        }
+    }
+
+    private static Set<HollowEffigy> fromEffigies(List<RecordDiff> recordDiffs, HollowEffigyFactory effigyFactory, HollowHistoricalState historicalState) {
+        Set<HollowEffigy> fromEffigies = new HashSet<>();
+        for (int i = 0; i < recordDiffs.size(); i++) {
+            RecordDiff recordDiff = recordDiffs.get(i);
+            HollowEffigy fromEffigy = effigyFactory.effigy(historicalState.getDataAccess(),
+                    "Movie", recordDiff.getFromOrdinal());
+            fromEffigies.add(fromEffigy);
+        }
+        return fromEffigies;
+    }
+
+    private static Set<HollowEffigy> toEffigies(List<RecordDiff> recordDiffs, HollowEffigyFactory effigyFactory, HollowHistoricalState historicalState) {
+        Set<HollowEffigy> toEffigies = new HashSet<>();
+        for (int i = 0; i < recordDiffs.size(); i++) {
+            RecordDiff recordDiff = recordDiffs.get(i);
+            HollowEffigy toEffigy = effigyFactory.effigy(historicalState.getDataAccess(),
+                    "Movie", recordDiff.getToOrdinal());
+            toEffigies.add(toEffigy);
+        }
+        return toEffigies;
+    }
+
+    private static long getNextStateVersion(HollowHistoricalState currentHistoricalState) {
+        if (currentHistoricalState.getNextState() != null)
+            return currentHistoricalState.getNextState().getVersion();
+        return -1;
+    }
+
+    private static long getPreviousStateVersion(HollowHistoricalState currentHistoricalState, HollowHistory history) {
+        for(HollowHistoricalState state : history.getHistoricalStates()) {
+            if(state.getNextState() == currentHistoricalState) {
+                return state.getVersion();
+            }
+        }
+        return -1;
+    }
+
+    private static void addMovie(HollowWriteStateEngine stateEngine, int id, String name) {
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord((HollowObjectSchema) stateEngine.getSchema("Movie"));
+        rec.setInt("id", id);
+        rec.setString("name", name);
+        stateEngine.add("Movie", rec);
+    }
+
+    private static void addActor(HollowWriteStateEngine stateEngine, int id) {
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord((HollowObjectSchema) stateEngine.getSchema("Actor"));
+        rec.setInt("id", id);
+        stateEngine.add("Actor", rec);
+    }
+}

--- a/hollow-diff-ui/src/test/java/com/netflix/hollow/diffview/HollowHistoryUITest.java
+++ b/hollow-diff-ui/src/test/java/com/netflix/hollow/diffview/HollowHistoryUITest.java
@@ -1,0 +1,269 @@
+package com.netflix.hollow.diffview;
+
+import static com.netflix.hollow.diffview.FakeHollowHistoryUtil.assertUiParity;
+import static org.junit.Assert.assertNotNull;
+
+import com.netflix.hollow.history.ui.HollowHistoryUI;
+import com.netflix.hollow.history.ui.jetty.HollowHistoryUIServer;
+import com.netflix.hollow.test.consumer.TestBlobRetriever;
+import com.netflix.hollow.test.consumer.TestHollowConsumer;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HollowHistoryUITest {
+
+    private final int PORT_EXPECTED = 7777;
+    private final int PORT_ACTUAL = 7778;
+
+    private TestBlobRetriever testBlobRetriever;
+    private TestHollowConsumer consumerExpected;    // builds history using only deltas
+    private TestHollowConsumer consumerFwd;
+    private TestHollowConsumer consumerRev;
+    private HollowHistoryUIServer historyUIServerExpected;
+    private HollowHistoryUIServer historyUIServerActual;
+    private HollowHistoryUI historyUiExpected;  // built using fwd deltas application only
+
+    public HollowHistoryUITest() throws Exception {
+        testBlobRetriever = new TestBlobRetriever();
+        FakeHollowHistoryUtil.createDeltaChain(testBlobRetriever);
+    }
+
+    @Before
+    public void init() {
+        consumerExpected = new TestHollowConsumer.Builder()
+                .withBlobRetriever(testBlobRetriever)
+                .build();
+        consumerExpected.triggerRefreshTo(1);
+        historyUIServerExpected = new HollowHistoryUIServer(consumerExpected, PORT_EXPECTED);
+        consumerExpected.triggerRefreshTo(2);
+        consumerExpected.triggerRefreshTo(3);
+        consumerExpected.triggerRefreshTo(4);
+        consumerExpected.triggerRefreshTo(5);
+        historyUiExpected = historyUIServerExpected.getUI();
+
+        consumerFwd = new TestHollowConsumer.Builder()
+                .withBlobRetriever(testBlobRetriever)
+                .build();
+        consumerRev = new TestHollowConsumer.Builder()
+                .withBlobRetriever(testBlobRetriever)
+                .build();
+    }
+
+    @Test
+    public void historyUsingOnlyFwdConsumer() throws Exception  {
+        consumerFwd.triggerRefreshTo(1);    // snapshot
+
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, PORT_ACTUAL);
+
+        consumerFwd.triggerRefreshTo(2);    // delta
+        consumerFwd.triggerRefreshTo(3);    // delta
+        consumerFwd.triggerRefreshTo(4);    // delta
+        consumerFwd.triggerRefreshTo(5);    // delta
+
+        hostUisIfPairtyCheckFails();
+    }
+
+    @Test
+    public void historyUsingFwdAndRevConsumer_onlyRevDeltasApplied() throws Exception  {
+        consumerFwd.triggerRefreshTo(5);
+        consumerRev.triggerRefreshTo(5);
+
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+
+        consumerRev.triggerRefreshTo(4);
+        consumerRev.triggerRefreshTo(3);
+        consumerRev.triggerRefreshTo(2);
+        consumerRev.triggerRefreshTo(1);
+
+        hostUisIfPairtyCheckFails();
+    }
+
+    @Test
+    public void historyUsingFwdAndRevConsumer_bothFwdAndRevDeltasApplied_FwdFirst() throws Exception  {
+        consumerFwd.triggerRefreshTo(3);
+        consumerRev.triggerRefreshTo(3);
+
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+
+        consumerFwd.triggerRefreshTo(4);
+            consumerRev.triggerRefreshTo(2);
+        consumerFwd.triggerRefreshTo(5);
+            consumerRev.triggerRefreshTo(1);
+
+        hostUisIfPairtyCheckFails();
+    }
+
+    @Test
+    public void historyUsingFwdAndRevConsumer_traversingStatesAlreadyVisited() throws Exception {
+        consumerFwd.triggerRefreshTo(3);
+        consumerRev.triggerRefreshTo(3);
+
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+
+        consumerFwd.triggerRefreshTo(4);
+            consumerRev.triggerRefreshTo(2);
+        consumerFwd.triggerRefreshTo(5);
+        consumerFwd.triggerRefreshTo(4);
+        consumerFwd.triggerRefreshTo(3);
+        consumerFwd.triggerRefreshTo(4);
+        consumerFwd.triggerRefreshTo(5);
+            consumerRev.triggerRefreshTo(1);
+
+        consumerExpected.triggerRefreshTo(4);
+        consumerExpected.triggerRefreshTo(3);
+        consumerExpected.triggerRefreshTo(4);
+        consumerExpected.triggerRefreshTo(5);
+
+        hostUisIfPairtyCheckFails();
+    }
+
+    @Test
+    public void historyUsingFwdAndRevConsumer_bothFwdAndRevDeltasApplied_RevFirst() throws Exception  {
+        consumerFwd.triggerRefreshTo(3);
+        consumerRev.triggerRefreshTo(3);
+
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+
+        consumerRev.triggerRefreshTo(2);
+            consumerFwd.triggerRefreshTo(4);
+        consumerRev.triggerRefreshTo(1);
+            consumerFwd.triggerRefreshTo(5);
+
+        hostUisIfPairtyCheckFails();
+    }
+
+    @Test
+    public void historyUsingFwdAndRevConsumer_doubleSnapshotInFwd() throws Exception {
+        consumerFwd.triggerRefreshTo(3);
+        consumerRev.triggerRefreshTo(3);
+
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+
+        consumerRev.triggerRefreshTo(2);
+        consumerFwd.triggerRefreshTo(4);
+        consumerRev.triggerRefreshTo(1);
+        consumerFwd.triggerRefreshTo(5);
+
+        consumerFwd.triggerRefreshTo(6);    // double snapshot on fwd consumer in bidirectional history (supported)
+        consumerExpected.triggerRefreshTo(6);   // double snapshot for fwd-only history (supported)
+
+        hostUisIfPairtyCheckFails();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void historyUsingFwdAndRevConsumer_doubleSnapshotInRev() {
+        consumerFwd.triggerRefreshTo(3);
+        consumerRev.triggerRefreshTo(3);
+
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+
+        consumerRev.triggerRefreshTo(2);
+        consumerFwd.triggerRefreshTo(4);
+        consumerRev.triggerRefreshTo(1);
+        consumerFwd.triggerRefreshTo(5);
+
+        consumerRev.triggerRefreshTo(0);   // double snapshot in rev direction (not supported)
+    }
+
+    @Test
+    public void historyUsingFwdAndRevConsumer_backwardsCompatbileSchemaChange() throws Exception {
+        consumerFwd.triggerRefreshTo(7);    // version in whcih actor type was introduced
+        consumerRev.triggerRefreshTo(7);
+
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+
+        consumerRev.triggerRefreshTo(6);
+
+        assertNotNull(historyUIServerActual.getUI().getHistory().getHistoricalState(7).getDataAccess()
+                .getTypeDataAccess("Actor").getDataAccess());
+    }
+
+    @Test
+    public void historyUsingFwdAndRevConsumer_removeOldestState() throws Exception {
+        consumerFwd.triggerRefreshTo(3);
+        consumerRev.triggerRefreshTo(3);
+
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+
+        consumerRev.triggerRefreshTo(2);
+        consumerFwd.triggerRefreshTo(4);
+        consumerRev.triggerRefreshTo(1);
+        consumerFwd.triggerRefreshTo(5);
+
+        // drop 1 state
+        historyUIServerActual.getUI().getHistory().removeHistoricalStates(1);
+
+        // expected history is built for versions 2 through 5
+        consumerExpected = new TestHollowConsumer.Builder()
+                .withBlobRetriever(testBlobRetriever)
+                .build();
+        consumerExpected.triggerRefreshTo(2);
+        historyUIServerExpected = new HollowHistoryUIServer(consumerExpected, PORT_EXPECTED);
+        consumerExpected.triggerRefreshTo(3);
+        consumerExpected.triggerRefreshTo(4);
+        consumerExpected.triggerRefreshTo(5);
+        historyUiExpected = historyUIServerExpected.getUI();
+
+        hostUisIfPairtyCheckFails();
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void historyUsingFwdAndRevConsumer_noPastVersionsAvailableAtInit()  {
+        // consumerFwd and consumerRev haven't incurred snapshot load yet
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void historyUsingFwdOnly_noPastVersionsAvailableAtInit()  {
+        // consumerFwd hasn't incurred snapshot load yet
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, PORT_ACTUAL);
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void historyUsingFwdAndRevConsumer_revConsumerMustBeInitialized() throws Exception  {
+
+        TestHollowConsumer consumerFwd = new TestHollowConsumer.Builder()
+                .withBlobRetriever(testBlobRetriever)
+                .build();
+        TestHollowConsumer consumerRev = new TestHollowConsumer.Builder()
+                .withBlobRetriever(testBlobRetriever)
+                .build();
+
+        consumerFwd.triggerRefreshTo(5);
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+
+        // snapshots are only supported in the fwd direction, rev consumer should have been initialized
+        consumerRev.triggerRefreshTo(5);
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void historyUsingFwdAndRevConsumer_revAndFwdConsumersMustBeOnSameVersionAtInit()  {
+
+        TestHollowConsumer consumerFwd = new TestHollowConsumer.Builder()
+                .withBlobRetriever(testBlobRetriever)
+                .build();
+        TestHollowConsumer consumerRev = new TestHollowConsumer.Builder()
+                .withBlobRetriever(testBlobRetriever)
+                .build();
+
+        consumerFwd.triggerRefreshTo(5);
+        consumerRev.triggerRefreshTo(3);
+        historyUIServerActual = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT_ACTUAL);
+    }
+
+    private void hostUisIfPairtyCheckFails() throws Exception {
+        try {
+            assertUiParity(historyUiExpected, historyUIServerActual.getUI());
+        } catch (AssertionError | Exception e) {
+            System.out.println(String.format("Error when comparing expected and actual history UIs for parity. " +
+                            "Expected and actual history UIs are hosted at ports %s and %s respectively. " +
+                            "Be sure to open in different browsers for isolated sessions state stored in cookie which " +
+                            "could affect the links generated in the output html",
+                    PORT_EXPECTED, PORT_ACTUAL));
+            e.printStackTrace();
+            historyUIServerExpected.start();
+            historyUIServerActual.start();
+            historyUIServerActual.join();
+        }
+    }
+}

--- a/hollow-diff-ui/src/tools/java/com/netflix/hollow/diff/ui/HistoryUITest.java
+++ b/hollow-diff-ui/src/tools/java/com/netflix/hollow/diff/ui/HistoryUITest.java
@@ -1,158 +1,240 @@
 package com.netflix.hollow.diff.ui;
 
-import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.read.HollowBlobInput;
 import com.netflix.hollow.core.read.engine.HollowBlobReader;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
+import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
-import com.netflix.hollow.core.schema.HollowSchema;
-import com.netflix.hollow.core.util.StateEngineRoundTripper;
 import com.netflix.hollow.core.write.HollowBlobWriter;
 import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
 import com.netflix.hollow.core.write.HollowObjectWriteRecord;
-import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.history.ui.jetty.HollowHistoryUIServer;
 import com.netflix.hollow.tools.history.HollowHistory;
-import com.netflix.hollow.tools.history.keyindex.HollowHistoryKeyIndex;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.BitSet;
 import org.junit.Test;
 
+/**
+ * A tool to create a simple delta chain with fake data and spin up history UIs
+ * that build history in (a) purely fwd direction, and (b) both fwd and reverse
+ * directions simultaneously. This is not run as a part of the test suite.
+ *
+ * Ordinal maps for data used in this test-
+ *
+ *
+ * V0
+ *
+ * 0: 3, 13
+ * 1: 4, 44
+ * 2: 15, 150
+ * 3: 16, 160
+ *
+ *
+ * V1
+ *
+ * 4: 1, 1
+ * 5: 2, 2
+ * 6: 3, 3
+ * 7: 4, 4
+ * 8: 5, 5
+ * 9: 6, 6
+ *
+ *
+ * V2
+ *
+ * 0: 2, 7
+ * 1: 5, 8
+ * 2: 7, 9
+ * 3: 8, 10
+ * 6: 3, 3
+ * 9: 6, 6
+ *
+ *
+ * V3
+ *
+ * 0: 2, 7
+ * 3: 8, 10
+ * 4: 1, 1
+ * 5: 3, 11
+ * 7: 6, 12
+ * 8: 7, 13
+ *
+ *
+ * V4
+ * 0: 2, 7
+ * 1: 1, 18
+ * 2: 3, 19
+ * 3: 8, 10
+ * 6: 15, 13
+ * 7: 6, 12
+ * 9: 18, 10
+ * 10: 28, 90
+ *
+ */
 public class HistoryUITest {
 
-    @Test
-    public void startServerOnPort7777() throws Exception {
-        HollowHistory history = createHistory();
+    private static final String CUSTOM_VERSION_TAG = "myVersion";
+    private final int MAX_STATES = 10;
+    private HollowObjectSchema schema;
 
-        HollowHistoryUIServer server = new HollowHistoryUIServer(history, 7777);
-        server.start();
-        server.join();
+    @Test
+    public void startServerOnPorts7777And7778() throws Exception {
+
+        HollowHistory historyD = createHistoryD();
+        HollowHistoryUIServer serverD = new HollowHistoryUIServer(historyD, 7777);
+        serverD.start();
+
+        HollowHistory historyR = createHistoryBidirectional();
+        HollowHistoryUIServer serverR = new HollowHistoryUIServer(historyR, 7778);
+        serverR.start();
+
+        // optionally, test dropping the oldest state
+        // historyR.removeHistoricalStates(1);
+
+        serverD.join();
+        serverR.join();
     }
 
+    private HollowHistory createHistoryBidirectional() throws IOException {
+        HollowHistory history;
+        HollowWriteStateEngine stateEngine;
 
-    private HollowWriteStateEngine stateEngine;
-    private HollowObjectSchema schema;
-    private HollowObjectSchema bSchema;
+        {
+            schema = new HollowObjectSchema("TypeA", 2);
+            stateEngine = new HollowWriteStateEngine();
+            schema.addField("a1", HollowObjectSchema.FieldType.INT);
+            schema.addField("a2", HollowObjectSchema.FieldType.INT);
+            stateEngine.addTypeState(new HollowObjectTypeWriteState(schema));
 
-    private HollowHistory createHistory() throws IOException {
-        stateEngine = new HollowWriteStateEngine();
+            // v0
+            stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v0");
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 3, 13 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 4, 44 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 15, 150 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 16, 160 });
+            stateEngine.prepareForWrite();
+            ByteArrayOutputStream baos_v0 = new ByteArrayOutputStream();
+            HollowBlobWriter writer = new HollowBlobWriter(stateEngine);
+            writer.writeSnapshot(baos_v0);
+            stateEngine.prepareForNextCycle();
 
-        schema = new HollowObjectSchema("TypeA", 2);
-        schema.addField("a1", FieldType.INT);
-        schema.addField("a2", FieldType.INT);
+            // v1
+            stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v1");
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 1, 1 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 2, 2 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 3, 3 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 4, 4 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 5, 5 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 6, 6 });
+            stateEngine.prepareForWrite();
+            ByteArrayOutputStream baos_v1 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v0_to_v1 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v1_to_v0 = new ByteArrayOutputStream();
+            writer = new HollowBlobWriter(stateEngine);
+            writer.writeSnapshot(baos_v1);
+            writer.writeDelta(baos_v0_to_v1);
+            writer.writeReverseDelta(baos_v1_to_v0);
+            stateEngine.prepareForNextCycle();
 
-        HollowTypeWriteState writeState = new HollowObjectTypeWriteState(schema);
+            // v2
+            stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v2");
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 2, 7 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 3, 3 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 5, 8 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 6, 6 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 7, 9 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 8, 10 });
+            stateEngine.prepareForWrite();
+            ByteArrayOutputStream baos_v2 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v1_to_v2 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v2_to_v1 = new ByteArrayOutputStream();
+            writer.writeSnapshot(baos_v2);
+            writer.writeDelta(baos_v1_to_v2);
+            writer.writeReverseDelta(baos_v2_to_v1);
+            stateEngine.prepareForNextCycle();
 
-        stateEngine.addTypeState(writeState);
+            // v3
+            stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v3");
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 1, 1 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 2, 7 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 3, 11 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 6, 12 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 7, 13 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 8, 10 });
+            stateEngine.prepareForWrite();
+            ByteArrayOutputStream baos_v2_to_v3 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v3_to_v2 = new ByteArrayOutputStream();
+            writer.writeDelta(baos_v2_to_v3);
+            writer.writeReverseDelta(baos_v3_to_v2);
 
-        addRecord(1, 1);
-        addRecord(2, 2);
-        addRecord(3, 3);
-        addRecord(4, 4);
-        addRecord(5, 5);
-        addRecord(6, 6);
+            // v4
+            stateEngine.prepareForNextCycle();
+            stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v4");
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 1, 18 });  // 0
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 2, 7 });   // 1
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 3, 19 });  // 2
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 6, 12 });  // 3
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 15, 13 }); // 4
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 8, 10 });  // 5
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 18, 10 }); // 6
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 28, 90 }); // 7
+            stateEngine.prepareForWrite();
+            ByteArrayOutputStream baos_v4 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v4_to_v3 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v3_to_v4 = new ByteArrayOutputStream();
+            writer.writeSnapshot(baos_v4);
+            writer.writeDelta(baos_v3_to_v4);
+            writer.writeReverseDelta(baos_v4_to_v3);
 
-        stateEngine.prepareForWrite();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        HollowBlobWriter writer = new HollowBlobWriter(stateEngine);
-        writer.writeSnapshot(baos);
+            // build history bi-directionally
+            HollowReadStateEngine fwdReadStateEngine = new HollowReadStateEngine();
+            HollowReadStateEngine revReadStateEngine = new HollowReadStateEngine();
+            HollowBlobReader fwdReader = new HollowBlobReader(fwdReadStateEngine);
+            HollowBlobReader revReader = new HollowBlobReader(revReadStateEngine);
+            fwdReader.readSnapshot(HollowBlobInput.serial(baos_v2.toByteArray()));
+            System.out.println("Ordinals populated in fwdReadStateEngine: ");
+            exploreOrdinals(fwdReadStateEngine);
+            revReader.readSnapshot(HollowBlobInput.serial(baos_v2.toByteArray()));
+            System.out.println("Ordinals populated in revReadStateEngine (same as fwdReadStateEngine): ");
+            exploreOrdinals(revReadStateEngine);
+            history = new HollowHistory(fwdReadStateEngine, 2L, MAX_STATES, true);
+            history.getKeyIndex().addTypeIndex("TypeA", "a1");
+            history.getKeyIndex().indexTypeField("TypeA", "a1");
+            history.initializeReverseStateEngine(revReadStateEngine, 2L);
 
+            fwdReader.applyDelta(HollowBlobInput.serial(baos_v2_to_v3.toByteArray()));
+            exploreOrdinals(fwdReadStateEngine);
+            history.deltaOccurred(3L);
 
-        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
-        HollowBlobReader reader = new HollowBlobReader(readStateEngine);
-        reader.readSnapshot(HollowBlobInput.serial(baos.toByteArray()));
-        HollowHistory history = new HollowHistory(readStateEngine, 0, 10);
-        history.getKeyIndex().addTypeIndex("TypeA", "a1");
+            revReader.applyDelta(HollowBlobInput.serial(baos_v2_to_v1.toByteArray()));
+            exploreOrdinals(revReadStateEngine);
+            history.reverseDeltaOccurred(1L);
 
-        stateEngine.prepareForNextCycle();
+            fwdReader.applyDelta(HollowBlobInput.serial(baos_v3_to_v4.toByteArray()));
+            exploreOrdinals(fwdReadStateEngine);
+            history.deltaOccurred(4L);
 
-        addRecord(1, 1);
-        addRecord(2, 7);
-        addRecord(3, 3);
-        addRecord(5, 8);
-        addRecord(6, 6);
-        addRecord(7, 9);
-        addRecord(8, 10);
-
-        stateEngine.prepareForWrite();
-
-        baos = new ByteArrayOutputStream();
-        writer.writeDelta(baos);
-        reader.applyDelta(HollowBlobInput.serial(baos.toByteArray()));
-        history.deltaOccurred(19991231235959999L);
-
-        stateEngine.prepareForNextCycle();
-
-        addRecord(1, 1);
-        addRecord(2, 7);
-        addRecord(3, 11);
-        addRecord(6, 12);
-        addRecord(7, 13);
-        addRecord(8, 10);
-
-        stateEngine.prepareForWrite();
-
-        baos = new ByteArrayOutputStream();
-        writer.writeDelta(baos);
-        reader.applyDelta(HollowBlobInput.serial(baos.toByteArray()));
-        history.deltaOccurred(20001231235959999L);
-
-        // Double Snapshot
-        bSchema = new HollowObjectSchema("TypeB", 2, "b1");
-        bSchema.addField("b1", FieldType.INT);
-        bSchema.addField("b2", FieldType.INT);
-        { // do double snapshot and introduce new type
-            HollowWriteStateEngine stateEngine2 = new HollowWriteStateEngine();
-            stateEngine2.addTypeState(new HollowObjectTypeWriteState(schema));
-            stateEngine2.addTypeState(new HollowObjectTypeWriteState(bSchema));
-            addRec(stateEngine2, schema, new String[] { "a1", "a2" }, new int[] { 1, 1 });
-            addRec(stateEngine2, schema, new String[] { "a1", "a2" }, new int[] { 2, 2 });
-            addRec(stateEngine2, bSchema, new String[] { "b1", "b2" }, new int[] { 9, 999 });
-
-            HollowReadStateEngine readStateEngine2 = new HollowReadStateEngine();
-            StateEngineRoundTripper.roundTripSnapshot(stateEngine2, readStateEngine2, null);
-            setupKeyIndex(readStateEngine2, history);
-            history.doubleSnapshotOccurred(readStateEngine2, 20011231235959999L);
-        }
-
-        { // do double snapshot and remove type
-            HollowWriteStateEngine stateEngine2 = new HollowWriteStateEngine();
-            stateEngine2.addTypeState(new HollowObjectTypeWriteState(schema));
-            addRec(stateEngine2, schema, new String[] { "a1", "a2" }, new int[] { 1, 1 });
-            addRec(stateEngine2, schema, new String[] { "a1", "a2" }, new int[] { 22, 22 });
-
-            HollowReadStateEngine readStateEngine2 = new HollowReadStateEngine();
-            StateEngineRoundTripper.roundTripSnapshot(stateEngine2, readStateEngine2, null);
-            setupKeyIndex(readStateEngine2, history);
-            history.doubleSnapshotOccurred(readStateEngine2, 20021231235959999L);
+            revReader.applyDelta(HollowBlobInput.serial(baos_v1_to_v0.toByteArray()));
+            exploreOrdinals(revReadStateEngine);
+            history.reverseDeltaOccurred(0L);
         }
 
         return history;
     }
 
-    private void addRecord(int a1, int a2) {
-        HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
-        rec.setInt("a1", a1);
-        rec.setInt("a2", a2);
-        stateEngine.add("TypeA", rec);
-    }
-
-    private void setupKeyIndex(HollowReadStateEngine stateEngine, HollowHistory history) {
-        HollowHistoryKeyIndex keyIndex = history.getKeyIndex();
-        for (String type : stateEngine.getAllTypes()) {
-
-            HollowTypeReadState typeState = stateEngine.getTypeState(type);
-            HollowSchema schema = typeState.getSchema();
-            if (schema instanceof HollowObjectSchema) {
-                HollowObjectSchema oSchema = (HollowObjectSchema) schema;
-                PrimaryKey pKey = oSchema.getPrimaryKey();
-                if (pKey == null) continue;
-
-                keyIndex.indexTypeField(pKey, stateEngine);
-                System.out.println("Setup KeyIndex: type=" + type + "\t" + pKey);
+    private void exploreOrdinals(HollowReadStateEngine readStateEngine) {
+        System.out.println("CUSTOM_VERSION_TAG= " + readStateEngine.getHeaderTags().get(CUSTOM_VERSION_TAG));
+        for (HollowTypeReadState typeReadState : readStateEngine.getTypeStates()) {
+            BitSet populatedOrdinals = typeReadState.getPopulatedOrdinals();
+            System.out.println("SNAP: PopulatedOrdinals= " + populatedOrdinals);
+            int ordinal = populatedOrdinals.nextSetBit(0);
+            while (ordinal != -1) {
+                HollowObjectTypeReadState o = (HollowObjectTypeReadState) typeReadState;
+                System.out.println(String.format("%s: %s, %s", ordinal, o.readInt(ordinal, 0), o.readInt(ordinal, 1)));
+                ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
             }
         }
     }
@@ -165,5 +247,120 @@ public class HistoryUITest {
         stateEngine.add(schema.getName(), rec);
     }
 
+    private HollowHistory createHistoryD() throws IOException {
+        HollowHistory history;
+        HollowReadStateEngine readStateEngine;
+        HollowBlobReader reader;
+        HollowWriteStateEngine stateEngine;
 
+        {
+            schema = new HollowObjectSchema("TypeA", 2);
+            stateEngine = new HollowWriteStateEngine();
+            schema.addField("a1", HollowObjectSchema.FieldType.INT);
+            schema.addField("a2", HollowObjectSchema.FieldType.INT);
+
+            //attach schema to write state engine
+            stateEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+
+            // v0
+            stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v0");
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 3, 13 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 4, 44 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 15, 150 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 16, 160 });
+            stateEngine.prepareForWrite();
+            ByteArrayOutputStream baos_v0 = new ByteArrayOutputStream();
+            HollowBlobWriter writer = new HollowBlobWriter(stateEngine);
+            writer.writeSnapshot(baos_v0);
+            stateEngine.prepareForNextCycle();
+
+            // v1
+            stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v1");
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 1, 1 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 2, 2 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 3, 3 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 4, 4 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 5, 5 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 6, 6 });
+            stateEngine.prepareForWrite();
+            ByteArrayOutputStream baos_v0_to_v1 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v1_to_v0 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v1 = new ByteArrayOutputStream();
+            writer = new HollowBlobWriter(stateEngine);
+            writer.writeSnapshot(baos_v1);
+            writer.writeDelta(baos_v0_to_v1);
+            writer.writeReverseDelta(baos_v1_to_v0);
+
+            stateEngine.prepareForNextCycle();
+
+            // v2
+            stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v2");
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 2, 7 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 3, 3 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 5, 8 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 6, 6 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 7, 9 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 8, 10 });
+            stateEngine.prepareForWrite();
+            ByteArrayOutputStream baos_v2 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v1_to_v2 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v2_to_v1 = new ByteArrayOutputStream();
+            writer.writeSnapshot(baos_v2);
+            writer.writeDelta(baos_v1_to_v2);
+            writer.writeReverseDelta(baos_v2_to_v1);
+            stateEngine.prepareForNextCycle();
+
+            // v3
+            stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v3");
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 1, 1 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 2, 7 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 3, 11 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 6, 12 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 7, 13 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 8, 10 });
+            stateEngine.prepareForWrite();
+            ByteArrayOutputStream baos_v3 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v2_to_v3 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v3_to_v2 = new ByteArrayOutputStream();
+            writer.writeSnapshot(baos_v3);
+            writer.writeDelta(baos_v2_to_v3);
+            writer.writeReverseDelta(baos_v3_to_v2);
+            stateEngine.prepareForNextCycle();
+
+            // v4
+            stateEngine.addHeaderTag(CUSTOM_VERSION_TAG, "v4");
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 1, 18 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 2, 7 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 3, 19 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 6, 12 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 15, 13 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 8, 10 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 18, 10 });
+            addRec(stateEngine, schema, new String[] { "a1", "a2" }, new int[] { 28, 90 });
+            stateEngine.prepareForWrite();
+            ByteArrayOutputStream baos_v4 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v3_to_v4 = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos_v4_to_v3 = new ByteArrayOutputStream();
+            writer.writeDelta(baos_v3_to_v4);
+            writer.writeReverseDelta(baos_v4_to_v3);
+            writer.writeSnapshot(baos_v4);
+
+            // Build history
+            readStateEngine = new HollowReadStateEngine();
+            reader = new HollowBlobReader(readStateEngine);
+            reader.readSnapshot(HollowBlobInput.serial(baos_v0.toByteArray()));
+            history = new HollowHistory(readStateEngine, 0L, MAX_STATES);
+            history.getKeyIndex().addTypeIndex("TypeA", "a1");
+            reader.applyDelta(HollowBlobInput.serial(baos_v0_to_v1.toByteArray()));
+            history.deltaOccurred(1L);
+            reader.applyDelta(HollowBlobInput.serial(baos_v1_to_v2.toByteArray()));
+            history.deltaOccurred(2L);
+            reader.applyDelta(HollowBlobInput.serial(baos_v2_to_v3.toByteArray()));
+            history.deltaOccurred(3L);
+            reader.applyDelta(HollowBlobInput.serial(baos_v3_to_v4.toByteArray()));
+            history.deltaOccurred(4L);
+        }
+
+        return history;
+    }
 }

--- a/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestBlobRetriever.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestBlobRetriever.java
@@ -19,6 +19,7 @@ package com.netflix.hollow.test.consumer;
 import com.netflix.hollow.api.consumer.HollowConsumer.Blob;
 import com.netflix.hollow.api.consumer.HollowConsumer.BlobRetriever;
 import com.netflix.hollow.api.consumer.HollowConsumer.HeaderBlob;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,17 +40,34 @@ public class TestBlobRetriever implements BlobRetriever {
 
     @Override
     public Blob retrieveSnapshotBlob(long desiredVersion) {
-        return snapshots.get(desiredVersion);
+        Blob b = snapshots.get(desiredVersion);
+        resetStream(b);
+        return b;
     }
 
     @Override
     public Blob retrieveDeltaBlob(long currentVersion) {
-        return deltas.get(currentVersion);
+        Blob b = deltas.get(currentVersion);
+        resetStream(b);
+        return b;
     }
 
     @Override
     public Blob retrieveReverseDeltaBlob(long currentVersion) {
-        return reverseDeltas.get(currentVersion);
+        Blob b = reverseDeltas.get(currentVersion);
+        resetStream(b);
+        return b;
+    }
+
+    // so blob can be reused
+    private void resetStream(Blob b) {
+        try {
+            if (b!= null && b.getInputStream() != null) {
+                b.getInputStream().reset();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to get and reset stream", e);
+        }
     }
 
     public void addSnapshot(long desiredVersion, Blob transition) {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListDeltaHistoricalStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListDeltaHistoricalStateCreator.java
@@ -32,23 +32,23 @@ import com.netflix.hollow.core.util.RemovedOrdinalIterator;
  */
 public class HollowListDeltaHistoricalStateCreator {
 
-    private final HollowListTypeReadState typeState;
-    private final HollowListTypeDataElements stateEngineDataElements[];
     private final HollowListTypeDataElements historicalDataElements;
-    private final RemovedOrdinalIterator iter;
 
     private final int shardNumberMask;
     private final int shardOrdinalShift;
 
+    private HollowListTypeReadState typeState;
+    private HollowListTypeDataElements stateEngineDataElements[];
+    private RemovedOrdinalIterator iter;
     private IntMap ordinalMapping;
     private int nextOrdinal = 0;
     private long nextStartElement = 0;
 
-    public HollowListDeltaHistoricalStateCreator(HollowListTypeReadState typeState) {
+    public HollowListDeltaHistoricalStateCreator(HollowListTypeReadState typeState, boolean reverse) {
         this.typeState = typeState;
         this.stateEngineDataElements = typeState.currentDataElements();
         this.historicalDataElements = new HollowListTypeDataElements(WastefulRecycler.DEFAULT_INSTANCE);
-        this.iter = new RemovedOrdinalIterator(typeState.getListener(PopulatedOrdinalListener.class));
+        this.iter = new RemovedOrdinalIterator(typeState.getListener(PopulatedOrdinalListener.class), reverse);
         this.shardNumberMask = stateEngineDataElements.length - 1;
         this.shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(stateEngineDataElements.length);
     }
@@ -68,6 +68,12 @@ public class HollowListDeltaHistoricalStateCreator {
 
             ordinal = iter.next();
         }
+    }
+
+    public void dereferenceTypeState() {
+        this.typeState = null;
+        this.stateEngineDataElements = null;
+        this.iter = null;
     }
 
     public IntMap getOrdinalMapping() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapDeltaHistoricalStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapDeltaHistoricalStateCreator.java
@@ -33,23 +33,23 @@ import com.netflix.hollow.core.util.RemovedOrdinalIterator;
  */
 public class HollowMapDeltaHistoricalStateCreator {
 
-    private final HollowMapTypeReadState typeState;
-    private final HollowMapTypeDataElements stateEngineDataElements[];
     private final HollowMapTypeDataElements historicalDataElements;
-    private final RemovedOrdinalIterator iter;
 
     private final int shardNumberMask;
     private final int shardOrdinalShift;
 
+    private HollowMapTypeReadState typeState;
+    private HollowMapTypeDataElements stateEngineDataElements[];
+    private RemovedOrdinalIterator iter;
     private IntMap ordinalMapping;
     private int nextOrdinal;
     private long nextStartBucket;
 
-    public HollowMapDeltaHistoricalStateCreator(HollowMapTypeReadState typeState) {
+    public HollowMapDeltaHistoricalStateCreator(HollowMapTypeReadState typeState, boolean reverse) {
         this.typeState = typeState;
         this.stateEngineDataElements = typeState.currentDataElements();
         this.historicalDataElements = new HollowMapTypeDataElements(WastefulRecycler.DEFAULT_INSTANCE);
-        this.iter = new RemovedOrdinalIterator(typeState.getListener(PopulatedOrdinalListener.class));
+        this.iter = new RemovedOrdinalIterator(typeState.getListener(PopulatedOrdinalListener.class), reverse);
         this.shardNumberMask = stateEngineDataElements.length - 1;
         this.shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(stateEngineDataElements.length);
     }
@@ -69,6 +69,12 @@ public class HollowMapDeltaHistoricalStateCreator {
 
             ordinal = iter.next();
         }
+    }
+
+    public void dereferenceTypeState() {
+        this.typeState = null;
+        this.stateEngineDataElements = null;
+        this.iter = null;
     }
 
     public IntMap getOrdinalMapping() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetDeltaHistoricalStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetDeltaHistoricalStateCreator.java
@@ -33,23 +33,23 @@ import com.netflix.hollow.core.util.RemovedOrdinalIterator;
  */
 public class HollowSetDeltaHistoricalStateCreator {
 
-    private final HollowSetTypeReadState typeState;
-    private final HollowSetTypeDataElements stateEngineDataElements[];
     private final HollowSetTypeDataElements historicalDataElements;
-    private final RemovedOrdinalIterator iter;
-    
+
     private final int shardNumberMask;
     private final int shardOrdinalShift;
 
+    private HollowSetTypeReadState typeState;
+    private HollowSetTypeDataElements stateEngineDataElements[];
+    private RemovedOrdinalIterator iter;
     private IntMap ordinalMapping;
     private int nextOrdinal;
     private long nextStartBucket;
 
-    public HollowSetDeltaHistoricalStateCreator(HollowSetTypeReadState typeState) {
+    public HollowSetDeltaHistoricalStateCreator(HollowSetTypeReadState typeState, boolean reverse) {
         this.typeState = typeState;
         this.stateEngineDataElements = typeState.currentDataElements();
         this.historicalDataElements = new HollowSetTypeDataElements(WastefulRecycler.DEFAULT_INSTANCE);
-        this.iter = new RemovedOrdinalIterator(typeState.getListener(PopulatedOrdinalListener.class));
+        this.iter = new RemovedOrdinalIterator(typeState.getListener(PopulatedOrdinalListener.class), reverse);
         this.shardNumberMask = stateEngineDataElements.length - 1;
         this.shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(stateEngineDataElements.length);
     }
@@ -69,6 +69,12 @@ public class HollowSetDeltaHistoricalStateCreator {
 
             ordinal = iter.next();
         }
+    }
+
+    public void dereferenceTypeState() {
+        this.typeState = null;
+        this.stateEngineDataElements = null;
+        this.iter = null;
     }
 
     public IntMap getOrdinalMapping() {

--- a/hollow/src/main/java/com/netflix/hollow/core/util/RemovedOrdinalIterator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/RemovedOrdinalIterator.java
@@ -36,9 +36,23 @@ public class RemovedOrdinalIterator {
     }
 
     public RemovedOrdinalIterator(BitSet previousOrdinals, BitSet populatedOrdinals) {
-        this.previousOrdinals = previousOrdinals;
-        this.populatedOrdinals = populatedOrdinals;
-        this.previousOrdinalsLength = previousOrdinals.length();
+        this(previousOrdinals, populatedOrdinals, false);
+    }
+
+    public RemovedOrdinalIterator(PopulatedOrdinalListener listener, boolean flip) {
+        this(listener.getPreviousOrdinals(), listener.getPopulatedOrdinals(), flip);
+    }
+
+    public RemovedOrdinalIterator(BitSet previousOrdinals, BitSet populatedOrdinals, boolean flip) {
+        if (!flip) {
+            this.previousOrdinals = previousOrdinals;
+            this.populatedOrdinals = populatedOrdinals;
+            this.previousOrdinalsLength = previousOrdinals.length();
+        } else {
+            this.previousOrdinals = populatedOrdinals;
+            this.populatedOrdinals = previousOrdinals;
+            this.previousOrdinalsLength = populatedOrdinals.length();
+        }
     }
 
     public int next() {

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistoricalStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/HollowHistoricalStateCreator.java
@@ -83,12 +83,16 @@ public class HollowHistoricalStateCreator {
      * @return a data access for history
      */
     public HollowHistoricalStateDataAccess createBasedOnNewDelta(long version, HollowReadStateEngine stateEngine) {
+        return createBasedOnNewDelta(version, stateEngine, false);
+    }
+
+    public HollowHistoricalStateDataAccess createBasedOnNewDelta(long version, HollowReadStateEngine stateEngine, boolean reverse) {
         IntMapOrdinalRemapper typeRemovedOrdinalMapping = new IntMapOrdinalRemapper();
 
         List<HollowTypeReadState> historicalTypeStates = new ArrayList<HollowTypeReadState>(stateEngine.getTypeStates().size());
 
         for(HollowTypeReadState typeState : stateEngine.getTypeStates()) {
-            createDeltaHistoricalTypeState(typeRemovedOrdinalMapping, historicalTypeStates, typeState);
+            createDeltaHistoricalTypeState(typeRemovedOrdinalMapping, historicalTypeStates, typeState, reverse);
         }
 
         HollowHistoricalStateDataAccess dataAccess = new HollowHistoricalStateDataAccess(totalHistory, version, stateEngine, historicalTypeStates, typeRemovedOrdinalMapping, Collections.<String, HollowHistoricalSchemaChange>emptyMap());
@@ -97,27 +101,32 @@ public class HollowHistoricalStateCreator {
         return dataAccess;
     }
 
-    private void createDeltaHistoricalTypeState(IntMapOrdinalRemapper typeRemovedOrdinalMapping, List<HollowTypeReadState> historicalTypeStates, HollowTypeReadState typeState) {
+    private void createDeltaHistoricalTypeState(IntMapOrdinalRemapper typeRemovedOrdinalMapping, List<HollowTypeReadState> historicalTypeStates, HollowTypeReadState typeState, boolean reverse) {
         if(typeState instanceof HollowObjectTypeReadState) {
-            HollowObjectDeltaHistoricalStateCreator deltaHistoryCreator = new HollowObjectDeltaHistoricalStateCreator((HollowObjectTypeReadState)typeState);
+            HollowObjectDeltaHistoricalStateCreator deltaHistoryCreator = new HollowObjectDeltaHistoricalStateCreator((HollowObjectTypeReadState)typeState, reverse);
             deltaHistoryCreator.populateHistory();
             typeRemovedOrdinalMapping.addOrdinalRemapping(typeState.getSchema().getName(), deltaHistoryCreator.getOrdinalMapping());
             historicalTypeStates.add(deltaHistoryCreator.createHistoricalTypeReadState());
+            // drop references into typeState to allow it to be GC'ed as soon as all historical states have been constructed
+            deltaHistoryCreator.dereferenceTypeState();
         } else if(typeState instanceof HollowListTypeReadState) {
-            HollowListDeltaHistoricalStateCreator deltaHistoryCreator = new HollowListDeltaHistoricalStateCreator((HollowListTypeReadState)typeState);
+            HollowListDeltaHistoricalStateCreator deltaHistoryCreator = new HollowListDeltaHistoricalStateCreator((HollowListTypeReadState)typeState, reverse);
             deltaHistoryCreator.populateHistory();
             typeRemovedOrdinalMapping.addOrdinalRemapping(typeState.getSchema().getName(), deltaHistoryCreator.getOrdinalMapping());
             historicalTypeStates.add(deltaHistoryCreator.createHistoricalTypeReadState());
+            deltaHistoryCreator.dereferenceTypeState();
         } else if(typeState instanceof HollowSetTypeReadState) {
-            HollowSetDeltaHistoricalStateCreator deltaHistoryCreator = new HollowSetDeltaHistoricalStateCreator((HollowSetTypeReadState)typeState);
+            HollowSetDeltaHistoricalStateCreator deltaHistoryCreator = new HollowSetDeltaHistoricalStateCreator((HollowSetTypeReadState)typeState, reverse);
             deltaHistoryCreator.populateHistory();
             typeRemovedOrdinalMapping.addOrdinalRemapping(typeState.getSchema().getName(), deltaHistoryCreator.getOrdinalMapping());
             historicalTypeStates.add(deltaHistoryCreator.createHistoricalTypeReadState());
+            deltaHistoryCreator.dereferenceTypeState();
         } else if(typeState instanceof HollowMapTypeReadState) {
-            HollowMapDeltaHistoricalStateCreator deltaHistoryCreator = new HollowMapDeltaHistoricalStateCreator((HollowMapTypeReadState)typeState);
+            HollowMapDeltaHistoricalStateCreator deltaHistoryCreator = new HollowMapDeltaHistoricalStateCreator((HollowMapTypeReadState)typeState, reverse);
             deltaHistoryCreator.populateHistory();
             typeRemovedOrdinalMapping.addOrdinalRemapping(typeState.getSchema().getName(), deltaHistoryCreator.getOrdinalMapping());
             historicalTypeStates.add(deltaHistoryCreator.createHistoricalTypeReadState());
+            deltaHistoryCreator.dereferenceTypeState();
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoricalStateTypeKeyOrdinalMapping.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoricalStateTypeKeyOrdinalMapping.java
@@ -39,6 +39,7 @@ public class HollowHistoricalStateTypeKeyOrdinalMapping {
         this.keyIndex = keyIndex;
     }
 
+    // this is only invoked for double snapshots
     private HollowHistoricalStateTypeKeyOrdinalMapping(String typeName, HollowHistoryTypeKeyIndex keyIndex, IntMap addedOrdinalMap, IntMap removedOrdinalMap) {
         this.typeName = typeName;
         this.keyIndex = keyIndex;
@@ -51,7 +52,6 @@ public class HollowHistoricalStateTypeKeyOrdinalMapping {
         this.addedOrdinalMap = new IntMap(numAdditions);
         this.removedOrdinalMap = new IntMap(numRemovals);
     }
-
     public void added(HollowTypeReadState typeState, int ordinal) {
         int recordKeyOrdinal = keyIndex.findKeyIndexOrdinal((HollowObjectTypeReadState)typeState, ordinal);
         addedOrdinalMap.put(recordKeyOrdinal, ordinal);
@@ -66,6 +66,7 @@ public class HollowHistoricalStateTypeKeyOrdinalMapping {
         removedOrdinalMap.put(recordKeyOrdinal, mappedOrdinal);
     }
 
+    // this is only invoked for double snapshots
     public HollowHistoricalStateTypeKeyOrdinalMapping remap(OrdinalRemapper remapper) {
         IntMap newAddedOrdinalMap = new IntMap(addedOrdinalMap.size());
         IntMapEntryIterator addedIter = addedOrdinalMap.iterator();

--- a/hollow/src/test/java/com/netflix/hollow/core/util/RemovedOrdinalIteratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/util/RemovedOrdinalIteratorTest.java
@@ -22,12 +22,12 @@ import org.junit.Test;
 
 public class RemovedOrdinalIteratorTest {
 
+    private static final BitSet PREVIOUS_ORDINALS = bitSet(1, 2, 3, 4, 6, 7, 9, 10);
+    private static final BitSet CURRENT_ORDINALS = bitSet(1, 3, 4, 5, 7, 8, 9);
+
     @Test
     public void iteratesOverRemovedOrdinals() {
-        BitSet previousOrdinals = bitSet(1, 2, 3, 4, 6, 7, 9, 10);
-        BitSet currentOrdinals = bitSet(1, 3, 4, 5, 7, 8, 9);
-
-        RemovedOrdinalIterator iter = new RemovedOrdinalIterator(previousOrdinals, currentOrdinals);
+        RemovedOrdinalIterator iter = new RemovedOrdinalIterator(PREVIOUS_ORDINALS, CURRENT_ORDINALS);
 
         Assert.assertEquals(2, iter.next());
         Assert.assertEquals(6, iter.next());
@@ -35,7 +35,16 @@ public class RemovedOrdinalIteratorTest {
         Assert.assertEquals(-1, iter.next());
     }
 
-    private BitSet bitSet(int... setBits) {
+    @Test
+    public void iteratesOverAddedOrdinals() {
+        RemovedOrdinalIterator iterFlip = new RemovedOrdinalIterator(PREVIOUS_ORDINALS, CURRENT_ORDINALS, true);
+
+        Assert.assertEquals(5, iterFlip.next());
+        Assert.assertEquals(8, iterFlip.next());
+        Assert.assertEquals(-1, iterFlip.next());
+    }
+
+    private static BitSet bitSet(int... setBits) {
         BitSet bitSet = new BitSet();
         for(int bit : setBits) {
             bitSet.set(bit);


### PR DESCRIPTION
Peering credit to @shoc2020 

HollowHistory maintains two read states- one that always moves in the forward direction and one that always moves in the reverse direction. Once max retention has been reached the read state corresponding to the reverse direction is dropped and (as before) each future forward delta application results in eviction of the oldest historical state.

Building history in reverse allows recent data versions to be available in the history tooling sooner at the time of HollowHistory initialization, and also has the nice property that history initialization uses the latest schema at the time of initialization so recently introduced backwards compatible schema changes are visible without the need to apply double snapshots.

The UI view of History built using reverse deltas is at parity with when building using forward deltas. 

NOTE: if computing history using reverse deltas, for header tags to be displayed accurately the producer needs to be on Hollow v7.0.2 - that release fixed a bug in how headers tags were set on reverse deltas.

Example usage:
(continue existing usage for fwd only)
```
consumerFwd.triggerRefreshTo(v);
HollowHistoryUIServer historyUIServer = new HollowHistoryUIServer(consumerFwd, PORT);
historyUIServer.start();
consumerFwd.triggerRefreshTo(v+1);
consumerFwd.triggerRefreshTo(v+2);
...
```
(new for building history in both directions)
```
consumerFwd.triggerRefreshTo(v);
  consumerRev.triggerRefreshTo(v);
HollowHistoryUIServer historyUIServer = new HollowHistoryUIServer(consumerFwd, consumerRev, PORT);
historyUIServer.start();
consumerFwd.triggerRefreshTo(v+1);
  consumerRev.triggerRefreshTo(v-1);
  consumerRev.triggerRefreshTo(v-2);
  consumerRev.triggerRefreshTo(v-3);
consumerFwd.triggerRefreshTo(v+2);
...

```

