### PR TITLE
Bugfix: check for null before calling Base64 encode string from java.util

### DIFF
--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diffview/effigy/HollowEffigyFactory.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diffview/effigy/HollowEffigyFactory.java
@@ -92,7 +92,12 @@ public class HollowEffigyFactory {
                 fieldValue = typeDataAccess.readBoolean(effigy.ordinal, i);
                 break;
             case BYTES:
-                fieldValue = base64.encodeToString(typeDataAccess.readBytes(effigy.ordinal, i));
+                byte[] fieldValueBytes = typeDataAccess.readBytes(effigy.ordinal, i);
+                if (fieldValueBytes == null || fieldValueBytes.length == 0) {
+                    fieldValue = fieldValueBytes;
+                } else {
+                    fieldValue = base64.encodeToString(fieldValueBytes);
+                }
                 break;
             case DOUBLE:
                 fieldValue = Double.valueOf(typeDataAccess.readDouble(effigy.ordinal, i));


### PR DESCRIPTION
This bug was introduced when we recently switched from apache commons to java util for base64 codec