### PR TITLE
Restore the constructors with HollowReadStateEngine to ensure binary compatibility

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -48,6 +48,22 @@ public class HollowHashIndex implements HollowTypeStateListener {
     private final String[] matchFields;
 
     /**
+     * This constructor is for binary-compatibility for code compiled against
+     * older builds. 
+     *
+     * @param stateEngine The state engine to index
+     * @param type The query starts with the specified type
+     * @param selectField The query will select records at this field (specify "" to select the specified type).
+     * The selectField may span collection elements and/or map keys or values, which can result in multiple matches per record of the specified start type.
+     * @param matchFields The query will match on the specified match fields.  The match fields may span collection elements and/or map keys or values.
+     * @deprecated Use {@link HollowHashIndex#HollowHashIndex(HollowDataAccess, String, String, String...)}
+     */
+    @Deprecated
+    public HollowHashIndex(HollowReadStateEngine stateEngine, String type, String selectField, String... matchFields) {
+        this((HollowDataAccess) stateEngine, type, selectField, matchFields);
+    }
+
+    /**
      * Define a {@link HollowHashIndex}.
      *
      * @param hollowDataAccess The state engine to index
@@ -66,7 +82,7 @@ public class HollowHashIndex implements HollowTypeStateListener {
         this.typeState = (HollowObjectTypeDataAccess) hollowDataAccess.getTypeDataAccess(type);
         this.selectField = selectField;
         this.matchFields = matchFields;
-        
+
         reindexHashIndex();
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexBuilder.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexBuilder.java
@@ -27,6 +27,7 @@ import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.core.memory.pool.WastefulRecycler;
 import com.netflix.hollow.core.read.HollowReadFieldUtils;
 import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
 import java.util.BitSet;
 
@@ -58,6 +59,22 @@ public class HollowHashIndexBuilder {
     private int intermediateMatchHashTableSizeBeforeGrow;
     private int matchCount;
 
+
+    /**
+     * This constructor is for binary-compatibility for code compiled against
+     * older builds.
+     *
+     * @param stateEngine state engine
+     * @param type The query starts with the specified type
+     * @param selectField The query will select records at this field (specify "" to select the specified type).
+     * The selectField may span collection elements and/or map keys or values, which can result in multiple matches per record of the specified start type.
+     * @param matchFields The query will match on the specified match fields.  The match fields may span collection elements and/or map keys or values.
+     * @deprecated Use {@link #HollowHashIndexBuilder(HollowDataAccess, String, String, String...)}
+     */
+    @Deprecated
+    public HollowHashIndexBuilder(HollowReadStateEngine stateEngine, String type, String selectField, String... matchFields) {
+        this((HollowDataAccess) stateEngine, type, selectField, matchFields);
+    }
 
     ///TODO: Optimization, make the matchFields[].schemaFieldPositionPath as short as possible, to reduce iteration
     /// this means merging the common roots of path from the same base field, and pushing all unique base fields down

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexField.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexField.java
@@ -20,6 +20,7 @@ import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
 import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 
+// Should this class be package private? It appears to be internal
 public class HollowHashIndexField {
     private final int baseIteratorFieldIdx;
     private final FieldPathSegment[] schemaFieldPositionPath;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPreindexer.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPreindexer.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+// Should this class be package private? It appears to be internal
 public class HollowPreindexer {
     
     private final HollowDataAccess stateEngine;


### PR DESCRIPTION
Some constructors were changed to use an interface. Unfortunately, this breaks binary compatibility for software compiled against older versions. The constructors have been restored and simply invokes the new constructor.

This should not affect compile-time compatibility for code originally written against older jars.