### PR TITLE
Explorer Null Issue in text mode

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
@@ -61,7 +61,7 @@ class HollowObjectTypeReadStateShard {
         case BYTES:
         case STRING:
             int numBits = currentData.bitsPerField[fieldIndex];
-            return (fixedLengthValue & (1 << (numBits - 1))) != 0;
+            return (fixedLengthValue & (1L << (numBits - 1))) != 0;
         case FLOAT:
             return (int)fixedLengthValue == HollowObjectWriteRecord.NULL_FLOAT_BITS;
         case DOUBLE:


### PR DESCRIPTION
The problem is there is an additional null check for the text stringifier and looks like there is a bug in there.
The following are the debugging values I extracted from debugging and you can see the issue can be easily reproducible with these values.
```    
       long fixedLengthValue = 8189729;
        int numBits = 33;
        long result = (fixedLengthValue & (1 << (numBits - 1)));
        System.out.println("result = " + result); 


        long endByte = 8189729;
        int numBitsForField = 33;
        result = (endByte & (1L << (numBitsForField - 1)));
        System.out.println("result = " + result); 


 
