### PR TITLE
Respect ValidationResultBuilder detail ordering

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/ValidationResult.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/ValidationResult.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.api.producer.validation;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -166,7 +167,7 @@ public final class ValidationResult {
 
         ValidationResultBuilder(String name) {
             this.name = Objects.requireNonNull(name);
-            this.details = new HashMap<>();
+            this.details = new LinkedHashMap<>();
         }
 
         /**
@@ -264,7 +265,7 @@ public final class ValidationResult {
         }
 
         private void reset() {
-            this.details = new HashMap<>();
+            this.details = new LinkedHashMap<>();
         }
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/ProducerValidationTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/ProducerValidationTests.java
@@ -26,6 +26,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 public class ProducerValidationTests {
     private InMemoryBlobStore blobStore;
 
@@ -133,6 +137,21 @@ public class ProducerValidationTests {
         producer.addListener(new DuplicateDataDetectionValidator("TypeWithPrimaryKey3"));
         // this adds the type state for TypeWithPrimarkyKey3
         producer.runCycle(newState -> newState.add(new TypeWithPrimaryKey3(1, "Bar")));
+    }
+
+
+    @Test
+    public void validationDetailOrdering() {
+        Map<String, String> expectedDetails = new LinkedHashMap<>();
+        expectedDetails.put("detail_key1", "detail_val1");
+        expectedDetails.put("detail_key2", "detail_val2");
+        expectedDetails.put("detail_key3", "detail_val3");
+
+        ValidationResult.ValidationResultBuilder validationResultBuilder = ValidationResult.from("my_validator");
+        expectedDetails.forEach(validationResultBuilder::detail);
+        ValidationResult result = validationResultBuilder.passed("everything is ok");
+
+        Assert.assertEquals(new ArrayList<>(expectedDetails.entrySet()), new ArrayList<>(result.getDetails().entrySet()));
     }
 
     @HollowPrimaryKey(fields = {"id", "name"})


### PR DESCRIPTION
Users may find it useful to get back a `detail` Map that reflects the order in which their validator added the details. Contrived example:
```java
ValidationResult result = ValidationResult.from("RecordCountVarianceValidator_MyType")
   .detail("AllowableVariancePercent", 20)
   .detail("Typename", "MyType")
   .detail("LatestRecordCount", 110)
   .detail("PreviousRecordCount", 100)
   .detail("ActualChangePercent", 10)
   .passed();

System.out.println(result.getDetails().entrySet().stream().flatMap(entry -> Stream.of(entry.getKey() + "=" + entry.getValue())).collect(Collectors.joining(", ")));
```

Having `AllowableVariancePercent=20, Typename=MyType, LatestRecordCount=110, PreviousRecordCount=100, ActualChangePercent=10` rather than `PreviousRecordCount=100, AllowableVariancePercent=20, Typename=MyType, ActualChangePercent=10, LatestRecordCount=110` is desirable.