### PR TITLE
Bugfix: destoy delta encodedAdditions only after its safe to do so

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListDeltaApplicator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListDeltaApplicator.java
@@ -72,7 +72,6 @@ class HollowListDeltaApplicator {
 
         from.encodedRemovals = null;
         removalsReader.destroy();
-        additionsReader.destroy();
     }
 
     private void slowDelta() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -123,6 +123,7 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
                 nextData.applyDelta(oldData, deltaData);
                 shards[i].setCurrentData(nextData);
                 notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+                deltaData.encodedAdditions.destroy();
                 oldData.destroy();
             }
             deltaData.destroy();

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapDeltaApplicator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapDeltaApplicator.java
@@ -81,7 +81,6 @@ class HollowMapDeltaApplicator {
 
         from.encodedRemovals = null;
         removalsReader.destroy();
-        additionsReader.destroy();
     }
 
     private void slowDelta() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -130,6 +130,7 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
                 nextData.applyDelta(oldData, deltaData);
                 shards[i].setCurrentData(nextData);
                 notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+                deltaData.encodedAdditions.destroy();
                 oldData.destroy();
             }
             deltaData.destroy();

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectDeltaApplicator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectDeltaApplicator.java
@@ -98,7 +98,6 @@ class HollowObjectDeltaApplicator {
 
         from.encodedRemovals = null;
         removalsReader.destroy();
-        additionsReader.destroy();
     }
 
     private boolean canDoFastDelta() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -131,6 +131,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
                 nextData.applyDelta(oldData, deltaData);
                 shards[i].setCurrentData(nextData);
                 notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+                deltaData.encodedAdditions.destroy();
                 oldData.destroy();
             }
             deltaData.destroy();

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetDeltaApplicator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetDeltaApplicator.java
@@ -78,7 +78,6 @@ class HollowSetDeltaApplicator {
 
         from.encodedRemovals = null;
         removalsReader.destroy();
-        additionsReader.destroy();
 
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -131,6 +131,7 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
                 nextData.applyDelta(oldData, deltaData);
                 shards[i].setCurrentData(nextData);
                 notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+                deltaData.encodedAdditions.destroy();
                 oldData.destroy();
             }
             deltaData.destroy();


### PR DESCRIPTION
`deltaData.encodedAdditions` is needed for `notifyListenerAboutDeltaChanges`, but destroy was being called on it before invocation to `notifyListenerAboutDeltaChanges` in the call to`nextData.applyDelta(oldData, deltaData);`. 

Theres no evidence of issues caused by this atm, just something noticed while implementing delta transitions for shared-memory mode (that code path caught it because invocation of destroy actually closes the backing file so access after destroy fails hard)
