### PR TITLE
enable pojo caching in HollowObjectCacheProvider

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProvider.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProvider.java
@@ -36,11 +36,11 @@ import java.util.logging.Logger;
  */
 public class HollowObjectCacheProvider<T> extends HollowObjectProvider<T> implements HollowTypeStateListener {
     private static final Logger log = Logger.getLogger(HollowObjectCacheProvider.class.getName());
-    private final List<T> cachedItems;
+    private volatile List<T> cachedItems;
 
-    private HollowFactory<T> factory;
-    private HollowTypeAPI typeAPI;
-    private HollowTypeReadState typeReadState;
+    private volatile HollowFactory<T> factory;
+    private volatile HollowTypeAPI typeAPI;
+    private volatile HollowTypeReadState typeReadState;
 
     public HollowObjectCacheProvider(HollowTypeDataAccess typeDataAccess, HollowTypeAPI typeAPI, HollowFactory<T> factory) {
         this(typeDataAccess, typeAPI, factory, null);
@@ -84,11 +84,18 @@ public class HollowObjectCacheProvider<T> extends HollowObjectProvider<T> implem
 
     @Override
     public T getHollowObject(int ordinal) {
-        return cachedItems.get(ordinal);
+        List<T> refCachedItems = cachedItems;   // SNAP: object cache
+        if (refCachedItems == null) {
+            throw new IllegalStateException("");
+        }
+        if (refCachedItems.size() <= ordinal) {
+            throw new IllegalStateException("");
+        }
+        return refCachedItems.get(ordinal);
     }
 
     public void detach() {
-        cachedItems.clear();
+        cachedItems = null;
         factory = null;
         typeAPI = null;
         typeReadState = null;

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowConsumerBuilderTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowConsumerBuilderTest.java
@@ -1,0 +1,69 @@
+package com.netflix.hollow.api.consumer;
+
+import com.netflix.hollow.test.HollowWriteStateEngineBuilder;
+import com.netflix.hollow.test.consumer.TestBlobRetriever;
+import com.netflix.hollow.test.consumer.TestHollowConsumer;
+import com.netflix.hollow.test.generated.MovieAPI;
+import com.netflix.hollow.test.model.Movie;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class HollowConsumerBuilderTest {
+    @Test
+    public void testCachedTypes() throws IOException {
+        TestHollowConsumer consumer = new TestHollowConsumer.Builder()
+                .withBlobRetriever(new TestBlobRetriever())
+                .withGeneratedAPIClass(MovieAPI.class, "Movie")
+                .build();
+        testConsumerCache(true, false, consumer);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCachedTypesDetached() throws IOException {
+        TestHollowConsumer consumer = new TestHollowConsumer.Builder()
+                .withBlobRetriever(new TestBlobRetriever())
+                .withGeneratedAPIClass(MovieAPI.class, "Movie")
+                .build();
+        testConsumerCache(true, true, consumer);
+    }
+
+    @Test
+    public void testNoCacheConsumer() throws IOException {
+        TestHollowConsumer consumer = new TestHollowConsumer.Builder()
+                .withBlobRetriever(new TestBlobRetriever())
+                .withGeneratedAPIClass(MovieAPI.class)
+                .build();
+        testConsumerCache(false, false, consumer);
+    }
+
+    private void testConsumerCache(boolean hasCache, boolean detachCache, TestHollowConsumer consumer) throws IOException {
+        consumer.addSnapshot(1l, new HollowWriteStateEngineBuilder().add(
+                new Movie(1, "test movie 1", 2023)).build());
+
+        consumer.triggerRefreshTo(1l);
+
+        consumer.addDelta(1l, 2l, new HollowWriteStateEngineBuilder().add(
+                new Movie(1, "test movie 1", 2023),
+                new Movie(2, "test movie 2", 2023)).build());
+
+        consumer.triggerRefreshTo(2l);
+
+        Assert.assertTrue(consumer.getCurrentVersionId() == 2l);
+
+        MovieAPI movieAPI = (MovieAPI) consumer.getAPI();
+        if (detachCache) {
+            movieAPI.detachCaches();
+        }
+        com.netflix.hollow.test.generated.Movie movie1 = movieAPI.getMovie(0);
+        com.netflix.hollow.test.generated.Movie movie2 = movieAPI.getMovie(0);
+
+        if (hasCache) {
+            Assert.assertTrue(movie1 == movie2);
+        } else {
+            Assert.assertFalse(movie1 == movie2);
+        }
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/HString.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/HString.java
@@ -1,0 +1,36 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
+
+@SuppressWarnings("all")
+@HollowTypeName(name="String")
+public class HString extends HollowObject {
+
+    public HString(StringDelegate delegate, int ordinal) {
+        super(delegate, ordinal);
+    }
+
+    public String getValue() {
+        return delegate().getValue(ordinal);
+    }
+
+    public boolean isValueEqual(String testValue) {
+        return delegate().isValueEqual(ordinal, testValue);
+    }
+
+    public MovieAPI api() {
+        return typeApi().getAPI();
+    }
+
+    public StringTypeAPI typeApi() {
+        return delegate().getTypeAPI();
+    }
+
+    protected StringDelegate delegate() {
+        return (StringDelegate)delegate;
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/Movie.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/Movie.java
@@ -1,0 +1,68 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.index.UniqueKeyIndex;
+import com.netflix.hollow.api.objects.HollowObject;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+
+@SuppressWarnings("all")
+public class Movie extends HollowObject {
+
+    public Movie(MovieDelegate delegate, int ordinal) {
+        super(delegate, ordinal);
+    }
+
+    public long getId() {
+        return delegate().getId(ordinal);
+    }
+
+    public Long getIdBoxed() {
+        return delegate().getIdBoxed(ordinal);
+    }
+
+    public HString getTitle() {
+        int refOrdinal = delegate().getTitleOrdinal(ordinal);
+        if(refOrdinal == -1)
+            return null;
+        return  api().getHString(refOrdinal);
+    }
+
+    public int getYear() {
+        return delegate().getYear(ordinal);
+    }
+
+    public Integer getYearBoxed() {
+        return delegate().getYearBoxed(ordinal);
+    }
+
+    public MovieAPI api() {
+        return typeApi().getAPI();
+    }
+
+    public MovieTypeAPI typeApi() {
+        return delegate().getTypeAPI();
+    }
+
+    protected MovieDelegate delegate() {
+        return (MovieDelegate)delegate;
+    }
+
+    /**
+     * Creates a unique key index for {@code Movie} that has a primary key.
+     * The primary key is represented by the type {@code long}.
+     * <p>
+     * By default the unique key index will not track updates to the {@code consumer} and thus
+     * any changes will not be reflected in matched results.  To track updates the index must be
+     * {@link HollowConsumer#addRefreshListener(HollowConsumer.RefreshListener) registered}
+     * with the {@code consumer}
+     *
+     * @param consumer the consumer
+     * @return the unique key index
+     */
+    public static UniqueKeyIndex<Movie, Long> uniqueIndex(HollowConsumer consumer) {
+        return UniqueKeyIndex.from(consumer, Movie.class)
+            .bindToPrimaryKey()
+            .usingPath("id", long.class);
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/MovieAPI.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/MovieAPI.java
@@ -1,0 +1,145 @@
+package com.netflix.hollow.test.generated;
+
+import java.util.Objects;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.Map;
+import com.netflix.hollow.api.consumer.HollowConsumerAPI;
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowListTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowSetTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.HollowMapTypeDataAccess;
+import com.netflix.hollow.core.read.dataaccess.missing.HollowObjectMissingDataAccess;
+import com.netflix.hollow.core.read.dataaccess.missing.HollowListMissingDataAccess;
+import com.netflix.hollow.core.read.dataaccess.missing.HollowSetMissingDataAccess;
+import com.netflix.hollow.core.read.dataaccess.missing.HollowMapMissingDataAccess;
+import com.netflix.hollow.api.objects.provider.HollowFactory;
+import com.netflix.hollow.api.objects.provider.HollowObjectProvider;
+import com.netflix.hollow.api.objects.provider.HollowObjectCacheProvider;
+import com.netflix.hollow.api.objects.provider.HollowObjectFactoryProvider;
+import com.netflix.hollow.api.sampling.HollowObjectCreationSampler;
+import com.netflix.hollow.api.sampling.HollowSamplingDirector;
+import com.netflix.hollow.api.sampling.SampleResult;
+import com.netflix.hollow.core.util.AllHollowRecordCollection;
+
+@SuppressWarnings("all")
+public class MovieAPI extends HollowAPI  {
+
+    private final HollowObjectCreationSampler objectCreationSampler;
+
+    private final StringTypeAPI stringTypeAPI;
+    private final MovieTypeAPI movieTypeAPI;
+
+    private final HollowObjectProvider stringProvider;
+    private final HollowObjectProvider movieProvider;
+
+    public MovieAPI(HollowDataAccess dataAccess) {
+        this(dataAccess, Collections.<String>emptySet());
+    }
+
+    public MovieAPI(HollowDataAccess dataAccess, Set<String> cachedTypes) {
+        this(dataAccess, cachedTypes, Collections.<String, HollowFactory<?>>emptyMap());
+    }
+
+    public MovieAPI(HollowDataAccess dataAccess, Set<String> cachedTypes, Map<String, HollowFactory<?>> factoryOverrides) {
+        this(dataAccess, cachedTypes, factoryOverrides, null);
+    }
+
+    public MovieAPI(HollowDataAccess dataAccess, Set<String> cachedTypes, Map<String, HollowFactory<?>> factoryOverrides, MovieAPI previousCycleAPI) {
+        super(dataAccess);
+        HollowTypeDataAccess typeDataAccess;
+        HollowFactory factory;
+
+        objectCreationSampler = new HollowObjectCreationSampler("String","Movie");
+
+        typeDataAccess = dataAccess.getTypeDataAccess("String");
+        if(typeDataAccess != null) {
+            stringTypeAPI = new StringTypeAPI(this, (HollowObjectTypeDataAccess)typeDataAccess);
+        } else {
+            stringTypeAPI = new StringTypeAPI(this, new HollowObjectMissingDataAccess(dataAccess, "String"));
+        }
+        addTypeAPI(stringTypeAPI);
+        factory = factoryOverrides.get("String");
+        if(factory == null)
+            factory = new StringHollowFactory();
+        if(cachedTypes.contains("String")) {
+            HollowObjectCacheProvider previousCacheProvider = null;
+            if(previousCycleAPI != null && (previousCycleAPI.stringProvider instanceof HollowObjectCacheProvider))
+                previousCacheProvider = (HollowObjectCacheProvider) previousCycleAPI.stringProvider;
+            stringProvider = new HollowObjectCacheProvider(typeDataAccess, stringTypeAPI, factory, previousCacheProvider);
+        } else {
+            stringProvider = new HollowObjectFactoryProvider(typeDataAccess, stringTypeAPI, factory);
+        }
+
+        typeDataAccess = dataAccess.getTypeDataAccess("Movie");
+        if(typeDataAccess != null) {
+            movieTypeAPI = new MovieTypeAPI(this, (HollowObjectTypeDataAccess)typeDataAccess);
+        } else {
+            movieTypeAPI = new MovieTypeAPI(this, new HollowObjectMissingDataAccess(dataAccess, "Movie"));
+        }
+        addTypeAPI(movieTypeAPI);
+        factory = factoryOverrides.get("Movie");
+        if(factory == null)
+            factory = new MovieHollowFactory();
+        if(cachedTypes.contains("Movie")) {
+            HollowObjectCacheProvider previousCacheProvider = null;
+            if(previousCycleAPI != null && (previousCycleAPI.movieProvider instanceof HollowObjectCacheProvider))
+                previousCacheProvider = (HollowObjectCacheProvider) previousCycleAPI.movieProvider;
+            movieProvider = new HollowObjectCacheProvider(typeDataAccess, movieTypeAPI, factory, previousCacheProvider);
+        } else {
+            movieProvider = new HollowObjectFactoryProvider(typeDataAccess, movieTypeAPI, factory);
+        }
+
+    }
+
+    public void detachCaches() {
+        if(stringProvider instanceof HollowObjectCacheProvider)
+            ((HollowObjectCacheProvider)stringProvider).detach();
+        if(movieProvider instanceof HollowObjectCacheProvider)
+            ((HollowObjectCacheProvider)movieProvider).detach();
+    }
+
+    public StringTypeAPI getStringTypeAPI() {
+        return stringTypeAPI;
+    }
+    public MovieTypeAPI getMovieTypeAPI() {
+        return movieTypeAPI;
+    }
+    public Collection<HString> getAllHString() {
+        HollowTypeDataAccess tda = Objects.requireNonNull(getDataAccess().getTypeDataAccess("String"), "type not loaded or does not exist in dataset; type=String");
+        return new AllHollowRecordCollection<HString>(tda.getTypeState()) {
+            protected HString getForOrdinal(int ordinal) {
+                return getHString(ordinal);
+            }
+        };
+    }
+    public HString getHString(int ordinal) {
+        objectCreationSampler.recordCreation(0);
+        return (HString)stringProvider.getHollowObject(ordinal);
+    }
+    public Collection<Movie> getAllMovie() {
+        HollowTypeDataAccess tda = Objects.requireNonNull(getDataAccess().getTypeDataAccess("Movie"), "type not loaded or does not exist in dataset; type=Movie");
+        return new AllHollowRecordCollection<Movie>(tda.getTypeState()) {
+            protected Movie getForOrdinal(int ordinal) {
+                return getMovie(ordinal);
+            }
+        };
+    }
+    public Movie getMovie(int ordinal) {
+        objectCreationSampler.recordCreation(1);
+        return (Movie)movieProvider.getHollowObject(ordinal);
+    }
+    public void setSamplingDirector(HollowSamplingDirector director) {
+        super.setSamplingDirector(director);
+        objectCreationSampler.setSamplingDirector(director);
+    }
+
+    public Collection<SampleResult> getObjectCreationSamplingResults() {
+        return objectCreationSampler.getSampleResults();
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/MovieAPIFactory.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/MovieAPIFactory.java
@@ -1,0 +1,35 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.client.HollowAPIFactory;
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.api.objects.provider.HollowFactory;
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import java.util.Collections;
+import java.util.Set;
+
+@SuppressWarnings("all")
+public class MovieAPIFactory implements HollowAPIFactory {
+
+    private final Set<String> cachedTypes;
+
+    public MovieAPIFactory() {
+        this(Collections.<String>emptySet());
+    }
+
+    public MovieAPIFactory(Set<String> cachedTypes) {
+        this.cachedTypes = cachedTypes;
+    }
+
+    @Override
+    public HollowAPI createAPI(HollowDataAccess dataAccess) {
+        return new MovieAPI(dataAccess, cachedTypes);
+    }
+
+    @Override
+    public HollowAPI createAPI(HollowDataAccess dataAccess, HollowAPI previousCycleAPI) {
+        if (!(previousCycleAPI instanceof MovieAPI)) {
+            throw new ClassCastException(previousCycleAPI.getClass() + " not instance of MovieAPI");        }
+        return new MovieAPI(dataAccess, cachedTypes, Collections.<String, HollowFactory<?>>emptyMap(), (MovieAPI) previousCycleAPI);
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/MovieAPIHashIndex.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/MovieAPIHashIndex.java
@@ -1,0 +1,56 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.core.index.HollowHashIndexResult;
+import java.util.Collections;
+import java.lang.Iterable;
+import com.netflix.hollow.api.consumer.index.AbstractHollowHashIndex;
+import com.netflix.hollow.api.consumer.data.AbstractHollowOrdinalIterable;
+
+
+/**
+ * @deprecated see {@link com.netflix.hollow.api.consumer.index.HashIndex} which can be built as follows:
+ * <pre>{@code
+ *     HashIndex<HString, K> uki = HashIndex.from(consumer, HString.class)
+ *         .usingBean(k);
+ *     Stream<HString> results = uki.findMatches(k);
+ * }</pre>
+ * where {@code K} is a class declaring key field paths members, annotated with
+ * {@link com.netflix.hollow.api.consumer.index.FieldPath}, and {@code k} is an instance of
+ * {@code K} that is the query to find the matching {@code HString} objects.
+ */
+@Deprecated
+@SuppressWarnings("all")
+public class MovieAPIHashIndex extends AbstractHollowHashIndex<MovieAPI> {
+
+    public MovieAPIHashIndex(HollowConsumer consumer, String queryType, String selectFieldPath, String... matchFieldPaths) {
+        super(consumer, true, queryType, selectFieldPath, matchFieldPaths);
+    }
+
+    public MovieAPIHashIndex(HollowConsumer consumer, boolean isListenToDataRefresh, String queryType, String selectFieldPath, String... matchFieldPaths) {
+        super(consumer, isListenToDataRefresh, queryType, selectFieldPath, matchFieldPaths);
+    }
+
+    public Iterable<HString> findStringMatches(Object... keys) {
+        HollowHashIndexResult matches = idx.findMatches(keys);
+        if(matches == null) return Collections.emptySet();
+
+        return new AbstractHollowOrdinalIterable<HString>(matches.iterator()) {
+            public HString getData(int ordinal) {
+                return api.getHString(ordinal);
+            }
+        };
+    }
+
+    public Iterable<Movie> findMovieMatches(Object... keys) {
+        HollowHashIndexResult matches = idx.findMatches(keys);
+        if(matches == null) return Collections.emptySet();
+
+        return new AbstractHollowOrdinalIterable<Movie>(matches.iterator()) {
+            public Movie getData(int ordinal) {
+                return api.getMovie(ordinal);
+            }
+        };
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/MovieDataAccessor.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/MovieDataAccessor.java
@@ -1,0 +1,38 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.data.AbstractHollowDataAccessor;
+import com.netflix.hollow.core.index.key.PrimaryKey;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+
+@SuppressWarnings("all")
+public class MovieDataAccessor extends AbstractHollowDataAccessor<Movie> {
+
+    public static final String TYPE = "Movie";
+    private MovieAPI api;
+
+    public MovieDataAccessor(HollowConsumer consumer) {
+        super(consumer, TYPE);
+        this.api = (MovieAPI)consumer.getAPI();
+    }
+
+    public MovieDataAccessor(HollowReadStateEngine rStateEngine, MovieAPI api) {
+        super(rStateEngine, TYPE);
+        this.api = api;
+    }
+
+    public MovieDataAccessor(HollowReadStateEngine rStateEngine, MovieAPI api, String ... fieldPaths) {
+        super(rStateEngine, TYPE, fieldPaths);
+        this.api = api;
+    }
+
+    public MovieDataAccessor(HollowReadStateEngine rStateEngine, MovieAPI api, PrimaryKey primaryKey) {
+        super(rStateEngine, TYPE, primaryKey);
+        this.api = api;
+    }
+
+    @Override public Movie getRecord(int ordinal){
+        return api.getMovie(ordinal);
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/MovieDelegate.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/MovieDelegate.java
@@ -1,0 +1,21 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.objects.delegate.HollowObjectDelegate;
+
+
+@SuppressWarnings("all")
+public interface MovieDelegate extends HollowObjectDelegate {
+
+    public long getId(int ordinal);
+
+    public Long getIdBoxed(int ordinal);
+
+    public int getTitleOrdinal(int ordinal);
+
+    public int getYear(int ordinal);
+
+    public Integer getYearBoxed(int ordinal);
+
+    public MovieTypeAPI getTypeAPI();
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/MovieDelegateCachedImpl.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/MovieDelegateCachedImpl.java
@@ -1,0 +1,66 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.objects.delegate.HollowObjectAbstractDelegate;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.api.custom.HollowTypeAPI;
+import com.netflix.hollow.api.objects.delegate.HollowCachedDelegate;
+
+@SuppressWarnings("all")
+public class MovieDelegateCachedImpl extends HollowObjectAbstractDelegate implements HollowCachedDelegate, MovieDelegate {
+
+    private final Long id;
+    private final int titleOrdinal;
+    private final Integer year;
+    private MovieTypeAPI typeAPI;
+
+    public MovieDelegateCachedImpl(MovieTypeAPI typeAPI, int ordinal) {
+        this.id = typeAPI.getIdBoxed(ordinal);
+        this.titleOrdinal = typeAPI.getTitleOrdinal(ordinal);
+        this.year = typeAPI.getYearBoxed(ordinal);
+        this.typeAPI = typeAPI;
+    }
+
+    public long getId(int ordinal) {
+        if(id == null)
+            return Long.MIN_VALUE;
+        return id.longValue();
+    }
+
+    public Long getIdBoxed(int ordinal) {
+        return id;
+    }
+
+    public int getTitleOrdinal(int ordinal) {
+        return titleOrdinal;
+    }
+
+    public int getYear(int ordinal) {
+        if(year == null)
+            return Integer.MIN_VALUE;
+        return year.intValue();
+    }
+
+    public Integer getYearBoxed(int ordinal) {
+        return year;
+    }
+
+    @Override
+    public HollowObjectSchema getSchema() {
+        return typeAPI.getTypeDataAccess().getSchema();
+    }
+
+    @Override
+    public HollowObjectTypeDataAccess getTypeDataAccess() {
+        return typeAPI.getTypeDataAccess();
+    }
+
+    public MovieTypeAPI getTypeAPI() {
+        return typeAPI;
+    }
+
+    public void updateTypeAPI(HollowTypeAPI typeAPI) {
+        this.typeAPI = (MovieTypeAPI) typeAPI;
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/MovieDelegateLookupImpl.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/MovieDelegateLookupImpl.java
@@ -1,0 +1,50 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.objects.delegate.HollowObjectAbstractDelegate;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+
+@SuppressWarnings("all")
+public class MovieDelegateLookupImpl extends HollowObjectAbstractDelegate implements MovieDelegate {
+
+    private final MovieTypeAPI typeAPI;
+
+    public MovieDelegateLookupImpl(MovieTypeAPI typeAPI) {
+        this.typeAPI = typeAPI;
+    }
+
+    public long getId(int ordinal) {
+        return typeAPI.getId(ordinal);
+    }
+
+    public Long getIdBoxed(int ordinal) {
+        return typeAPI.getIdBoxed(ordinal);
+    }
+
+    public int getTitleOrdinal(int ordinal) {
+        return typeAPI.getTitleOrdinal(ordinal);
+    }
+
+    public int getYear(int ordinal) {
+        return typeAPI.getYear(ordinal);
+    }
+
+    public Integer getYearBoxed(int ordinal) {
+        return typeAPI.getYearBoxed(ordinal);
+    }
+
+    public MovieTypeAPI getTypeAPI() {
+        return typeAPI;
+    }
+
+    @Override
+    public HollowObjectSchema getSchema() {
+        return typeAPI.getTypeDataAccess().getSchema();
+    }
+
+    @Override
+    public HollowObjectTypeDataAccess getTypeDataAccess() {
+        return typeAPI.getTypeDataAccess();
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/MovieHollowFactory.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/MovieHollowFactory.java
@@ -1,0 +1,20 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.objects.provider.HollowFactory;
+import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
+import com.netflix.hollow.api.custom.HollowTypeAPI;
+
+@SuppressWarnings("all")
+public class MovieHollowFactory<T extends Movie> extends HollowFactory<T> {
+
+    @Override
+    public T newHollowObject(HollowTypeDataAccess dataAccess, HollowTypeAPI typeAPI, int ordinal) {
+        return (T)new Movie(((MovieTypeAPI)typeAPI).getDelegateLookupImpl(), ordinal);
+    }
+
+    @Override
+    public T newCachedHollowObject(HollowTypeDataAccess dataAccess, HollowTypeAPI typeAPI, int ordinal) {
+        return (T)new Movie(new MovieDelegateCachedImpl((MovieTypeAPI)typeAPI, ordinal), ordinal);
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/MoviePrimaryKeyIndex.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/MoviePrimaryKeyIndex.java
@@ -1,0 +1,47 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.index.AbstractHollowUniqueKeyIndex;
+import com.netflix.hollow.api.consumer.index.HollowUniqueKeyIndex;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+
+/**
+ * @deprecated see {@link com.netflix.hollow.api.consumer.index.UniqueKeyIndex} which can be built as follows:
+ * <pre>{@code
+ *     UniqueKeyIndex<Movie, K> uki = UniqueKeyIndex.from(consumer, Movie.class)
+ *         .usingBean(k);
+ *     Movie m = uki.findMatch(k);
+ * }</pre>
+ * where {@code K} is a class declaring key field paths members, annotated with
+ * {@link com.netflix.hollow.api.consumer.index.FieldPath}, and {@code k} is an instance of
+ * {@code K} that is the key to find the unique {@code Movie} object.
+ */
+@Deprecated
+@SuppressWarnings("all")
+public class MoviePrimaryKeyIndex extends AbstractHollowUniqueKeyIndex<MovieAPI, Movie> implements HollowUniqueKeyIndex<Movie> {
+
+    public MoviePrimaryKeyIndex(HollowConsumer consumer) {
+        this(consumer, true);
+    }
+
+    public MoviePrimaryKeyIndex(HollowConsumer consumer, boolean isListenToDataRefresh) {
+        this(consumer, isListenToDataRefresh, ((HollowObjectSchema)consumer.getStateEngine().getNonNullSchema("Movie")).getPrimaryKey().getFieldPaths());
+    }
+
+    public MoviePrimaryKeyIndex(HollowConsumer consumer, String... fieldPaths) {
+        this(consumer, true, fieldPaths);
+    }
+
+    public MoviePrimaryKeyIndex(HollowConsumer consumer, boolean isListenToDataRefresh, String... fieldPaths) {
+        super(consumer, "Movie", isListenToDataRefresh, fieldPaths);
+    }
+
+    @Override
+    public Movie findMatch(Object... keys) {
+        int ordinal = idx.getMatchingOrdinal(keys);
+        if(ordinal == -1)
+            return null;
+        return api.getMovie(ordinal);
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/MovieTypeAPI.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/MovieTypeAPI.java
@@ -1,0 +1,81 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.custom.HollowObjectTypeAPI;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+
+@SuppressWarnings("all")
+public class MovieTypeAPI extends HollowObjectTypeAPI {
+
+    private final MovieDelegateLookupImpl delegateLookupImpl;
+
+    public MovieTypeAPI(MovieAPI api, HollowObjectTypeDataAccess typeDataAccess) {
+        super(api, typeDataAccess, new String[] {
+            "id",
+            "title",
+            "year"
+        });
+        this.delegateLookupImpl = new MovieDelegateLookupImpl(this);
+    }
+
+    public long getId(int ordinal) {
+        if(fieldIndex[0] == -1)
+            return missingDataHandler().handleLong("Movie", ordinal, "id");
+        return getTypeDataAccess().readLong(ordinal, fieldIndex[0]);
+    }
+
+    public Long getIdBoxed(int ordinal) {
+        long l;
+        if(fieldIndex[0] == -1) {
+            l = missingDataHandler().handleLong("Movie", ordinal, "id");
+        } else {
+            boxedFieldAccessSampler.recordFieldAccess(fieldIndex[0]);
+            l = getTypeDataAccess().readLong(ordinal, fieldIndex[0]);
+        }
+        if(l == Long.MIN_VALUE)
+            return null;
+        return Long.valueOf(l);
+    }
+
+
+
+    public int getTitleOrdinal(int ordinal) {
+        if(fieldIndex[1] == -1)
+            return missingDataHandler().handleReferencedOrdinal("Movie", ordinal, "title");
+        return getTypeDataAccess().readOrdinal(ordinal, fieldIndex[1]);
+    }
+
+    public StringTypeAPI getTitleTypeAPI() {
+        return getAPI().getStringTypeAPI();
+    }
+
+    public int getYear(int ordinal) {
+        if(fieldIndex[2] == -1)
+            return missingDataHandler().handleInt("Movie", ordinal, "year");
+        return getTypeDataAccess().readInt(ordinal, fieldIndex[2]);
+    }
+
+    public Integer getYearBoxed(int ordinal) {
+        int i;
+        if(fieldIndex[2] == -1) {
+            i = missingDataHandler().handleInt("Movie", ordinal, "year");
+        } else {
+            boxedFieldAccessSampler.recordFieldAccess(fieldIndex[2]);
+            i = getTypeDataAccess().readInt(ordinal, fieldIndex[2]);
+        }
+        if(i == Integer.MIN_VALUE)
+            return null;
+        return Integer.valueOf(i);
+    }
+
+
+
+    public MovieDelegateLookupImpl getDelegateLookupImpl() {
+        return delegateLookupImpl;
+    }
+
+    @Override
+    public MovieAPI getAPI() {
+        return (MovieAPI) api;
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/StringDataAccessor.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/StringDataAccessor.java
@@ -1,0 +1,38 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.data.AbstractHollowDataAccessor;
+import com.netflix.hollow.core.index.key.PrimaryKey;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+
+@SuppressWarnings("all")
+public class StringDataAccessor extends AbstractHollowDataAccessor<HString> {
+
+    public static final String TYPE = "String";
+    private MovieAPI api;
+
+    public StringDataAccessor(HollowConsumer consumer) {
+        super(consumer, TYPE);
+        this.api = (MovieAPI)consumer.getAPI();
+    }
+
+    public StringDataAccessor(HollowReadStateEngine rStateEngine, MovieAPI api) {
+        super(rStateEngine, TYPE);
+        this.api = api;
+    }
+
+    public StringDataAccessor(HollowReadStateEngine rStateEngine, MovieAPI api, String ... fieldPaths) {
+        super(rStateEngine, TYPE, fieldPaths);
+        this.api = api;
+    }
+
+    public StringDataAccessor(HollowReadStateEngine rStateEngine, MovieAPI api, PrimaryKey primaryKey) {
+        super(rStateEngine, TYPE, primaryKey);
+        this.api = api;
+    }
+
+    @Override public HString getRecord(int ordinal){
+        return api.getHString(ordinal);
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/StringDelegate.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/StringDelegate.java
@@ -1,0 +1,15 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.objects.delegate.HollowObjectDelegate;
+
+
+@SuppressWarnings("all")
+public interface StringDelegate extends HollowObjectDelegate {
+
+    public String getValue(int ordinal);
+
+    public boolean isValueEqual(int ordinal, String testValue);
+
+    public StringTypeAPI getTypeAPI();
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/StringDelegateCachedImpl.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/StringDelegateCachedImpl.java
@@ -1,0 +1,48 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.objects.delegate.HollowObjectAbstractDelegate;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.api.custom.HollowTypeAPI;
+import com.netflix.hollow.api.objects.delegate.HollowCachedDelegate;
+
+@SuppressWarnings("all")
+public class StringDelegateCachedImpl extends HollowObjectAbstractDelegate implements HollowCachedDelegate, StringDelegate {
+
+    private final String value;
+    private StringTypeAPI typeAPI;
+
+    public StringDelegateCachedImpl(StringTypeAPI typeAPI, int ordinal) {
+        this.value = typeAPI.getValue(ordinal);
+        this.typeAPI = typeAPI;
+    }
+
+    public String getValue(int ordinal) {
+        return value;
+    }
+
+    public boolean isValueEqual(int ordinal, String testValue) {
+        if(testValue == null)
+            return value == null;
+        return testValue.equals(value);
+    }
+
+    @Override
+    public HollowObjectSchema getSchema() {
+        return typeAPI.getTypeDataAccess().getSchema();
+    }
+
+    @Override
+    public HollowObjectTypeDataAccess getTypeDataAccess() {
+        return typeAPI.getTypeDataAccess();
+    }
+
+    public StringTypeAPI getTypeAPI() {
+        return typeAPI;
+    }
+
+    public void updateTypeAPI(HollowTypeAPI typeAPI) {
+        this.typeAPI = (StringTypeAPI) typeAPI;
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/StringDelegateLookupImpl.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/StringDelegateLookupImpl.java
@@ -1,0 +1,38 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.objects.delegate.HollowObjectAbstractDelegate;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+
+@SuppressWarnings("all")
+public class StringDelegateLookupImpl extends HollowObjectAbstractDelegate implements StringDelegate {
+
+    private final StringTypeAPI typeAPI;
+
+    public StringDelegateLookupImpl(StringTypeAPI typeAPI) {
+        this.typeAPI = typeAPI;
+    }
+
+    public String getValue(int ordinal) {
+        return typeAPI.getValue(ordinal);
+    }
+
+    public boolean isValueEqual(int ordinal, String testValue) {
+        return typeAPI.isValueEqual(ordinal, testValue);
+    }
+
+    public StringTypeAPI getTypeAPI() {
+        return typeAPI;
+    }
+
+    @Override
+    public HollowObjectSchema getSchema() {
+        return typeAPI.getTypeDataAccess().getSchema();
+    }
+
+    @Override
+    public HollowObjectTypeDataAccess getTypeDataAccess() {
+        return typeAPI.getTypeDataAccess();
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/StringHollowFactory.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/StringHollowFactory.java
@@ -1,0 +1,20 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.objects.provider.HollowFactory;
+import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
+import com.netflix.hollow.api.custom.HollowTypeAPI;
+
+@SuppressWarnings("all")
+public class StringHollowFactory<T extends HString> extends HollowFactory<T> {
+
+    @Override
+    public T newHollowObject(HollowTypeDataAccess dataAccess, HollowTypeAPI typeAPI, int ordinal) {
+        return (T)new HString(((StringTypeAPI)typeAPI).getDelegateLookupImpl(), ordinal);
+    }
+
+    @Override
+    public T newCachedHollowObject(HollowTypeDataAccess dataAccess, HollowTypeAPI typeAPI, int ordinal) {
+        return (T)new HString(new StringDelegateCachedImpl((StringTypeAPI)typeAPI, ordinal), ordinal);
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/StringPrimaryKeyIndex.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/StringPrimaryKeyIndex.java
@@ -1,0 +1,47 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.index.AbstractHollowUniqueKeyIndex;
+import com.netflix.hollow.api.consumer.index.HollowUniqueKeyIndex;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+
+/**
+ * @deprecated see {@link com.netflix.hollow.api.consumer.index.UniqueKeyIndex} which can be built as follows:
+ * <pre>{@code
+ *     UniqueKeyIndex<HString, K> uki = UniqueKeyIndex.from(consumer, HString.class)
+ *         .usingBean(k);
+ *     HString m = uki.findMatch(k);
+ * }</pre>
+ * where {@code K} is a class declaring key field paths members, annotated with
+ * {@link com.netflix.hollow.api.consumer.index.FieldPath}, and {@code k} is an instance of
+ * {@code K} that is the key to find the unique {@code HString} object.
+ */
+@Deprecated
+@SuppressWarnings("all")
+public class StringPrimaryKeyIndex extends AbstractHollowUniqueKeyIndex<MovieAPI, HString> implements HollowUniqueKeyIndex<HString> {
+
+    public StringPrimaryKeyIndex(HollowConsumer consumer) {
+        this(consumer, true);
+    }
+
+    public StringPrimaryKeyIndex(HollowConsumer consumer, boolean isListenToDataRefresh) {
+        this(consumer, isListenToDataRefresh, ((HollowObjectSchema)consumer.getStateEngine().getNonNullSchema("String")).getPrimaryKey().getFieldPaths());
+    }
+
+    public StringPrimaryKeyIndex(HollowConsumer consumer, String... fieldPaths) {
+        this(consumer, true, fieldPaths);
+    }
+
+    public StringPrimaryKeyIndex(HollowConsumer consumer, boolean isListenToDataRefresh, String... fieldPaths) {
+        super(consumer, "String", isListenToDataRefresh, fieldPaths);
+    }
+
+    @Override
+    public HString findMatch(Object... keys) {
+        int ordinal = idx.getMatchingOrdinal(keys);
+        if(ordinal == -1)
+            return null;
+        return api.getHString(ordinal);
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/StringTypeAPI.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/StringTypeAPI.java
@@ -1,0 +1,40 @@
+package com.netflix.hollow.test.generated;
+
+import com.netflix.hollow.api.custom.HollowObjectTypeAPI;
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+
+@SuppressWarnings("all")
+public class StringTypeAPI extends HollowObjectTypeAPI {
+
+    private final StringDelegateLookupImpl delegateLookupImpl;
+
+    public StringTypeAPI(MovieAPI api, HollowObjectTypeDataAccess typeDataAccess) {
+        super(api, typeDataAccess, new String[] {
+            "value"
+        });
+        this.delegateLookupImpl = new StringDelegateLookupImpl(this);
+    }
+
+    public String getValue(int ordinal) {
+        if(fieldIndex[0] == -1)
+            return missingDataHandler().handleString("String", ordinal, "value");
+        boxedFieldAccessSampler.recordFieldAccess(fieldIndex[0]);
+        return getTypeDataAccess().readString(ordinal, fieldIndex[0]);
+    }
+
+    public boolean isValueEqual(int ordinal, String testValue) {
+        if(fieldIndex[0] == -1)
+            return missingDataHandler().handleStringEquals("String", ordinal, "value", testValue);
+        return getTypeDataAccess().isStringFieldEqual(ordinal, fieldIndex[0], testValue);
+    }
+
+    public StringDelegateLookupImpl getDelegateLookupImpl() {
+        return delegateLookupImpl;
+    }
+
+    @Override
+    public MovieAPI getAPI() {
+        return (MovieAPI) api;
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/test/model/Movie.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/model/Movie.java
@@ -1,0 +1,16 @@
+package com.netflix.hollow.test.model;
+
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+
+@HollowPrimaryKey(fields = {"id"})
+public class Movie {
+    long id;
+    String title;
+    int year;
+
+    public Movie(long id, String title, int year) {
+        this.id = id;
+        this.title = title;
+        this.year = year;
+    }
+}


### PR DESCRIPTION
1. enable pojo caching in HollowObjectCacheProvider
2. modify the detach logic so the right exception is thrown when object is accessed after detach