### PR TITLE
Gracefully handle partial downloads, Preserve exception in runCycle

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -419,7 +419,12 @@ abstract class AbstractHollowProducer {
                 log.info("Populate stage completed with no delta in output state; skipping publish, announce, etc.");
             }
         } catch (Throwable th) {
-            writeEngine.resetToLastPrepareForNextCycle();
+            try {
+                writeEngine.resetToLastPrepareForNextCycle();
+            } catch (Throwable innerTh) {
+                log.log(Level.SEVERE, "resetToLastPrepareForNextCycle encountered an exception when attempting recovery:", innerTh);
+                // swallow the inner throwable to preserve the original
+            }
             cycleStatus.fail(th);
 
             if (th instanceof RuntimeException) {


### PR DESCRIPTION
* HollowFilesystemBlobRetriever should handle partial downloads gracefully- ignore them. Earlier caused a "corruption" behavior requiring cleanup of blob cache.
* If `writeEngine.resetToLastPrepareForNextCycle()`  threw it caused the original throwable to be lost. Now preserve original but also report if `resetToLastPrepareForNextCycle` throws