### PR TITLE
Consumer auto double snapshot on schema change

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -293,11 +293,22 @@ public class HollowConsumer {
      * @param version the version to refresh to
      */
     public void triggerRefreshTo(long version) {
+        triggerRefreshTo(new VersionInfo(version));
+    }
+
+    /**
+     * Similar to {@link #triggerRefreshTo(long)} but instead of accepting a long version no. it accepts a
+     * {@link VersionInfo} instance that contains (in addition to version no.) version specific metadata and
+     * pinning status.
+     *
+     * @param versionInfo version no., metadata, and pined status for the desired version
+     */
+    public void triggerRefreshTo(VersionInfo versionInfo) {
         if (announcementWatcher != null)
             throw new UnsupportedOperationException("Cannot trigger refresh to specified version when a HollowConsumer.AnnouncementWatcher is present");
 
         try {
-            updater.updateTo(version);
+            updater.updateTo(versionInfo);
         } catch (Error | RuntimeException e) {
             throw e;
         } catch (Throwable t) {
@@ -691,6 +702,8 @@ public class HollowConsumer {
 
         int maxDeltasBeforeDoubleSnapshot();
 
+        default boolean doubleSnapshotOnSchemaChange() { return false; }
+
         DoubleSnapshotConfig DEFAULT_CONFIG = new DoubleSnapshotConfig() {
             @Override
             public int maxDeltasBeforeDoubleSnapshot() {
@@ -831,6 +844,7 @@ public class HollowConsumer {
          * @param requestedVersionInfo requested version's information comprising version, announcement metadata and its pinned status
          * */
         default void versionDetected(VersionInfo requestedVersionInfo) {};
+
         /**
          * Indicates that a refresh has begun.  Generally useful for logging.
          * <p>

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -39,6 +39,7 @@ import com.netflix.hollow.core.read.engine.HollowBlobHeaderReader;
 import com.netflix.hollow.core.read.engine.HollowBlobReader;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchemaHash;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.util.HollowWriteStateCreator;
 import com.netflix.hollow.core.write.HollowBlobWriter;
@@ -372,6 +373,7 @@ abstract class AbstractHollowProducer {
 
             // 3. Produce a new state if there's work to do
             if (writeEngine.hasChangedSinceLastCycle()) {
+                writeEngine.addHeaderTag(HollowStateEngine.HEADER_TAG_SCHEMA_HASH, new HollowSchemaHash(writeEngine.getSchemas()).getHash());
                 boolean schemaChangedFromPriorVersion = readStates.hasCurrent() &&
                         !writeEngine.hasIdenticalSchemas(readStates.current().getStateEngine());
                 if (schemaChangedFromPriorVersion) {

--- a/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
@@ -43,9 +43,14 @@ public interface HollowStateEngine extends HollowDataset {
      * A header tag indicating that the schema has changed from that of the prior version.
      * <p>
      * If the header tag is present in the state engine and the value is "true" (ignoring case)
-     * then the schema has changed from that of the the prior version.
+     * then the schema has changed from that of the prior version.
      */
     String HEADER_TAG_SCHEMA_CHANGE = "hollow.schema.changedFromPriorVersion";
+
+    /**
+     * A header tag containing the hash of serialized hollow schema.
+     */
+    String HEADER_TAG_SCHEMA_HASH = "hollow.schema.hash";
 
     /**
      * A header tag indicating the timestamp in milliseconds of when the producer cycle started

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaHash.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaHash.java
@@ -1,0 +1,59 @@
+package com.netflix.hollow.core.schema;
+
+import com.netflix.hollow.core.HollowStateEngine;
+import com.netflix.hollow.core.memory.encoding.HashCodes;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+public class HollowSchemaHash {
+    private final String hash;
+
+    public HollowSchemaHash(String hash) {
+        this.hash = hash;
+    }
+
+    public HollowSchemaHash(HollowStateEngine stateEngine) {
+        this(stateEngine.getSchemas());
+    }
+
+    public HollowSchemaHash(Collection<HollowSchema> schemas) {
+        // Order the Schemas
+        Map<String, HollowSchema> schemaMap = new TreeMap<>();
+        schemas.forEach( s -> schemaMap.put(s.getName(), s));
+
+        // serialize
+        StringBuilder schemaSB = new StringBuilder();
+        schemaMap.forEach( (k, v) -> schemaSB.append(v));
+
+        this.hash = calculateHash(schemaSB.toString());
+    }
+
+    private String calculateHash(String schemaString) {
+        int hashCode = HashCodes.hashCode(schemaString);
+        return String.valueOf(hashCode);
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HollowSchemaHash that = (HollowSchemaHash) o;
+        return Objects.equals(hash, that.hash);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hash);
+    }
+
+    @Override
+    public String toString() {
+        return getHash();
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.api.client;
 
 import static com.netflix.hollow.core.HollowConstants.VERSION_LATEST;
 import static com.netflix.hollow.core.HollowConstants.VERSION_NONE;
+import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_SCHEMA_HASH;
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -28,17 +29,32 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.api.metrics.HollowConsumerMetrics;
+import com.netflix.hollow.core.HollowStateEngine;
 import com.netflix.hollow.core.memory.MemoryMode;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchemaHash;
 import com.netflix.hollow.core.write.HollowBlobWriter;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.test.HollowWriteStateEngineBuilder;
+import com.netflix.hollow.test.consumer.TestBlob;
+import com.netflix.hollow.test.consumer.TestBlobRetriever;
+import com.netflix.hollow.test.consumer.TestHollowConsumer;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -71,12 +87,13 @@ public class HollowClientUpdaterTest {
     @Test
     public void testUpdateTo_noVersions() throws Throwable {
         when(snapshotConfig.allowDoubleSnapshot()).thenReturn(false);
+        when(snapshotConfig.doubleSnapshotOnSchemaChange()).thenReturn(false);
 
         assertTrue(subject.updateTo(VERSION_NONE));
         HollowReadStateEngine readStateEngine = subject.getStateEngine();
         assertTrue("Should have no types", readStateEngine.getAllTypes().isEmpty());
         assertTrue("Should create snapshot plan next, even if double snapshot config disallows it",
-                subject.shouldCreateSnapshotPlan());
+                subject.shouldCreateSnapshotPlan(new HollowConsumer.VersionInfo(VERSION_NONE)));
         assertTrue(subject.updateTo(VERSION_NONE));
         assertTrue("Should still have no types", readStateEngine.getAllTypes().isEmpty());
     }
@@ -169,6 +186,192 @@ public class HollowClientUpdaterTest {
         } catch(Throwable ex) {
             // do nothing
         }
-
     }
+
+    @Test
+    public void testDoubleSnapshotOnSchemaChange() throws Exception {
+        HollowWriteStateEngine stateEngine = new HollowWriteStateEngine();
+        TestHollowConsumer testHollowConsumer = schemaChangeSubject(stateEngine, true, false, true, true);
+        Map<String, String> v2Metadata = new HashMap<String, String>() {{ put(HollowStateEngine.HEADER_TAG_SCHEMA_HASH, (new HollowSchemaHash(stateEngine)).getHash()); }};
+        testHollowConsumer.triggerRefreshTo(new HollowConsumer.VersionInfo(2, Optional.of(v2Metadata), Optional.empty()));
+    }
+
+    @Test
+    public void testDoubleSnapshotOnSchemaChange_flagDisabled() throws Exception {
+        HollowWriteStateEngine stateEngine = new HollowWriteStateEngine();
+        TestHollowConsumer testHollowConsumer = schemaChangeSubject(stateEngine, false, true, false, true);
+        Map<String, String> v2Metadata = new HashMap<String, String>() {{ put(HollowStateEngine.HEADER_TAG_SCHEMA_HASH, (new HollowSchemaHash(stateEngine)).getHash()); }};
+        testHollowConsumer.triggerRefreshTo(new HollowConsumer.VersionInfo(2, Optional.of(v2Metadata), Optional.empty()));
+    }
+
+    @Test
+    public void testDoubleSnapshotOnSchemaChange_noVersionMetadata_logsWarning() throws Exception {
+        WarnLogHandler logHandler = (WarnLogHandler) configureLogger(HollowClientUpdater.class.getName(), Level.WARNING,
+                "Double snapshots on schema change are enabled and its functioning depends on " +
+                        "visibility into incoming version's schema through metadata but NO metadata was available " +
+                        "for version 2. Check that the mechanism that triggered " +
+                        "the refresh (usually announcementWatcher) supports passing version metadata. This refresh will " +
+                        "not be able to reflect any schema changes.");
+
+        HollowWriteStateEngine stateEngine = new HollowWriteStateEngine();
+        TestHollowConsumer testHollowConsumer = schemaChangeSubject(stateEngine, true, true, false, true);
+        testHollowConsumer.triggerRefreshTo(2);
+
+        assertTrue("Warning should be logged", logHandler.isContains());
+    }
+
+    @Test
+    public void testDoubleSnapshotOnSchemaChange_noSchemaHashInMetadata_logsWarning() throws Exception {
+        WarnLogHandler logHandler = (WarnLogHandler) configureLogger(HollowClientUpdater.class.getName(), Level.WARNING,
+                "Double snapshots on schema change are enabled but version metadata for incoming " +
+                        "version 2 did not contain the required attribute (" +
+                        HEADER_TAG_SCHEMA_HASH + "). Check that the producer supports setting this attribute. This " +
+                        "refresh will not be able to reflect any schema changes.");
+
+        HollowWriteStateEngine stateEngine = new HollowWriteStateEngine();
+        TestHollowConsumer testHollowConsumer = schemaChangeSubject(stateEngine, true, true, false, true);
+        testHollowConsumer.triggerRefreshTo(new HollowConsumer.VersionInfo(2, Optional.of(new HashMap<>()), Optional.empty()));
+
+        assertTrue("Warning should be logged", logHandler.isContains());
+    }
+
+    @Test
+    public void testDoubleSnapshotOnSchemaChange_prohibitDoubleSnapshot_logsWarning() throws Exception {
+        WarnLogHandler logHandler = (WarnLogHandler) configureLogger(HollowClientUpdater.class.getName(), Level.WARNING,
+                "Auto double snapshots on schema changes are enabled but double snapshots on consumer " +
+                        "are prohibited by doubleSnapshotConfig. This refresh will not be able to reflect any schema changes.");
+
+        HollowWriteStateEngine stateEngine = new HollowWriteStateEngine();
+        TestHollowConsumer testHollowConsumer = schemaChangeSubject(stateEngine, true, true, false, false);
+        Map<String, String> v2Metadata = new HashMap<String, String>() {{ put(HollowStateEngine.HEADER_TAG_SCHEMA_HASH, (new HollowSchemaHash(stateEngine)).getHash()); }};
+        testHollowConsumer.triggerRefreshTo(new HollowConsumer.VersionInfo(2, Optional.of(v2Metadata), Optional.empty()));
+
+        assertTrue("Warning should be logged", logHandler.isContains());
+    }
+
+    private static void addMovie(HollowWriteStateEngine stateEngine, int id) {
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord((HollowObjectSchema) stateEngine.getSchema("Movie"));
+        rec.setInt("id", id);
+        stateEngine.add("Movie", rec);
+    }
+
+    private static void addActor(HollowWriteStateEngine stateEngine, int id) {
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord((HollowObjectSchema) stateEngine.getSchema("Actor"));
+        rec.setInt("id", id);
+        stateEngine.add("Actor", rec);
+    }
+
+    private TestHollowConsumer schemaChangeSubject(HollowWriteStateEngine stateEngine, boolean doubleSnapshotOnSchemaChange,
+                                                   boolean failIfDoubleSnapshot, boolean failIfDelta, boolean allowDoubleSnapshots) throws Exception {
+        HollowConsumer.DoubleSnapshotConfig supportsSchemaChange = new HollowConsumer.DoubleSnapshotConfig() {
+            @Override
+            public boolean allowDoubleSnapshot() {
+                return allowDoubleSnapshots;
+            }
+            @Override
+            public int maxDeltasBeforeDoubleSnapshot() {
+                return 32;
+            }
+            @Override
+            public boolean doubleSnapshotOnSchemaChange() {
+                return doubleSnapshotOnSchemaChange;
+            }
+        };
+        TestBlobRetriever testBlobRetriever = new TestBlobRetriever();
+
+        HollowObjectSchema movieSchema = new HollowObjectSchema("Movie", 1, "id");
+        movieSchema.addField("id", HollowObjectSchema.FieldType.INT);
+
+        stateEngine.addTypeState(new HollowObjectTypeWriteState(movieSchema));
+
+        class AssertNoDeltas extends HollowConsumer.AbstractRefreshListener {
+            private boolean initialLoad = true;
+            @Override
+            public void snapshotUpdateOccurred(HollowAPI api, HollowReadStateEngine stateEngine, long version) throws Exception {
+                if (!initialLoad && failIfDoubleSnapshot) {
+                    fail();
+                }
+                initialLoad = false;
+            }
+            @Override
+            public void deltaUpdateOccurred(HollowAPI api, HollowReadStateEngine stateEngine, long version) throws Exception {
+                if (failIfDelta) {
+                    fail();
+                }
+            }
+        }
+        // v1
+        addMovie(stateEngine, 1);
+        stateEngine.prepareForWrite();
+        ByteArrayOutputStream baos_v1 = new ByteArrayOutputStream();
+        HollowBlobWriter writer = new HollowBlobWriter(stateEngine);
+        writer.writeSnapshot(baos_v1);
+        testBlobRetriever.addSnapshot(1, new TestBlob(1,new ByteArrayInputStream(baos_v1.toByteArray())));
+        TestHollowConsumer testHollowConsumer = (new TestHollowConsumer.Builder())
+                .withBlobRetriever(testBlobRetriever)
+                .withDoubleSnapshotConfig(supportsSchemaChange)
+                .withRefreshListener(new AssertNoDeltas())
+                .build();
+
+        testHollowConsumer.triggerRefreshTo(1);
+
+        // v2
+        stateEngine.prepareForNextCycle();
+        HollowObjectSchema actorSchema = new HollowObjectSchema("Actor", 1, "id");
+        actorSchema.addField("id", HollowObjectSchema.FieldType.INT);
+        stateEngine.addTypeState(new HollowObjectTypeWriteState(actorSchema));
+
+        addActor(stateEngine, 1);
+        stateEngine.prepareForWrite();
+        ByteArrayOutputStream baos_v1_to_v2 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v2_to_v1 = new ByteArrayOutputStream();
+        ByteArrayOutputStream baos_v2 = new ByteArrayOutputStream();
+        writer.writeSnapshot(baos_v2);
+        writer.writeDelta(baos_v1_to_v2);
+        writer.writeReverseDelta(baos_v2_to_v1);
+        testBlobRetriever.addSnapshot(2, new TestBlob(2,new ByteArrayInputStream(baos_v2.toByteArray())));
+        testBlobRetriever.addDelta(1, new TestBlob(1, 2, new ByteArrayInputStream(baos_v1_to_v2.toByteArray())));
+        testBlobRetriever.addReverseDelta(2, new TestBlob(2, 1, new ByteArrayInputStream(baos_v2_to_v1.toByteArray())));
+
+        return testHollowConsumer;
+    }
+
+    private Handler configureLogger(String classLogger, Level level, String msg) {
+        Logger logger = LogManager.getLogManager().getLogger(classLogger);
+        Handler logHandler = new WarnLogHandler(msg);
+        logHandler.setLevel(Level.ALL);
+        logger.setUseParentHandlers(false);
+        logger.addHandler(logHandler);
+        return logHandler;
+    }
+
+    private class WarnLogHandler extends Handler {
+        private final String msg;
+        private boolean contains = false;
+
+        WarnLogHandler(String msg) {
+            this.msg = msg;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (record.getLevel().equals(Level.WARNING)) {
+                if (record.getMessage().equals(msg)) {
+                    contains = true;
+                }
+            }
+        }
+        @Override
+        public void flush() {
+        }
+        @Override
+        public void close() throws SecurityException {
+        }
+
+        public boolean isContains() {
+            return contains;
+        }
+    }
+
+
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/schema/HollowSchemaHashTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/schema/HollowSchemaHashTest.java
@@ -1,0 +1,34 @@
+package com.netflix.hollow.core.schema;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+import com.netflix.hollow.test.HollowReadStateEngineBuilder;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.Test;
+
+public class HollowSchemaHashTest {
+
+    @HollowPrimaryKey(fields = "id")
+    class Movie {
+        int id;
+        Map<Integer, String> aMap;
+    }
+
+    @Test
+    public void schemaHashTest() {
+        SimpleHollowDataset dataset = SimpleHollowDataset.fromClassDefinitions(Long.class, Movie.class);
+        HollowReadStateEngine readState = new HollowReadStateEngineBuilder(Arrays.asList(Long.class, Movie.class)).build();
+
+        HollowSchemaHash hollowSchemaHash1 = new HollowSchemaHash(dataset.getSchemas());
+        HollowSchemaHash hollowSchemaHash2 = new HollowSchemaHash(readState.getSchemas());
+
+        assertEquals(hollowSchemaHash1, hollowSchemaHash2);
+        assertNotNull(hollowSchemaHash1.getHash());
+        assertNotEquals("", hollowSchemaHash1.getHash());
+    }
+}


### PR DESCRIPTION
To use the feature, a consumer must 
(a) be built with double snapshot config that elects to double snapshot on schema change
(b) be able to lookup a schema hash attribute in version metadata (so producer must update code to start publishing this, and announcement watcher or the call to triggerRefreshTo must provide metadata)

Note no support for optional parts atm. 
