### PR TITLE
Add getter for HollowTypeProxyDataAccess's currentDataAccess

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/read/dataaccess/proxy/HollowTypeProxyDataAccess.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/dataaccess/proxy/HollowTypeProxyDataAccess.java
@@ -41,6 +41,10 @@ public abstract class HollowTypeProxyDataAccess implements HollowTypeDataAccess 
         this.currentDataAccess = typeDataAccess;
     }
 
+    public HollowTypeDataAccess getCurrentDataAccess() {
+        return currentDataAccess;
+    }
+
     @Override
     public HollowDataAccess getDataAccess() {
         return dataAccess;


### PR DESCRIPTION
Once place where this will be helpful is- the generated client API can determine if `currentDataAccess` is an instance of `HollowHistoricalTypeDataAccess` so it calls `getTypeState` only when the underlying type state supports it