### PR TITLE
MkDocs: Use 80% of the screen to render content

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,0 +1,3 @@
+.md-grid {
+  max-width: 80%;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,9 @@ theme:
         icon: material/toggle-switch
         name: Switch to light mode
 
+extra_css:
+  - css/extra.css
+
 plugins:
   - search
 


### PR DESCRIPTION
This commit allows the content of the MkDocs site to occupy up to 80% of the screen. This provides a better experience for folks that use wider screens when reading docs.