### PR TITLE
Enhanced HollowHistoryTypeKeyIndex with Optimized Mappings and Memoization

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/read/HollowReadFieldUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/HollowReadFieldUtils.java
@@ -63,6 +63,26 @@ public class HollowReadFieldUtils {
         throw new IllegalStateException("I don't know how to hash a " + schema.getFieldType(fieldPosition));
     }
 
+    public static int hashObject(Object value) {
+        if(value instanceof Integer) {
+            return HollowReadFieldUtils.intHashCode((Integer)value);
+        } else if(value instanceof String) {
+            return HollowReadFieldUtils.stringHashCode((String)value);
+        } else if(value instanceof Float) {
+            return HollowReadFieldUtils.floatHashCode((Float)value);
+        } else if(value instanceof Double) {
+            return HollowReadFieldUtils.doubleHashCode((Double)value);
+        } else if(value instanceof Boolean) {
+            return HollowReadFieldUtils.booleanHashCode((Boolean) value);
+        } else if(value instanceof Long) {
+            return HollowReadFieldUtils.longHashCode((Long) value);
+        } else if(value instanceof byte[]) {
+            return HollowReadFieldUtils.byteArrayHashCode((byte[]) value);
+        } else {
+            throw new RuntimeException("Unable to hash field of type " + value.getClass().getName());
+        }
+    }
+
     /**
      * Determine whether two OBJECT field records are exactly equal.
      *

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryKeyIndex.java
@@ -64,7 +64,16 @@ public class HollowHistoryKeyIndex {
     }
 
     public HollowHistoryTypeKeyIndex addTypeIndex(PrimaryKey primaryKey, HollowDataset dataModel) {
+        HollowHistoryTypeKeyIndex prevKeyIdx = typeKeyIndexes.get(primaryKey.getType());
         HollowHistoryTypeKeyIndex keyIdx = new HollowHistoryTypeKeyIndex(primaryKey, dataModel);
+        // retain any previous indexed fields
+        if (prevKeyIdx != null) {
+            for (int i = 0; i < prevKeyIdx.getKeyFields().length; i++) {
+                if (prevKeyIdx.getKeyFieldIsIndexed()[i]) {
+                    keyIdx.addFieldIndex(prevKeyIdx.getKeyFields()[i], dataModel);
+                }
+            }
+        }
         typeKeyIndexes.put(primaryKey.getType(), keyIdx);
         return keyIdx;
     }
@@ -72,6 +81,7 @@ public class HollowHistoryKeyIndex {
     public void indexTypeField(String type, String keyFieldPath) {
         typeKeyIndexes.get(type).addFieldIndex(keyFieldPath, history.getLatestState());
     }
+
 
     public void indexTypeField(PrimaryKey primaryKey) {
         indexTypeField(primaryKey, history.getLatestState());

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -92,18 +92,24 @@ public class HollowHistoryTypeKeyIndex {
         if (isInitialized) return;
         HollowObjectSchema schema = initialTypeState.getSchema();
 
-        for (String[] keyFieldPart : keyFieldNames) addSchemaField(schema, keyFieldPart, 0);
+        for (int i= 0; i < keyFieldNames.length; i ++) {
+            String[] keyFieldPart = keyFieldNames[i];
+            fieldTypes[i] = addSchemaField(schema, keyFieldPart, 0);
+        }
         isInitialized = true;
     }
 
-    private void addSchemaField(HollowObjectSchema schema, String[] keyFieldNames, int keyFieldPartPosition) {
+    private FieldType addSchemaField(HollowObjectSchema schema, String[] keyFieldNames, int keyFieldPartPosition) {
         int schemaPosition = schema.getPosition(keyFieldNames[keyFieldPartPosition]);
         if (keyFieldPartPosition < keyFieldNames.length - 1) {
             HollowObjectSchema nextPartSchema = (HollowObjectSchema) schema.getReferencedTypeState(schemaPosition).getSchema();
-            addSchemaField(nextPartSchema, keyFieldNames, keyFieldPartPosition + 1);
-        } else {
-            fieldTypes[keyFieldPartPosition] = schema.getFieldType(schemaPosition);
+            return addSchemaField(nextPartSchema, keyFieldNames, keyFieldPartPosition + 1);
         }
+        return schema.getFieldType(schemaPosition);
+    }
+
+    public boolean[] getKeyFieldIsIndexed() {
+        return keyFieldIsIndexed;
     }
 
     private void initializeKeyParts(HollowDataset dataModel) {

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -169,33 +169,12 @@ public class HollowHistoryTypeKeyIndex {
             return;
 
         Object fieldObject = ordinalMapping.getFieldObject(assignedOrdinal, fieldIdx);
-        int fieldHash = HashCodes.hashInt(hashObject(fieldObject));
+        int fieldHash = HashCodes.hashInt(HollowReadFieldUtils.hashObject(fieldObject));
         if(!ordinalFieldHashMapping.containsKey(fieldHash))
             ordinalFieldHashMapping.put(fieldHash, new IntList());
 
         IntList matchingFieldList = ordinalFieldHashMapping.get(fieldHash);
         matchingFieldList.add(assignedOrdinal);
-    }
-
-    // Retain consistency with rest of Hollow Hashing when hashing boxed primitives
-    private int hashObject(Object value) {
-        if(value instanceof Integer) {
-            return HollowReadFieldUtils.intHashCode((Integer)value);
-        } else if(value instanceof String) {
-            return HollowReadFieldUtils.stringHashCode((String)value);
-        } else if(value instanceof Float) {
-            return HollowReadFieldUtils.floatHashCode((Float)value);
-        } else if(value instanceof Double) {
-            return HollowReadFieldUtils.doubleHashCode((Double)value);
-        } else if(value instanceof Boolean) {
-            return HollowReadFieldUtils.booleanHashCode((Boolean) value);
-        } else if(value instanceof Long) {
-            return HollowReadFieldUtils.longHashCode((Long) value);
-        } else if(value instanceof byte[]) {
-            return HollowReadFieldUtils.byteArrayHashCode((byte[]) value);
-        } else {
-            throw new RuntimeException("Unable to hash field of type " + value.getClass().getName());
-        }
     }
 
     public String getKeyDisplayString(int keyOrdinal) {

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -19,6 +19,7 @@ package com.netflix.hollow.tools.history.keyindex;
 import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
 import static com.netflix.hollow.tools.util.SearchUtils.MULTI_FIELD_KEY_DELIMITER;
 
+import com.netflix.hollow.Hollow;
 import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.memory.encoding.HashCodes;
@@ -158,18 +159,21 @@ public class HollowHistoryTypeKeyIndex {
         if(assignedIndex==ORDINAL_NONE)
             return;
 
-        for (int i = 0; i < primaryKey.numFields(); i++) {
-            if (!keyFieldIsIndexed[i])
-                continue;
+        for (int i = 0; i < primaryKey.numFields(); i++)
+            writeKeyField(assignedOrdinal, i);
+    }
 
-            Object fieldObject = ordinalMapping.getFieldObject(assignedOrdinal, i);
-            int fieldHash = HashCodes.hashInt(hashObject(fieldObject));
-            if(!ordinalFieldHashMapping.containsKey(fieldHash))
-                ordinalFieldHashMapping.put(fieldHash, new IntList());
+    private void writeKeyField(int assignedOrdinal, int fieldIdx) {
+        if (!keyFieldIsIndexed[fieldIdx])
+            return;
 
-            IntList matchingFieldList = ordinalFieldHashMapping.get(fieldHash);
-            matchingFieldList.add(assignedOrdinal);
-        }
+        Object fieldObject = ordinalMapping.getFieldObject(assignedOrdinal, fieldIdx);
+        int fieldHash = HashCodes.hashInt(hashObject(fieldObject));
+        if(!ordinalFieldHashMapping.containsKey(fieldHash))
+            ordinalFieldHashMapping.put(fieldHash, new IntList());
+
+        IntList matchingFieldList = ordinalFieldHashMapping.get(fieldHash);
+        matchingFieldList.add(assignedOrdinal);
     }
 
     private int hashObject(Object value) {
@@ -183,6 +187,8 @@ public class HollowHistoryTypeKeyIndex {
             return HollowReadFieldUtils.doubleHashCode((Double)value);
         } else if(value instanceof Boolean) {
             return HollowReadFieldUtils.booleanHashCode((Boolean) value);
+        } else if(value instanceof Long) {
+            return HollowReadFieldUtils.longHashCode((Long) value);
         } else if(value instanceof byte[]) {
             return HollowReadFieldUtils.byteArrayHashCode((byte[]) value);
         } else {

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -46,7 +46,7 @@ public class HollowHistoryTypeKeyIndex {
     private int maxIndexedOrdinal = 0;
 
     private final HollowOrdinalMapper ordinalMapping;
-    private final HashMap<Integer, IntList> ordinalFieldHashMapping;
+    private final HashMap<Integer, int[]> ordinalFieldHashMapping;
 
 
     public HollowHistoryTypeKeyIndex(PrimaryKey primaryKey, HollowDataset dataModel) {
@@ -182,10 +182,12 @@ public class HollowHistoryTypeKeyIndex {
         Object fieldObject = fieldObjects[fieldIdx];
         int fieldHash = HashCodes.hashInt(HollowReadFieldUtils.hashObject(fieldObject));
         if(!ordinalFieldHashMapping.containsKey(fieldHash))
-            ordinalFieldHashMapping.put(fieldHash, new IntList());
+            ordinalFieldHashMapping.put(fieldHash, new int[0]);
 
-        IntList matchingFieldList = ordinalFieldHashMapping.get(fieldHash);
-        matchingFieldList.add(assignedOrdinal);
+        int[] matchingFieldList = ordinalFieldHashMapping.get(fieldHash);
+        int[] newFieldList = Arrays.copyOf(matchingFieldList, matchingFieldList.length + 1);
+        newFieldList[matchingFieldList.length] = assignedOrdinal;
+        ordinalFieldHashMapping.put(fieldHash, newFieldList);
     }
 
     public String getKeyDisplayString(int keyOrdinal) {
@@ -247,10 +249,7 @@ public class HollowHistoryTypeKeyIndex {
         if (!ordinalFieldHashMapping.containsKey(hashCode))
             return;
 
-        IntList matchingOrdinals = ordinalFieldHashMapping.get(hashCode);
-        for(int i=0;i<matchingOrdinals.size();i++) {
-            int ordinal = matchingOrdinals.get(i);
-
+        for(int ordinal : ordinalFieldHashMapping.get(hashCode)) {
             Object matchingObject = ordinalMapping.getFieldObject(ordinal, field, fieldTypes[field]);
             if(objectToMatch.equals(matchingObject)) {
                 results.add(ordinal);

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -31,8 +31,6 @@ import com.netflix.hollow.core.util.IntList;
 import com.netflix.hollow.core.util.RemovedOrdinalIterator;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.HashMap;
-import java.util.Optional;
 
 public class HollowHistoryTypeKeyIndex {
     private final PrimaryKey primaryKey;
@@ -138,7 +136,7 @@ public class HollowHistoryTypeKeyIndex {
         RemovedOrdinalIterator iter = new RemovedOrdinalIterator(populatedOrdinals, previousOrdinals);
         int ordinal = iter.next();
         while (ordinal != ORDINAL_NONE) {
-            writeKeyObject(typeState, ordinal, true);
+            writeKeyObject(typeState, ordinal);
             ordinal = iter.next();
         }
     }
@@ -152,11 +150,11 @@ public class HollowHistoryTypeKeyIndex {
 
         for (int i = 0; i < maxLength; i++) {
             if (populatedOrdinals.get(i) || previousOrdinals.get(i))
-                writeKeyObject(typeState, i, false);
+                writeKeyObject(typeState, i);
         }
     }
 
-    private void writeKeyObject(HollowObjectTypeReadState typeState, int ordinal, boolean isDelta) {
+    private void writeKeyObject(HollowObjectTypeReadState typeState, int ordinal) {
         int assignedOrdinal = maxIndexedOrdinal;
         boolean storedUniqueRecord = ordinalMapping.storeNewRecord(typeState, ordinal, assignedOrdinal);
 
@@ -164,13 +162,6 @@ public class HollowHistoryTypeKeyIndex {
         if(!storedUniqueRecord)
             return;
         maxIndexedOrdinal+=1;
-        Object[] fieldObjects = new Object[primaryKey.numFields()];
-        for (int i = 0; i < primaryKey.numFields(); i++) {
-            fieldObjects[i] = ordinalMapping.readValueInState(typeState, ordinal, i);
-        }
-
-        for (int i = 0; i < primaryKey.numFields(); i++)
-            ordinalMapping.writeKeyField(fieldObjects, assignedOrdinal, i);
     }
 
     public String getKeyDisplayString(int keyOrdinal) {

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -19,7 +19,6 @@ package com.netflix.hollow.tools.history.keyindex;
 import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
 import static com.netflix.hollow.tools.util.SearchUtils.MULTI_FIELD_KEY_DELIMITER;
 
-import com.netflix.hollow.Hollow;
 import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.memory.encoding.HashCodes;
@@ -58,7 +57,7 @@ public class HollowHistoryTypeKeyIndex {
         this.keyFieldIsIndexed = new boolean[primaryKey.numFields()];
         initializeKeyParts(dataModel);
 
-        this.ordinalMapping = new HollowOrdinalMapper(primaryKey, keyFieldIsIndexed, keyFieldIndices);
+        this.ordinalMapping = new HollowOrdinalMapper(primaryKey, keyFieldIsIndexed, keyFieldIndices, fieldTypes);
         this.ordinalFieldHashMapping = new HashMap<>();
     }
 
@@ -168,7 +167,7 @@ public class HollowHistoryTypeKeyIndex {
         if (!keyFieldIsIndexed[fieldIdx])
             return;
 
-        Object fieldObject = ordinalMapping.getFieldObject(assignedOrdinal, fieldIdx);
+        Object fieldObject = ordinalMapping.getFieldObject(assignedOrdinal, fieldIdx, fieldTypes[fieldIdx]);
         int fieldHash = HashCodes.hashInt(HollowReadFieldUtils.hashObject(fieldObject));
         if(!ordinalFieldHashMapping.containsKey(fieldHash))
             ordinalFieldHashMapping.put(fieldHash, new IntList());
@@ -180,7 +179,7 @@ public class HollowHistoryTypeKeyIndex {
     public String getKeyDisplayString(int keyOrdinal) {
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < primaryKey.numFields(); i++) {
-            Object valueAtField = ordinalMapping.getFieldObject(keyOrdinal, i);
+            Object valueAtField = ordinalMapping.getFieldObject(keyOrdinal, i, fieldTypes[i]);
             builder.append(valueAtField);
             if (i < primaryKey.numFields() - 1)
                 builder.append(MULTI_FIELD_KEY_DELIMITER);
@@ -240,7 +239,7 @@ public class HollowHistoryTypeKeyIndex {
         for(int i=0;i<matchingOrdinals.size();i++) {
             int ordinal = matchingOrdinals.get(i);
 
-            Object matchingObject = ordinalMapping.getFieldObject(ordinal, field);
+            Object matchingObject = ordinalMapping.getFieldObject(ordinal, field, fieldTypes[field]);
             if(objectToMatch.equals(matchingObject)) {
                 results.add(ordinal);
             }
@@ -248,6 +247,6 @@ public class HollowHistoryTypeKeyIndex {
     }
 
     public Object getKeyFieldValue(int keyFieldIdx, int keyOrdinal) {
-        return ordinalMapping.getFieldObject(keyOrdinal, keyFieldIdx);
+        return ordinalMapping.getFieldObject(keyOrdinal, keyFieldIdx, fieldTypes[keyFieldIdx]);
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -52,6 +52,9 @@ public class HollowHistoryTypeKeyIndex {
     private final HashMap<Integer, IntList> ordinalFieldHashMapping;
     private final HashMap<Integer, Object[]> ordinalFieldObjectMapping;
 
+    private final ObjectInternPool memoizedPool;
+
+
     public HollowHistoryTypeKeyIndex(PrimaryKey primaryKey, HollowDataset dataModel) {
         this.primaryKey = primaryKey;
         this.keyFieldIsIndexed = new boolean[primaryKey.numFields()];
@@ -65,6 +68,8 @@ public class HollowHistoryTypeKeyIndex {
         this.ordinalMapping = new HashMap<>();
         this.ordinalFieldHashMapping = new HashMap<>();
         this.ordinalFieldObjectMapping = new HashMap<>();
+
+        this.memoizedPool = new ObjectInternPool();
     }
 
     public boolean isInitialized() {
@@ -203,7 +208,8 @@ public class HollowHistoryTypeKeyIndex {
             IntList currFieldList = ordinalFieldHashMapping.get(fieldHash);
             currFieldList.add(assignedOrdinal);
 
-            ordinalFieldObjectMapping.get(assignedOrdinal)[i] = readValue(typeState, ordinal, i);
+            Object objectToStore = readValue(typeState, ordinal, i);
+            ordinalFieldObjectMapping.get(assignedOrdinal)[i] = memoizedPool.intern(objectToStore);
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -152,7 +152,7 @@ public class HollowOrdinalMapper {
             int assignedOrdinal = entry.getKey();
             int previousIndex = entry.getValue();
             int newIndex = ordinalMappings[previousIndex];
-            
+
             assignedOrdinalToIndex.put(assignedOrdinal, newIndex);
         }
 
@@ -170,8 +170,8 @@ public class HollowOrdinalMapper {
         return newIndex;
     }
 
-    public Object getFieldObject(int keyOrdinal, int fieldIndex) {
-        int index = assignedOrdinalToIndex.get(keyOrdinal);
+    public Object getFieldObject(int assignedOrdinal, int fieldIndex) {
+        int index = assignedOrdinalToIndex.get(assignedOrdinal);
         return indexFieldObjectMapping.get(index)[fieldIndex];
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -26,6 +26,7 @@ import com.netflix.hollow.tools.util.ObjectInternPool;
 import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 public class HollowOrdinalMapper {
     private int size = 0;
@@ -142,6 +143,17 @@ public class HollowOrdinalMapper {
 
             Object[] fieldObjects = indexFieldObjectMapping.get(i);
             newIndexFieldObjectMapping.put(newIndex, fieldObjects);
+
+            // Store new index in old table so we can remap assignedOrdinalToIndex
+            ordinalMappings[i]=newIndex;
+        }
+
+        for (Map.Entry<Integer, Integer> entry : assignedOrdinalToIndex.entrySet()) {
+            int assignedOrdinal = entry.getKey();
+            int previousIndex = entry.getValue();
+            int newIndex = ordinalMappings[previousIndex];
+            
+            assignedOrdinalToIndex.put(assignedOrdinal, newIndex);
         }
 
         this.ordinalMappings = newTable;
@@ -154,7 +166,6 @@ public class HollowOrdinalMapper {
         while (newTable[newIndex]!=ORDINAL_NONE)
             newIndex = (newIndex + 1) % newTable.length;
 
-        assignedOrdinalToIndex.put(assignedOrdinal, newIndex);
         newTable[newIndex] = assignedOrdinal;
         return newIndex;
     }

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.tools.history.keyindex;
 
 import com.netflix.hollow.core.index.key.PrimaryKey;

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -167,7 +167,8 @@ public class HollowOrdinalMapper {
     private int hashKeyRecord(HollowObjectTypeReadState typeState, int ordinal) {
         int hashCode = 0;
         for (int i = 0; i < primaryKey.numFields(); i++) {
-            int fieldHashCode = HollowReadFieldUtils.fieldHashCode(typeState, ordinal, i);
+            Object fieldObjectToHash = readValueInState(typeState, ordinal, i);
+            int fieldHashCode = HollowReadFieldUtils.hashObject(fieldObjectToHash);
             hashCode = (hashCode * 31) ^ fieldHashCode;
         }
         return HashCodes.hashInt(hashCode);

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -5,37 +5,45 @@ import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.read.HollowReadFieldUtils;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.tools.util.ObjectInternPool;
 
 import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
 import java.util.Arrays;
 import java.util.HashMap;
 
 public class HollowOrdinalMapper {
-    // Open addressing/linear probing, hashed ordinals to assigned ordinals
-    // If hash collision and
-    final private Integer[] ordinalMappings;
-    private final HashMap<Integer, Object[]> ordinalFieldObjectMapping;
-    private final HashMap<Integer, Integer> assignedOrdinalToIndex;
     private int size = 0;
     private static final double LOAD_FACTOR = 0.7;
+    
+    private Integer[] ordinalMappings;
+    private final HashMap<Integer, Object[]> indexFieldObjectMapping;
+    private final HashMap<Integer, Integer> assignedOrdinalToIndex;
 
     private final PrimaryKey primaryKey;
     private final int[][] keyFieldIndices;
+    private final boolean[] keyFieldIsIndexed;
 
-    public HollowOrdinalMapper(PrimaryKey primaryKey, int[][] keyFieldIndices, HashMap<Integer, Object[]> ofom) {
+    private final ObjectInternPool memoizedPool;
+
+    public HollowOrdinalMapper(PrimaryKey primaryKey, boolean[] keyFieldIsIndexed, int[][] keyFieldIndices) {
         // Start with prime number to assist OA
         this.ordinalMappings = new Integer[2069];
         Arrays.fill(this.ordinalMappings, ORDINAL_NONE);
 
         this.primaryKey = primaryKey;
         this.keyFieldIndices = keyFieldIndices;
-        this.ordinalFieldObjectMapping = ofom;
+        this.keyFieldIsIndexed = keyFieldIsIndexed;
+
+        this.indexFieldObjectMapping = new HashMap<>();
         this.assignedOrdinalToIndex = new HashMap<>();
+
+        this.memoizedPool = new ObjectInternPool();
     }
 
     public int findAssignedOrdinal(HollowObjectTypeReadState typeState, int keyOrdinal) {
         int hashedRecord = hashKeyRecord(typeState, keyOrdinal);
-        int index = modulus(hashedRecord, ordinalMappings.length);
+        int index = indexFromHash(hashedRecord);
+
         while (ordinalMappings[index]!=ORDINAL_NONE) {
             if(recordsAreEqual(typeState, keyOrdinal, hashedRecord))
                 return ordinalMappings[index];
@@ -49,10 +57,12 @@ public class HollowOrdinalMapper {
         if(keyHash!=hashedRecord) {
             return false;
         }
-        int index = modulus(hashedRecord, ordinalMappings.length);
+        int index = indexFromHash(hashedRecord);
         for(int i=0;i<primaryKey.numFields();i++) {
-            Object newFieldValue = readValue(typeState, keyOrdinal, i);
-            Object existingFieldValue = ordinalFieldObjectMapping.get(index)[i];
+            if(!keyFieldIsIndexed[i])
+                continue;
+            Object newFieldValue = readValueInState(typeState, keyOrdinal, i);
+            Object existingFieldValue = indexFieldObjectMapping.get(index)[i];
             if(!newFieldValue.equals(existingFieldValue)) {
                 return false;
             }
@@ -60,21 +70,22 @@ public class HollowOrdinalMapper {
         return true;
     }
 
-    private static int modulus(int dividend, int divisor) {
-        int modulus = dividend % divisor;
-        return modulus < 0 ? modulus + divisor : modulus;
+    // Java modulo is more like a remainder, and we don't want it to be negative
+    // Even if the hash is
+    private int indexFromHash(int hashedValue) {
+        int modulus = hashedValue % ordinalMappings.length;
+        return modulus < 0 ? modulus + ordinalMappings.length : modulus;
     }
 
     //returns stored index
-    public int storeNewOrdinal(HollowObjectTypeReadState typeState, int ordinal, int assignedOrdinal) {
+    public int storeNewRecord(HollowObjectTypeReadState typeState, int ordinal, int assignedOrdinal) {
         int hashedRecord = hashKeyRecord(typeState, ordinal);
 
         if ((double) size / ordinalMappings.length > LOAD_FACTOR) {
-            System.exit(1); //implement later
-            //expandTable();
+            expandTable();
         }
 
-        int index = modulus(hashedRecord, ordinalMappings.length);
+        int index = indexFromHash(hashedRecord);
 
         // Linear probing
         while (ordinalMappings[index] != ORDINAL_NONE) {
@@ -88,13 +99,35 @@ public class HollowOrdinalMapper {
 
         ordinalMappings[index] = assignedOrdinal;
         size++;
-        //designed to be overwritten
+
+        storeFields(typeState, ordinal, index);
+
         this.assignedOrdinalToIndex.put(assignedOrdinal, index);
         return index;
     }
 
-    public int getIndex(int ordinal) {
-        return this.assignedOrdinalToIndex.get(ordinal);
+    private void expandTable() {
+        Integer[] newOrdinalMapping = new Integer[ordinalMappings.length * 2];
+        System.arraycopy(ordinalMappings, 0, newOrdinalMapping, 0, ordinalMappings.length);
+        ordinalMappings = newOrdinalMapping;
+        System.exit(1);
+        //TODO: support rehashing
+    }
+
+    private void storeFields(HollowObjectTypeReadState typeState, int ordinal, int index) {
+        if(!indexFieldObjectMapping.containsKey(index))
+            indexFieldObjectMapping.put(index, new Object[primaryKey.numFields()]);
+        for(int i=0;i<primaryKey.numFields();i++) {
+            if(!keyFieldIsIndexed[i])
+                continue;
+            Object objectToStore = readValueInState(typeState, ordinal, i);
+            indexFieldObjectMapping.get(index)[i] = memoizedPool.intern(objectToStore);
+        }
+    }
+
+    public Object getFieldObject(int keyOrdinal, int fieldIndex) {
+        int index = assignedOrdinalToIndex.get(keyOrdinal);
+        return indexFieldObjectMapping.get(index)[fieldIndex];
     }
 
     private int hashKeyRecord(HollowObjectTypeReadState typeState, int ordinal) {
@@ -107,7 +140,7 @@ public class HollowOrdinalMapper {
     }
 
     //taken and modified from HollowPrimaryKeyValueDeriver
-    private Object readValue(HollowObjectTypeReadState typeState, int ordinal, int fieldIdx) {
+    private Object readValueInState(HollowObjectTypeReadState typeState, int ordinal, int fieldIdx) {
         HollowObjectSchema schema = typeState.getSchema();
 
         int lastFieldPath = keyFieldIndices[fieldIdx].length - 1;

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -1,0 +1,123 @@
+package com.netflix.hollow.tools.history.keyindex;
+
+import com.netflix.hollow.core.index.key.PrimaryKey;
+import com.netflix.hollow.core.memory.encoding.HashCodes;
+import com.netflix.hollow.core.read.HollowReadFieldUtils;
+import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+
+import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class HollowOrdinalMapper {
+    // Open addressing/linear probing, hashed ordinals to assigned ordinals
+    // If hash collision and
+    final private Integer[] ordinalMappings;
+    private final HashMap<Integer, Object[]> ordinalFieldObjectMapping;
+    private final HashMap<Integer, Integer> assignedOrdinalToIndex;
+    private int size = 0;
+    private static final double LOAD_FACTOR = 0.7;
+
+    private final PrimaryKey primaryKey;
+    private final int[][] keyFieldIndices;
+
+    public HollowOrdinalMapper(PrimaryKey primaryKey, int[][] keyFieldIndices, HashMap<Integer, Object[]> ofom) {
+        // Start with prime number to assist OA
+        this.ordinalMappings = new Integer[2069];
+        Arrays.fill(this.ordinalMappings, ORDINAL_NONE);
+
+        this.primaryKey = primaryKey;
+        this.keyFieldIndices = keyFieldIndices;
+        this.ordinalFieldObjectMapping = ofom;
+        this.assignedOrdinalToIndex = new HashMap<>();
+    }
+
+    public int findAssignedOrdinal(HollowObjectTypeReadState typeState, int keyOrdinal) {
+        int hashedRecord = hashKeyRecord(typeState, keyOrdinal);
+        int index = modulus(hashedRecord, ordinalMappings.length);
+        while (ordinalMappings[index]!=ORDINAL_NONE) {
+            if(recordsAreEqual(typeState, keyOrdinal, hashedRecord))
+                return ordinalMappings[index];
+            index = (index + 1) % ordinalMappings.length;
+        }
+        return ORDINAL_NONE;
+    }
+
+    private boolean recordsAreEqual(HollowObjectTypeReadState typeState, int keyOrdinal, int hashedRecord) {
+        int keyHash = hashKeyRecord(typeState, keyOrdinal);
+        if(keyHash!=hashedRecord) {
+            return false;
+        }
+        int index = modulus(hashedRecord, ordinalMappings.length);
+        for(int i=0;i<primaryKey.numFields();i++) {
+            Object newFieldValue = readValue(typeState, keyOrdinal, i);
+            Object existingFieldValue = ordinalFieldObjectMapping.get(index)[i];
+            if(!newFieldValue.equals(existingFieldValue)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int modulus(int dividend, int divisor) {
+        int modulus = dividend % divisor;
+        return modulus < 0 ? modulus + divisor : modulus;
+    }
+
+    //returns stored index
+    public int storeNewOrdinal(HollowObjectTypeReadState typeState, int ordinal, int assignedOrdinal) {
+        int hashedRecord = hashKeyRecord(typeState, ordinal);
+
+        if ((double) size / ordinalMappings.length > LOAD_FACTOR) {
+            System.exit(1); //implement later
+            //expandTable();
+        }
+
+        int index = modulus(hashedRecord, ordinalMappings.length);
+
+        // Linear probing
+        while (ordinalMappings[index] != ORDINAL_NONE) {
+            if(recordsAreEqual(typeState, ordinal, index)) {
+                //TODO: not ordinal, shouldn't return ORDINAL_NONE
+                this.assignedOrdinalToIndex.put(assignedOrdinal, index);
+                return ORDINAL_NONE;
+            }
+            index = (index + 1) % ordinalMappings.length;
+        }
+
+        ordinalMappings[index] = assignedOrdinal;
+        size++;
+        //designed to be overwritten
+        this.assignedOrdinalToIndex.put(assignedOrdinal, index);
+        return index;
+    }
+
+    public int getIndex(int ordinal) {
+        return this.assignedOrdinalToIndex.get(ordinal);
+    }
+
+    private int hashKeyRecord(HollowObjectTypeReadState typeState, int ordinal) {
+        int hashCode = 0;
+        for (int i = 0; i < primaryKey.numFields(); i++) {
+            int fieldHashCode = HollowReadFieldUtils.fieldHashCode(typeState, ordinal, i);
+            hashCode = (hashCode * 31) ^ fieldHashCode;
+        }
+        return HashCodes.hashInt(hashCode);
+    }
+
+    //taken and modified from HollowPrimaryKeyValueDeriver
+    private Object readValue(HollowObjectTypeReadState typeState, int ordinal, int fieldIdx) {
+        HollowObjectSchema schema = typeState.getSchema();
+
+        int lastFieldPath = keyFieldIndices[fieldIdx].length - 1;
+        for (int i = 0; i < lastFieldPath; i++) {
+            int fieldPosition = keyFieldIndices[fieldIdx][i];
+            ordinal = typeState.readOrdinal(ordinal, fieldPosition);
+            typeState = (HollowObjectTypeReadState) schema.getReferencedTypeState(fieldPosition);
+            schema = typeState.getSchema();
+        }
+
+        return HollowReadFieldUtils.fieldValueObject(typeState, ordinal, keyFieldIndices[fieldIdx][lastFieldPath]);
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -124,7 +124,7 @@ public class HollowOrdinalMapper {
                 continue;
 
             Object objectToStore = readValueInState(typeState, ordinal, i);
-            indexFieldObjectMapping.get(index)[i] = memoizedPool.intern(objectToStore);
+            indexFieldObjectMapping.get(index)[i] = objectToStore;
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -90,10 +90,13 @@ public class HollowOrdinalMapper {
 
             Object newFieldValue = readValueInState(typeState, keyOrdinal, fieldIdx);
             int existingFieldOrdinalValue = indexFieldOrdinalMapping.get(index)[fieldIdx];
-            if(memoizedPool.writtenInCycle(existingFieldOrdinalValue))
+
+            //Assuming two records in the same cycle cannot be equal
+            if(memoizedPool.ordinalInCurrentCycle(existingFieldOrdinalValue)) {
                 return false;
+            }
             Object existingFieldObjectValue = memoizedPool.getObject(existingFieldOrdinalValue, keyFieldTypes[fieldIdx]);
-            if(!newFieldValue.equals(existingFieldObjectValue)) {
+            if (!newFieldValue.equals(existingFieldObjectValue)) {
                 return false;
             }
         }

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -57,23 +57,17 @@ public class HollowOrdinalMapper {
     }
 
     private boolean recordsAreEqual(HollowObjectTypeReadState typeState, int keyOrdinal, int index) {
-        for(int i=0;i<primaryKey.numFields();i++) {
-            if(!keyFieldIsIndexed[i])
+        for(int fieldIdx=0;fieldIdx<primaryKey.numFields();fieldIdx++) {
+            if(!keyFieldIsIndexed[fieldIdx])
                 continue;
 
-            Object newFieldValue = readValueInState(typeState, keyOrdinal, i);
-            Object existingFieldValue = indexFieldObjectMapping.get(index)[i];
+            Object newFieldValue = readValueInState(typeState, keyOrdinal, fieldIdx);
+            Object existingFieldValue = indexFieldObjectMapping.get(index)[fieldIdx];
             if(!newFieldValue.equals(existingFieldValue)) {
                 return false;
             }
         }
         return true;
-    }
-
-    // Java modulo is more like a remainder, indices can't be negative
-    private static int indexFromHash(int hashedValue, int length) {
-        int modulus = hashedValue % length;
-        return modulus < 0 ? modulus + length : modulus;
     }
 
     public int storeNewRecord(HollowObjectTypeReadState typeState, int ordinal, int assignedOrdinal) {
@@ -113,8 +107,7 @@ public class HollowOrdinalMapper {
                 continue;
 
             Object objectToStore = readValueInState(typeState, ordinal, i);
-            //indexFieldObjectMapping.get(index)[i] = memoizedPool.intern(objectToStore);
-            indexFieldObjectMapping.get(index)[i] = objectToStore;
+            indexFieldObjectMapping.get(index)[i] = memoizedPool.intern(objectToStore);
         }
     }
 
@@ -177,5 +170,11 @@ public class HollowOrdinalMapper {
         }
 
         return HollowReadFieldUtils.fieldValueObject(typeState, ordinal, keyFieldIndices[fieldIdx][lastFieldPath]);
+    }
+
+    // Java modulo is more like a remainder, indices can't be negative
+    private static int indexFromHash(int hashedValue, int length) {
+        int modulus = hashedValue % length;
+        return modulus < 0 ? modulus + length : modulus;
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -36,8 +36,8 @@ public class HollowOrdinalMapper {
     private int size = 0;
     private static final double LOAD_FACTOR = 0.7;
     
-    private Integer[] ordinalMappings;
-    private Integer[] originalHash;
+    private int[] ordinalMappings;
+    private int[] originalHash;
 
     private HashMap<Integer, int[]> indexFieldOrdinalMapping;
     private final HashMap<Integer, Integer> assignedOrdinalToIndex;
@@ -51,8 +51,8 @@ public class HollowOrdinalMapper {
 
     public HollowOrdinalMapper(PrimaryKey primaryKey, boolean[] keyFieldIsIndexed, int[][] keyFieldIndices, FieldType[] keyFieldTypes) {
         // Start with prime number to assist OA
-        this.ordinalMappings = new Integer[2069];
-        this.originalHash = new Integer[2069];
+        this.ordinalMappings = new int[2069];
+        this.originalHash = new int[2069];
         Arrays.fill(this.ordinalMappings, ORDINAL_NONE);
 
         this.primaryKey = primaryKey;
@@ -146,10 +146,10 @@ public class HollowOrdinalMapper {
     }
 
     private void expandAndRehashTable() {
-        Integer[] newTable = new Integer[ordinalMappings.length*2];
+        int[] newTable = new int[ordinalMappings.length*2];
         Arrays.fill(newTable, ORDINAL_NONE);
 
-        Integer[] newOriginalHash = new Integer[originalHash.length*2];
+        int[] newOriginalHash = new int[originalHash.length*2];
         HashMap<Integer, int[]> newIndexFieldObjectMapping = new HashMap<>();
 
         for(int i=0;i<ordinalMappings.length;i++) {
@@ -178,7 +178,7 @@ public class HollowOrdinalMapper {
         this.indexFieldOrdinalMapping = newIndexFieldObjectMapping;
     }
 
-    private int rehashExistingRecord(Integer[] newTable, int originalHash, int assignedOrdinal) {
+    private int rehashExistingRecord(int[] newTable, int originalHash, int assignedOrdinal) {
         int newIndex = indexFromHash(originalHash, newTable.length);
         while (newTable[newIndex]!=ORDINAL_NONE)
             newIndex = (newIndex + 1) % newTable.length;

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
@@ -91,10 +91,6 @@ public class ObjectInternPool {
         return new String(bytes);
     }
 
-    //TODO: consider splitting into individual functions?
-    //NOTE: this function is inefficient if repeatedly read/write
-    //designed to read, then write, etc
-    //TODO: see if this can be improved
     public int writeAndGetOrdinal(Object objectToIntern) {
         ByteDataArray buf = new ByteDataArray();
         if(objectToIntern==null) {
@@ -115,19 +111,13 @@ public class ObjectInternPool {
             long longBits = (long) objectToIntern;
             VarInt.writeVLong(buf, longBits);
         } else if(objectToIntern instanceof String) {
-            //add length to beginning of string
             VarInt.writeVInt(buf, ((String) objectToIntern).length());
             for (byte b : ((String) objectToIntern).getBytes()) {
                 buf.write(b);
             }
         } else if(objectToIntern instanceof Boolean) {
-            //for consistency
-            boolean bool = (boolean) objectToIntern;
-            if(bool) {
-                VarInt.writeVInt(buf, 1);
-            } else {
-                VarInt.writeVInt(buf, 0);
-            }
+            int valToWrite = (boolean) objectToIntern ? 1 : 0;
+            VarInt.writeVInt(buf, valToWrite);
         } else {
             String className = objectToIntern.getClass().getName();
             throw new IllegalArgumentException("Cannot intern object of type " + className);

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
@@ -6,6 +6,7 @@ import com.netflix.hollow.core.memory.ByteData;
 import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.util.HashSet;
+import java.util.Optional;
 
 
 // This class memoizes types by returning references to existing objects, or storing
@@ -20,10 +21,6 @@ public class ObjectInternPool {
         this.ordinalsInCycle = new HashSet<>();
     }
 
-    public boolean writtenInCycle(int ordinal) {
-        return ordinalsInCycle.contains(ordinal);
-    }
-
     public void prepareForRead() {
         if(!isReadyToRead) {
             ordinalMap.prepareForWrite();
@@ -32,14 +29,12 @@ public class ObjectInternPool {
         isReadyToRead = true;
     }
 
-    //WARNING: assumes already ready to read
-    public Object getObject(int ordinal, FieldType type) {
-        prepareForRead();
+    public boolean ordinalInCurrentCycle(int ordinal) {
+        return ordinalsInCycle.contains(ordinal);
+    }
 
+    public Object getObject(int ordinal, FieldType type) {
         long pointer = ordinalMap.getPointerForData(ordinal);
-        if (pointer==-1L) {
-            return null;
-        }
 
         switch (type) {
             case BOOLEAN:

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
@@ -1,68 +1,148 @@
 package com.netflix.hollow.tools.util;
 
-import java.util.Map;
-import java.util.HashMap;
+import com.netflix.hollow.core.memory.ByteArrayOrdinalMap;
+import com.netflix.hollow.core.memory.ByteDataArray;
+import com.netflix.hollow.core.memory.ByteData;
+import com.netflix.hollow.core.memory.encoding.VarInt;
+
 
 // This class memoizes types by returning references to existing objects, or storing
 // Objects if they are not currently in the pool
 public class ObjectInternPool {
-    final private GenericInternPool<Integer> integerInternPool = new GenericInternPool<>();
-    final private GenericInternPool<Float> floatInternPool = new GenericInternPool<>();
-    final private GenericInternPool<Double> doubleInternPool = new GenericInternPool<>();
-    final private GenericInternPool<Long> longInternPool = new GenericInternPool<>();
+    final private ByteArrayOrdinalMap ordinalMap;
+    private boolean isReadyToRead = false;
+    public ObjectInternPool() {
+        this.ordinalMap = new ByteArrayOrdinalMap(1024);
+    }
 
-    public Object intern(Object objectToIntern) {
+    private void ensureReadyToRead() {
+        if(!isReadyToRead) {
+            ordinalMap.prepareForWrite();
+        }
+        isReadyToRead = true;
+    }
+
+    public boolean getBoolean(int ordinal) {
+        ensureReadyToRead();
+
+        long pointer = ordinalMap.getPointerForData(ordinal);
+        if (pointer==-1L) {
+            return false;
+        }
+
+        ByteData byteData = ordinalMap.getByteData().getUnderlyingArray();
+        return byteData.get(pointer) == 1;
+    }
+
+    public float getFloat(int ordinal) {
+        ensureReadyToRead();
+
+        long pointer = ordinalMap.getPointerForData(ordinal);
+        if (pointer==-1L) {
+            return Float.NaN; //TODO: could have actual NaN's in memory, bad way of representing "not found"
+        }
+
+        ByteData byteData = ordinalMap.getByteData().getUnderlyingArray();
+        int intBytes = VarInt.readVInt(byteData, pointer);
+        return Float.intBitsToFloat(intBytes);
+    }
+
+    public double getDouble(int ordinal) {
+        ensureReadyToRead();
+
+        long pointer = ordinalMap.getPointerForData(ordinal);
+        if (pointer==-1L) {
+            return Double.NaN; //TODO: could have actual NaN's in memory, bad way of representing "not found"
+        }
+
+        ByteData byteData = ordinalMap.getByteData().getUnderlyingArray();
+        long longBytes = VarInt.readVLong(byteData, pointer);
+        return Double.longBitsToDouble(longBytes);
+    }
+
+    public int getInt(int ordinal) {
+        ensureReadyToRead();
+
+        long pointer = ordinalMap.getPointerForData(ordinal);
+        if (pointer==-1L) {
+            return -1; //TODO: could have actual -1's in memory, bad way of representing "not found"
+        }
+
+        ByteData byteData = ordinalMap.getByteData().getUnderlyingArray();
+        return VarInt.readVInt(byteData, pointer);
+    }
+
+    public long getLong(int ordinal) {
+        ensureReadyToRead();
+
+        long pointer = ordinalMap.getPointerForData(ordinal);
+        if (pointer==-1L) {
+            return -1L; //TODO: could have actual -1's in memory, bad way of representing "not found"
+        }
+
+        ByteData byteData = ordinalMap.getByteData().getUnderlyingArray();
+        return VarInt.readVLong(byteData, pointer);
+    }
+
+    public String getString(int ordinal) {
+        ensureReadyToRead();
+
+        long pointer = ordinalMap.getPointerForData(ordinal);
+        if (pointer==-1L) {
+            return null;
+        }
+
+        ByteData byteData = ordinalMap.getByteData().getUnderlyingArray();
+        int length = byteData.get(pointer);
+        byte[] bytes = new byte[length];
+        for(int i=0;i<length;i++) {
+            bytes[i] = byteData.get(pointer+1+i);
+        }
+        return new String(bytes);
+    }
+
+    //TODO: consider splitting into individual functions?
+    //NOTE: this function is inefficient if repeatedly read/write
+    //designed to read, then write, etc
+    //TODO: see if this can be improved
+    public int writeAndGetOrdinal(Object objectToIntern) {
+        ByteDataArray buf = new ByteDataArray();
         if(objectToIntern==null) {
             throw new IllegalArgumentException("Cannot intern null objects");
         }
-
-        // Automatically handles booleans and integers within cached range
-        if(objectAutomaticallyCached(objectToIntern)) {
-            return objectToIntern;
-        }
+        isReadyToRead = false;
 
         if(objectToIntern instanceof Float) {
-            return floatInternPool.intern((Float) objectToIntern);
+            int intBits = Float.floatToIntBits((Float) objectToIntern);
+            VarInt.writeVInt(buf, intBits);
         } else if(objectToIntern instanceof Double) {
-            return doubleInternPool.intern((Double) objectToIntern);
+            long longBits = Double.doubleToLongBits((Double) objectToIntern);
+            VarInt.writeVLong(buf, longBits);
         } else if(objectToIntern instanceof Integer) {
-            return integerInternPool.intern((Integer) objectToIntern);
+            int intBits = (int) objectToIntern;
+            VarInt.writeVInt(buf, intBits);
         } else if(objectToIntern instanceof Long) {
-            return longInternPool.intern((Long) objectToIntern);
+            long longBits = (long) objectToIntern;
+            VarInt.writeVLong(buf, longBits);
         } else if(objectToIntern instanceof String) {
-            // Use Java's builtin intern function
-            return ((String) objectToIntern).intern();
+            //add length to beginning of string
+            VarInt.writeVInt(buf, ((String) objectToIntern).length());
+            for (byte b : ((String) objectToIntern).getBytes()) {
+                buf.write(b);
+            }
+        } else if(objectToIntern instanceof Boolean) {
+            //for consistency
+            boolean bool = (boolean) objectToIntern;
+            if(bool) {
+                VarInt.writeVInt(buf, 1);
+            } else {
+                VarInt.writeVInt(buf, 0);
+            }
         } else {
             String className = objectToIntern.getClass().getName();
             throw new IllegalArgumentException("Cannot intern object of type " + className);
         }
-    }
 
-    private boolean objectAutomaticallyCached(Object objectToIntern) {
-        if(objectToIntern instanceof Boolean) {
-            return true;
-        } else if(objectToIntern instanceof Integer) {
-            return -128 <= (Integer) objectToIntern && (Integer) objectToIntern <= 127;
-        }
-        return false;
-    }
-}
-
-class GenericInternPool<T> {
-    private final Map<T, T> pool = new HashMap<>();
-
-    public T intern(T object) {
-        if (object == null) {
-            throw new IllegalArgumentException("Cannot intern null objects");
-        }
-
-        synchronized (pool) {
-            T interned = pool.get(object);
-            if (interned == null) {
-                interned = object;
-                pool.put(object, object);
-            }
-            return interned;
-        }
+        return ordinalMap.getOrAssignOrdinal(buf);
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
@@ -1,0 +1,56 @@
+package com.netflix.hollow.tools.util;
+
+import java.util.Map;
+import java.util.HashMap;
+
+// This class memoizes types by returning references to existing objects, or storing
+// Objects if they are not currently in the pool
+public class ObjectInternPool {
+    final private GenericInternPool<Integer> integerInternPool = new GenericInternPool<Integer>();
+    final private GenericInternPool<Float> floatInternPool = new GenericInternPool<Float>();
+    final private GenericInternPool<Double> doubleInternPool = new GenericInternPool<Double>();
+    // Only two possible values (and technically null), no reason for hashmap
+    final Boolean falseBool = false;
+    final Boolean trueBool = true;
+
+    public Object intern(Object objectToIntern) {
+        if(objectToIntern==null) {
+            throw new IllegalArgumentException("Cannot intern null objects");
+        }
+
+        if(objectToIntern instanceof Float) {
+            return floatInternPool.intern((Float) objectToIntern);
+        } else if(objectToIntern instanceof Double) {
+            return doubleInternPool.intern((Double) objectToIntern);
+        } else if(objectToIntern instanceof Integer) {
+            return integerInternPool.intern((Integer) objectToIntern);
+        } else if(objectToIntern instanceof String) {
+            //just use Java's builtin intern function
+            return ((String) objectToIntern).intern();
+        } else if(objectToIntern instanceof Boolean) {
+            return (Boolean) objectToIntern ? trueBool : falseBool;
+        } else {
+            String className = objectToIntern.getClass().getName();
+            throw new IllegalArgumentException("Cannot intern object of type " + className);
+        }
+    }
+}
+
+class GenericInternPool<T> {
+    private final Map<T, T> pool = new HashMap<>();
+
+    public T intern(T object) {
+        if (object == null) {
+            throw new IllegalArgumentException("Cannot intern null objects");
+        }
+
+        synchronized (pool) {
+            T interned = pool.get(object);
+            if (interned == null) {
+                interned = object;
+                pool.put(object, object);
+            }
+            return interned;
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
@@ -6,16 +6,19 @@ import java.util.HashMap;
 // This class memoizes types by returning references to existing objects, or storing
 // Objects if they are not currently in the pool
 public class ObjectInternPool {
-    final private GenericInternPool<Integer> integerInternPool = new GenericInternPool<Integer>();
-    final private GenericInternPool<Float> floatInternPool = new GenericInternPool<Float>();
-    final private GenericInternPool<Double> doubleInternPool = new GenericInternPool<Double>();
-    // Only two possible values (and technically null), no reason for hashmap
-    final Boolean falseBool = false;
-    final Boolean trueBool = true;
+    final private GenericInternPool<Integer> integerInternPool = new GenericInternPool<>();
+    final private GenericInternPool<Float> floatInternPool = new GenericInternPool<>();
+    final private GenericInternPool<Double> doubleInternPool = new GenericInternPool<>();
+    final private GenericInternPool<Long> longInternPool = new GenericInternPool<>();
 
     public Object intern(Object objectToIntern) {
         if(objectToIntern==null) {
             throw new IllegalArgumentException("Cannot intern null objects");
+        }
+
+        // Automatically handles booleans and integers within cached range
+        if(objectAutomaticallyCached(objectToIntern)) {
+            return objectToIntern;
         }
 
         if(objectToIntern instanceof Float) {
@@ -24,15 +27,24 @@ public class ObjectInternPool {
             return doubleInternPool.intern((Double) objectToIntern);
         } else if(objectToIntern instanceof Integer) {
             return integerInternPool.intern((Integer) objectToIntern);
+        } else if(objectToIntern instanceof Long) {
+            return longInternPool.intern((Long) objectToIntern);
         } else if(objectToIntern instanceof String) {
-            //just use Java's builtin intern function
+            // Use Java's builtin intern function
             return ((String) objectToIntern).intern();
-        } else if(objectToIntern instanceof Boolean) {
-            return (Boolean) objectToIntern ? trueBool : falseBool;
         } else {
             String className = objectToIntern.getClass().getName();
             throw new IllegalArgumentException("Cannot intern object of type " + className);
         }
+    }
+
+    private boolean objectAutomaticallyCached(Object objectToIntern) {
+        if(objectToIntern instanceof Boolean) {
+            return true;
+        } else if(objectToIntern instanceof Integer) {
+            return -128 <= (Integer) objectToIntern && (Integer) objectToIntern <= 127;
+        }
+        return false;
     }
 }
 

--- a/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryRehashTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryRehashTest.java
@@ -1,0 +1,138 @@
+package com.netflix.hollow.tools.history;
+
+import com.netflix.hollow.core.AbstractStateEngineTest;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import com.netflix.hollow.tools.history.keyindex.HollowHistoryKeyIndex;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class HollowHistoryRehashTest extends AbstractStateEngineTest {
+    private HollowObjectSchema schema;
+
+    @Before
+    public void setUp() {
+        schema = new HollowObjectSchema("A", 2);
+        schema.addField("id", FieldType.FLOAT);
+        schema.addField("anotherField", FieldType.LONG);
+
+        super.setUp();
+    }
+
+    @Test
+    public void correctlyRehashesKeys_beforeAndAfterSnapshot() throws IOException {
+        HollowReadStateEngine readEngine = StateEngineRoundTripper.roundTripSnapshot(writeStateEngine);
+        HollowHistory history = new HollowHistory(readEngine, 1L, 1);
+        HollowHistoryKeyIndex keyIdx = new HollowHistoryKeyIndex(history);
+        keyIdx.addTypeIndex("A", "id", "anotherField");
+        keyIdx.indexTypeField("A", "id");
+        keyIdx.indexTypeField("A", "anotherField");
+
+        // Will rehash before 2069, otherwise couldn't store all values
+        for(int i=0;i<5000;i++) {
+            addRecord((float)i, (long)i);
+        }
+
+        roundTripSnapshot();
+        keyIdx.update(readStateEngine, false);
+
+        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) readStateEngine.getTypeState("A");
+
+        // Test objects before and after rehash
+        for(int ordinal=0;ordinal<5000;ordinal++) {
+            Assert.assertEquals(keyIdx.getRecordKeyOrdinal(typeState, ordinal), ordinal);
+            String expectedString = (float)ordinal+":"+ordinal;
+            Assert.assertEquals(keyIdx.getKeyDisplayString("A", ordinal), expectedString);
+        }
+    }
+
+    @Test
+    public void correctlyRehashesKeys_ignoresDuplicates() throws IOException {
+        HollowReadStateEngine readEngine = StateEngineRoundTripper.roundTripSnapshot(writeStateEngine);
+        HollowHistory history = new HollowHistory(readEngine, 1L, 1);
+        HollowHistoryKeyIndex keyIdx = new HollowHistoryKeyIndex(history);
+        keyIdx.addTypeIndex("A", "id", "anotherField");
+        keyIdx.indexTypeField("A", "id");
+        keyIdx.indexTypeField("A", "anotherField");
+
+        // Should ignore second ones and keep hashes of first
+        for(int i=0;i<5000;i++) {
+            addRecord((float)i, (long)i);
+        }
+
+        roundTripSnapshot();
+        keyIdx.update(readStateEngine, false);
+
+        for(int i=5000;i>0;i--) {
+            addRecord((float)i, (long)i);
+        }
+
+        roundTripSnapshot();
+        keyIdx.update(readStateEngine, false);
+
+        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) readStateEngine.getTypeState("A");
+
+        // Test objects before and after rehash
+        for(int ordinal=0;ordinal<5000;ordinal++) {
+            Assert.assertEquals(keyIdx.getRecordKeyOrdinal(typeState, ordinal), ordinal);
+            String expectedString = (float)ordinal+":"+ordinal;
+            Assert.assertEquals(keyIdx.getKeyDisplayString("A", ordinal), expectedString);
+        }
+    }
+
+    @Test
+    public void correctlyRehashesKeys_beforeAndAfterDelta() throws IOException {
+        HollowReadStateEngine readEngine = StateEngineRoundTripper.roundTripSnapshot(writeStateEngine);
+        HollowHistory history = new HollowHistory(readEngine, 1L, 1);
+        HollowHistoryKeyIndex keyIdx = new HollowHistoryKeyIndex(history);
+        keyIdx.addTypeIndex("A", "id", "anotherField");
+        keyIdx.indexTypeField("A", "id");
+        keyIdx.indexTypeField("A", "anotherField");
+
+        // Will rehash before 2069, otherwise couldn't store all values
+        for(int i=0;i<1000;i++) {
+            addRecord((float)i, (long)i);
+        }
+
+        roundTripSnapshot();
+        keyIdx.update(readStateEngine, false);
+
+        for(int i=1000;i<5000;i++) {
+            addRecord((float)i, (long)i);
+        }
+
+        roundTripDelta();
+        keyIdx.update(readStateEngine, true);
+
+        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) readStateEngine.getTypeState("A");
+
+        // Test objects before and after rehash
+        for(int ordinal=0;ordinal<5000;ordinal++) {
+            Assert.assertEquals(keyIdx.getRecordKeyOrdinal(typeState, ordinal), ordinal);
+            String expectedString = (float)ordinal+":"+ordinal;
+            Assert.assertEquals(keyIdx.getKeyDisplayString("A", ordinal), expectedString);
+        }
+    }
+
+    @Override
+    protected void initializeTypeStates() {
+        HollowObjectTypeWriteState writeState = new HollowObjectTypeWriteState(schema);
+        writeStateEngine.addTypeState(writeState);
+    }
+
+    private void addRecord(float id, Long secondId) {
+        HollowObjectWriteRecord aRec = new HollowObjectWriteRecord(schema);
+        aRec.setFloat("id", id);
+        aRec.setLong("anotherField", secondId);
+        writeStateEngine.add("A", aRec);
+    }
+
+}

--- a/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryRehashTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryRehashTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.tools.history;
 
 import com.netflix.hollow.core.AbstractStateEngineTest;

--- a/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryRehashTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryRehashTest.java
@@ -71,40 +71,6 @@ public class HollowHistoryRehashTest extends AbstractStateEngineTest {
     }
 
     @Test
-    public void correctlyRehashesKeys_ignoresDuplicates() throws IOException {
-        HollowReadStateEngine readEngine = StateEngineRoundTripper.roundTripSnapshot(writeStateEngine);
-        HollowHistory history = new HollowHistory(readEngine, 1L, 1);
-        HollowHistoryKeyIndex keyIdx = new HollowHistoryKeyIndex(history);
-        keyIdx.addTypeIndex("A", "id", "anotherField");
-        keyIdx.indexTypeField("A", "id");
-        keyIdx.indexTypeField("A", "anotherField");
-
-        // Should ignore second ones and keep hashes of first
-        for(int i=0;i<5000;i++) {
-            addRecord((float)i, (long)i);
-        }
-
-        roundTripSnapshot();
-        keyIdx.update(readStateEngine, false);
-
-        for(int i=5000;i>0;i--) {
-            addRecord((float)i, (long)i);
-        }
-
-        roundTripSnapshot();
-        keyIdx.update(readStateEngine, false);
-
-        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) readStateEngine.getTypeState("A");
-
-        // Test objects before and after rehash
-        for(int ordinal=0;ordinal<5000;ordinal++) {
-            Assert.assertEquals(keyIdx.getRecordKeyOrdinal(typeState, ordinal), ordinal);
-            String expectedString = (float)ordinal+":"+ordinal;
-            Assert.assertEquals(keyIdx.getKeyDisplayString("A", ordinal), expectedString);
-        }
-    }
-
-    @Test
     public void correctlyRehashesKeys_beforeAndAfterDelta() throws IOException {
         HollowReadStateEngine readEngine = StateEngineRoundTripper.roundTripSnapshot(writeStateEngine);
         HollowHistory history = new HollowHistory(readEngine, 1L, 1);

--- a/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
@@ -25,158 +25,131 @@ import org.junit.Test;
 
 public class ObjectInternPoolTest {
 
-    GenericInternPool<Integer> integerPool;
-    GenericInternPool<Float> floatPool;
-    GenericInternPool<Double> doublePool;
-    GenericInternPool<Long> longPool;
-    ObjectInternPool internPool;
+    ObjectInternPool internPool = new ObjectInternPool();
 
     @Before
     public void setup() {
-        integerPool = new GenericInternPool<>();
-        floatPool = new GenericInternPool<>();
-        doublePool = new GenericInternPool<>();
-        longPool = new GenericInternPool<>();
-
         internPool = new ObjectInternPool();
     }
 
     @Test
-    public void testInteger() {
-        // Java caches boxed integers between -127 and 128
-        // Must be outside that range to test interning
-        Integer intObj = 130;
-        Integer dupIntObj = 130;
+    public void testInt() {
+        Integer intObj1 = 130;
+        Integer intObj2 = 130;
 
-        Integer internedInt = integerPool.intern(intObj);
-        Integer dupInternedInt = integerPool.intern(dupIntObj);
+        int int1Ordinal = internPool.writeAndGetOrdinal(intObj1);
+        int int2Ordinal = internPool.writeAndGetOrdinal(intObj2);
 
-        assertNotSame(intObj, dupIntObj);
-        assertSame(internedInt, dupInternedInt);
-        assertEquals(intObj, internedInt);
+        assertEquals(int1Ordinal, int2Ordinal);
+        assertEquals(internPool.getInt(int1Ordinal), 130);
+
+        Integer intObj3 = 1900;
+        Integer intObj4 = 1900;
+
+        int int3Ordinal = internPool.writeAndGetOrdinal(intObj3);
+        int int4Ordinal = internPool.writeAndGetOrdinal(intObj4);
+
+        assertEquals(int3Ordinal, int4Ordinal);
+        assertEquals(internPool.getInt(int3Ordinal), 1900);
     }
 
     @Test
     public void testFloat() {
-        Float floatObj = 130f;
-        Float dupFloatObj = 130f;
+        Float floatObj1 = 130.0f;
+        Float floatObj2 = 130.0f;
+        Float floatObj3 = 1900.0f;
+        Float floatObj4 = 1900.0f;
 
-        Float internedFloat = floatPool.intern(floatObj);
-        Float dupInternedFloat = floatPool.intern(dupFloatObj);
+        int float1Ordinal = internPool.writeAndGetOrdinal(floatObj1);
+        int float2Ordinal = internPool.writeAndGetOrdinal(floatObj2);
 
-        assertNotSame(floatObj, dupFloatObj);
-        assertSame(internedFloat, dupInternedFloat);
-        assertEquals(floatObj, internedFloat);
-    }
+        assertEquals(float1Ordinal, float2Ordinal);
+        assertEquals(internPool.getFloat(float1Ordinal), 130.0f, 0.0f);
 
-    @Test
-    public void testDouble() {
-        Double doubleObj = 130d;
-        Double dupDoubleObj = 130d;
+        int float3Ordinal = internPool.writeAndGetOrdinal(floatObj3);
+        int float4Ordinal = internPool.writeAndGetOrdinal(floatObj4);
 
-        Double internedDouble = doublePool.intern(doubleObj);
-        Double dupInternedDouble = doublePool.intern(dupDoubleObj);
-
-        assertNotSame(doubleObj, dupDoubleObj);
-        assertSame(internedDouble, dupInternedDouble);
-        assertEquals(doubleObj, internedDouble);
+        assertEquals(float3Ordinal, float4Ordinal);
+        assertEquals(internPool.getFloat(float3Ordinal), 1900.0f, 0.0f);
     }
 
     @Test
     public void testLong() {
-        Long longObj = 130L;
-        Long dupLongObj = 130L;
+        Long longObj1 = 130L;
+        Long longObj2 = 130L;
+        Long longObj3 = 1900L;
+        Long longObj4 = 1900L;
 
-        Long internedLong = longPool.intern(longObj);
-        Long dupInternedLong = longPool.intern(dupLongObj);
+        int long1Ordinal = internPool.writeAndGetOrdinal(longObj1);
+        int long2Ordinal = internPool.writeAndGetOrdinal(longObj2);
 
-        assertNotSame(longObj, dupLongObj);
-        assertSame(internedLong, dupInternedLong);
-        assertEquals(longObj, internedLong);
+        assertEquals(long1Ordinal, long2Ordinal);
+        assertEquals(internPool.getLong(long1Ordinal), 130L);
+
+        int long3Ordinal = internPool.writeAndGetOrdinal(longObj3);
+        int long4Ordinal = internPool.writeAndGetOrdinal(longObj4);
+
+        assertEquals(long3Ordinal, long4Ordinal);
+        assertEquals(internPool.getLong(long3Ordinal), 1900L);
     }
 
     @Test
-    public void testAutoInternInteger() {
-        //Java should automatically cache these
-        Integer lowInt = -128;
-        Integer dupLowInt = -128;
+    public void testDouble() {
+        Double doubleObj1 = 130.0;
+        Double doubleObj2 = 130.0;
+        Double doubleObj3 = 1900.0;
+        Double doubleObj4 = 1900.0;
 
-        Integer highInt = 127;
-        Integer dupHighInt = 127;
+        int double1Ordinal = internPool.writeAndGetOrdinal(doubleObj1);
+        int double2Ordinal = internPool.writeAndGetOrdinal(doubleObj2);
 
-        Integer internedLow1 = integerPool.intern(lowInt);
-        Integer internedLow2 = integerPool.intern(dupLowInt);
+        assertEquals(double1Ordinal, double2Ordinal);
+        assertEquals(internPool.getDouble(double1Ordinal), 130.0, 0.0);
 
-        Integer internedHigh1 = integerPool.intern(highInt);
-        Integer internedHigh2 = integerPool.intern(dupHighInt);
+        int double3Ordinal = internPool.writeAndGetOrdinal(doubleObj3);
+        int double4Ordinal = internPool.writeAndGetOrdinal(doubleObj4);
 
-        assertSame(lowInt, dupLowInt);
-        assertSame(highInt, dupHighInt);
-
-        assertSame(internedLow1, internedLow2);
-        assertSame(internedHigh1, internedHigh2);
-
-        assertEquals(lowInt, internedLow1);
-        assertEquals(highInt, internedHigh1);
+        assertEquals(double3Ordinal, double4Ordinal);
+        assertEquals(internPool.getDouble(double3Ordinal), 1900.0, 0.0);
     }
 
     @Test
-    public void testAll() {
-        Integer intObj = 130;
-        Integer dupIntObj = 130;
+    public void testString() {
+        String stringObj1 = "I am Groot";
+        String stringObj2 = "I am Groot";
+        String stringObj3 = "I can do this all day";
+        String stringObj4 = "I can do this all day";
 
-        Float floatObj = 140f;
-        Float dupFloatObj = 140f;
+        int string1Ordinal = internPool.writeAndGetOrdinal(stringObj1);
+        int string2Ordinal = internPool.writeAndGetOrdinal(stringObj2);
 
-        Double doubleObj = 150d;
-        Double dupDoubleObj = 150d;
+        assertEquals(string1Ordinal, string2Ordinal);
+        assertEquals(internPool.getString(string1Ordinal), "I am Groot");
 
-        Long longObj = 160L;
-        Long dupLongObj = 160L;
+        int string3Ordinal = internPool.writeAndGetOrdinal(stringObj3);
+        int string4Ordinal = internPool.writeAndGetOrdinal(stringObj4);
 
-        String stringObj = new String("I am groot");
-        String dupStringObj = new String("I am groot");
+        assertEquals(string3Ordinal, string4Ordinal);
+        assertEquals(internPool.getString(string3Ordinal), "I can do this all day");
+    }
 
-        Boolean booleanObj = true;
-        Boolean dupBooleanObj = true;
+    @Test
+    public void testBool() {
+        Boolean boolObj1 = true;
+        Boolean boolObj2 = true;
+        Boolean boolObj3 = false;
+        Boolean boolObj4 = false;
 
-        assertNotSame(intObj, dupIntObj);
-        assertNotSame(floatObj, dupFloatObj);
-        assertNotSame(doubleObj, dupDoubleObj);
-        assertNotSame(stringObj, dupStringObj);
-        assertNotSame(longObj, dupLongObj);
-        //booleans always cached
+        int bool1Ordinal = internPool.writeAndGetOrdinal(boolObj1);
+        int bool2Ordinal = internPool.writeAndGetOrdinal(boolObj2);
 
-        Integer internedInt1 = (Integer)internPool.intern(intObj);
-        Integer internedInt2 = (Integer)internPool.intern(dupIntObj);
+        assertEquals(bool1Ordinal, bool2Ordinal);
+        assertEquals(internPool.getBoolean(bool1Ordinal), true);
 
-        Float internedFloat1 = (Float)internPool.intern(floatObj);
-        Float internedFloat2 = (Float)internPool.intern(dupFloatObj);
+        int bool3Ordinal = internPool.writeAndGetOrdinal(boolObj3);
+        int bool4Ordinal = internPool.writeAndGetOrdinal(boolObj4);
 
-        Double internedDouble1 = (Double)internPool.intern(doubleObj);
-        Double internedDouble2 = (Double)internPool.intern(dupDoubleObj);
-
-        Long internedLong1 = (Long)internPool.intern(longObj);
-        Long internedLong2 = (Long)internPool.intern(dupLongObj);
-
-        String internedString1 = (String)internPool.intern(stringObj);
-        String internedString2 = (String)internPool.intern(dupStringObj);
-
-        Boolean internedBoolean1 = (Boolean)internPool.intern(booleanObj);
-        Boolean internedBoolean2 = (Boolean)internPool.intern(dupBooleanObj);
-
-        assertSame(internedInt1, internedInt2);
-        assertSame(internedFloat1, internedFloat2);
-        assertSame(internedDouble1, internedDouble2);
-        assertSame(internedLong1, internedLong2);
-        assertSame(internedString1, internedString2);
-        assertSame(internedBoolean1, internedBoolean2);
-
-        assertEquals(intObj, internedInt1);
-        assertEquals(floatObj, internedFloat1);
-        assertEquals(doubleObj, internedDouble1);
-        assertEquals(longObj, internedLong1);
-        assertEquals(stringObj, internedString1);
-        assertEquals(booleanObj, internedBoolean1);
+        assertEquals(bool3Ordinal, bool4Ordinal);
+        assertEquals(internPool.getBoolean(bool3Ordinal), false);
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
@@ -1,0 +1,166 @@
+package com.netflix.hollow.tools.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ObjectInternPoolTest {
+
+    GenericInternPool<Integer> integerPool;
+    GenericInternPool<Float> floatPool;
+    GenericInternPool<Double> doublePool;
+    GenericInternPool<Long> longPool;
+    ObjectInternPool internPool;
+
+    @Before
+    public void setup() {
+        integerPool = new GenericInternPool<>();
+        floatPool = new GenericInternPool<>();
+        doublePool = new GenericInternPool<>();
+        longPool = new GenericInternPool<>();
+
+        internPool = new ObjectInternPool();
+    }
+
+    @Test
+    public void testInteger() {
+        // Java caches boxed integers between -127 and 128
+        // Must be outside that range to test interning
+        Integer intObj = 130;
+        Integer dupIntObj = 130;
+
+        Integer internedInt = integerPool.intern(intObj);
+        Integer dupInternedInt = integerPool.intern(dupIntObj);
+
+        assertNotSame(intObj, dupIntObj);
+        assertSame(internedInt, dupInternedInt);
+        assertEquals(intObj, internedInt);
+    }
+
+    @Test
+    public void testFloat() {
+        Float floatObj = 130f;
+        Float dupFloatObj = 130f;
+
+        Float internedFloat = floatPool.intern(floatObj);
+        Float dupInternedFloat = floatPool.intern(dupFloatObj);
+
+        assertNotSame(floatObj, dupFloatObj);
+        assertSame(internedFloat, dupInternedFloat);
+        assertEquals(floatObj, internedFloat);
+    }
+
+    @Test
+    public void testDouble() {
+        Double doubleObj = 130d;
+        Double dupDoubleObj = 130d;
+
+        Double internedDouble = doublePool.intern(doubleObj);
+        Double dupInternedDouble = doublePool.intern(dupDoubleObj);
+
+        assertNotSame(doubleObj, dupDoubleObj);
+        assertSame(internedDouble, dupInternedDouble);
+        assertEquals(doubleObj, internedDouble);
+    }
+
+    @Test
+    public void testLong() {
+        Long longObj = 130L;
+        Long dupLongObj = 130L;
+
+        Long internedLong = longPool.intern(longObj);
+        Long dupInternedLong = longPool.intern(dupLongObj);
+
+        assertNotSame(longObj, dupLongObj);
+        assertSame(internedLong, dupInternedLong);
+        assertEquals(longObj, internedLong);
+    }
+
+    @Test
+    public void testAutoInternInteger() {
+        //Java should automatically cache these
+        Integer lowInt = -128;
+        Integer dupLowInt = -128;
+
+        Integer highInt = 127;
+        Integer dupHighInt = 127;
+
+        Integer internedLow1 = integerPool.intern(lowInt);
+        Integer internedLow2 = integerPool.intern(dupLowInt);
+
+        Integer internedHigh1 = integerPool.intern(highInt);
+        Integer internedHigh2 = integerPool.intern(dupHighInt);
+
+        assertSame(lowInt, dupLowInt);
+        assertSame(highInt, dupHighInt);
+
+        assertSame(internedLow1, internedLow2);
+        assertSame(internedHigh1, internedHigh2);
+
+        assertEquals(lowInt, internedLow1);
+        assertEquals(highInt, internedHigh1);
+    }
+
+    @Test
+    public void testAll() {
+        Integer intObj = 130;
+        Integer dupIntObj = 130;
+
+        Float floatObj = 140f;
+        Float dupFloatObj = 140f;
+
+        Double doubleObj = 150d;
+        Double dupDoubleObj = 150d;
+
+        Long longObj = 160L;
+        Long dupLongObj = 160L;
+
+        String stringObj = new String("I am groot");
+        String dupStringObj = new String("I am groot");
+
+        Boolean booleanObj = true;
+        Boolean dupBooleanObj = true;
+
+        assertNotSame(intObj, dupIntObj);
+        assertNotSame(floatObj, dupFloatObj);
+        assertNotSame(doubleObj, dupDoubleObj);
+        assertNotSame(stringObj, dupStringObj);
+        assertNotSame(longObj, dupLongObj);
+        //booleans always cached
+
+        Integer internedInt1 = (Integer)internPool.intern(intObj);
+        Integer internedInt2 = (Integer)internPool.intern(dupIntObj);
+
+        Float internedFloat1 = (Float)internPool.intern(floatObj);
+        Float internedFloat2 = (Float)internPool.intern(dupFloatObj);
+
+        Double internedDouble1 = (Double)internPool.intern(doubleObj);
+        Double internedDouble2 = (Double)internPool.intern(dupDoubleObj);
+
+        Long internedLong1 = (Long)internPool.intern(longObj);
+        Long internedLong2 = (Long)internPool.intern(dupLongObj);
+
+        String internedString1 = (String)internPool.intern(stringObj);
+        String internedString2 = (String)internPool.intern(dupStringObj);
+
+        Boolean internedBoolean1 = (Boolean)internPool.intern(booleanObj);
+        Boolean internedBoolean2 = (Boolean)internPool.intern(dupBooleanObj);
+
+        assertSame(internedInt1, internedInt2);
+        assertSame(internedFloat1, internedFloat2);
+        assertSame(internedDouble1, internedDouble2);
+        assertSame(internedLong1, internedLong2);
+        assertSame(internedString1, internedString2);
+        assertSame(internedBoolean1, internedBoolean2);
+
+        assertEquals(intObj, internedInt1);
+        assertEquals(floatObj, internedFloat1);
+        assertEquals(doubleObj, internedDouble1);
+        assertEquals(longObj, internedLong1);
+        assertEquals(stringObj, internedString1);
+        assertEquals(booleanObj, internedBoolean1);
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
@@ -17,8 +17,7 @@
 package com.netflix.hollow.tools.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -40,8 +39,10 @@ public class ObjectInternPoolTest {
         int int1Ordinal = internPool.writeAndGetOrdinal(intObj1);
         int int2Ordinal = internPool.writeAndGetOrdinal(intObj2);
 
+        int retrievedInt1 = (int) internPool.getObject(int1Ordinal, FieldType.INT);
+
         assertEquals(int1Ordinal, int2Ordinal);
-        assertEquals(internPool.getInt(int1Ordinal), 130);
+        assertEquals(retrievedInt1, 130);
 
         Integer intObj3 = 1900;
         Integer intObj4 = 1900;
@@ -49,8 +50,10 @@ public class ObjectInternPoolTest {
         int int3Ordinal = internPool.writeAndGetOrdinal(intObj3);
         int int4Ordinal = internPool.writeAndGetOrdinal(intObj4);
 
+        int retrievedInt3 = (int) internPool.getObject(int3Ordinal, FieldType.INT);
+
         assertEquals(int3Ordinal, int4Ordinal);
-        assertEquals(internPool.getInt(int3Ordinal), 1900);
+        assertEquals(retrievedInt3, 1900);
     }
 
     @Test
@@ -63,14 +66,18 @@ public class ObjectInternPoolTest {
         int float1Ordinal = internPool.writeAndGetOrdinal(floatObj1);
         int float2Ordinal = internPool.writeAndGetOrdinal(floatObj2);
 
+        float retrievedFloat1 = (float) internPool.getObject(float1Ordinal, FieldType.FLOAT);
+
         assertEquals(float1Ordinal, float2Ordinal);
-        assertEquals(internPool.getFloat(float1Ordinal), 130.0f, 0.0f);
+        assertEquals(retrievedFloat1, 130.0f, 0.0f);
 
         int float3Ordinal = internPool.writeAndGetOrdinal(floatObj3);
         int float4Ordinal = internPool.writeAndGetOrdinal(floatObj4);
 
+        float retrievedFloat2 = (float) internPool.getObject(float3Ordinal, FieldType.FLOAT);
+
         assertEquals(float3Ordinal, float4Ordinal);
-        assertEquals(internPool.getFloat(float3Ordinal), 1900.0f, 0.0f);
+        assertEquals(retrievedFloat2, 1900.0f, 0.0f);
     }
 
     @Test
@@ -83,14 +90,18 @@ public class ObjectInternPoolTest {
         int long1Ordinal = internPool.writeAndGetOrdinal(longObj1);
         int long2Ordinal = internPool.writeAndGetOrdinal(longObj2);
 
+        long retrievedLong1 = (Long) internPool.getObject(long1Ordinal, FieldType.LONG);
+
         assertEquals(long1Ordinal, long2Ordinal);
-        assertEquals(internPool.getLong(long1Ordinal), 130L);
+        assertEquals(retrievedLong1, 130L);
 
         int long3Ordinal = internPool.writeAndGetOrdinal(longObj3);
         int long4Ordinal = internPool.writeAndGetOrdinal(longObj4);
 
+        long retrievedLong2 = (Long) internPool.getObject(long3Ordinal, FieldType.LONG);
+
         assertEquals(long3Ordinal, long4Ordinal);
-        assertEquals(internPool.getLong(long3Ordinal), 1900L);
+        assertEquals(retrievedLong2, 1900L);
     }
 
     @Test
@@ -103,14 +114,18 @@ public class ObjectInternPoolTest {
         int double1Ordinal = internPool.writeAndGetOrdinal(doubleObj1);
         int double2Ordinal = internPool.writeAndGetOrdinal(doubleObj2);
 
+        double retrievedDouble1 = (double) internPool.getObject(double1Ordinal, FieldType.DOUBLE);
+
         assertEquals(double1Ordinal, double2Ordinal);
-        assertEquals(internPool.getDouble(double1Ordinal), 130.0, 0.0);
+        assertEquals(retrievedDouble1, 130.0, 0.0);
 
         int double3Ordinal = internPool.writeAndGetOrdinal(doubleObj3);
         int double4Ordinal = internPool.writeAndGetOrdinal(doubleObj4);
 
+        double retrievedDouble2 = (double) internPool.getObject(double3Ordinal, FieldType.DOUBLE);
+
         assertEquals(double3Ordinal, double4Ordinal);
-        assertEquals(internPool.getDouble(double3Ordinal), 1900.0, 0.0);
+        assertEquals(retrievedDouble2, 1900.0, 0.0);
     }
 
     @Test
@@ -123,14 +138,18 @@ public class ObjectInternPoolTest {
         int string1Ordinal = internPool.writeAndGetOrdinal(stringObj1);
         int string2Ordinal = internPool.writeAndGetOrdinal(stringObj2);
 
+        String retrievedString1 = (String) internPool.getObject(string1Ordinal, FieldType.STRING);
+
         assertEquals(string1Ordinal, string2Ordinal);
-        assertEquals(internPool.getString(string1Ordinal), "I am Groot");
+        assertEquals(retrievedString1, "I am Groot");
 
         int string3Ordinal = internPool.writeAndGetOrdinal(stringObj3);
         int string4Ordinal = internPool.writeAndGetOrdinal(stringObj4);
 
+        String retrievedString2 = (String) internPool.getObject(string3Ordinal, FieldType.STRING);
+
         assertEquals(string3Ordinal, string4Ordinal);
-        assertEquals(internPool.getString(string3Ordinal), "I can do this all day");
+        assertEquals(retrievedString2, "I can do this all day");
     }
 
     @Test
@@ -143,13 +162,17 @@ public class ObjectInternPoolTest {
         int bool1Ordinal = internPool.writeAndGetOrdinal(boolObj1);
         int bool2Ordinal = internPool.writeAndGetOrdinal(boolObj2);
 
+        boolean retrievedBool1 = (boolean) internPool.getObject(bool1Ordinal, FieldType.BOOLEAN);
+
         assertEquals(bool1Ordinal, bool2Ordinal);
-        assertEquals(internPool.getBoolean(bool1Ordinal), true);
+        assertEquals(retrievedBool1, true);
 
         int bool3Ordinal = internPool.writeAndGetOrdinal(boolObj3);
         int bool4Ordinal = internPool.writeAndGetOrdinal(boolObj4);
 
+        boolean retrievedBool2 = (boolean) internPool.getObject(bool3Ordinal, FieldType.BOOLEAN);
+
         assertEquals(bool3Ordinal, bool4Ordinal);
-        assertEquals(internPool.getBoolean(bool3Ordinal), false);
+        assertEquals(retrievedBool2, false);
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.hollow.tools.util;
 
 import static org.junit.Assert.assertEquals;

--- a/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
@@ -38,6 +38,7 @@ public class ObjectInternPoolTest {
 
         int int1Ordinal = internPool.writeAndGetOrdinal(intObj1);
         int int2Ordinal = internPool.writeAndGetOrdinal(intObj2);
+        internPool.prepareForRead();
 
         int retrievedInt1 = (int) internPool.getObject(int1Ordinal, FieldType.INT);
 
@@ -49,6 +50,7 @@ public class ObjectInternPoolTest {
 
         int int3Ordinal = internPool.writeAndGetOrdinal(intObj3);
         int int4Ordinal = internPool.writeAndGetOrdinal(intObj4);
+        internPool.prepareForRead();
 
         int retrievedInt3 = (int) internPool.getObject(int3Ordinal, FieldType.INT);
 
@@ -65,6 +67,7 @@ public class ObjectInternPoolTest {
 
         int float1Ordinal = internPool.writeAndGetOrdinal(floatObj1);
         int float2Ordinal = internPool.writeAndGetOrdinal(floatObj2);
+        internPool.prepareForRead();
 
         float retrievedFloat1 = (float) internPool.getObject(float1Ordinal, FieldType.FLOAT);
 
@@ -73,6 +76,7 @@ public class ObjectInternPoolTest {
 
         int float3Ordinal = internPool.writeAndGetOrdinal(floatObj3);
         int float4Ordinal = internPool.writeAndGetOrdinal(floatObj4);
+        internPool.prepareForRead();
 
         float retrievedFloat2 = (float) internPool.getObject(float3Ordinal, FieldType.FLOAT);
 
@@ -89,6 +93,7 @@ public class ObjectInternPoolTest {
 
         int long1Ordinal = internPool.writeAndGetOrdinal(longObj1);
         int long2Ordinal = internPool.writeAndGetOrdinal(longObj2);
+        internPool.prepareForRead();
 
         long retrievedLong1 = (Long) internPool.getObject(long1Ordinal, FieldType.LONG);
 
@@ -97,6 +102,7 @@ public class ObjectInternPoolTest {
 
         int long3Ordinal = internPool.writeAndGetOrdinal(longObj3);
         int long4Ordinal = internPool.writeAndGetOrdinal(longObj4);
+        internPool.prepareForRead();
 
         long retrievedLong2 = (Long) internPool.getObject(long3Ordinal, FieldType.LONG);
 
@@ -113,6 +119,7 @@ public class ObjectInternPoolTest {
 
         int double1Ordinal = internPool.writeAndGetOrdinal(doubleObj1);
         int double2Ordinal = internPool.writeAndGetOrdinal(doubleObj2);
+        internPool.prepareForRead();
 
         double retrievedDouble1 = (double) internPool.getObject(double1Ordinal, FieldType.DOUBLE);
 
@@ -121,6 +128,7 @@ public class ObjectInternPoolTest {
 
         int double3Ordinal = internPool.writeAndGetOrdinal(doubleObj3);
         int double4Ordinal = internPool.writeAndGetOrdinal(doubleObj4);
+        internPool.prepareForRead();
 
         double retrievedDouble2 = (double) internPool.getObject(double3Ordinal, FieldType.DOUBLE);
 
@@ -137,6 +145,7 @@ public class ObjectInternPoolTest {
 
         int string1Ordinal = internPool.writeAndGetOrdinal(stringObj1);
         int string2Ordinal = internPool.writeAndGetOrdinal(stringObj2);
+        internPool.prepareForRead();
 
         String retrievedString1 = (String) internPool.getObject(string1Ordinal, FieldType.STRING);
 
@@ -145,6 +154,7 @@ public class ObjectInternPoolTest {
 
         int string3Ordinal = internPool.writeAndGetOrdinal(stringObj3);
         int string4Ordinal = internPool.writeAndGetOrdinal(stringObj4);
+        internPool.prepareForRead();
 
         String retrievedString2 = (String) internPool.getObject(string3Ordinal, FieldType.STRING);
 
@@ -161,6 +171,7 @@ public class ObjectInternPoolTest {
 
         int bool1Ordinal = internPool.writeAndGetOrdinal(boolObj1);
         int bool2Ordinal = internPool.writeAndGetOrdinal(boolObj2);
+        internPool.prepareForRead();
 
         boolean retrievedBool1 = (boolean) internPool.getObject(bool1Ordinal, FieldType.BOOLEAN);
 
@@ -169,6 +180,7 @@ public class ObjectInternPoolTest {
 
         int bool3Ordinal = internPool.writeAndGetOrdinal(boolObj3);
         int bool4Ordinal = internPool.writeAndGetOrdinal(boolObj4);
+        internPool.prepareForRead();
 
         boolean retrievedBool2 = (boolean) internPool.getObject(bool3Ordinal, FieldType.BOOLEAN);
 


### PR DESCRIPTION
This PR introduces a major optimization to the HollowHistoryTypeKeyIndex to significantly reduce unnecessary state update round trips. Consequently, performance and memory management are substantially enhanced.

**Architectural Overview:**

Leveraging the **`HollowOrdinalMapper`**, the architecture now utilizes open-addressed hash tables with linear probing to manage associations such as:
1. Mappings from hashed records to assigned ordinals.
2. Associations of hashed records with int[] of field object ordinals.
3. Mapping hashed fields to their assigned ordinals.
4. Assigned ordinals to their corresponding locations in arrays from points 1 & 2.

**Key Benefits:**

1. **Streamlined Updates:** State mappings now instantly reflect the latest typeState, eliminating the need for round trips.
2. **Immediate Storage & Hashing:** Keys are hashed and stored directly upon updates, removing previous layers of indirection.
3. **Reduced Memory Footprint:** Instead of individual POJOs for each record in every state, we now leverage a **`ByteArrayOrdinalMap`** to store distinct field objects. We then refer to these objects using their object ordinals.
4. **Enhanced Query Speed:** Direct hash table lookups now speed up querying, making readStateEngine traversals obsolete.


**Supporting Classes Introduced:**

- **HollowOrdinalMapper:** This class is dedicated to hashing and storage tasks for records and their fields. By decoupling from **`HollowHistoryTypeKeyIndex`**, the latter now solely focuses on state update functions.
- **ObjectInternPool:** This utility manages the storage of unique field objects across states. Each distinct object is stored once and assigned an integer ordinal, implementing extremely memory efficient memoization via a variable-length packed ByteOrdinalArray. This process facilitates HollowOrdinalMapper in storing just an integer per field in the hash table, optimizing memory use.

**Highlights & Impact:**

- **Code Conciseness:** The **`HollowHistoryTypeKeyIndex`** has been streamlined from ~550 lines to roughly 225 lines, improving readability.
- **Performance Boost:** Preliminary tests suggest that history processing speed has increased 3-4 times. However, when considering dataset processing as a whole (which includes several other functions), the speed improvement is about 30-50%.
- **Memory Efficiency:** Compared to the previous approach, which kept a full read/write state, ordinal mapping, hash mapping, and did not utilize memoization, the new implementation showcased a 12% memory usage reduction in tests.

## Profiler screenshots to illustrate the performance improvements
Note the stack percentages in the bottom left
### Old implementation
![Old implementation](https://github.com/Netflix/hollow/assets/47366039/3d22c50d-99c9-4226-bad2-eb6c8cdee6b5)
### New implementation
![New implementation](https://github.com/Netflix/hollow/assets/47366039/d1c4726c-2350-4aba-8d65-bb6309f124c6)