### PR TITLE
In code generator retrofit support for custom type names that start with a lowercase character

### DIFF
--- a/docs/data-modeling.md
+++ b/docs/data-modeling.md
@@ -132,7 +132,7 @@ Namespacing fields is also useful if some consumers don't need the contents of a
     Using an appropriately _namespaced_ type reduces the heap footprint cost of `REFERENCE` fields.
 
 !!! hint "Changing default _type names_"
-    The `@HollowTypeName` annotation can also be used at the class level to select a default type name for a class other than its simple name.
+    The `@HollowTypeName` annotation can also be used at the class level to select a default type name for a class other than its simple name. Custom type names should begin with an upper case character to avoid ambiguity in naming in the generated API, although this is not enforced by Hollow due to backwards compatibility reasons.
 
 ### Grouping Associated Fields
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowConsumerJavaFileGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowConsumerJavaFileGenerator.java
@@ -118,7 +118,7 @@ public abstract class HollowConsumerJavaFileGenerator implements HollowJavaFileG
                     }
                 }
                 for (String schemaName : schemaNameSet) {
-                    appendImportFromBasePackage(builder, schemaName + config.getClassPostfix());
+                    appendImportFromBasePackage(builder, HollowCodeGenerationUtils.upperFirstChar(schemaName) + config.getClassPostfix());
                 }
                 appendImportFromBasePackage(builder, "core.*");
                 if (useCollectionsImport) {

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/api/HollowDataAccessorGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/api/HollowDataAccessorGenerator.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.api.codegen.api;
 
 import com.netflix.hollow.api.codegen.CodeGeneratorConfig;
 import com.netflix.hollow.api.codegen.HollowAPIGenerator;
+import com.netflix.hollow.api.codegen.HollowCodeGenerationUtils;
 import com.netflix.hollow.api.codegen.HollowConsumerJavaFileGenerator;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.consumer.data.AbstractHollowDataAccessor;
@@ -51,7 +52,7 @@ public class HollowDataAccessorGenerator extends HollowConsumerJavaFileGenerator
     }
 
     protected String getClassName(HollowObjectSchema schema) {
-        return schema.getName() + "DataAccessor";
+        return HollowCodeGenerationUtils.upperFirstChar(schema.getName()) + "DataAccessor";
     }
 
     @Override


### PR DESCRIPTION
5 years ago when *DataAccessor classes were added to the generated API we lost support for custom type names that start with a lower case character (for e.g. "profileId").  This PR retro-fits that support to unblock one such known use case.

In general it would be good to not allow type names that start with a lower case character but that would be a breaking change for clients.