### PR TITLE
Significantly improved efficiency of HollowHistoryKeyIndex

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -52,6 +52,9 @@ public class HollowHistoryTypeKeyIndex {
     private final HashMap<Integer, IntList> ordinalFieldHashMapping;
     private final HashMap<Integer, Object[]> ordinalFieldObjectMapping;
 
+    private final ObjectInternPool memoizedPool;
+
+
     public HollowHistoryTypeKeyIndex(PrimaryKey primaryKey, HollowDataset dataModel) {
         this.primaryKey = primaryKey;
         this.keyFieldIsIndexed = new boolean[primaryKey.numFields()];
@@ -65,6 +68,8 @@ public class HollowHistoryTypeKeyIndex {
         this.ordinalMapping = new HashMap<>();
         this.ordinalFieldHashMapping = new HashMap<>();
         this.ordinalFieldObjectMapping = new HashMap<>();
+
+        this.memoizedPool = new ObjectInternPool();
     }
 
     public boolean isInitialized() {
@@ -203,7 +208,8 @@ public class HollowHistoryTypeKeyIndex {
             IntList currFieldList = ordinalFieldHashMapping.get(fieldHash);
             currFieldList.add(assignedOrdinal);
 
-            ordinalFieldObjectMapping.get(assignedOrdinal)[i] = readValue(typeState, ordinal, i);
+            Object objectToStore = readValue(typeState, ordinal, i);
+            ordinalFieldObjectMapping.get(assignedOrdinal)[i] = memoizedPool.intern(objectToStore);
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -5,37 +5,45 @@ import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.read.HollowReadFieldUtils;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.tools.util.ObjectInternPool;
 
 import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
 import java.util.Arrays;
 import java.util.HashMap;
 
 public class HollowOrdinalMapper {
-    // Open addressing/linear probing, hashed ordinals to assigned ordinals
-    // If hash collision and
-    final private Integer[] ordinalMappings;
-    private final HashMap<Integer, Object[]> ordinalFieldObjectMapping;
-    private final HashMap<Integer, Integer> assignedOrdinalToIndex;
     private int size = 0;
     private static final double LOAD_FACTOR = 0.7;
+    
+    private Integer[] ordinalMappings;
+    private final HashMap<Integer, Object[]> indexFieldObjectMapping;
+    private final HashMap<Integer, Integer> assignedOrdinalToIndex;
 
     private final PrimaryKey primaryKey;
     private final int[][] keyFieldIndices;
+    private final boolean[] keyFieldIsIndexed;
 
-    public HollowOrdinalMapper(PrimaryKey primaryKey, int[][] keyFieldIndices, HashMap<Integer, Object[]> ofom) {
+    private final ObjectInternPool memoizedPool;
+
+    public HollowOrdinalMapper(PrimaryKey primaryKey, boolean[] keyFieldIsIndexed, int[][] keyFieldIndices) {
         // Start with prime number to assist OA
         this.ordinalMappings = new Integer[2069];
         Arrays.fill(this.ordinalMappings, ORDINAL_NONE);
 
         this.primaryKey = primaryKey;
         this.keyFieldIndices = keyFieldIndices;
-        this.ordinalFieldObjectMapping = ofom;
+        this.keyFieldIsIndexed = keyFieldIsIndexed;
+
+        this.indexFieldObjectMapping = new HashMap<>();
         this.assignedOrdinalToIndex = new HashMap<>();
+
+        this.memoizedPool = new ObjectInternPool();
     }
 
     public int findAssignedOrdinal(HollowObjectTypeReadState typeState, int keyOrdinal) {
         int hashedRecord = hashKeyRecord(typeState, keyOrdinal);
-        int index = modulus(hashedRecord, ordinalMappings.length);
+        int index = indexFromHash(hashedRecord);
+
         while (ordinalMappings[index]!=ORDINAL_NONE) {
             if(recordsAreEqual(typeState, keyOrdinal, hashedRecord))
                 return ordinalMappings[index];
@@ -49,10 +57,12 @@ public class HollowOrdinalMapper {
         if(keyHash!=hashedRecord) {
             return false;
         }
-        int index = modulus(hashedRecord, ordinalMappings.length);
+        int index = indexFromHash(hashedRecord);
         for(int i=0;i<primaryKey.numFields();i++) {
-            Object newFieldValue = readValue(typeState, keyOrdinal, i);
-            Object existingFieldValue = ordinalFieldObjectMapping.get(index)[i];
+            if(!keyFieldIsIndexed[i])
+                continue;
+            Object newFieldValue = readValueInState(typeState, keyOrdinal, i);
+            Object existingFieldValue = indexFieldObjectMapping.get(index)[i];
             if(!newFieldValue.equals(existingFieldValue)) {
                 return false;
             }
@@ -60,21 +70,22 @@ public class HollowOrdinalMapper {
         return true;
     }
 
-    private static int modulus(int dividend, int divisor) {
-        int modulus = dividend % divisor;
-        return modulus < 0 ? modulus + divisor : modulus;
+    // Java modulo is more like a remainder, and we don't want it to be negative
+    // Even if the hash is
+    private int indexFromHash(int hashedValue) {
+        int modulus = hashedValue % ordinalMappings.length;
+        return modulus < 0 ? modulus + ordinalMappings.length : modulus;
     }
 
     //returns stored index
-    public int storeNewOrdinal(HollowObjectTypeReadState typeState, int ordinal, int assignedOrdinal) {
+    public int storeNewRecord(HollowObjectTypeReadState typeState, int ordinal, int assignedOrdinal) {
         int hashedRecord = hashKeyRecord(typeState, ordinal);
 
         if ((double) size / ordinalMappings.length > LOAD_FACTOR) {
-            System.exit(1); //implement later
-            //expandTable();
+            expandTable();
         }
 
-        int index = modulus(hashedRecord, ordinalMappings.length);
+        int index = indexFromHash(hashedRecord);
 
         // Linear probing
         while (ordinalMappings[index] != ORDINAL_NONE) {
@@ -88,13 +99,35 @@ public class HollowOrdinalMapper {
 
         ordinalMappings[index] = assignedOrdinal;
         size++;
-        //designed to be overwritten
+
+        storeFields(typeState, ordinal, index);
+
         this.assignedOrdinalToIndex.put(assignedOrdinal, index);
         return index;
     }
 
-    public int getIndex(int ordinal) {
-        return this.assignedOrdinalToIndex.get(ordinal);
+    private void expandTable() {
+        Integer[] newOrdinalMapping = new Integer[ordinalMappings.length * 2];
+        System.arraycopy(ordinalMappings, 0, newOrdinalMapping, 0, ordinalMappings.length);
+        ordinalMappings = newOrdinalMapping;
+        System.exit(1);
+        //TODO: support rehashing
+    }
+
+    private void storeFields(HollowObjectTypeReadState typeState, int ordinal, int index) {
+        if(!indexFieldObjectMapping.containsKey(index))
+            indexFieldObjectMapping.put(index, new Object[primaryKey.numFields()]);
+        for(int i=0;i<primaryKey.numFields();i++) {
+            if(!keyFieldIsIndexed[i])
+                continue;
+            Object objectToStore = readValueInState(typeState, ordinal, i);
+            indexFieldObjectMapping.get(index)[i] = memoizedPool.intern(objectToStore);
+        }
+    }
+
+    public Object getFieldObject(int keyOrdinal, int fieldIndex) {
+        int index = assignedOrdinalToIndex.get(keyOrdinal);
+        return indexFieldObjectMapping.get(index)[fieldIndex];
     }
 
     private int hashKeyRecord(HollowObjectTypeReadState typeState, int ordinal) {
@@ -107,7 +140,7 @@ public class HollowOrdinalMapper {
     }
 
     //taken and modified from HollowPrimaryKeyValueDeriver
-    private Object readValue(HollowObjectTypeReadState typeState, int ordinal, int fieldIdx) {
+    private Object readValueInState(HollowObjectTypeReadState typeState, int ordinal, int fieldIdx) {
         HollowObjectSchema schema = typeState.getSchema();
 
         int lastFieldPath = keyFieldIndices[fieldIdx].length - 1;

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -1,0 +1,123 @@
+package com.netflix.hollow.tools.history.keyindex;
+
+import com.netflix.hollow.core.index.key.PrimaryKey;
+import com.netflix.hollow.core.memory.encoding.HashCodes;
+import com.netflix.hollow.core.read.HollowReadFieldUtils;
+import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+
+import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class HollowOrdinalMapper {
+    // Open addressing/linear probing, hashed ordinals to assigned ordinals
+    // If hash collision and
+    final private Integer[] ordinalMappings;
+    private final HashMap<Integer, Object[]> ordinalFieldObjectMapping;
+    private final HashMap<Integer, Integer> assignedOrdinalToIndex;
+    private int size = 0;
+    private static final double LOAD_FACTOR = 0.7;
+
+    private final PrimaryKey primaryKey;
+    private final int[][] keyFieldIndices;
+
+    public HollowOrdinalMapper(PrimaryKey primaryKey, int[][] keyFieldIndices, HashMap<Integer, Object[]> ofom) {
+        // Start with prime number to assist OA
+        this.ordinalMappings = new Integer[2069];
+        Arrays.fill(this.ordinalMappings, ORDINAL_NONE);
+
+        this.primaryKey = primaryKey;
+        this.keyFieldIndices = keyFieldIndices;
+        this.ordinalFieldObjectMapping = ofom;
+        this.assignedOrdinalToIndex = new HashMap<>();
+    }
+
+    public int findAssignedOrdinal(HollowObjectTypeReadState typeState, int keyOrdinal) {
+        int hashedRecord = hashKeyRecord(typeState, keyOrdinal);
+        int index = modulus(hashedRecord, ordinalMappings.length);
+        while (ordinalMappings[index]!=ORDINAL_NONE) {
+            if(recordsAreEqual(typeState, keyOrdinal, hashedRecord))
+                return ordinalMappings[index];
+            index = (index + 1) % ordinalMappings.length;
+        }
+        return ORDINAL_NONE;
+    }
+
+    private boolean recordsAreEqual(HollowObjectTypeReadState typeState, int keyOrdinal, int hashedRecord) {
+        int keyHash = hashKeyRecord(typeState, keyOrdinal);
+        if(keyHash!=hashedRecord) {
+            return false;
+        }
+        int index = modulus(hashedRecord, ordinalMappings.length);
+        for(int i=0;i<primaryKey.numFields();i++) {
+            Object newFieldValue = readValue(typeState, keyOrdinal, i);
+            Object existingFieldValue = ordinalFieldObjectMapping.get(index)[i];
+            if(!newFieldValue.equals(existingFieldValue)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int modulus(int dividend, int divisor) {
+        int modulus = dividend % divisor;
+        return modulus < 0 ? modulus + divisor : modulus;
+    }
+
+    //returns stored index
+    public int storeNewOrdinal(HollowObjectTypeReadState typeState, int ordinal, int assignedOrdinal) {
+        int hashedRecord = hashKeyRecord(typeState, ordinal);
+
+        if ((double) size / ordinalMappings.length > LOAD_FACTOR) {
+            System.exit(1); //implement later
+            //expandTable();
+        }
+
+        int index = modulus(hashedRecord, ordinalMappings.length);
+
+        // Linear probing
+        while (ordinalMappings[index] != ORDINAL_NONE) {
+            if(recordsAreEqual(typeState, ordinal, index)) {
+                //TODO: not ordinal, shouldn't return ORDINAL_NONE
+                this.assignedOrdinalToIndex.put(assignedOrdinal, index);
+                return ORDINAL_NONE;
+            }
+            index = (index + 1) % ordinalMappings.length;
+        }
+
+        ordinalMappings[index] = assignedOrdinal;
+        size++;
+        //designed to be overwritten
+        this.assignedOrdinalToIndex.put(assignedOrdinal, index);
+        return index;
+    }
+
+    public int getIndex(int ordinal) {
+        return this.assignedOrdinalToIndex.get(ordinal);
+    }
+
+    private int hashKeyRecord(HollowObjectTypeReadState typeState, int ordinal) {
+        int hashCode = 0;
+        for (int i = 0; i < primaryKey.numFields(); i++) {
+            int fieldHashCode = HollowReadFieldUtils.fieldHashCode(typeState, ordinal, i);
+            hashCode = (hashCode * 31) ^ fieldHashCode;
+        }
+        return HashCodes.hashInt(hashCode);
+    }
+
+    //taken and modified from HollowPrimaryKeyValueDeriver
+    private Object readValue(HollowObjectTypeReadState typeState, int ordinal, int fieldIdx) {
+        HollowObjectSchema schema = typeState.getSchema();
+
+        int lastFieldPath = keyFieldIndices[fieldIdx].length - 1;
+        for (int i = 0; i < lastFieldPath; i++) {
+            int fieldPosition = keyFieldIndices[fieldIdx][i];
+            ordinal = typeState.readOrdinal(ordinal, fieldPosition);
+            typeState = (HollowObjectTypeReadState) schema.getReferencedTypeState(fieldPosition);
+            schema = typeState.getSchema();
+        }
+
+        return HollowReadFieldUtils.fieldValueObject(typeState, ordinal, keyFieldIndices[fieldIdx][lastFieldPath]);
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
@@ -1,0 +1,56 @@
+package com.netflix.hollow.tools.util;
+
+import java.util.Map;
+import java.util.HashMap;
+
+// This class memoizes types by returning references to existing objects, or storing
+// Objects if they are not currently in the pool
+public class ObjectInternPool {
+    final private GenericInternPool<Integer> integerInternPool = new GenericInternPool<Integer>();
+    final private GenericInternPool<Float> floatInternPool = new GenericInternPool<Float>();
+    final private GenericInternPool<Double> doubleInternPool = new GenericInternPool<Double>();
+    // Only two possible values (and technically null), no reason for hashmap
+    final Boolean falseBool = false;
+    final Boolean trueBool = true;
+
+    public Object intern(Object objectToIntern) {
+        if(objectToIntern==null) {
+            throw new IllegalArgumentException("Cannot intern null objects");
+        }
+
+        if(objectToIntern instanceof Float) {
+            return floatInternPool.intern((Float) objectToIntern);
+        } else if(objectToIntern instanceof Double) {
+            return doubleInternPool.intern((Double) objectToIntern);
+        } else if(objectToIntern instanceof Integer) {
+            return integerInternPool.intern((Integer) objectToIntern);
+        } else if(objectToIntern instanceof String) {
+            //just use Java's builtin intern function
+            return ((String) objectToIntern).intern();
+        } else if(objectToIntern instanceof Boolean) {
+            return (Boolean) objectToIntern ? trueBool : falseBool;
+        } else {
+            String className = objectToIntern.getClass().getName();
+            throw new IllegalArgumentException("Cannot intern object of type " + className);
+        }
+    }
+}
+
+class GenericInternPool<T> {
+    private final Map<T, T> pool = new HashMap<>();
+
+    public T intern(T object) {
+        if (object == null) {
+            throw new IllegalArgumentException("Cannot intern null objects");
+        }
+
+        synchronized (pool) {
+            T interned = pool.get(object);
+            if (interned == null) {
+                interned = object;
+                pool.put(object, object);
+            }
+            return interned;
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
@@ -6,16 +6,19 @@ import java.util.HashMap;
 // This class memoizes types by returning references to existing objects, or storing
 // Objects if they are not currently in the pool
 public class ObjectInternPool {
-    final private GenericInternPool<Integer> integerInternPool = new GenericInternPool<Integer>();
-    final private GenericInternPool<Float> floatInternPool = new GenericInternPool<Float>();
-    final private GenericInternPool<Double> doubleInternPool = new GenericInternPool<Double>();
-    // Only two possible values (and technically null), no reason for hashmap
-    final Boolean falseBool = false;
-    final Boolean trueBool = true;
+    final private GenericInternPool<Integer> integerInternPool = new GenericInternPool<>();
+    final private GenericInternPool<Float> floatInternPool = new GenericInternPool<>();
+    final private GenericInternPool<Double> doubleInternPool = new GenericInternPool<>();
+    final private GenericInternPool<Long> longInternPool = new GenericInternPool<>();
 
     public Object intern(Object objectToIntern) {
         if(objectToIntern==null) {
             throw new IllegalArgumentException("Cannot intern null objects");
+        }
+
+        // Automatically handles booleans and integers within cached range
+        if(objectAutomaticallyCached(objectToIntern)) {
+            return objectToIntern;
         }
 
         if(objectToIntern instanceof Float) {
@@ -24,15 +27,24 @@ public class ObjectInternPool {
             return doubleInternPool.intern((Double) objectToIntern);
         } else if(objectToIntern instanceof Integer) {
             return integerInternPool.intern((Integer) objectToIntern);
+        } else if(objectToIntern instanceof Long) {
+            return longInternPool.intern((Long) objectToIntern);
         } else if(objectToIntern instanceof String) {
-            //just use Java's builtin intern function
+            // Use Java's builtin intern function
             return ((String) objectToIntern).intern();
-        } else if(objectToIntern instanceof Boolean) {
-            return (Boolean) objectToIntern ? trueBool : falseBool;
         } else {
             String className = objectToIntern.getClass().getName();
             throw new IllegalArgumentException("Cannot intern object of type " + className);
         }
+    }
+
+    private boolean objectAutomaticallyCached(Object objectToIntern) {
+        if(objectToIntern instanceof Boolean) {
+            return true;
+        } else if(objectToIntern instanceof Integer) {
+            return -128 <= (Integer) objectToIntern && (Integer) objectToIntern <= 127;
+        }
+        return false;
     }
 }
 

--- a/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
@@ -1,0 +1,166 @@
+package com.netflix.hollow.tools.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ObjectInternPoolTest {
+
+    GenericInternPool<Integer> integerPool;
+    GenericInternPool<Float> floatPool;
+    GenericInternPool<Double> doublePool;
+    GenericInternPool<Long> longPool;
+    ObjectInternPool internPool;
+
+    @Before
+    public void setup() {
+        integerPool = new GenericInternPool<>();
+        floatPool = new GenericInternPool<>();
+        doublePool = new GenericInternPool<>();
+        longPool = new GenericInternPool<>();
+
+        internPool = new ObjectInternPool();
+    }
+
+    @Test
+    public void testInteger() {
+        // Java caches boxed integers between -127 and 128
+        // Must be outside that range to test interning
+        Integer intObj = 130;
+        Integer dupIntObj = 130;
+
+        Integer internedInt = integerPool.intern(intObj);
+        Integer dupInternedInt = integerPool.intern(dupIntObj);
+
+        assertNotSame(intObj, dupIntObj);
+        assertSame(internedInt, dupInternedInt);
+        assertEquals(intObj, internedInt);
+    }
+
+    @Test
+    public void testFloat() {
+        Float floatObj = 130f;
+        Float dupFloatObj = 130f;
+
+        Float internedFloat = floatPool.intern(floatObj);
+        Float dupInternedFloat = floatPool.intern(dupFloatObj);
+
+        assertNotSame(floatObj, dupFloatObj);
+        assertSame(internedFloat, dupInternedFloat);
+        assertEquals(floatObj, internedFloat);
+    }
+
+    @Test
+    public void testDouble() {
+        Double doubleObj = 130d;
+        Double dupDoubleObj = 130d;
+
+        Double internedDouble = doublePool.intern(doubleObj);
+        Double dupInternedDouble = doublePool.intern(dupDoubleObj);
+
+        assertNotSame(doubleObj, dupDoubleObj);
+        assertSame(internedDouble, dupInternedDouble);
+        assertEquals(doubleObj, internedDouble);
+    }
+
+    @Test
+    public void testLong() {
+        Long longObj = 130L;
+        Long dupLongObj = 130L;
+
+        Long internedLong = longPool.intern(longObj);
+        Long dupInternedLong = longPool.intern(dupLongObj);
+
+        assertNotSame(longObj, dupLongObj);
+        assertSame(internedLong, dupInternedLong);
+        assertEquals(longObj, internedLong);
+    }
+
+    @Test
+    public void testAutoInternInteger() {
+        //Java should automatically cache these
+        Integer lowInt = -128;
+        Integer dupLowInt = -128;
+
+        Integer highInt = 127;
+        Integer dupHighInt = 127;
+
+        Integer internedLow1 = integerPool.intern(lowInt);
+        Integer internedLow2 = integerPool.intern(dupLowInt);
+
+        Integer internedHigh1 = integerPool.intern(highInt);
+        Integer internedHigh2 = integerPool.intern(dupHighInt);
+
+        assertSame(lowInt, dupLowInt);
+        assertSame(highInt, dupHighInt);
+
+        assertSame(internedLow1, internedLow2);
+        assertSame(internedHigh1, internedHigh2);
+
+        assertEquals(lowInt, internedLow1);
+        assertEquals(highInt, internedHigh1);
+    }
+
+    @Test
+    public void testAll() {
+        Integer intObj = 130;
+        Integer dupIntObj = 130;
+
+        Float floatObj = 140f;
+        Float dupFloatObj = 140f;
+
+        Double doubleObj = 150d;
+        Double dupDoubleObj = 150d;
+
+        Long longObj = 160L;
+        Long dupLongObj = 160L;
+
+        String stringObj = new String("I am groot");
+        String dupStringObj = new String("I am groot");
+
+        Boolean booleanObj = true;
+        Boolean dupBooleanObj = true;
+
+        assertNotSame(intObj, dupIntObj);
+        assertNotSame(floatObj, dupFloatObj);
+        assertNotSame(doubleObj, dupDoubleObj);
+        assertNotSame(stringObj, dupStringObj);
+        assertNotSame(longObj, dupLongObj);
+        //booleans always cached
+
+        Integer internedInt1 = (Integer)internPool.intern(intObj);
+        Integer internedInt2 = (Integer)internPool.intern(dupIntObj);
+
+        Float internedFloat1 = (Float)internPool.intern(floatObj);
+        Float internedFloat2 = (Float)internPool.intern(dupFloatObj);
+
+        Double internedDouble1 = (Double)internPool.intern(doubleObj);
+        Double internedDouble2 = (Double)internPool.intern(dupDoubleObj);
+
+        Long internedLong1 = (Long)internPool.intern(longObj);
+        Long internedLong2 = (Long)internPool.intern(dupLongObj);
+
+        String internedString1 = (String)internPool.intern(stringObj);
+        String internedString2 = (String)internPool.intern(dupStringObj);
+
+        Boolean internedBoolean1 = (Boolean)internPool.intern(booleanObj);
+        Boolean internedBoolean2 = (Boolean)internPool.intern(dupBooleanObj);
+
+        assertSame(internedInt1, internedInt2);
+        assertSame(internedFloat1, internedFloat2);
+        assertSame(internedDouble1, internedDouble2);
+        assertSame(internedLong1, internedLong2);
+        assertSame(internedString1, internedString2);
+        assertSame(internedBoolean1, internedBoolean2);
+
+        assertEquals(intObj, internedInt1);
+        assertEquals(floatObj, internedFloat1);
+        assertEquals(doubleObj, internedDouble1);
+        assertEquals(longObj, internedLong1);
+        assertEquals(stringObj, internedString1);
+        assertEquals(booleanObj, internedBoolean1);
+    }
+}


### PR DESCRIPTION
This PR optimizes `HollowHistoryTypeKeyIndex` by eliminating the need for both readStateEngine and writeStateEngine, effectively removing a round trip for each state update. This significantly enhances performance in terms of CPU usage and memory management.

In the newly proposed implementation, `HollowHistoryTypeKeyIndex` maintains the following associations in Java HashMaps:

1. Hashed ordinals mapped to assigned ordinals
2. Hashed fields mapped to assigned ordinals
3. Assigned ordinals mapping to the corresponding record's field string representations

This approach has a few key advantages:

1. **Efficient Updates**: Round trips are completely eliminated for key updates, instead, updates to mappings occur based on the latest typeState.
2. **Immediate Storing and Hashing**: Keys are stored and hashed immediately upon update and within the same function, removing the need for added indirection present previously.
3. **Enhanced Querying Performance**: Querying is now significantly faster due to the direct lookup in a hashmap instead of going through the readStateEngine.

The modified HollowHistoryTypeKeyIndex is also more concise, with about 300 lines of code as compared to the previous 500 lines, contributing to improved readability.

The performance impact of these changes is considerable. Preliminary profiling indicates that history processing is 3-4 times faster. Additionally, memory usage is likely reduced as it's no longer necessary to store objects in conjunction with their hashes and mappings.

Todos (potentially after initial CR, will discuss with Drew)

 - [x] ~~Implement support for multi-field key delimiters during queries~~
 - [x] Store field values by object, rather than by string
 - [x] Fix potential hash collision edge case where records are not equal but hashes are
 - [x] Implement memoization for fields
     - [x] Strings: intern() builtin
     - [x] Other (bytearray, float, etc): implement intern equivalent

Unit/integration tests for potential sources of bugs (or make sure they already exist):
- [x] Unit tests for ObjectInternPool
- [ ] Record hash collision test? inherently hard to find two records that collide though

## Profiler screenshots to illustrate the performance improvements
Note the stack percentages in the bottom left
### Old implementation
![Old implementation](https://github.com/Netflix/hollow/assets/47366039/3d22c50d-99c9-4226-bad2-eb6c8cdee6b5)
### New implementation
![New implementation](https://github.com/Netflix/hollow/assets/47366039/d1c4726c-2350-4aba-8d65-bb6309f124c6)
