### PR TITLE
Make creator serializable

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/memory/pool/RecyclingRecycler.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/pool/RecyclingRecycler.java
@@ -115,7 +115,7 @@ public class RecyclingRecycler implements ArraySegmentRecycler {
         }
     }
 
-    private interface Creator<T> {
+    private interface Creator<T> extends Serializable {
         T create();
     }
 


### PR DESCRIPTION
Creator is instantiated with lambdas. We have been using hollow in pipeline environments and so being serializable by either the Java Serializer or others (like Kryo) need lambdas to be serializable as well. I am not sure if this change has any effect in hollow itself so feel free to reject it, but this would help my experience with Hollow right now