### PR TITLE
Prefix index: memory usage stats, change default sizing of elements per node to 1, other cleanup/refactor

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
@@ -18,8 +18,6 @@ package com.netflix.hollow.core.index;
 
 import static java.util.Objects.requireNonNull;
 
-import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
-import com.netflix.hollow.core.memory.encoding.FixedLengthMultipleOccurrenceElementArray;
 import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.core.memory.pool.WastefulRecycler;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
@@ -27,18 +25,30 @@ import com.netflix.hollow.core.read.engine.HollowTypeStateListener;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
-import java.util.ArrayDeque;
 import java.util.BitSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Queue;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.logging.Logger;
 
 /**
- * This class builds a prefix index. A prefix index can be used to build applications like auto-complete, spell checker.
+ * This class builds a prefix index. A prefix index can be used to build applications like auto-complete or spell checker.
+ * The current prefix index implementation is backed by a TST (Ternary Search Tree) that is capable of indexing multiple
+ * elements per tree node.
+ * <p>
+ * Although TSTs are typically more space efficient than tries for prefix search, there are some important
+ * considerations when using this implementation that can impact memory usage and query performance:
+ * <p><ul>
+ * <li> Memory utilization will be efficient with more duplicates in the indexed keys. This is because by default
+ *      the underlying TST reserves space for one key reference per node but as it encounters duplicate keys it the data it
+ *      dynamically resizes each node in the tree to hold multiple references. This leads to un-utilized space at nodes
+ *      corresponding to which there is less duplication in keys and memory churn from resize when building the index. If
+ *      measure of duplication of values is known upfront it can be specified during index initialization to minimize resizing.
+ * <li> Future: bits per key defaults to 16 (for utf-16), but if the input character set can be represented in fewer bits
+ *      (for e.g. 1 for binary strings and 4 for hex strings) then the implementation could support a constructor that accepts
+ *      custom bitsPerKey to allocate less space per node.
+ * </ul><p>
+ * Includes methods for getting stats on memory usage and query performance.
  */
 public class HollowPrefixIndex implements HollowTypeStateListener {
+    private static final Logger LOG = Logger.getLogger(HollowPrefixIndex.class.getName());
 
     private final FieldPath fieldPath;
     private final HollowReadStateEngine readStateEngine;
@@ -55,19 +65,24 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
     private boolean buildIndexOnUpdate;
 
     /**
-     * This constructor defaults the estimatedMaxStringDuplicates to 4. If you expect a large
-     * number of duplicate strings across your type, you should provide your own estimate for
-     * estimatedMaxStringDuplicates.
+     * Initializes a new prefix index.
      *
-     * @param readStateEngine the read state
-     * @param type the type name
-     * @param fieldPath the field path
-     * @see #HollowPrefixIndex(HollowReadStateEngine, String, String)
+     * This constructor defaults the estimatedMaxStringDuplicates to 1, however while building the index it is observed
+     * that an indexed key references more than one records in the type then the prefix index dynamically resizes each node
+     * to accommodate the multiple references. Note that this has an adverse impact on memory usage, both in terms of
+     * memory footprint of prefix index and memory churn when building the index. If the expected number of duplicate
+     * strings across the type are specified upfront (see other constructor) then the memory churn due to resizing can be avoided.
+     *
+     * @param readStateEngine              state engine to read data from
+     * @param type                         type in the read state engine. Ordinals for this type
+     *                                     will be returned when queried for a prefix.
+     * @param fieldPath                    fieldPath should ultimately lead to a string field.
+     *                                     The fields in the path could reference another Object,
+     *                                     List, Set or a Map. The fields should be separated by ".".
+     *
      */
-    @SuppressWarnings("WeakerAccess")
     public HollowPrefixIndex(HollowReadStateEngine readStateEngine, String type, String fieldPath) {
-        // pass in a hardcoded estimate of 4 for now - in the future we could calculate this
-        this(readStateEngine, type, fieldPath, 4);
+        this(readStateEngine, type, fieldPath, 1);
     }
 
     /**
@@ -81,10 +96,9 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
      *                                     List, Set or a Map. The fields should be separated by ".".
      * @param estimatedMaxStringDuplicates The estimated number of strings that are duplicated
      *                                     across instances of your type. Note that this means an
-     *                                     exactly matching string, not a prefix match. This
-     *                                     parameter affects the efficiency of the index building.
+     *                                     exactly matching string, not a prefix match. A higher value will mean
+     *                                     the prefix tree will reserve more memory to reference several elements per node.
      */
-    @SuppressWarnings("WeakerAccess")
     public HollowPrefixIndex(HollowReadStateEngine readStateEngine, String type, String fieldPath,
             int estimatedMaxStringDuplicates) {
         requireNonNull(type, "Hollow Prefix Key Index creation failed because type was null");
@@ -123,7 +137,7 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
         BitSet keyBitSet = objectTypeReadState.getPopulatedOrdinals();
         int ordinal = keyBitSet.nextSetBit(0);
         while (ordinal != -1) {
-            avg += ((double) objectTypeReadState.readString(ordinal, 0).length()) / ((double) objectTypeReadState.maxOrdinal());
+            avg += ((double) objectTypeReadState.readString(ordinal, 0).length()) / ((double) totalWords);
             ordinal = keyBitSet.nextSetBit(ordinal + 1);
         }
         averageWordLen = (int) Math.ceil(avg);
@@ -143,8 +157,9 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
         TST current = prefixIndexVolatile;
         if (current != null) current.recycleMemory(memoryRecycle);
 
-        long estimatedNumberOfNodes = estimateNumNodes(totalWords, averageWordLen);
-        TST tst = new TST(estimatedNumberOfNodes, estimatedMaxStringDuplicates, maxOrdinalOfType,
+        // This is a hard limit, and currently assumes worst case unbalanced tree i.e. the total length of all words
+        long estimatedMaxNodes = estimateNumNodes(totalWords, averageWordLen);
+        TST tst = new TST(estimatedMaxNodes, estimatedMaxStringDuplicates, maxOrdinalOfType,
                 memoryRecycle);
         BitSet ordinals = readStateEngine.getTypeState(type).getPopulatedOrdinals();
         int ordinal = ordinals.nextSetBit(0);
@@ -159,10 +174,13 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
         // safe to return previous long arrays on next request for long array.
         memoryRecycle.swap();
         buildIndexOnUpdate = false;
+
+        Stats stats = usageStats();
+        LOG.info("Prefix index built with stats= [" + stats + "]");
     }
 
     /**
-     * Estimates the total number of nodes that will required to create the index.
+     * Estimates the total number of nodes that will be required to create the index.
      * Override this method if lower/higher estimate is needed compared to the default implementation.
      *
      * @param totalWords the total number of words
@@ -277,228 +295,38 @@ public class HollowPrefixIndex implements HollowTypeStateListener {
         initialize();
     }
 
-    private static class TST {  // ternary search tree
+    /**
+     * Returns memory usage stats for the prefix index. Not thread-safe with concurrent updates to index.
+     * @return approx heap footprint in bytes
+     */
+    public Stats usageStats() {
+        Stats stats = new Stats();
+        stats.nodesCapacity = prefixIndexVolatile.getMaxNodes();
+        stats.nodesUsed = prefixIndexVolatile.getNumNodes();
+        stats.nodesEmpty = prefixIndexVolatile.getEmptyNodes();
+        stats.worstCaseLookups = prefixIndexVolatile.getMaxDepth();
+        stats.maxValuesPerNode = prefixIndexVolatile.getMaxElementsPerNode();
 
-        private enum NodeType {
-            Left, Right, Middle
-        }
+        stats.approxHeapFootprintInBytes = prefixIndexVolatile.approxHeapFootprintInBytes();
+        return stats;
+    }
 
-        // each node segment can be thought of as 16 bit key and bits to hold index of its children
-        private int bitsPerNode;
-        private int bitsPerKey;
-        private int bitsForChildPointer;
-        private int bitsPerOrdinal;
+    public static class Stats {
+        long nodesCapacity;  // allocated capacity in underlying tree
+        long nodesUsed;      // utilized nodes
+        long nodesEmpty;     // un-utilized nodes (capacity - utilized)
+        long worstCaseLookups;  // no. of nodes looked up for serving worst case query
+        int maxValuesPerNode; // a single tree node reserves capacity to reference upto these many records
+        long approxHeapFootprintInBytes;    // approx heap footprint of tree
 
-        // helper offsets
-        private long leftChildOffset;
-        private long middleChildOffset;
-        private long rightChildOffset;
-        private long isEndFlagOffset;   // indicates end of a value stored in TST
-
-        private long maxNodes;
-        private FixedLengthElementArray nodes;
-        private FixedLengthMultipleOccurrenceElementArray ordinalSet;
-        private long indexTracker;
-
-        /**
-         * Create new prefix index. Represents a ternary search tree.
-         *
-         * @param estimatedNumNodes estimate number of max nodes that will created.
-         * @param estimatedMaxStringDuplicates estimated number string duplicates across all nodes
-         * @param maxOrdinalValue  max ordinal that can be referenced
-         * @param memoryRecycler   to reuse arrays from memory pool
-         */
-        private TST(long estimatedNumNodes, int estimatedMaxStringDuplicates, int maxOrdinalValue,
-                ArraySegmentRecycler memoryRecycler) {
-
-            // best guess
-            maxNodes = estimatedNumNodes;
-
-            // bits for pointers in a single node:
-            bitsPerKey = 16;// key
-            bitsForChildPointer = 64 - Long.numberOfLeadingZeros(maxNodes);// a child pointer
-            bitsPerOrdinal = maxOrdinalValue == 0 ? 1 : 32 - Integer.numberOfLeadingZeros(maxOrdinalValue);
-
-            // bits to represent one node
-            bitsPerNode = bitsPerKey + (3 * bitsForChildPointer) + 1;
-
-            nodes = new FixedLengthElementArray(memoryRecycler, bitsPerNode * maxNodes);
-            ordinalSet = new FixedLengthMultipleOccurrenceElementArray(memoryRecycler,
-                    maxNodes, bitsPerOrdinal, estimatedMaxStringDuplicates);
-            indexTracker = 0;
-
-            // initialize offsets
-            leftChildOffset = bitsPerKey;// after first 16 bits in node is first left child offset.
-            middleChildOffset = leftChildOffset + bitsForChildPointer;
-            rightChildOffset = middleChildOffset + bitsForChildPointer;
-            isEndFlagOffset = rightChildOffset + bitsForChildPointer;
-        }
-
-        // tell memory recycler to use these long array on next long array request from memory ONLY AFTER swap is called on memory recycler
-        private void recycleMemory(ArraySegmentRecycler memoryRecycler) {
-            nodes.destroy(memoryRecycler);
-            ordinalSet.destroy();
-        }
-
-        private long getChildOffset(NodeType nodeType) {
-            long offset;
-            if (nodeType.equals(NodeType.Left)) offset = leftChildOffset;
-            else if (nodeType.equals(NodeType.Middle)) offset = middleChildOffset;
-            else offset = rightChildOffset;
-            return offset;
-        }
-
-        private long getChildIndex(long currentNode, NodeType nodeType) {
-            long offset = getChildOffset(nodeType);
-            return nodes.getElementValue((currentNode * bitsPerNode) + offset, bitsForChildPointer);
-        }
-
-        private void setChildIndex(long currentNode, NodeType nodeType, long indexForNode) {
-            long offset = getChildOffset(nodeType);
-            nodes.setElementValue((currentNode * bitsPerNode) + offset, bitsForChildPointer, indexForNode);
-        }
-
-        private void setKey(long index, char ch) {
-            nodes.setElementValue(index * bitsPerNode, bitsPerKey, ch);
-        }
-
-        private long getKey(long nodeIndex) {
-            return nodes.getElementValue(nodeIndex * bitsPerNode, bitsPerKey);
-        }
-
-        private boolean isEndNode(long nodeIndex) {
-            return nodes.getElementValue((nodeIndex * bitsPerNode) + isEndFlagOffset, 1) == 1;
-        }
-
-        private void addOrdinal(long nodeIndex, long ordinal) {
-            ordinalSet.addElement(nodeIndex, ordinal);
-            nodes.setElementValue((nodeIndex * bitsPerNode) + isEndFlagOffset, 1, 1);
-        }
-
-        private Set<Integer> getOrdinals(long nodeIndex) {
-            return ordinalSet.getElements(nodeIndex).stream()
-                    .map(Long::intValue).collect(Collectors.toSet());
-        }
-
-        /**
-         * Insert into ternary search tree for the given key and ordinal.
-         */
-        private void insert(String key, int ordinal) {
-            if (key == null) throw new IllegalArgumentException("Null key cannot be indexed");
-            long currentNodeIndex = 0;
-            int keyIndex = 0;
-
-            while (keyIndex < key.length()) {
-
-                char ch = key.charAt(keyIndex);
-                if (getKey(currentNodeIndex) == 0) {
-                    setKey(currentNodeIndex, ch);
-                    indexTracker++;
-                    if (indexTracker >= maxNodes)
-                        throw new IllegalStateException("Index Tracker reached max capacity. Try with larger estimate of number of nodes");
-                }
-
-                long keyAtCurrentNode = getKey(currentNodeIndex);
-                if (ch < keyAtCurrentNode) {
-                    long leftIndex = getChildIndex(currentNodeIndex, NodeType.Left);
-                    if (leftIndex == 0) leftIndex = indexTracker;
-                    setChildIndex(currentNodeIndex, NodeType.Left, leftIndex);
-                    currentNodeIndex = leftIndex;
-                } else if (ch > keyAtCurrentNode) {
-                    long rightIndex = getChildIndex(currentNodeIndex, NodeType.Right);
-                    if (rightIndex == 0) rightIndex = indexTracker;
-                    setChildIndex(currentNodeIndex, NodeType.Right, rightIndex);
-                    currentNodeIndex = rightIndex;
-                } else {
-                    keyIndex++;
-                    if (keyIndex < key.length()) {
-                        long midIndex = getChildIndex(currentNodeIndex, NodeType.Middle);
-                        if (midIndex == 0) midIndex = indexTracker;
-                        setChildIndex(currentNodeIndex, NodeType.Middle, midIndex);
-                        currentNodeIndex = midIndex;
-                    }
-                }
-            }
-            addOrdinal(currentNodeIndex, ordinal);
-        }
-
-        /**
-         * This functions checks if the given key exists in the trie.
-         *
-         * @return index of the node that findNodeWithKey the last character of the key, if not found then returns -1.
-         */
-        private long findNodeWithKey(String key) {
-            long index = -1;
-
-            boolean atRoot = true;
-            long currentNodeIndex = 0;
-            int keyIndex = 0;
-
-            while (true) {
-                if (currentNodeIndex == 0 && !atRoot) break;
-                long currentValue = getKey(currentNodeIndex);
-                char ch = key.charAt(keyIndex);
-                if (ch < currentValue) currentNodeIndex = getChildIndex(currentNodeIndex, NodeType.Left);
-                else if (ch > currentValue) currentNodeIndex = getChildIndex(currentNodeIndex, NodeType.Right);
-                else {
-                    if (keyIndex == (key.length() - 1)) {
-                        index = currentNodeIndex;
-                        break;
-                    }
-                    currentNodeIndex = getChildIndex(currentNodeIndex, NodeType.Middle);
-                    keyIndex++;
-                }
-                if (atRoot) atRoot = false;
-            }
-            return index;
-        }
-
-        private boolean contains(String key) {
-            long nodeIndex = findNodeWithKey(key);
-            return nodeIndex >= 0 && isEndNode(nodeIndex);
-        }
-
-        /**
-         * Find all the ordinals that match the given prefix.
-         */
-        private HollowOrdinalIterator findKeysWithPrefix(String prefix) {
-            if (prefix == null) throw new IllegalArgumentException("Cannot findKeysWithPrefix null prefix");
-            final Set<Integer> ordinals = new HashSet<>();
-            long currentNodeIndex = findNodeWithKey(prefix.toLowerCase());
-
-            if (currentNodeIndex >= 0) {
-
-                if (isEndNode(currentNodeIndex))
-                    ordinals.addAll(getOrdinals(currentNodeIndex));
-
-                // go to all leaf nodes from current node mid pointer
-                long subTree = getChildIndex(currentNodeIndex, NodeType.Middle);
-                if (subTree != 0) {
-                    Queue<Long> queue = new ArrayDeque<>();
-                    queue.add(subTree);
-                    while (!queue.isEmpty()) {
-                        long nodeIndex = queue.remove();
-                        long left = getChildIndex(nodeIndex, NodeType.Left);
-                        long mid = getChildIndex(nodeIndex, NodeType.Middle);
-                        long right = getChildIndex(nodeIndex, NodeType.Right);
-
-                        if (isEndNode(nodeIndex)) ordinals.addAll(getOrdinals(nodeIndex));
-                        if (left != 0) queue.add(left);
-                        if (mid != 0) queue.add(mid);
-                        if (right != 0) queue.add(right);
-                    }
-                }
-            }
-
-            return new HollowOrdinalIterator() {
-                private Iterator<Integer> it = ordinals.iterator();
-
-                @Override
-                public int next() {
-                    if (it.hasNext()) return it.next();
-                    return NO_MORE_ORDINALS;
-                }
-            };
+        @Override
+        public String toString() {
+            return "nodesCapacity=" + nodesCapacity + ", "
+                 + "nodesUsed=" + nodesUsed + ", "
+                 + "nodesEmpty=" + nodesEmpty + ", "
+                 + "worstCaseLookups=" + worstCaseLookups + ", "
+                 + "maxValuesPerNode=" + maxValuesPerNode + ", "
+                 + "approxHeapFootprintInBytes=" + approxHeapFootprintInBytes;
         }
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/index/TST.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/TST.java
@@ -1,0 +1,317 @@
+package com.netflix.hollow.core.index;
+
+import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
+import com.netflix.hollow.core.memory.encoding.FixedLengthMultipleOccurrenceElementArray;
+import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
+import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Ternary Search Tree implementation. Insertion order of elements in TST controls the balancing factor of the tree and
+ * in turn space utilization and query performance. The tree would be least balanced with worst performance if the keys
+ * are inserted in sorted order, and it would be somewhat balanced with good performance if keys are inserted in random order.
+ *
+ * This implementation supports duplicate element references from a single tree node. As duplicate elements are encountered,
+ * the per-node capacity of referencing elements is dynamically resized. A best effort guess of the measure of duplication
+ * in inserted keys is helpful to avoid expensive resize operations.
+ *
+ * The total node capacity of the tree i.e. max no. of nodes in the tree is pre-allocated at the time of initialization
+ * and can not be dynamically resized.
+ */
+class TST {   // ternary search tree
+    private enum NodeType {
+        Left, Right, Middle
+    }
+
+    // each node segment can be thought of as 16 bit key and bits to hold index of its children
+    private int bitsPerNode;
+    private int bitsPerKey;
+    private int bitsForChildPointer;
+    private int bitsPerOrdinal;
+
+    // helper offsets
+    private long leftChildOffset;
+    private long middleChildOffset;
+    private long rightChildOffset;
+    private long isEndFlagOffset;   // indicates end of a value stored in TST
+
+    private long maxNodes;
+
+    // pre-allocated array to store all nodes in the TST
+    // each node contains a data key, links to 3 child nodes, and one bit for indicating if this node marks the end of a value
+    private FixedLengthElementArray nodes;
+
+    // dynamically resized array that can store multiple ordinals in the type state corresponding to a node in the TST
+    private FixedLengthMultipleOccurrenceElementArray ordinalSet;
+    private long indexTracker;
+    private long maxDepth;
+
+    /**
+     * Create new prefix index. Represents a ternary search tree.
+     *
+     * @param estimatedMaxNodes estimate number of max nodes that will be created. This is a hard limit.
+     * @param estimatedMaxStringDuplicates estimated number string duplicates across all nodes
+     * @param maxOrdinalValue  max ordinal that can be referenced
+     * @param memoryRecycler   to reuse arrays from memory pool
+     */
+    TST(long estimatedMaxNodes, int estimatedMaxStringDuplicates, int maxOrdinalValue, ArraySegmentRecycler memoryRecycler) {
+        // best guess, hard limit
+        maxNodes = estimatedMaxNodes;
+
+        // bits for pointers in a single node:
+        bitsPerKey = 16;// key
+        bitsForChildPointer = 64 - Long.numberOfLeadingZeros(maxNodes);// a child pointer
+        bitsPerOrdinal = maxOrdinalValue == 0 ? 1 : 32 - Integer.numberOfLeadingZeros(maxOrdinalValue);
+
+        // bits to represent one node
+        bitsPerNode = bitsPerKey + (3 * bitsForChildPointer) + 1;
+
+        nodes = new FixedLengthElementArray(memoryRecycler, bitsPerNode * maxNodes);
+        ordinalSet = new FixedLengthMultipleOccurrenceElementArray(memoryRecycler,
+                maxNodes, bitsPerOrdinal, estimatedMaxStringDuplicates);
+        indexTracker = 0;
+        maxDepth = 0;
+
+        // initialize offsets
+        leftChildOffset = bitsPerKey;// after first 16 bits in node is first left child offset.
+        middleChildOffset = leftChildOffset + bitsForChildPointer;
+        rightChildOffset = middleChildOffset + bitsForChildPointer;
+        isEndFlagOffset = rightChildOffset + bitsForChildPointer;
+    }
+
+    // tell memory recycler to use these long array on next long array request from memory ONLY AFTER swap is called on memory recycler
+    void recycleMemory(ArraySegmentRecycler memoryRecycler) {
+        nodes.destroy(memoryRecycler);
+        ordinalSet.destroy();
+    }
+
+    private long getChildOffset(NodeType nodeType) {
+        long offset;
+        if (nodeType.equals(NodeType.Left)) offset = leftChildOffset;
+        else if (nodeType.equals(NodeType.Middle)) offset = middleChildOffset;
+        else offset = rightChildOffset;
+        return offset;
+    }
+
+    private long getChildIndex(long currentNode, NodeType nodeType) {
+        long offset = getChildOffset(nodeType);
+        return nodes.getElementValue((currentNode * bitsPerNode) + offset, bitsForChildPointer);
+    }
+
+    private void setChildIndex(long currentNode, NodeType nodeType, long indexForNode) {
+        long offset = getChildOffset(nodeType);
+        nodes.setElementValue((currentNode * bitsPerNode) + offset, bitsForChildPointer, indexForNode);
+    }
+
+    private void setKey(long index, char ch) {
+        nodes.setElementValue(index * bitsPerNode, bitsPerKey, ch);
+    }
+
+    private long getKey(long nodeIndex) {
+        return nodes.getElementValue(nodeIndex * bitsPerNode, bitsPerKey);
+    }
+
+    private boolean isEndNode(long nodeIndex) {
+        return nodes.getElementValue((nodeIndex * bitsPerNode) + isEndFlagOffset, 1) == 1;
+    }
+
+    private void addOrdinal(long nodeIndex, long ordinal) {
+        ordinalSet.addElement(nodeIndex, ordinal);
+        nodes.setElementValue((nodeIndex * bitsPerNode) + isEndFlagOffset, 1, 1);
+    }
+
+    private Set<Integer> getOrdinals(long nodeIndex) {
+        return ordinalSet.getElements(nodeIndex).stream()
+                .map(Long::intValue).collect(Collectors.toSet());
+    }
+
+    /**
+     * Insert into ternary search tree for the given key and ordinal.
+     */
+    void insert(String key, int ordinal) {
+        if (key == null) throw new IllegalArgumentException("Null key cannot be indexed");
+        long currentNodeIndex = 0;
+        int keyIndex = 0;
+        int depth = 0;
+
+        while (keyIndex < key.length()) {
+
+            char ch = key.charAt(keyIndex);
+            if (getKey(currentNodeIndex) == 0) {
+                setKey(currentNodeIndex, ch);
+                indexTracker++;
+                if (indexTracker >= maxNodes)
+                    throw new IllegalStateException("Index Tracker reached max capacity. Try with larger estimate of number of nodes");
+            }
+
+            long keyAtCurrentNode = getKey(currentNodeIndex);
+            if (ch < keyAtCurrentNode) {
+                long leftIndex = getChildIndex(currentNodeIndex, NodeType.Left);
+                if (leftIndex == 0) leftIndex = indexTracker;
+                setChildIndex(currentNodeIndex, NodeType.Left, leftIndex);
+                currentNodeIndex = leftIndex;
+            } else if (ch > keyAtCurrentNode) {
+                long rightIndex = getChildIndex(currentNodeIndex, NodeType.Right);
+                if (rightIndex == 0) rightIndex = indexTracker;
+                setChildIndex(currentNodeIndex, NodeType.Right, rightIndex);
+                currentNodeIndex = rightIndex;
+            } else {
+                keyIndex++;
+                if (keyIndex < key.length()) {
+                    long midIndex = getChildIndex(currentNodeIndex, NodeType.Middle);
+                    if (midIndex == 0) midIndex = indexTracker;
+                    setChildIndex(currentNodeIndex, NodeType.Middle, midIndex);
+                    currentNodeIndex = midIndex;
+                }
+            }
+            depth++;
+        }
+        addOrdinal(currentNodeIndex, ordinal);
+        if (depth > maxDepth) {
+            maxDepth = depth;
+        }
+    }
+
+    /**
+     * This functions checks if the given key exists in the trie.
+     *
+     * @return index of the node that findNodeWithKey the last character of the key, if not found then returns -1.
+     */
+    long findNodeWithKey(String key) {
+        long index = -1;
+
+        boolean atRoot = true;
+        long currentNodeIndex = 0;
+        int keyIndex = 0;
+
+        while (true) {
+            if (currentNodeIndex == 0 && !atRoot) break;
+            long currentValue = getKey(currentNodeIndex);
+            char ch = key.charAt(keyIndex);
+            if (ch < currentValue) currentNodeIndex = getChildIndex(currentNodeIndex, NodeType.Left);
+            else if (ch > currentValue) currentNodeIndex = getChildIndex(currentNodeIndex, NodeType.Right);
+            else {
+                if (keyIndex == (key.length() - 1)) {
+                    index = currentNodeIndex;
+                    break;
+                }
+                currentNodeIndex = getChildIndex(currentNodeIndex, NodeType.Middle);
+                keyIndex++;
+            }
+            if (atRoot) atRoot = false;
+        }
+        return index;
+    }
+
+    boolean contains(String key) {
+        long nodeIndex = findNodeWithKey(key);
+        return nodeIndex >= 0 && isEndNode(nodeIndex);
+    }
+
+    /**
+     * Find all the ordinals that match the given prefix.
+     */
+    HollowOrdinalIterator findKeysWithPrefix(String prefix) {
+        if (prefix == null) throw new IllegalArgumentException("Cannot findKeysWithPrefix null prefix");
+        final Set<Integer> ordinals = new HashSet<>();
+        long currentNodeIndex = findNodeWithKey(prefix.toLowerCase());
+
+        if (currentNodeIndex >= 0) {
+
+            if (isEndNode(currentNodeIndex))
+                ordinals.addAll(getOrdinals(currentNodeIndex));
+
+            // go to all leaf nodes from current node mid pointer
+            long subTree = getChildIndex(currentNodeIndex, NodeType.Middle);
+            if (subTree != 0) {
+                Queue<Long> queue = new ArrayDeque<>();
+                queue.add(subTree);
+                while (!queue.isEmpty()) {
+                    long nodeIndex = queue.remove();
+                    long left = getChildIndex(nodeIndex, NodeType.Left);
+                    long mid = getChildIndex(nodeIndex, NodeType.Middle);
+                    long right = getChildIndex(nodeIndex, NodeType.Right);
+
+                    if (isEndNode(nodeIndex)) ordinals.addAll(getOrdinals(nodeIndex));
+                    if (left != 0) queue.add(left);
+                    if (mid != 0) queue.add(mid);
+                    if (right != 0) queue.add(right);
+                }
+            }
+        }
+
+        return new HollowOrdinalIterator() {
+            private Iterator<Integer> it = ordinals.iterator();
+
+            @Override
+            public int next() {
+                if (it.hasNext()) return it.next();
+                return NO_MORE_ORDINALS;
+            }
+        };
+    }
+
+    /**
+     * Returns the max depth of the prefix tree. The depth depends on insertion order of elements and effects the
+     * worst case no. of hops for search. For e.g., a more balanced tree depth closer to log n (n being the no. of nodes)
+     * will yield closer to O(log n) search time complexity whereas a balanced tree with depth closer to n would mean
+     * upto O(n) search time complexity.
+     * @return the max depth of the tree
+     */
+    long getMaxDepth() {
+        return maxDepth;
+    }
+
+    /**
+     * Returns the no. of empty nodes (capacity minus populated) as a measure of how much pre-allocated space is
+     * under utilized.
+     * @return no. of populated nodes in prefix tree
+     */
+    long getEmptyNodes() {
+        return maxNodes - indexTracker;
+    }
+
+    /**
+     * Returns the no. of populated nodes (out of the entire node capcity) in the underlying prefix tree. The no. of
+     * nodes required to index a set of records can vary depending on underlying prefix tree implementation and
+     * insertion order of records.
+     * @return no. of populated nodes in prefix tree
+     */
+    long getNumNodes() {
+        return indexTracker;
+    }
+
+    /**
+     * Returns the max node capacity of the underlying prefix tree, used as a measure of in-memory space efficiency.
+     * An attempt to insert no. of nodes greater than this value will result in failure. The no. of nodes required to
+     * index over the a set of records, can vary depending on underlying prefix tree implementation and insertion order
+     * of records.
+     * @return max node capacity of underlying prefix tree
+     */
+    long getMaxNodes() {
+        return maxNodes;
+    }
+
+    /**
+     * This is a measure of duplication in the indexed field. Duplication has an adverse effect on memory efficiency, since
+     * each node of the tree reserves space to reference multiple records.
+     * @return no. of elements that can be referenced from a single node of the tree
+     */
+    int getMaxElementsPerNode() {
+        return ordinalSet.getMaxElementsPerNode();
+    }
+
+    /**
+     * Returns the approx heap footprint of the prefix tree
+     * @return approx heap footprint in bytes
+     */
+    long approxHeapFootprintInBytes() {
+        return nodes.approxHeapFootprintInBytes()
+                + ordinalSet.approxHeapFootprintInBytes();
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthElementArray.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/FixedLengthElementArray.java
@@ -62,11 +62,17 @@ public class FixedLengthElementArray extends SegmentedLongArray implements Fixed
 
     private final int log2OfSegmentSizeInBytes;
     private final int byteBitmask;
+    private final long sizeBits;
 
     public FixedLengthElementArray(ArraySegmentRecycler memoryRecycler, long numBits) {
         super(memoryRecycler, ((numBits - 1) >>> 6) + 1);
         this.log2OfSegmentSizeInBytes = log2OfSegmentSize + 3;
         this.byteBitmask = (1 << log2OfSegmentSizeInBytes) - 1;
+        this.sizeBits = numBits;
+    }
+
+    public long approxHeapFootprintInBytes() {
+        return sizeBits / 8;
     }
 
     @Override


### PR DESCRIPTION
* Prefix index logs memory usage stats after every refresh, for e.g.
```
INFO: Prefix index built with stats= [nodesCapacity=267421, nodesUsed=76960, nodesEmpty=190461, worstCaseLookups=63, maxValuesPerNode=3596, approxHeapFootprintInBytes=1925798903]
```
* Since the elements per node can be dynamically resized when building index, default to 1 for efficient memory usage for cases where prefix index is declared on unique values, and also since resize is expensive log a warning when we do resize- to hopefully prompt developer to specify a duplication estimate in prefix index constructor.
* The TST class was simply moved to a different file and some javadoc added.
* Bugfix: compute average word length based on total words not max ordinal. Since the max nodes (hardlimit) in tree is estimated based on avg * total words, this could avoid a runtime failure when total words < max ordinal 