### PR TITLE
Update README.md links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.com/Netflix/hollow.svg?branch=master)](https://travis-ci.com/Netflix/hollow)
 [![Join the chat at https://gitter.im/Netflix/hollow](https://badges.gitter.im/Netflix/hollow.svg)](https://gitter.im/Netflix/hollow?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/hollow.svg)](#)
-[ ![Download](https://api.bintray.com/packages/netflixoss/maven/hollow/images/download.svg) ](https://bintray.com/netflixoss/maven/hollow/_latestVersion)
+[![Project Map](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/netflixhollow/)
 
 Hollow is a java library and toolset for disseminating in-memory datasets from a single producer to many consumers for high performance read-only access. [Read more](http://techblog.netflix.com/2016/12/netflixoss-announcing-hollow.html).
 


### PR DESCRIPTION
Removing Bintray badge (seems that service has been permanently terminated).

Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/netflixhollow/). Intended to simplify developer's introduction to the project. Built directly from source and updated on schedule. (In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful).