### PR TITLE
Bugfix: prefix index resizing when nodes per element is one

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthMultipleOccurrenceElementArray.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthMultipleOccurrenceElementArray.java
@@ -144,7 +144,7 @@ public class FixedLengthMultipleOccurrenceElementArray {
      */
     private void resizeStorage() {
         int currentElementsPerNode = maxElementsPerNode;
-        int newElementsPerNode = (int) (currentElementsPerNode * RESIZE_MULTIPLE);
+        int newElementsPerNode = (int) Math.ceil((double) currentElementsPerNode * RESIZE_MULTIPLE);
         if (newElementsPerNode <= currentElementsPerNode) {
             throw new IllegalStateException("cannot resize fixed length array from "
                     + currentElementsPerNode + " to " + newElementsPerNode);


### PR DESCRIPTION
It would retuned `newElementsPerNode` same as `currentElementsPerNode` with `currentElementsPerNode` at 1 and  `RESIZE_MULTIPLE` at 1.5 