### PR TITLE
Patch: ui tools backwards compatibility

### DIFF
--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUIRouter.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUIRouter.java
@@ -37,32 +37,32 @@ public class HollowDiffUIRouter extends HollowUIRouter {
         this.diffUIs = new LinkedHashMap<>();
     }
 
-    public void handle(String target, HttpServletRequest request, HttpServletResponse response)
+    public void handle(String target, HttpServletRequest req, HttpServletResponse resp)
             throws IOException {
-        doGet(request, response);
+        String diffUIKey = getTargetRootPath(target);
+
+        if ("resource".equals(diffUIKey)) {
+            if (serveResource(req, resp, getResourceName(target, diffUIKey)))
+                return;
+        } else {
+            HollowDiffUI ui = diffUIs.get(diffUIKey);
+            if (ui == null) {
+                ui = diffUIs.get("");
+                if (ui != null) {  // if a diff was added at path ""
+                    diffUIKey = "";
+                }
+            }
+
+            if (ui != null) {
+                if (ui.serveRequest(getResourceName(target, diffUIKey), req, resp))
+                    return;
+            }
+        }
     }
 
     @Override
     public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        String diffUIKey = getTargetRootPath(req.getPathInfo());
-
-        if ("resource".equals(diffUIKey)) {
-             if (serveResource(req, resp, getResourceName(req.getPathInfo(), diffUIKey)))
-                  return;
-        } else {
-             HollowDiffUI ui = diffUIs.get(diffUIKey);
-             if (ui == null) {
-                 ui = diffUIs.get("");
-                 if (ui != null) {  // if a diff was added at path ""
-                     diffUIKey = "";
-                 }
-             }
-
-             if (ui != null) {
-                 if (ui.serveRequest(getResourceName(req.getPathInfo(), diffUIKey), req, resp))
-                     return;
-             }
-        }
+        handle(req.getPathInfo(), req, resp);
     }
 
     public Map<String, HollowDiffUI> getDiffUIs() {

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/HollowHistoryUI.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/HollowHistoryUI.java
@@ -161,14 +161,9 @@ public class HollowHistoryUI extends HollowUIRouter implements HollowRecordDiffU
         return history;
     }
 
-    public void handle(String target, HttpServletRequest request, HttpServletResponse response)
+    public void handle(String target, HttpServletRequest req, HttpServletResponse resp)
             throws IOException {
-        doGet(request, response);
-    }
-
-    @Override
-    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        String pageName = getTargetRootPath(req.getPathInfo());
+        String pageName = getTargetRootPath(target);
 
         if("diffrowdata".equals(pageName)) {
             diffViewOutputGenerator.uncollapseRow(req, resp);
@@ -182,25 +177,25 @@ public class HollowHistoryUI extends HollowUIRouter implements HollowRecordDiffU
 
 
         if("resource".equals(pageName)) {
-            if(serveResource(req, resp, getResourceName(req.getPathInfo())))
+            if(serveResource(req, resp, getResourceName(target)))
                 return;
         } else if("".equals(pageName) || "overview".equals(pageName)) {
-        	if(req.getParameter("format") != null && req.getParameter("format").equals("json")) {
-        		overviewPage.sendJson(req, resp);
-        		return;
-        	}
+            if(req.getParameter("format") != null && req.getParameter("format").equals("json")) {
+                overviewPage.sendJson(req, resp);
+                return;
+            }
             overviewPage.render(req, getSession(req, resp), resp.getWriter());
         } else if("state".equals(pageName)) {
-        	if(req.getParameter("format") != null && req.getParameter("format").equals("json")) {
-        		statePage.sendJson(req, resp);
-        		return;
-        	}
+            if(req.getParameter("format") != null && req.getParameter("format").equals("json")) {
+                statePage.sendJson(req, resp);
+                return;
+            }
             statePage.render(req, getSession(req, resp), resp.getWriter());
         } else if("statetype".equals(pageName)) {
-        	if(req.getParameter("format") != null && req.getParameter("format").equals("json")) {
-        		stateTypePage.sendJson(req, getSession(req, resp),  resp);
-        		return;
-        	}
+            if(req.getParameter("format") != null && req.getParameter("format").equals("json")) {
+                stateTypePage.sendJson(req, getSession(req, resp),  resp);
+                return;
+            }
             stateTypePage.render(req, getSession(req, resp), resp.getWriter());
         } else if("statetypeexpand".equals(pageName)) {
             stateTypeExpandPage.render(req, getSession(req, resp), resp.getWriter());
@@ -209,6 +204,11 @@ public class HollowHistoryUI extends HollowUIRouter implements HollowRecordDiffU
         } else if("historicalObject".equals(pageName)) {
             objectDiffPage.render(req, getSession(req, resp), resp.getWriter());
         }
+    }
+
+    @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        handle(req.getPathInfo(), req, resp);
     }
     
     public void addCustomHollowRecordNamer(String typeName, HollowHistoryRecordNamer recordNamer) {

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
@@ -71,17 +71,12 @@ public class HollowExplorerUI extends HollowUIRouter {
         this.queryPage = new QueryPage(this);
     }
 
-    public void handle( String target, HttpServletRequest request, HttpServletResponse response)
+    public void handle(String target, HttpServletRequest req, HttpServletResponse resp)
             throws IOException {
-        doGet(request, response);
-    }
+        String pageName = getTargetRootPath(target);
 
-    @Override
-    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        String pageName = getTargetRootPath(req.getPathInfo());
-        
         HollowUISession session = HollowUISession.getSession(req, resp);
-        
+
         if("".equals(pageName) || "home".equals(pageName)) {
             showAllTypesPage.render(req, resp, session);
             return;
@@ -95,6 +90,11 @@ public class HollowExplorerUI extends HollowUIRouter {
             queryPage.render(req, resp, session);
             return;
         }
+    }
+
+    @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        handle(req.getPathInfo(), req, resp);
     }
 
     public long getCurrentStateVersion() {

--- a/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HollowUIRouter.java
+++ b/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HollowUIRouter.java
@@ -59,6 +59,10 @@ public abstract class HollowUIRouter extends HttpServlet {
         if(target.length() < baseLength)
             return "";
 
+        if (target == null) {
+            throw new IllegalStateException("target is null. It defaults to HttpServletRequest::getPathInfo() but can be " +
+                    "customized by invoking handle method on HollowExplorerUI HollowDiffUI et al classes.");
+        }
         int secondSlashIndex = target.indexOf('/', baseLength);
 
         if(secondSlashIndex == -1)


### PR DESCRIPTION
When specific target is passed, it was being ignored and we were relying on `req.getPathInfo()` but turns out thats implemented different for jetty vs. tomcat etc. 