### PR TITLE
FlatRecords can be returned to POJOs

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
@@ -22,6 +22,7 @@ import com.netflix.hollow.core.write.HollowListTypeWriteState;
 import com.netflix.hollow.core.write.HollowListWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecord;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -107,6 +108,12 @@ public class HollowListTypeMapper extends HollowTypeMapper {
             }
         }
         return rec;
+    }
+
+
+    @Override
+    protected int parseFlatRecord(FlatRecord rec, int currentRecordPointer, List<Object> parsedObjects) {
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -17,17 +17,18 @@
 package com.netflix.hollow.core.write.objectmapper;
 
 import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.write.HollowMapTypeWriteState;
 import com.netflix.hollow.core.write.HollowMapWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecord;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -124,8 +125,21 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
     }
 
     @Override
-    protected int parseFlatRecord(FlatRecord rec, int currentRecordPointer, List<Object> parsedObjects) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    protected Object parseFlatRecord(HollowSchema recordSchema, FlatRecordReader reader, Map<Integer, Object> parsedObjects) {
+        Map<Object, Object> collection = new HashMap<>();
+
+        int size = reader.readCollectionSize();
+        int keyOrdinal = 0;
+        for (int i = 0; i < size; i++) {
+            int keyOrdinalDelta = reader.readOrdinal();
+            int valueOrdinal = reader.readOrdinal();
+            keyOrdinal += keyOrdinalDelta;
+            Object key = parsedObjects.get(keyOrdinal);
+            Object value = parsedObjects.get(valueOrdinal);
+            collection.put(key, value);
+        }
+
+        return collection;
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -23,9 +23,11 @@ import com.netflix.hollow.core.write.HollowMapWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecord;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -119,6 +121,11 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
             rec.addEntry(keyOrdinal, valueOrdinal, hashCode);
         }
         return rec;
+    }
+
+    @Override
+    protected int parseFlatRecord(FlatRecord rec, int currentRecordPointer, List<Object> parsedObjects) {
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -18,15 +18,14 @@ package com.netflix.hollow.core.write.objectmapper;
 
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.memory.HollowUnsafeHandle;
-import com.netflix.hollow.core.memory.encoding.VarInt;
-import com.netflix.hollow.core.memory.encoding.ZigZag;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
 import com.netflix.hollow.core.write.HollowObjectWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecord;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -35,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import sun.misc.Unsafe;
 
@@ -187,17 +187,26 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
     }
     
     @Override
-    protected int parseFlatRecord(FlatRecord rec, int currentRecordPointer, List<Object> parsedObjects) {
+    protected Object parseFlatRecord(HollowSchema recordSchema, FlatRecordReader reader, Map<Integer, Object> parsedObjects) {
         try {
-            Object obj = clazz.newInstance();
+            HollowObjectSchema recordObjectSchema = (HollowObjectSchema) recordSchema;
 
-            for (int i = 0; i < mappedFields.size(); i++) {
-                currentRecordPointer = mappedFields.get(i).parse(obj, rec, currentRecordPointer, parsedObjects);
+            Object obj;
+            if (schema.numFields() == 1 && schema.getFieldType(0) != HollowObjectSchema.FieldType.REFERENCE) {
+                obj = mappedFields.get(0).parseBoxedWrapper(reader);
+            } else  {
+                obj = clazz.newInstance();
+                for (int i = 0; i < recordObjectSchema.numFields(); i++) {
+                    int posInPojoSchema = schema.getPosition(recordObjectSchema.getFieldName(i));
+                    if (posInPojoSchema != -1) {
+                        mappedFields.get(posInPojoSchema).parse(obj, reader, parsedObjects);
+                    } else {
+                        reader.skipField(recordObjectSchema.getFieldType(i));
+                    }
+                }
             }
-            
-            parsedObjects.add(obj);
-            
-            return currentRecordPointer;
+
+            return obj;
         } catch(Exception ex) {
             throw new RuntimeException(ex);
         }
@@ -489,258 +498,230 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             }
         }
 
-        private int parse(Object obj, FlatRecord record, int currentRecordPointer, List<Object> parsedRecords) {
+        private Object parseBoxedWrapper(FlatRecordReader reader) {
+            switch (fieldType) {
+                case BOOLEAN: {
+                    return reader.readBoolean();
+                }
+                case INT: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        return Integer.valueOf(value);
+                    }
+                    break;
+                }
+                case SHORT: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        return Short.valueOf((short) value);
+                    }
+                    break;
+                }
+                case BYTE: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        return Byte.valueOf((byte) value);
+                    }
+                    break;
+                }
+                case CHAR: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        return Character.valueOf((char) value);
+                    }
+                    break;
+                }
+                case LONG: {
+                    long value = reader.readLong();
+                    if (value != Long.MIN_VALUE) {
+                        return Long.valueOf(value);
+                    }
+                    break;
+                }
+                case FLOAT: {
+                    float value = reader.readFloat();
+                    if (!Float.isNaN(value)) {
+                        return Float.valueOf(value);
+                    }
+                    break;
+                }
+                case DOUBLE: {
+                    double value = reader.readDouble();
+                    if (!Double.isNaN(value)) {
+                        return Double.valueOf(value);
+                    }
+                    break;
+                }
+                case STRING: {
+                    return reader.readString();
+                }
+                case BYTES: {
+                    return reader.readBytes();
+                }
+            }
+            return null;
+        }
+
+        private void parse(Object obj, FlatRecordReader reader, Map<Integer, Object> parsedRecords) {
             switch(fieldType) {
-                case BOOLEAN:
-                    if(!VarInt.readVNull(record.data, currentRecordPointer)) {
-                        boolean value = record.data.get(currentRecordPointer) == 1;
-                        if(obj != null)
-                            unsafe.putBoolean(obj, fieldOffset, value);
+                case BOOLEAN: {
+                    Boolean value = reader.readBoolean();
+                    if (value != null) {
+                        unsafe.putBoolean(obj, fieldOffset, value == Boolean.TRUE);
                     }
-                    
-                    return currentRecordPointer + 1;
-                case INT:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    int ivalue = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(ivalue);
-                    if(obj != null)
-                        unsafe.putInt(obj, fieldOffset, ZigZag.decodeInt(ivalue));
-                    
-                    return currentRecordPointer;
-                case SHORT:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    ivalue = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(ivalue);
-                    if(obj != null)
-                        unsafe.putShort(obj, fieldOffset, (short)ZigZag.decodeInt(ivalue));
-                    
-                    return currentRecordPointer;
-                case BYTE:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    ivalue = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(ivalue);
-                    if(obj != null)
-                        unsafe.putByte(obj, fieldOffset, (byte)ZigZag.decodeInt(ivalue));
-                    
-                    return currentRecordPointer;
-                case CHAR:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    ivalue = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(ivalue);
-                    if(obj != null)
-                        unsafe.putChar(obj, fieldOffset, (char)ZigZag.decodeInt(ivalue));
-                    
-                    return currentRecordPointer;
-                case LONG:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    long lvalue = VarInt.readVLong(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVLong(lvalue);
-                    if(obj != null)
-                        unsafe.putLong(obj, fieldOffset, lvalue);
-                    
-                    return currentRecordPointer;
-                case FLOAT:
-                    int intBits = record.data.readIntBits(currentRecordPointer);
-                    if(intBits != HollowObjectWriteRecord.NULL_FLOAT_BITS) {
-                        float fvalue = Float.intBitsToFloat(intBits);
-                        if(obj != null)
-                            unsafe.putFloat(obj, fieldOffset, fvalue);
+                    break;
+                }
+                case INT: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        unsafe.putInt(obj, fieldOffset, value);
                     }
-                    
-                    return currentRecordPointer + 4;
-                case DOUBLE:
-                    long longBits = record.data.readLongBits(currentRecordPointer);
-                    if(longBits != HollowObjectWriteRecord.NULL_DOUBLE_BITS) {
-                        double dvalue = Double.longBitsToDouble(longBits);
-                        if(obj != null)
-                            unsafe.putDouble(obj, fieldOffset, dvalue);
+                    break;
+                }
+                case SHORT: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        unsafe.putShort(obj, fieldOffset, (short) value);
                     }
-                    
-                    return currentRecordPointer + 8;
-                case STRING:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-                    
-                    int length = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(length);
-                    
-                    int cLength = VarInt.countVarIntsInRange(record.data, currentRecordPointer, length);
-                    char[] s = new char[cLength];
-                    
-                    for(int i=0;i<cLength;i++) {
-                        int charValue = VarInt.readVInt(record.data, currentRecordPointer); 
-                        s[i] = (char)charValue;
-                        currentRecordPointer += VarInt.sizeOfVInt(charValue);
+                    break;
+                }
+                case BYTE: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        unsafe.putByte(obj, fieldOffset, (byte) value);
                     }
-                    
-                    if(obj != null)
-                        unsafe.putObject(obj, fieldOffset, new String(s));
-                    return currentRecordPointer;
-                case BYTES:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-                    
-                    length = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(length);
-                    byte[] b = new byte[length];
-                    
-                    for(int i=0;i<length;i++) {
-                        b[i] = record.data.get(currentRecordPointer++);
+                    break;
+                }
+                case CHAR: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        unsafe.putChar(obj, fieldOffset, (char) value);
                     }
-
-                    if(obj != null)
-                        unsafe.putObject(obj, fieldOffset, b);
-                    return currentRecordPointer;
-                case INLINED_BOOLEAN:
-                    if(!VarInt.readVNull(record.data, currentRecordPointer)) {
-                        boolean value = record.data.get(currentRecordPointer) == 1;
-                        if(obj != null)
-                            unsafe.putObject(obj, fieldOffset, Boolean.valueOf(value));
+                    break;
+                }
+                case LONG: {
+                    long value = reader.readLong();
+                    if (value != Long.MIN_VALUE) {
+                        unsafe.putLong(obj, fieldOffset, value);
                     }
-                    
-                    return currentRecordPointer + 1;
-                case INLINED_INT:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    ivalue = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(ivalue);
-                    if(obj != null)
-                        unsafe.putObject(obj, fieldOffset, Integer.valueOf(ZigZag.decodeInt(ivalue)));
-                    
-                    return currentRecordPointer;
-                case INLINED_SHORT:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    ivalue = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(ivalue);
-                    if(obj != null)
-                        unsafe.putObject(obj, fieldOffset, Short.valueOf((short)ZigZag.decodeInt(ivalue)));
-                    
-                    return currentRecordPointer;
-                case INLINED_BYTE:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    ivalue = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(ivalue);
-                    if(obj != null)
-                        unsafe.putObject(obj, fieldOffset, Byte.valueOf((byte)ZigZag.decodeInt(ivalue)));
-                    
-                    return currentRecordPointer;
-                case INLINED_CHAR:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    ivalue = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(ivalue);
-                    if(obj != null)
-                        unsafe.putObject(obj, fieldOffset, Character.valueOf((char)ZigZag.decodeInt(ivalue)));
-                    
-                    return currentRecordPointer;
-                case INLINED_LONG:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    lvalue = VarInt.readVLong(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVLong(lvalue);
-                    if(obj != null)
-                        unsafe.putObject(obj, fieldOffset, Long.valueOf(ZigZag.decodeLong(lvalue)));
-                    
-                    return currentRecordPointer;
-                case INLINED_FLOAT:
-                    intBits = record.data.readIntBits(currentRecordPointer);
-                    if(intBits != HollowObjectWriteRecord.NULL_FLOAT_BITS) {
-                        float fvalue = Float.intBitsToFloat(intBits);
-                        if(obj != null)
-                            unsafe.putObject(obj, fieldOffset, Float.valueOf(fvalue));
+                    break;
+                }
+                case FLOAT: {
+                    float value = reader.readFloat();
+                    if (!Float.isNaN(value)) {
+                        unsafe.putFloat(obj, fieldOffset, value);
                     }
-                    
-                    return currentRecordPointer + 4;
-                case INLINED_DOUBLE:
-                    longBits = record.data.readLongBits(currentRecordPointer);
-                    if(longBits != HollowObjectWriteRecord.NULL_DOUBLE_BITS) {
-                        double dvalue = Double.longBitsToDouble(longBits);
-                        if(obj != null)
-                            unsafe.putObject(obj, fieldOffset, Double.valueOf(dvalue));
+                    break;
+                }
+                case DOUBLE: {
+                    double value = reader.readDouble();
+                    if (!Double.isNaN(value)) {
+                        unsafe.putDouble(obj, fieldOffset, value);
                     }
-                    
-                    return currentRecordPointer + 8;
-                case INLINED_STRING:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-                    
-                    length = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(length);
-                    
-                    cLength = VarInt.countVarIntsInRange(record.data, currentRecordPointer, length);
-                    s = new char[cLength];
-                    
-                    for(int i=0;i<cLength;i++) {
-                        int charValue = VarInt.readVInt(record.data, currentRecordPointer); 
-                        s[i] = (char)charValue;
-                        currentRecordPointer += VarInt.sizeOfVInt(charValue);
+                    break;
+                }
+                case STRING: {
+                    String value = reader.readString();
+                    if (value != null) {
+                        unsafe.putObject(obj, fieldOffset, value);
                     }
-                    
-                    if(obj != null)
-                        unsafe.putObject(obj, fieldOffset, new String(s));
-                    return currentRecordPointer;
-                case DATE_TIME:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-
-                    lvalue = VarInt.readVLong(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVLong(lvalue);
-                    if(obj != null)
-                        unsafe.putObject(obj, fieldOffset, new Date(ZigZag.decodeLong(lvalue)));
-                    
-                    return currentRecordPointer;
-                case ENUM_NAME:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-                    
-                    length = VarInt.readVInt(record.data, currentRecordPointer);
-                    currentRecordPointer += VarInt.sizeOfVInt(length);
-                    
-                    cLength = VarInt.countVarIntsInRange(record.data, currentRecordPointer, length);
-                    s = new char[cLength];
-                    
-                    for(int i=0;i<cLength;i++) {
-                        int charValue = VarInt.readVInt(record.data, currentRecordPointer); 
-                        s[i] = (char)charValue;
-                        currentRecordPointer += VarInt.sizeOfVInt(charValue);
+                    break;
+                }
+                case BYTES: {
+                    byte[] value = reader.readBytes();
+                    if (value != null) {
+                        unsafe.putObject(obj, fieldOffset, value);
                     }
-                    
-                    if(obj != null)
-                        unsafe.putObject(obj, fieldOffset, Enum.valueOf((Class)type, new String(s)));
-                    return currentRecordPointer;
-                case REFERENCE:
-                    if(VarInt.readVNull(record.data, currentRecordPointer))
-                        return currentRecordPointer + 1;
-                    
-                    int ordinal = VarInt.readVInt(record.data, currentRecordPointer);
-                    
-                    if(obj != null) {
+                    break;
+                }
+                case INLINED_BOOLEAN: {
+                    Boolean value = reader.readBoolean();
+                    if (value != null) {
+                        unsafe.putObject(obj, fieldOffset, value);
+                    }
+                    break;
+                }
+                case INLINED_INT: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        unsafe.putObject(obj, fieldOffset, Integer.valueOf(value));
+                    }
+                    break;
+                }
+                case INLINED_SHORT: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        unsafe.putObject(obj, fieldOffset, Short.valueOf((short) value));
+                    }
+                    break;
+                }
+                case INLINED_BYTE: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        unsafe.putObject(obj, fieldOffset, Byte.valueOf((byte) value));
+                    }
+                    break;
+                }
+                case INLINED_CHAR: {
+                    int value = reader.readInt();
+                    if (value != Integer.MIN_VALUE) {
+                        unsafe.putObject(obj, fieldOffset, Character.valueOf((char) value));
+                    }
+                    break;
+                }
+                case INLINED_LONG: {
+                    long value = reader.readLong();
+                    if (value != Long.MIN_VALUE) {
+                        unsafe.putObject(obj, fieldOffset, Long.valueOf(value));
+                    }
+                    break;
+                }
+                case INLINED_FLOAT: {
+                    float value = reader.readFloat();
+                    if (!Float.isNaN(value)) {
+                        unsafe.putObject(obj, fieldOffset, Float.valueOf(value));
+                    }
+                    break;
+                }
+                case INLINED_DOUBLE: {
+                    double value = reader.readDouble();
+                    if (!Double.isNaN(value)) {
+                        unsafe.putObject(obj, fieldOffset, Double.valueOf(value));
+                    }
+                    break;
+                }
+                case INLINED_STRING: {
+                    String value = reader.readString();
+                    if (value != null) {
+                        unsafe.putObject(obj, fieldOffset, value);
+                    }
+                    break;
+                }
+                case DATE_TIME: {
+                    long value = reader.readLong();
+                    if (value != Long.MIN_VALUE) {
+                        unsafe.putObject(obj, fieldOffset, new Date(value));
+                    }
+                    break;
+                }
+                case ENUM_NAME: {
+                    String value = reader.readString();
+                    if (value != null) {
+                        unsafe.putObject(obj, fieldOffset, Enum.valueOf((Class) type, value));
+                    }
+                    break;
+                }
+                case REFERENCE: {
+                    int ordinal = reader.readOrdinal();
+                    if (ordinal != -1) {
                         unsafe.putObject(obj, fieldOffset, parsedRecords.get(ordinal));
                     }
-                    
-                    return currentRecordPointer + VarInt.sizeOfVInt(ordinal);
+                    break;
+                }
                 default:
                     throw new IllegalArgumentException("Unknown field type: " + fieldType);
             }
         }
-
         
         public Object retrieveFieldValue(Object obj, int[] fieldPathIdx, int idx) {
             Object fieldObject;
@@ -821,7 +802,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             throw new IllegalArgumentException("Expected char[] or String value container for STRING.");
         }
     }
-    
+
     private static enum MappedFieldType {
         BOOLEAN(FieldType.BOOLEAN),
         NULLABLE_PRIMITIVE_BOOLEAN(FieldType.BOOLEAN),

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.hollow.core.write.objectmapper;
 
+import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.write.HollowSetTypeWriteState;
@@ -23,11 +24,12 @@ import com.netflix.hollow.core.write.HollowSetWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecord;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class HollowSetTypeMapper extends HollowTypeMapper {
@@ -103,8 +105,19 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
     }
 
     @Override
-    protected int parseFlatRecord(FlatRecord rec, int currentRecordPointer, List<Object> parsedObjects) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    protected Object parseFlatRecord(HollowSchema recordSchema, FlatRecordReader reader, Map<Integer, Object> parsedObjects) {
+        Set<Object> collection = new HashSet<>();
+
+        int size = reader.readCollectionSize();
+        int ordinal = 0;
+        for (int i = 0; i < size; i++) {
+            int ordinalDelta = reader.readOrdinal();
+            ordinal += ordinalDelta;
+            Object element = parsedObjects.get(ordinal);
+            collection.add(element);
+        }
+
+        return collection;
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -23,9 +23,11 @@ import com.netflix.hollow.core.write.HollowSetWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecord;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Set;
 
 public class HollowSetTypeMapper extends HollowTypeMapper {
@@ -98,6 +100,11 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
             rec.addElement(ordinal, hashCode);
         }
         return rec;
+    }
+
+    @Override
+    protected int parseFlatRecord(FlatRecord rec, int currentRecordPointer, List<Object> parsedObjects) {
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeMapper.java
@@ -17,10 +17,11 @@
 package com.netflix.hollow.core.write.objectmapper;
 
 import com.netflix.hollow.core.memory.ByteDataArray;
+import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecord;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -42,7 +43,7 @@ public abstract class HollowTypeMapper {
 
     protected abstract int writeFlat(Object obj, FlatRecordWriter flatRecordWriter);
     
-    protected abstract int parseFlatRecord(FlatRecord rec, int currentRecordPointer, List<Object> parsedObjects);
+    protected abstract Object parseFlatRecord(HollowSchema schema, FlatRecordReader reader, Map<Integer, Object> parsedObjects);
     
     protected abstract HollowWriteRecord newWriteRecord();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeMapper.java
@@ -20,6 +20,7 @@ import com.netflix.hollow.core.memory.ByteDataArray;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecord;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -40,6 +41,8 @@ public abstract class HollowTypeMapper {
     protected abstract int write(Object obj);
 
     protected abstract int writeFlat(Object obj, FlatRecordWriter flatRecordWriter);
+    
+    protected abstract int parseFlatRecord(FlatRecord rec, int currentRecordPointer, List<Object> parsedObjects);
     
     protected abstract HollowWriteRecord newWriteRecord();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecord.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecord.java
@@ -106,22 +106,22 @@ public class FlatRecord {
         case STRING:
             int length = VarInt.readVInt(data, location);
             location += VarInt.sizeOfVInt(length);
-            
+
             int endLocation = location + length;
-            
+
             char[] s = new char[length];
             int cnt = 0;
-            
+
             while(location < endLocation) {
                 int c = VarInt.readVInt(data, location);
                 s[cnt] = (char)c;
                 location += VarInt.sizeOfVInt(c);
                 cnt++;
             }
-            
+
             if(cnt < s.length)
                 s = Arrays.copyOf(s, cnt);
-            
+
             return new String(s);
         case BYTES:
             length = VarInt.readVInt(data, location);
@@ -143,5 +143,5 @@ public class FlatRecord {
     public RecordPrimaryKey getRecordPrimaryKey() {
         return recordPrimaryKey;
     }
-    
+
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecord.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecord.java
@@ -27,15 +27,12 @@ import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
 import com.netflix.hollow.core.write.objectmapper.RecordPrimaryKey;
 import java.util.Arrays;
 
-/**
- * Warning: Experimental.  the FlatRecord feature is subject to breaking changes.
- */
 public class FlatRecord {
 
-    public final HollowSchemaIdentifierMapper schemaIdMapper;
-    public final ByteData data;
-    public final int dataStartByte;
-    public final int dataEndByte;
+    final HollowSchemaIdentifierMapper schemaIdMapper;
+    final ByteData data;
+    final int dataStartByte;
+    final int dataEndByte;
     final RecordPrimaryKey recordPrimaryKey;
 
     public FlatRecord(ByteData recordData, HollowSchemaIdentifierMapper schemaIdMapper) {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecord.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecord.java
@@ -32,10 +32,10 @@ import java.util.Arrays;
  */
 public class FlatRecord {
 
-    final HollowSchemaIdentifierMapper schemaIdMapper;
-    final ByteData data;
-    final int dataStartByte;
-    final int dataEndByte;
+    public final HollowSchemaIdentifierMapper schemaIdMapper;
+    public final ByteData data;
+    public final int dataStartByte;
+    public final int dataEndByte;
     final RecordPrimaryKey recordPrimaryKey;
 
     public FlatRecord(ByteData recordData, HollowSchemaIdentifierMapper schemaIdMapper) {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordDumper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordDumper.java
@@ -33,9 +33,6 @@ import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Warning: Experimental.  the FlatRecord feature is subject to breaking changes.
- */
 public class FlatRecordDumper {
     
     private final Map<Integer, Integer> ordinalMapping;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordExtractor.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordExtractor.java
@@ -36,9 +36,6 @@ import com.netflix.hollow.tools.combine.OrdinalRemapper;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Warning: Experimental.  the FlatRecord feature is subject to breaking changes.
- */
 public class FlatRecordExtractor {
     
     private final HollowReadStateEngine extractFrom;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordReader.java
@@ -6,7 +6,6 @@ import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.write.HollowObjectWriteRecord;
 
-
 public class FlatRecordReader {
   private final FlatRecord record;
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordReader.java
@@ -1,0 +1,196 @@
+package com.netflix.hollow.core.write.objectmapper.flatrecords;
+
+import com.netflix.hollow.core.memory.encoding.VarInt;
+import com.netflix.hollow.core.memory.encoding.ZigZag;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+
+
+public class FlatRecordReader {
+  private final FlatRecord record;
+
+  private int pointer;
+
+  public FlatRecordReader(FlatRecord record) {
+    this.record = record;
+    this.pointer = record.dataStartByte;
+  }
+
+  public boolean hasMore() {
+    return pointer < record.dataEndByte;
+  }
+
+  public HollowSchema readSchema() {
+    int schemaId = VarInt.readVInt(record.data, this.pointer);
+    this.pointer += VarInt.sizeOfVInt(schemaId);
+    return record.schemaIdMapper.getSchema(schemaId);
+  }
+
+  public int readCollectionSize() {
+    int size = VarInt.readVInt(record.data, this.pointer);
+    this.pointer += VarInt.sizeOfVInt(size);
+    return size;
+  }
+
+  public int readOrdinal() {
+    if (VarInt.readVNull(record.data, this.pointer)) {
+      this.pointer += 1;
+      return -1;
+    }
+
+    int value = VarInt.readVInt(record.data, this.pointer);
+    this.pointer += VarInt.sizeOfVInt(value);
+
+    return value;
+  }
+
+  public Boolean readBoolean() {
+    if(VarInt.readVNull(record.data, this.pointer)) {
+      this.pointer += 1;
+      return null;
+    }
+
+    int value = record.data.get(this.pointer);
+    this.pointer += 1;
+
+    return value == 1 ? Boolean.TRUE : Boolean.FALSE;
+  }
+
+  public int readInt() {
+    if (VarInt.readVNull(record.data, this.pointer)) {
+      this.pointer += 1;
+      return Integer.MIN_VALUE;
+    }
+
+    int value = VarInt.readVInt(record.data, this.pointer);
+    this.pointer += VarInt.sizeOfVInt(value);
+
+    return ZigZag.decodeInt(value);
+  }
+
+  public long readLong() {
+    if (VarInt.readVNull(record.data, this.pointer)) {
+      this.pointer += 1;
+      return Long.MIN_VALUE;
+    }
+
+    long value = VarInt.readVLong(record.data, this.pointer);
+    this.pointer += VarInt.sizeOfVLong(value);
+    return ZigZag.decodeLong(value);
+  }
+
+  public float readFloat() {
+    int value = record.data.readIntBits(this.pointer);
+    this.pointer += 4;
+    if (value == HollowObjectWriteRecord.NULL_FLOAT_BITS) {
+      return Float.NaN;
+    }
+    return Float.intBitsToFloat(value);
+  }
+
+  public double readDouble() {
+    long value = record.data.readLongBits(this.pointer);
+    this.pointer += 8;
+    if (value == HollowObjectWriteRecord.NULL_DOUBLE_BITS) {
+      return Double.NaN;
+    }
+    return Double.longBitsToDouble(value);
+  }
+
+  public String readString() {
+    if (VarInt.readVNull(record.data, this.pointer)) {
+        this.pointer += 1;
+        return null;
+    }
+
+    int length = VarInt.readVInt(record.data, this.pointer);
+    this.pointer += VarInt.sizeOfVInt(length);
+
+    int cLength = VarInt.countVarIntsInRange(record.data, this.pointer, length);
+    char[] s = new char[cLength];
+
+    for(int i=0;i<cLength;i++) {
+      int charValue = VarInt.readVInt(record.data, this.pointer);
+      s[i] = (char)charValue;
+      this.pointer += VarInt.sizeOfVInt(charValue);
+    }
+
+    return new String(s);
+  }
+
+  public byte[] readBytes() {
+    if (VarInt.readVNull(record.data, this.pointer)) {
+        this.pointer += 1;
+        return null;
+    }
+
+    int length = VarInt.readVInt(record.data, this.pointer);
+    this.pointer += VarInt.sizeOfVInt(length);
+    byte[] b = new byte[length];
+
+    for(int i=0;i<length;i++) {
+      b[i] = record.data.get(this.pointer++);
+    }
+
+    return b;
+  }
+
+  public void skipSchema(HollowSchema schema) {
+    switch (schema.getSchemaType()) {
+      case OBJECT: {
+        HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
+        int numFields = objectSchema.numFields();
+        for (int i = 0; i < numFields; i++) {
+          skipField(objectSchema.getFieldType(i));
+        }
+        break;
+      }
+      case LIST:
+      case SET: {
+        int numElements = readCollectionSize();
+        for (int i = 0; i < numElements; i++) {
+          readOrdinal();
+        }
+        break;
+      }
+      case MAP: {
+        int numElements = readCollectionSize();
+        for (int i = 0; i < numElements; i++) {
+          readOrdinal(); // key
+          readOrdinal(); // value
+        }
+        break;
+      }
+    }
+  }
+
+  public void skipField(HollowObjectSchema.FieldType fieldType) {
+    switch(fieldType) {
+      case BOOLEAN:
+        readBoolean();
+        break;
+      case BYTES:
+        readBytes();
+        break;
+      case DOUBLE:
+        readDouble();
+        break;
+      case FLOAT:
+        readFloat();
+        break;
+      case INT:
+        readInt();
+        break;
+      case LONG:
+        readLong();
+        break;
+      case REFERENCE:
+        readOrdinal();
+        break;
+      case STRING:
+        readString();
+        break;
+    }
+  }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordWriter.java
@@ -38,9 +38,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Warning: Experimental.  the FlatRecord feature is subject to breaking changes.
- */
 public class FlatRecordWriter {
 
     private final HollowDataset dataset;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/HollowSchemaIdentifierMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/HollowSchemaIdentifierMapper.java
@@ -19,9 +19,6 @@ package com.netflix.hollow.core.write.objectmapper.flatrecords;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import com.netflix.hollow.core.schema.HollowSchema;
 
-/**
- * Warning: Experimental.  the FlatRecord feature is subject to breaking changes.
- */
 public interface HollowSchemaIdentifierMapper {
 	
 	public HollowSchema getSchema(int identifier);

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperFlatRecordParserTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperFlatRecordParserTest.java
@@ -1,0 +1,440 @@
+package com.netflix.hollow.core.write.objectmapper;
+
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FakeHollowSchemaIdentifierMapper;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecord;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HollowObjectMapperFlatRecordParserTest {
+  private HollowObjectMapper mapper;
+  private FlatRecordWriter flatRecordWriter;
+
+  @Before
+  public void setUp() {
+    mapper = new HollowObjectMapper(new HollowWriteStateEngine());
+    mapper.initializeTypeState(TypeWithAllSimpleTypes.class);
+    mapper.initializeTypeState(InternalTypeA.class);
+    mapper.initializeTypeState(TypeWithCollections.class);
+    mapper.initializeTypeState(VersionedType2.class);
+
+    flatRecordWriter = new FlatRecordWriter(
+        mapper.getStateEngine(), new FakeHollowSchemaIdentifierMapper(mapper.getStateEngine()));
+  }
+
+  @Test
+  public void testSimpleTypes() {
+    TypeWithAllSimpleTypes typeWithAllSimpleTypes = new TypeWithAllSimpleTypes();
+    typeWithAllSimpleTypes.boxedIntegerField = 1;
+    typeWithAllSimpleTypes.boxedBooleanField = true;
+    typeWithAllSimpleTypes.boxedDoubleField = 1.0;
+    typeWithAllSimpleTypes.boxedFloatField = 1.0f;
+    typeWithAllSimpleTypes.boxedLongField = 1L;
+    typeWithAllSimpleTypes.boxedShortField = (short) 1;
+    typeWithAllSimpleTypes.boxedByteField = (byte) 1;
+    typeWithAllSimpleTypes.boxedCharField = 'a';
+    typeWithAllSimpleTypes.primitiveIntegerField = 1;
+    typeWithAllSimpleTypes.primitiveBooleanField = true;
+    typeWithAllSimpleTypes.primitiveDoubleField = 1.0;
+    typeWithAllSimpleTypes.primitiveFloatField = 1.0f;
+    typeWithAllSimpleTypes.primitiveLongField = 1L;
+    typeWithAllSimpleTypes.primitiveShortField = (short) 1;
+    typeWithAllSimpleTypes.primitiveByteField = (byte) 1;
+    typeWithAllSimpleTypes.primitiveCharField = 'a';
+    typeWithAllSimpleTypes.stringField = "string";
+    typeWithAllSimpleTypes.inlinedIntegerField = 1;
+    typeWithAllSimpleTypes.inlinedBooleanField = true;
+    typeWithAllSimpleTypes.inlinedDoubleField = 1.0;
+    typeWithAllSimpleTypes.inlinedFloatField = 1.0f;
+    typeWithAllSimpleTypes.inlinedLongField = 1L;
+    typeWithAllSimpleTypes.inlinedShortField = (short) 1;
+    typeWithAllSimpleTypes.inlinedByteField = (byte) 1;
+    typeWithAllSimpleTypes.inlinedCharField = 'a';
+    typeWithAllSimpleTypes.inlinedStringField = "inlinedstring";
+    typeWithAllSimpleTypes.internalTypeAField = new InternalTypeA();
+    typeWithAllSimpleTypes.internalTypeAField.id = 1;
+    typeWithAllSimpleTypes.internalTypeAField.name = "name";
+
+    flatRecordWriter.reset();
+    mapper.writeFlat(typeWithAllSimpleTypes, flatRecordWriter);
+    FlatRecord fr = flatRecordWriter.generateFlatRecord();
+
+    TypeWithAllSimpleTypes result = mapper.readFlat(fr);
+
+    Assert.assertEquals(typeWithAllSimpleTypes, result);
+  }
+
+  @Test
+  public void testCollections() {
+    TypeWithCollections type = new TypeWithCollections();
+    type.id = 1;
+    type.stringList = Arrays.asList("a", "b", "c");
+    type.stringSet = new HashSet<>(type.stringList);
+    // we are in Java 8
+    type.integerStringMap = type.stringList.stream().collect(
+        java.util.stream.Collectors.toMap(
+            s -> type.stringList.indexOf(s),
+            s -> s
+        )
+    );
+    type.internalTypeAList = Arrays.asList(new InternalTypeA(1), new InternalTypeA(2));
+    type.internalTypeASet = new HashSet<>(type.internalTypeAList);
+    type.integerInternalTypeAMap = type.internalTypeAList.stream().collect(
+        java.util.stream.Collectors.toMap(
+            b -> b.id,
+            b -> b
+        )
+    );
+    type.internalTypeAStringMap = type.internalTypeAList.stream().collect(
+        java.util.stream.Collectors.toMap(
+            b -> b,
+            b -> b.name
+        )
+    );
+
+    flatRecordWriter.reset();
+    mapper.writeFlat(type, flatRecordWriter);
+    FlatRecord fr = flatRecordWriter.generateFlatRecord();
+
+    TypeWithCollections result = mapper.readFlat(fr);
+
+    Assert.assertEquals(type, result);
+  }
+
+
+  @Test
+  public void testMapFromVersionedTypes() {
+    HollowObjectMapper readerMapper = new HollowObjectMapper(new HollowWriteStateEngine());
+    readerMapper.initializeTypeState(TypeWithAllSimpleTypes.class);
+    readerMapper.initializeTypeState(InternalTypeA.class);
+    readerMapper.initializeTypeState(TypeWithCollections.class);
+    readerMapper.initializeTypeState(VersionedType1.class);
+
+    VersionedType2 versionedType2 = new VersionedType2();
+    versionedType2.boxedIntegerField = 1;
+    versionedType2.internalTypeBField = new InternalTypeB(1);
+    versionedType2.charField = 'a';
+    versionedType2.primitiveDoubleField = 1.0;
+    versionedType2.stringSet = new HashSet<>(Arrays.asList("a", "b", "c"));
+
+    mapper.writeFlat(versionedType2, flatRecordWriter);
+    FlatRecord fr = flatRecordWriter.generateFlatRecord();
+
+    VersionedType1 result = readerMapper.readFlat(fr);
+
+    Assert.assertEquals(null, result.stringField);
+    Assert.assertEquals(versionedType2.boxedIntegerField, result.boxedIntegerField);
+    Assert.assertEquals(versionedType2.primitiveDoubleField, result.primitiveDoubleField, 0);
+    Assert.assertEquals(null, result.internalTypeAField);
+    Assert.assertEquals(versionedType2.stringSet, result.stringSet);
+  }
+
+  @HollowPrimaryKey(fields={"boxedIntegerField", "stringField"})
+  private static class TypeWithAllSimpleTypes {
+    Integer boxedIntegerField;
+    Boolean boxedBooleanField;
+    Double boxedDoubleField;
+    Float boxedFloatField;
+    Long boxedLongField;
+    Short boxedShortField;
+    Byte boxedByteField;
+    Character boxedCharField;
+    int primitiveIntegerField;
+    boolean primitiveBooleanField;
+    double primitiveDoubleField;
+    float primitiveFloatField;
+    long primitiveLongField;
+    short primitiveShortField;
+    byte primitiveByteField;
+    char primitiveCharField;
+    String stringField;
+    @HollowInline
+    Integer inlinedIntegerField;
+    @HollowInline
+    Boolean inlinedBooleanField;
+    @HollowInline
+    Double inlinedDoubleField;
+    @HollowInline
+    Float inlinedFloatField;
+    @HollowInline
+    Long inlinedLongField;
+    @HollowInline
+    Short inlinedShortField;
+    @HollowInline
+    Byte inlinedByteField;
+    @HollowInline
+    Character inlinedCharField;
+    @HollowInline
+    String inlinedStringField;
+    InternalTypeA internalTypeAField;
+
+    public TypeWithAllSimpleTypes() {}
+
+    @Override
+    public boolean equals(Object o) {
+        if(o instanceof TypeWithAllSimpleTypes) {
+            TypeWithAllSimpleTypes other = (TypeWithAllSimpleTypes)o;
+            return Objects.equals(boxedIntegerField, other.boxedIntegerField) &&
+                Objects.equals(boxedBooleanField, other.boxedBooleanField) &&
+                Objects.equals(boxedDoubleField, other.boxedDoubleField) &&
+                Objects.equals(boxedFloatField, other.boxedFloatField) &&
+                Objects.equals(boxedLongField, other.boxedLongField) &&
+                Objects.equals(boxedShortField, other.boxedShortField) &&
+                Objects.equals(boxedByteField, other.boxedByteField) &&
+                Objects.equals(boxedCharField, other.boxedCharField) &&
+                primitiveIntegerField == other.primitiveIntegerField &&
+                primitiveBooleanField == other.primitiveBooleanField &&
+                primitiveDoubleField == other.primitiveDoubleField &&
+                primitiveFloatField == other.primitiveFloatField &&
+                primitiveLongField == other.primitiveLongField &&
+                primitiveShortField == other.primitiveShortField &&
+                primitiveByteField == other.primitiveByteField &&
+                primitiveCharField == other.primitiveCharField &&
+                Objects.equals(stringField, other.stringField) &&
+                Objects.equals(inlinedIntegerField, other.inlinedIntegerField) &&
+                Objects.equals(inlinedBooleanField, other.inlinedBooleanField) &&
+                Objects.equals(inlinedDoubleField, other.inlinedDoubleField) &&
+                Objects.equals(inlinedFloatField, other.inlinedFloatField) &&
+                Objects.equals(inlinedLongField, other.inlinedLongField) &&
+                Objects.equals(inlinedShortField, other.inlinedShortField) &&
+                Objects.equals(inlinedByteField, other.inlinedByteField) &&
+                Objects.equals(inlinedCharField, other.inlinedCharField) &&
+                Objects.equals(inlinedStringField, other.inlinedStringField) &&
+                Objects.equals(internalTypeAField, other.internalTypeAField);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "TypeA{" +
+            "boxedIntegerField=" + boxedIntegerField +
+            ", boxedBooleanField=" + boxedBooleanField +
+            ", boxedDoubleField=" + boxedDoubleField +
+            ", boxedFloatField=" + boxedFloatField +
+            ", boxedLongField=" + boxedLongField +
+            ", boxedShortField=" + boxedShortField +
+            ", boxedByteField=" + boxedByteField +
+            ", boxedCharField=" + boxedCharField +
+            ", primitiveIntegerField=" + primitiveIntegerField +
+            ", primitiveBooleanField=" + primitiveBooleanField +
+            ", primitiveDoubleField=" + primitiveDoubleField +
+            ", primitiveFloatField=" + primitiveFloatField +
+            ", primitiveLongField=" + primitiveLongField +
+            ", primitiveShortField=" + primitiveShortField +
+            ", primitiveByteField=" + primitiveByteField +
+            ", primitiveCharField=" + primitiveCharField +
+            ", stringField='" + stringField + '\'' +
+            ", inlinedIntegerField=" + inlinedIntegerField +
+            ", inlinedBooleanField=" + inlinedBooleanField +
+            ", inlinedDoubleField=" + inlinedDoubleField +
+            ", inlinedFloatField=" + inlinedFloatField +
+            ", inlinedLongField=" + inlinedLongField +
+            ", inlinedShortField=" + inlinedShortField +
+            ", inlinedByteField=" + inlinedByteField +
+            ", inlinedCharField=" + inlinedCharField +
+            ", internalTypeAField=" + internalTypeAField +
+            '}';
+    }
+  }
+
+  @HollowPrimaryKey(fields={"id"})
+  private static class TypeWithCollections {
+    int id;
+    List<String> stringList;
+    Set<String> stringSet;
+    Map<Integer, String> integerStringMap;
+    List<InternalTypeA> internalTypeAList;
+    Set<InternalTypeA> internalTypeASet;
+    Map<Integer, InternalTypeA> integerInternalTypeAMap;
+    Map<InternalTypeA, String> internalTypeAStringMap;
+
+    public TypeWithCollections() {}
+
+    @Override
+    public boolean equals(Object o) {
+      if(o instanceof TypeWithCollections) {
+        TypeWithCollections other = (TypeWithCollections)o;
+        return id == other.id &&
+            Objects.equals(stringList, other.stringList) &&
+            Objects.equals(stringSet, other.stringSet) &&
+            Objects.equals(integerStringMap, other.integerStringMap) &&
+            Objects.equals(internalTypeAList, other.internalTypeAList) &&
+            Objects.equals(internalTypeASet, other.internalTypeASet) &&
+            Objects.equals(integerInternalTypeAMap, other.integerInternalTypeAMap) &&
+            Objects.equals(internalTypeAStringMap, other.internalTypeAStringMap);
+      }
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "TypeWithCollections{" +
+          "id=" + id +
+          ", stringList=" + stringList +
+          ", stringSet=" + stringSet +
+          ", integerStringMap=" + integerStringMap +
+          ", internalTypeAList=" + internalTypeAList +
+          ", internalTypeASet=" + internalTypeASet +
+          ", integerInternalTypeAMap=" + integerInternalTypeAMap +
+          ", internalTypeAStringMap=" + internalTypeAStringMap +
+          '}';
+    }
+  }
+
+  @HollowTypeName(name = "VersionedType")
+  private static class VersionedType1 {
+    String stringField;
+    Integer boxedIntegerField;
+    double primitiveDoubleField;
+    InternalTypeA internalTypeAField;
+    Set<String> stringSet;
+
+    public VersionedType1() {}
+
+    @Override
+    public boolean equals(Object o) {
+      if(o instanceof VersionedType1) {
+        VersionedType1 other = (VersionedType1)o;
+        return Objects.equals(stringField, other.stringField) &&
+            Objects.equals(boxedIntegerField, other.boxedIntegerField) &&
+            primitiveDoubleField == other.primitiveDoubleField &&
+            Objects.equals(internalTypeAField, other.internalTypeAField) &&
+            Objects.equals(stringSet, other.stringSet);
+      }
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "VersionedType1{" +
+          "stringField='" + stringField + '\'' +
+          ", boxedIntegerField=" + boxedIntegerField +
+          ", primitiveDoubleField=" + primitiveDoubleField +
+          ", internalTypeAField=" + internalTypeAField +
+          ", stringSet=" + stringSet +
+          '}';
+    }
+  }
+
+  @HollowTypeName(name = "VersionedType")
+  private static class VersionedType2 {
+    // No longer has the stringField
+    Integer boxedIntegerField;
+    double primitiveDoubleField;
+    // No longer has the typeBField
+    Set<String> stringSet;
+    char charField; // Added a char field
+    InternalTypeB internalTypeBField; // Added a new type field
+
+    public VersionedType2() {}
+
+    @Override
+    public boolean equals(Object o) {
+      if(o instanceof VersionedType2) {
+        VersionedType2 other = (VersionedType2)o;
+        return Objects.equals(boxedIntegerField, other.boxedIntegerField) &&
+            primitiveDoubleField == other.primitiveDoubleField &&
+            Objects.equals(stringSet, other.stringSet) &&
+            charField == other.charField &&
+            Objects.equals(internalTypeBField, other.internalTypeBField);
+      }
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "VersionedType2{" +
+          "boxedIntegerField=" + boxedIntegerField +
+          ", primitiveDoubleField=" + primitiveDoubleField +
+          ", stringSet=" + stringSet +
+          ", charField=" + charField +
+          ", internalTypeBField=" + internalTypeBField +
+          '}';
+    }
+  }
+
+  private static class InternalTypeA {
+    Integer id;
+    String name;
+
+    public InternalTypeA() {}
+
+    public InternalTypeA(Integer id) {
+      this(id, String.valueOf(id));
+    }
+
+    public InternalTypeA(Integer id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if(o instanceof InternalTypeA) {
+        InternalTypeA other = (InternalTypeA)o;
+        return id.equals(other.id) && name.equals(other.name);
+      }
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "InternalTypeA{" +
+          "id=" + id +
+          ", name='" + name + '\'' +
+          '}';
+    }
+  }
+
+  private static class InternalTypeB {
+    Integer id;
+    String name;
+
+    public InternalTypeB() {}
+
+    public InternalTypeB(Integer id) {
+      this(id, String.valueOf(id));
+    }
+
+    public InternalTypeB(Integer id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if(o instanceof InternalTypeB) {
+        InternalTypeB other = (InternalTypeB)o;
+        return id.equals(other.id) && name.equals(other.name);
+      }
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "InternalTypeB{" +
+          "id=" + id +
+          ", name='" + name + '\'' +
+          '}';
+    }
+  }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperFlatRecordParserTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapperFlatRecordParserTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,9 +60,7 @@ public class HollowObjectMapperFlatRecordParserTest {
     typeWithAllSimpleTypes.inlinedByteField = (byte) 1;
     typeWithAllSimpleTypes.inlinedCharField = 'a';
     typeWithAllSimpleTypes.inlinedStringField = "inlinedstring";
-    typeWithAllSimpleTypes.internalTypeAField = new InternalTypeA();
-    typeWithAllSimpleTypes.internalTypeAField.id = 1;
-    typeWithAllSimpleTypes.internalTypeAField.name = "name";
+    typeWithAllSimpleTypes.internalTypeAField = new InternalTypeA(1, "name");
 
     flatRecordWriter.reset();
     mapper.writeFlat(typeWithAllSimpleTypes, flatRecordWriter);
@@ -78,9 +77,8 @@ public class HollowObjectMapperFlatRecordParserTest {
     type.id = 1;
     type.stringList = Arrays.asList("a", "b", "c");
     type.stringSet = new HashSet<>(type.stringList);
-    // we are in Java 8
     type.integerStringMap = type.stringList.stream().collect(
-        java.util.stream.Collectors.toMap(
+        Collectors.toMap(
             s -> type.stringList.indexOf(s),
             s -> s
         )
@@ -88,13 +86,13 @@ public class HollowObjectMapperFlatRecordParserTest {
     type.internalTypeAList = Arrays.asList(new InternalTypeA(1), new InternalTypeA(2));
     type.internalTypeASet = new HashSet<>(type.internalTypeAList);
     type.integerInternalTypeAMap = type.internalTypeAList.stream().collect(
-        java.util.stream.Collectors.toMap(
+        Collectors.toMap(
             b -> b.id,
             b -> b
         )
     );
     type.internalTypeAStringMap = type.internalTypeAList.stream().collect(
-        java.util.stream.Collectors.toMap(
+        Collectors.toMap(
             b -> b,
             b -> b.name
         )
@@ -108,7 +106,6 @@ public class HollowObjectMapperFlatRecordParserTest {
 
     Assert.assertEquals(type, result);
   }
-
 
   @Test
   public void testMapFromVersionedTypes() {
@@ -130,10 +127,10 @@ public class HollowObjectMapperFlatRecordParserTest {
 
     VersionedType1 result = readerMapper.readFlat(fr);
 
-    Assert.assertEquals(null, result.stringField);
+    Assert.assertEquals(null, result.stringField); // stringField is not present in VersionedType1
     Assert.assertEquals(versionedType2.boxedIntegerField, result.boxedIntegerField);
     Assert.assertEquals(versionedType2.primitiveDoubleField, result.primitiveDoubleField, 0);
-    Assert.assertEquals(null, result.internalTypeAField);
+    Assert.assertEquals(null, result.internalTypeAField); // internalTypeAField is not present in VersionedType1
     Assert.assertEquals(versionedType2.stringSet, result.stringSet);
   }
 


### PR DESCRIPTION
The `HollowObjectMapper` can read a `FlatRecord` back into the original POJO.