### PR TITLE
HollowObjectTypeDataElements utilities for splitting and joining

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/memory/FixedLengthDataFactory.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/FixedLengthDataFactory.java
@@ -22,6 +22,14 @@ public class FixedLengthDataFactory {
         }
     }
 
+    public static FixedLengthData get(long numBits, MemoryMode memoryMode, ArraySegmentRecycler memoryRecycler) {
+        if (memoryMode.equals(MemoryMode.ON_HEAP)) {
+            return new FixedLengthElementArray(memoryRecycler, numBits);
+        } else {
+            throw new UnsupportedOperationException("Memory mode " + memoryMode.name() + " not supported");
+        }
+    }
+
     public static void destroy(FixedLengthData fld, ArraySegmentRecycler memoryRecycler) {
         if (fld instanceof FixedLengthElementArray) {
             ((FixedLengthElementArray) fld).destroy(memoryRecycler);

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElements.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElements.java
@@ -52,8 +52,8 @@ public class HollowObjectTypeDataElements {
     final long nullValueForField[];
     int bitsPerRecord;
 
-    private int bitsPerUnfilteredField[];
-    private boolean unfilteredFieldIsIncluded[];
+    int bitsPerUnfilteredField[];
+    boolean unfilteredFieldIsIncluded[];
 
     final ArraySegmentRecycler memoryRecycler;
     final MemoryMode memoryMode;
@@ -211,4 +211,48 @@ public class HollowObjectTypeDataElements {
         }
     }
 
+    static long varLengthStartByte(HollowObjectTypeDataElements from, int ordinal, int fieldIdx) {
+        if(ordinal == 0)
+            return 0;
+
+        int numBitsForField = from.bitsPerField[fieldIdx];
+        long currentBitOffset = ((long)from.bitsPerRecord * ordinal) + from.bitOffsetPerField[fieldIdx];
+        long startByte = from.fixedLengthData.getElementValue(currentBitOffset - from.bitsPerRecord, numBitsForField) & (1L << (numBitsForField - 1)) - 1;
+
+        return startByte;
+    }
+
+    static long varLengthEndByte(HollowObjectTypeDataElements from, int ordinal, int fieldIdx) {
+        int numBitsForField = from.bitsPerField[fieldIdx];
+        long currentBitOffset = ((long)from.bitsPerRecord * ordinal) + from.bitOffsetPerField[fieldIdx];
+        long endByte = from.fixedLengthData.getElementValue(currentBitOffset, numBitsForField) & (1L << (numBitsForField - 1)) - 1;
+
+        return endByte;
+    }
+
+    static long varLengthSize(HollowObjectTypeDataElements from, int ordinal, int fieldIdx) {
+        int numBitsForField = from.bitsPerField[fieldIdx];
+        long fromBitOffset = ((long)from.bitsPerRecord*ordinal) + from.bitOffsetPerField[fieldIdx];
+        long fromEndByte = from.fixedLengthData.getElementValue(fromBitOffset, numBitsForField) & (1L << (numBitsForField - 1)) - 1;
+        long fromStartByte = ordinal != 0 ? from.fixedLengthData.getElementValue(fromBitOffset - from.bitsPerRecord, numBitsForField) & (1L << (numBitsForField - 1)) - 1 : 0;
+        return fromEndByte - fromStartByte;
+    }
+
+    static void copyRecord(HollowObjectTypeDataElements to, int toOrdinal, HollowObjectTypeDataElements from, int fromOrdinal, long[] currentWriteVarLengthDataPointers) {
+        for(int fieldIndex=0;fieldIndex<to.schema.numFields();fieldIndex++) {
+            if(to.varLengthData[fieldIndex] == null) {
+                long value = from.fixedLengthData.getLargeElementValue(((long)fromOrdinal * from.bitsPerRecord) + from.bitOffsetPerField[fieldIndex], from.bitsPerField[fieldIndex]);
+                to.fixedLengthData.setElementValue(((long)toOrdinal * to.bitsPerRecord) + to.bitOffsetPerField[fieldIndex], to.bitsPerField[fieldIndex], value);
+            } else {
+                long fromStartByte = varLengthStartByte(from, fromOrdinal, fieldIndex);
+                long fromEndByte = varLengthEndByte(from, fromOrdinal, fieldIndex);
+                long size = fromEndByte - fromStartByte;
+
+                to.fixedLengthData.setElementValue(((long)toOrdinal * to.bitsPerRecord) + to.bitOffsetPerField[fieldIndex], to.bitsPerField[fieldIndex], currentWriteVarLengthDataPointers[fieldIndex] + size);
+                to.varLengthData[fieldIndex].copy(from.varLengthData[fieldIndex], fromStartByte, currentWriteVarLengthDataPointers[fieldIndex], size);
+
+                currentWriteVarLengthDataPointers[fieldIndex] += size;
+            }
+        }
+    }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElements.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElements.java
@@ -255,4 +255,21 @@ public class HollowObjectTypeDataElements {
             }
         }
     }
+
+    static void writeNullField(HollowObjectTypeDataElements target, int fieldIndex, long currentWriteFixedLengthStartBit, long[] currentWriteVarLengthDataPointers) {
+        if(target.varLengthData[fieldIndex] != null) {
+            writeNullVarLengthField(target, fieldIndex, currentWriteFixedLengthStartBit, currentWriteVarLengthDataPointers);
+        } else {
+            writeNullFixedLengthField(target, fieldIndex, currentWriteFixedLengthStartBit);
+        }
+    }
+
+    static void writeNullVarLengthField(HollowObjectTypeDataElements target, int fieldIndex, long currentWriteFixedLengthStartBit, long[] currentWriteVarLengthDataPointers) {
+        long writeValue = (1L << (target.bitsPerField[fieldIndex] - 1)) | currentWriteVarLengthDataPointers[fieldIndex];
+        target.fixedLengthData.setElementValue(currentWriteFixedLengthStartBit, target.bitsPerField[fieldIndex], writeValue);
+    }
+
+    static void writeNullFixedLengthField(HollowObjectTypeDataElements target, int fieldIndex, long currentWriteFixedLengthStartBit) {
+        target.fixedLengthData.setElementValue(currentWriteFixedLengthStartBit, target.bitsPerField[fieldIndex], target.nullValueForField[fieldIndex]);
+    }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElements.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElements.java
@@ -52,8 +52,8 @@ public class HollowObjectTypeDataElements {
     final long nullValueForField[];
     int bitsPerRecord;
 
-    int bitsPerUnfilteredField[];
-    boolean unfilteredFieldIsIncluded[];
+    private int bitsPerUnfilteredField[];
+    private boolean unfilteredFieldIsIncluded[];
 
     final ArraySegmentRecycler memoryRecycler;
     final MemoryMode memoryMode;

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoiner.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoiner.java
@@ -76,7 +76,10 @@ public class HollowObjectTypeDataElementsJoiner {
 
         for(int fieldIdx=0;fieldIdx<to.schema.numFields();fieldIdx++) {
             if(from[0].varLengthData[fieldIdx] == null) {
-                to.bitsPerField[fieldIdx] = from[0].bitsPerField[fieldIdx];
+                // do not assume bitsPerField will be uniform
+                for(int fromIndex=0;fromIndex<from.length;fromIndex++) {
+                    to.bitsPerField[fieldIdx] = Math.max(to.bitsPerField[fieldIdx], from[fromIndex].bitsPerField[fieldIdx]);
+                }
             } else {
                 to.bitsPerField[fieldIdx] = (64 - Long.numberOfLeadingZeros(varLengthSizes[fieldIdx] + 1)) + 1;
             }
@@ -85,7 +88,8 @@ public class HollowObjectTypeDataElementsJoiner {
             to.bitsPerRecord += to.bitsPerField[fieldIdx];
         }
 
-        to.bitsPerUnfilteredField = from[0].bitsPerUnfilteredField;
-        to.unfilteredFieldIsIncluded = from[0].unfilteredFieldIsIncluded;
+        // unused
+        //  to.bitsPerUnfilteredField
+        //  to.unfilteredFieldIsIncluded
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoiner.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoiner.java
@@ -1,0 +1,91 @@
+package com.netflix.hollow.core.read.engine.object;
+
+import static com.netflix.hollow.core.read.engine.object.HollowObjectTypeDataElements.copyRecord;
+import static com.netflix.hollow.core.read.engine.object.HollowObjectTypeDataElements.varLengthSize;
+
+import com.netflix.hollow.core.memory.FixedLengthDataFactory;
+import com.netflix.hollow.core.memory.VariableLengthDataFactory;
+import com.netflix.hollow.core.memory.encoding.GapEncodedVariableLengthIntegerReader;
+
+/**
+ * Join multiple {@code HollowObjectTypeDataElements}s into 1 {@code HollowObjectTypeDataElements}.
+ * Ordinals are remapped and corresponding data is copied over.
+ * The original data elements are not destroyed.
+ * The no. of passed data elements must be a power of 2.
+ */
+public class HollowObjectTypeDataElementsJoiner {
+
+    HollowObjectTypeDataElements join(HollowObjectTypeDataElements[] from) {
+        final int fromMask = from.length - 1;
+        final int fromOrdinalShift = 31 - Integer.numberOfLeadingZeros(from.length);
+        long[] currentWriteVarLengthDataPointers;
+
+        if (from.length<=0 || !((from.length&(from.length-1))==0)) {
+            throw new IllegalStateException("No. of DataElements to be joined must be a power of 2");
+        }
+
+        HollowObjectTypeDataElements to = new HollowObjectTypeDataElements(from[0].schema, from[0].memoryMode, from[0].memoryRecycler);
+        currentWriteVarLengthDataPointers = new long[from[0].schema.numFields()];
+
+        populateStats(to, from);
+
+        GapEncodedVariableLengthIntegerReader[] fromRemovals = new GapEncodedVariableLengthIntegerReader[from.length];
+        for (int i=0;i<from.length;i++) {
+            fromRemovals[i] = from[i].encodedRemovals;
+        }
+        to.encodedRemovals = GapEncodedVariableLengthIntegerReader.join(fromRemovals);
+
+        for (HollowObjectTypeDataElements elements : from) {
+            if (elements.encodedAdditions != null) {
+                throw new IllegalStateException("Encountered encodedAdditions in data elements joiner- this is not expected " +
+                        "since encodedAdditions only exist on delta data elements and they dont carry over to target data elements, " +
+                        "delta data elements are never split/joined");
+            }
+        }
+
+        to.fixedLengthData = FixedLengthDataFactory.get((long)to.bitsPerRecord * (to.maxOrdinal + 1), to.memoryMode, to.memoryRecycler);
+        for(int fieldIdx=0;fieldIdx<to.schema.numFields();fieldIdx++) {
+            if(from[0].varLengthData[fieldIdx] != null) {
+                to.varLengthData[fieldIdx] = VariableLengthDataFactory.get(to.memoryMode, to.memoryRecycler);
+            }
+        }
+
+        for(int ordinal=0;ordinal<=to.maxOrdinal;ordinal++) {
+            int fromIndex = ordinal & fromMask;
+            int fromOrdinal = ordinal >> fromOrdinalShift;
+            copyRecord(to, ordinal, from[fromIndex], fromOrdinal, currentWriteVarLengthDataPointers);
+        }
+
+        return to;
+    }
+
+    void populateStats(HollowObjectTypeDataElements to, HollowObjectTypeDataElements[] from) {
+        long[] varLengthSizes = new long[to.schema.numFields()];
+
+        to.maxOrdinal = -1;
+        for(int fromIndex=0;fromIndex<from.length;fromIndex++) {
+            for(int ordinal=0;ordinal<=from[fromIndex].maxOrdinal;ordinal++) {
+                for(int fieldIdx=0;fieldIdx<to.schema.numFields();fieldIdx++) {
+                    if(from[fromIndex].varLengthData[fieldIdx] != null) {
+                        varLengthSizes[fieldIdx] += varLengthSize(from[fromIndex], ordinal, fieldIdx);
+                    }
+                }
+            }
+            to.maxOrdinal+= from[fromIndex].maxOrdinal + 1;
+        }
+
+        for(int fieldIdx=0;fieldIdx<to.schema.numFields();fieldIdx++) {
+            if(from[0].varLengthData[fieldIdx] == null) {
+                to.bitsPerField[fieldIdx] = from[0].bitsPerField[fieldIdx];
+            } else {
+                to.bitsPerField[fieldIdx] = (64 - Long.numberOfLeadingZeros(varLengthSizes[fieldIdx] + 1)) + 1;
+            }
+            to.nullValueForField[fieldIdx] = to.bitsPerField[fieldIdx] == 64 ? -1L : (1L << to.bitsPerField[fieldIdx]) - 1;
+            to.bitOffsetPerField[fieldIdx] = to.bitsPerRecord;
+            to.bitsPerRecord += to.bitsPerField[fieldIdx];
+        }
+
+        to.bitsPerUnfilteredField = from[0].bitsPerUnfilteredField;
+        to.unfilteredFieldIsIncluded = from[0].unfilteredFieldIsIncluded;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitter.java
@@ -1,0 +1,95 @@
+package com.netflix.hollow.core.read.engine.object;
+
+import static com.netflix.hollow.core.read.engine.object.HollowObjectTypeDataElements.copyRecord;
+import static com.netflix.hollow.core.read.engine.object.HollowObjectTypeDataElements.varLengthSize;
+
+import com.netflix.hollow.core.memory.FixedLengthDataFactory;
+import com.netflix.hollow.core.memory.VariableLengthDataFactory;
+import com.netflix.hollow.core.memory.encoding.GapEncodedVariableLengthIntegerReader;
+
+/**
+ * Split a {@code HollowObjectTypeDataElements} into multiple {@code HollowObjectTypeDataElements}s.
+ * Ordinals are remapped and corresponding data is copied over.
+ * The original data elements are not destroyed.
+ * {@code numSplits} must be a power of 2.
+ */
+public class HollowObjectTypeDataElementsSplitter {
+
+    HollowObjectTypeDataElements[] split(HollowObjectTypeDataElements from, int numSplits) {
+        final int toMask = numSplits - 1;
+        final int toOrdinalShift = 31 - Integer.numberOfLeadingZeros(numSplits);
+        final long[][] currentWriteVarLengthDataPointers;
+
+        if (numSplits<=0 || !((numSplits&(numSplits-1))==0)) {
+            throw new IllegalStateException("Must split by power of 2");
+        }
+
+        HollowObjectTypeDataElements[] to = new HollowObjectTypeDataElements[numSplits];
+        for(int i=0;i<to.length;i++) {
+            to[i] = new HollowObjectTypeDataElements(from.schema, from.memoryMode, from.memoryRecycler);
+            to[i].maxOrdinal = -1;
+        }
+        currentWriteVarLengthDataPointers = new long[numSplits][from.schema.numFields()];
+
+        populateStats(to, from, toMask, toOrdinalShift);
+
+        if (from.encodedRemovals != null) {
+            GapEncodedVariableLengthIntegerReader[] splitRemovals = from.encodedRemovals.split(numSplits);
+            for(int i=0;i<to.length;i++) {
+                to[i].encodedRemovals = splitRemovals[i];
+            }
+        }
+        if (from.encodedAdditions != null) {
+            throw new IllegalStateException("Encountered encodedAdditions in data elements splitter- this is not expected " +
+                    "since encodedAdditions only exist on delta data elements and they dont carry over to target data elements, " +
+                    "delta data elements are never split/joined");
+        }
+
+        for(int i=0;i<to.length;i++) {
+            to[i].fixedLengthData = FixedLengthDataFactory.get((long)to[i].bitsPerRecord * (to[i].maxOrdinal + 1), to[i].memoryMode, to[i].memoryRecycler);
+            for(int fieldIdx=0;fieldIdx<from.schema.numFields();fieldIdx++) {
+                if(from.varLengthData[fieldIdx] != null) {
+                    to[i].varLengthData[fieldIdx] = VariableLengthDataFactory.get(from.memoryMode, from.memoryRecycler);
+                }
+            }
+        }
+
+        for(int i=0;i<=from.maxOrdinal;i++) {
+            int toIndex = i & toMask;
+            int toOrdinal = i >> toOrdinalShift;
+            copyRecord(to[toIndex], toOrdinal, from, i, currentWriteVarLengthDataPointers[toIndex]);
+        }
+        return to;
+    }
+
+    private void populateStats(HollowObjectTypeDataElements[] to, HollowObjectTypeDataElements from, int toMask, int toOrdinalShift) {
+        long[][] varLengthSizes = new long[to.length][from.schema.numFields()];
+
+        for(int ordinal=0;ordinal<=from.maxOrdinal;ordinal++) {
+            int toIndex = ordinal & toMask;
+            int toOrdinal = ordinal >> toOrdinalShift;
+            to[toIndex].maxOrdinal = toOrdinal;
+            for(int fieldIdx=0;fieldIdx<from.schema.numFields();fieldIdx++) {
+                if(from.varLengthData[fieldIdx] != null) {
+                    varLengthSizes[toIndex][fieldIdx] += varLengthSize(from, ordinal, fieldIdx);
+                }
+            }
+        }
+
+        for(int toIndex=0;toIndex<to.length;toIndex++) {
+            for(int fieldIdx=0;fieldIdx<from.schema.numFields();fieldIdx++) {
+                if(from.varLengthData[fieldIdx] == null) {
+                    to[toIndex].bitsPerField[fieldIdx] = from.bitsPerField[fieldIdx];
+                } else {
+                    to[toIndex].bitsPerField[fieldIdx] = (64 - Long.numberOfLeadingZeros(varLengthSizes[toIndex][fieldIdx] + 1)) + 1;
+                }
+                to[toIndex].nullValueForField[fieldIdx] = (to[toIndex].bitsPerField[fieldIdx] == 64) ? -1L : (1L << to[toIndex].bitsPerField[fieldIdx]) - 1;
+                to[toIndex].bitOffsetPerField[fieldIdx] = to[toIndex].bitsPerRecord;
+                to[toIndex].bitsPerRecord += to[toIndex].bitsPerField[fieldIdx];
+
+                to[toIndex].bitsPerUnfilteredField = from.bitsPerUnfilteredField;
+                to[toIndex].unfilteredFieldIsIncluded = from.unfilteredFieldIsIncluded;
+            }
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitter.java
@@ -87,8 +87,9 @@ public class HollowObjectTypeDataElementsSplitter {
                 to[toIndex].bitOffsetPerField[fieldIdx] = to[toIndex].bitsPerRecord;
                 to[toIndex].bitsPerRecord += to[toIndex].bitsPerField[fieldIdx];
 
-                to[toIndex].bitsPerUnfilteredField = from.bitsPerUnfilteredField;
-                to[toIndex].unfilteredFieldIsIncluded = from.unfilteredFieldIsIncluded;
+                // unused
+                // to[toIndex].bitsPerUnfilteredField = from.bitsPerUnfilteredField;
+                // to[toIndex].unfilteredFieldIsIncluded = from.unfilteredFieldIsIncluded;
             }
         }
     }

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/AbstractHollowObjectTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/AbstractHollowObjectTypeDataElementsSplitJoinTest.java
@@ -5,7 +5,10 @@ import static org.mockito.Mockito.when;
 
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
 import com.netflix.hollow.core.AbstractStateEngineTest;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.filter.HollowFilterConfig;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
 import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
 import com.netflix.hollow.core.write.HollowObjectWriteRecord;
 import java.io.IOException;
@@ -21,9 +24,11 @@ public class AbstractHollowObjectTypeDataElementsSplitJoinTest extends AbstractS
 
     @Before
     public void setUp() {
-        schema = new HollowObjectSchema("TestObject", 2);
+        schema = new HollowObjectSchema("TestObject", 4);
         schema.addField("longField", HollowObjectSchema.FieldType.LONG);
         schema.addField("stringField", HollowObjectSchema.FieldType.STRING);
+        schema.addField("intField", HollowObjectSchema.FieldType.INT);
+        schema.addField("doubleField", HollowObjectSchema.FieldType.DOUBLE);
 
         MockitoAnnotations.initMocks(this);
         HollowObjectTypeDataElements[] fakeDataElements = new HollowObjectTypeDataElements[5];
@@ -37,17 +42,32 @@ public class AbstractHollowObjectTypeDataElementsSplitJoinTest extends AbstractS
         writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema));
     }
 
-    protected HollowObjectTypeReadState populateTypeStateWith(int numRecords) throws IOException {
+    private void populateWriteStateEngine(int numRecords) {
         initWriteStateEngine();
         HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
         for(int i=0;i<numRecords;i++) {
             rec.reset();
             rec.setLong("longField", i);
             rec.setString("stringField", "Value" + i);
+            rec.setInt("intField", i);
+            rec.setDouble("doubleField", i);
 
             writeStateEngine.add("TestObject", rec);
         }
+    }
+
+    protected HollowObjectTypeReadState populateTypeStateWith(int numRecords) throws IOException {
+        populateWriteStateEngine(numRecords);
         roundTripSnapshot();
+        return (HollowObjectTypeReadState) readStateEngine.getTypeState("TestObject");
+    }
+
+    protected HollowObjectTypeReadState populateTypeStateWithFilter(int numRecords) throws IOException {
+        populateWriteStateEngine(numRecords);
+        readStateEngine = new HollowReadStateEngine();
+        HollowFilterConfig readFilter = new HollowFilterConfig(true);
+        readFilter.addField("TestObject", "intField");
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine, readFilter);
         return (HollowObjectTypeReadState) readStateEngine.getTypeState("TestObject");
     }
 
@@ -56,6 +76,11 @@ public class AbstractHollowObjectTypeDataElementsSplitJoinTest extends AbstractS
             GenericHollowObject obj = new GenericHollowObject(readStateEngine, "TestObject", i);
             assertEquals(i, obj.getLong("longField"));
             assertEquals("Value"+i, obj.getString("stringField"));
+            HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) readStateEngine.getTypeState("TestObject");
+            assertEquals((double)i, obj.getDouble("doubleField"), 0);
+            if (typeState.getSchema().numFields() == 4) {   // filtered
+                assertEquals(i, obj.getInt("intField"));
+            }
         }
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/AbstractHollowObjectTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/AbstractHollowObjectTypeDataElementsSplitJoinTest.java
@@ -1,0 +1,61 @@
+package com.netflix.hollow.core.read.engine.object;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.core.AbstractStateEngineTest;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import java.io.IOException;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AbstractHollowObjectTypeDataElementsSplitJoinTest extends AbstractStateEngineTest {
+    protected HollowObjectSchema schema;
+
+    @Mock
+    protected HollowObjectTypeReadState mockObjectTypeState;
+
+    @Before
+    public void setUp() {
+        schema = new HollowObjectSchema("TestObject", 2);
+        schema.addField("longField", HollowObjectSchema.FieldType.LONG);
+        schema.addField("stringField", HollowObjectSchema.FieldType.STRING);
+
+        MockitoAnnotations.initMocks(this);
+        HollowObjectTypeDataElements[] fakeDataElements = new HollowObjectTypeDataElements[5];
+        when(mockObjectTypeState.currentDataElements()).thenReturn(fakeDataElements);
+        super.setUp();
+    }
+
+    @Override
+    protected void initializeTypeStates() {
+        writeStateEngine.setTargetMaxTypeShardSize(4096);
+        writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+    }
+
+    protected HollowObjectTypeReadState populateTypeStateWith(int numRecords) throws IOException {
+        initWriteStateEngine();
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
+        for(int i=0;i<numRecords;i++) {
+            rec.reset();
+            rec.setLong("longField", i);
+            rec.setString("stringField", "Value" + i);
+
+            writeStateEngine.add("TestObject", rec);
+        }
+        roundTripSnapshot();
+        return (HollowObjectTypeReadState) readStateEngine.getTypeState("TestObject");
+    }
+
+    protected void assertDataUnchanged(int numRecords) {
+        for(int i=0;i<numRecords;i++) {
+            GenericHollowObject obj = new GenericHollowObject(readStateEngine, "TestObject", i);
+            assertEquals(i, obj.getLong("longField"));
+            assertEquals("Value"+i, obj.getString("stringField"));
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/AbstractHollowObjectTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/AbstractHollowObjectTypeDataElementsSplitJoinTest.java
@@ -56,8 +56,28 @@ public class AbstractHollowObjectTypeDataElementsSplitJoinTest extends AbstractS
         }
     }
 
+    private void populateWriteStateEngine(int[] recordIds) {
+        initWriteStateEngine();
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
+        for(int recordId : recordIds) {
+            rec.reset();
+            rec.setLong("longField", recordId);
+            rec.setString("stringField", "Value" + recordId);
+            rec.setInt("intField", recordId);
+            rec.setDouble("doubleField", recordId);
+
+            writeStateEngine.add("TestObject", rec);
+        }
+    }
+
     protected HollowObjectTypeReadState populateTypeStateWith(int numRecords) throws IOException {
         populateWriteStateEngine(numRecords);
+        roundTripSnapshot();
+        return (HollowObjectTypeReadState) readStateEngine.getTypeState("TestObject");
+    }
+
+    protected HollowObjectTypeReadState populateTypeStateWith(int[] recordIds) throws IOException {
+        populateWriteStateEngine(recordIds);
         roundTripSnapshot();
         return (HollowObjectTypeReadState) readStateEngine.getTypeState("TestObject");
     }

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoinerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoinerTest.java
@@ -2,20 +2,31 @@ package com.netflix.hollow.core.read.engine.object;
 
 import static org.junit.Assert.assertEquals;
 
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
 import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class HollowObjectTypeDataElementsJoinerTest extends AbstractHollowObjectTypeDataElementsSplitJoinTest {
+    @Override
+    protected void initializeTypeStates() {
+        writeStateEngine.setTargetMaxTypeShardSize(16);
+        writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+    }
+
     @Test
     public void testJoin() throws IOException {
         HollowObjectTypeDataElementsJoiner joiner = new HollowObjectTypeDataElementsJoiner();
 
-        HollowObjectTypeReadState typeReadState = populateTypeStateWith(5);
+        HollowObjectTypeReadState typeReadState = populateTypeStateWith(1);
         assertEquals(1, typeReadState.numShards());
-        assertDataUnchanged(5);
 
-        HollowObjectTypeDataElements joinedDataElements = joiner.join(typeReadState.currentDataElements());
+        HollowObjectTypeReadState typeReadStateSharded = populateTypeStateWith(5);
+        assertDataUnchanged(5);
+        assertEquals(8, typeReadStateSharded.numShards());
+
+        HollowObjectTypeDataElements joinedDataElements = joiner.join(typeReadStateSharded.currentDataElements());
+
         typeReadState.setCurrentData(joinedDataElements);
         assertDataUnchanged(5);
 

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoinerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoinerTest.java
@@ -1,0 +1,29 @@
+package com.netflix.hollow.core.read.engine.object;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HollowObjectTypeDataElementsJoinerTest extends AbstractHollowObjectTypeDataElementsSplitJoinTest {
+    @Test
+    public void testJoin() throws IOException {
+        HollowObjectTypeDataElementsJoiner joiner = new HollowObjectTypeDataElementsJoiner();
+
+        HollowObjectTypeReadState typeReadState = populateTypeStateWith(5);
+        assertEquals(1, typeReadState.numShards());
+        assertDataUnchanged(5);
+
+        HollowObjectTypeDataElements joinedDataElements = joiner.join(typeReadState.currentDataElements());
+        typeReadState.setCurrentData(joinedDataElements);
+        assertDataUnchanged(5);
+
+        try {
+            joiner.join(mockObjectTypeState.currentDataElements());
+            Assert.fail();
+        } catch (IllegalStateException e) {
+            // expected, numSplits should be a power of 2
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoinerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoinerTest.java
@@ -1,8 +1,14 @@
 package com.netflix.hollow.core.read.engine.object;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
 import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import com.netflix.hollow.test.InMemoryBlobStore;
 import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,5 +42,130 @@ public class HollowObjectTypeDataElementsJoinerTest extends AbstractHollowObject
         } catch (IllegalStateException e) {
             // expected, numSplits should be a power of 2
         }
+    }
+
+    @Test
+    public void testJoinDifferentFieldWidths() throws IOException {
+        HollowObjectTypeDataElementsJoiner joiner = new HollowObjectTypeDataElementsJoiner();
+
+        HollowObjectTypeReadState typeReadStateSmall = populateTypeStateWith(new int[] {1});
+        assertEquals(1, typeReadStateSmall.numShards());
+        HollowObjectTypeDataElements dataElementsSmall = typeReadStateSmall.currentDataElements()[0];
+        int intFieldPosSmall = dataElementsSmall.schema.getPosition("intField");
+        int widthSmall = dataElementsSmall.bitsPerField[intFieldPosSmall];
+        long valSmall = dataElementsSmall.fixedLengthData.getElementValue(dataElementsSmall.bitOffsetPerField[intFieldPosSmall], widthSmall);
+
+        HollowObjectTypeReadState typeReadStateBig = populateTypeStateWith(new int[] {2});
+        assertEquals(1, typeReadStateBig.numShards());
+        HollowObjectTypeDataElements dataElementsBig = typeReadStateBig.currentDataElements()[0];
+        int intFieldPosBig = dataElementsBig.schema.getPosition("intField");
+        int widthBig = dataElementsBig.bitsPerField[intFieldPosBig];
+        long valBig = dataElementsBig.fixedLengthData.getElementValue(dataElementsBig.bitOffsetPerField[intFieldPosBig], widthBig);
+
+        assertTrue(widthBig > widthSmall);
+
+        HollowObjectTypeDataElements dataElementsJoined = joiner.join(new HollowObjectTypeDataElements[]
+                {dataElementsSmall, dataElementsBig});
+        int intFieldPosJoined = dataElementsJoined.schema.getPosition("intField");
+        int widthJoined = dataElementsJoined.bitsPerField[intFieldPosJoined];
+
+        long val0 = dataElementsJoined.fixedLengthData.getElementValue(dataElementsJoined.bitOffsetPerField[intFieldPosJoined], widthJoined);
+        long val1 = dataElementsJoined.fixedLengthData.getElementValue(dataElementsJoined.bitsPerRecord + dataElementsJoined.bitOffsetPerField[intFieldPosJoined], widthJoined);
+
+        assertEquals(widthBig, widthJoined);
+        assertEquals(valSmall, val0);
+        assertEquals(valBig, val1);
+    }
+
+//    TODO: manually invoked, depends on producer side changes for supporting changing numShards in a delta chain
+//    @Test
+//    public void testLopsidedShards() {
+//        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+//        HollowProducer p = HollowProducer.withPublisher(blobStore)
+//                .withBlobStager(new HollowInMemoryBlobStager())
+//                .build();
+//
+//        p.initializeDataModel(schema);
+//        int targetSize = 64;
+//        p.getWriteEngine().setTargetMaxTypeShardSize(targetSize);
+//        long v1 = oneRunCycle(p, new int[] {0, 1, 2, 3, 4, 5, 6, 7});
+//
+//        HollowConsumer c = HollowConsumer
+//                .withBlobRetriever(blobStore)
+//                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
+//                    @Override
+//                    public boolean allowDoubleSnapshot() {
+//                        return false;
+//                    }
+//
+//                    @Override
+//                    public int maxDeltasBeforeDoubleSnapshot() {
+//                        return Integer.MAX_VALUE;
+//                    }
+//                })
+//                .withSkipTypeShardUpdateWithNoAdditions()
+//                .build();
+//        c.triggerRefreshTo(v1);
+//
+//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
+//        assertEquals(true, c.getStateEngine().isSkipTypeShardUpdateWithNoAdditions());
+//
+//        long v2 = oneRunCycle(p, new int[] {0, 1, 2, 3, 5, 7});
+//        c.triggerRefreshTo(v2);
+//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
+//
+//        long v3 = oneRunCycle(p, new int[] { 0, 1, 3, 5}); // drop to 1 ordinal per shard, skipTypeShardWithNoAdds will make it so that maxOrdinal is adjusted
+//        c.triggerRefreshTo(v3);
+//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
+//
+//        long v4 = oneRunCycle(p, new int[] { 0, 1, 2, 3}); // now add another ordinal to one shard, maxOrdinals will be lopsided
+//        c.triggerRefreshTo(v4);
+//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
+//
+//        readStateEngine = c.getStateEngine();
+//        assertDataUnchanged(3);
+//
+//        long v5 = oneRunCycle(p, new int[] {0, 1});
+//
+//        // assert lopsided shards before join
+//        assertEquals(2, ((HollowObjectTypeReadState) c.getStateEngine().getTypeState("TestObject")).shardsVolatile.shards[0].currentDataElements().maxOrdinal);
+//        assertEquals(3, ((HollowObjectTypeReadState) c.getStateEngine().getTypeState("TestObject")).shardsVolatile.shards[1].currentDataElements().maxOrdinal);
+//        c.triggerRefreshTo(v5);
+//        assertEquals(1, c.getStateEngine().getTypeState("TestObject").numShards()); // joined to 1 shard
+//        readStateEngine = c.getStateEngine();
+//        assertDataUnchanged(2);
+//
+//        long v6 = oneRunCycle(p, new int[] {0, 1, 2, 3, 4, 5 });
+//        c.triggerRefreshTo(v6);
+//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards()); // split to 2 shards
+//
+//        long v7 = oneRunCycle(p, new int[] {8, 9});
+//        c.triggerRefreshTo(v7);
+//        assertEquals(4, c.getStateEngine().getTypeState("TestObject").numShards()); // still 2 shards
+//
+//        long v8 = oneRunCycle(p, new int[] {8});
+//        c.triggerRefreshTo(v8);
+//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards()); // down to 1 shard
+//
+//        c.triggerRefreshTo(v1);
+//        assertEquals(v1, c.getCurrentVersionId());
+//
+//        c.triggerRefreshTo(v8);
+//        assertEquals(v8, c.getCurrentVersionId());
+//    }
+
+    private long oneRunCycle(HollowProducer p, int recordIds[]) {
+        return p.runCycle(state -> {
+            HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
+            for(int recordId : recordIds) {
+                rec.reset();
+                rec.setLong("longField", recordId);
+                rec.setString("stringField", "Value" + recordId);
+                rec.setInt("intField", recordId);
+                rec.setDouble("doubleField", recordId);
+
+                state.getStateEngine().add("TestObject", rec);
+            }
+        });
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitJoinTest.java
@@ -44,9 +44,31 @@ public class HollowObjectTypeDataElementsSplitJoinTest extends AbstractHollowObj
         }
     }
 
+    @Test
+    public void testSplitThenJoinWithFilter() throws IOException {
+        HollowObjectTypeDataElementsSplitter splitter = new HollowObjectTypeDataElementsSplitter();
+        HollowObjectTypeDataElementsJoiner joiner = new HollowObjectTypeDataElementsJoiner();
+
+        int numSplits = 2;
+        for (int numRecords=0;numRecords<1*1000;numRecords++) {
+            HollowObjectTypeReadState typeReadState = populateTypeStateWithFilter(numRecords);
+            assertEquals(1, typeReadState.numShards());
+            assertDataUnchanged(numRecords);
+            HollowChecksum origChecksum = typeReadState.getChecksum(typeReadState.getSchema());
+
+            HollowObjectTypeDataElements[] splitElements = splitter.split(typeReadState.currentDataElements()[0], numSplits);
+            HollowObjectTypeDataElements joinedElements = joiner.join(splitElements);
+            typeReadState.setCurrentData(joinedElements);
+
+            assertDataUnchanged(numRecords);
+            HollowChecksum resultChecksum = typeReadState.getChecksum(typeReadState.getSchema());
+            assertEquals(origChecksum, resultChecksum);
+        }
+    }
+
     // manually invoked
     // @Test
-    public void testSplittingAndJoiningWithVms() throws Exception {
+    public void testSplittingAndJoiningWithSnapshotBlob() throws Exception {
 
         String blobPath = null; // dir where snapshot blob exists for e.g. "/tmp/";
         long v = 0l; // snapshot version for e.g. 20230915162636001l;

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitJoinTest.java
@@ -66,6 +66,23 @@ public class HollowObjectTypeDataElementsSplitJoinTest extends AbstractHollowObj
         }
     }
 
+    @Test
+    public void testSplitThenJoinWithEmptyJoin() throws IOException {
+        HollowObjectTypeDataElementsSplitter splitter = new HollowObjectTypeDataElementsSplitter();
+
+        HollowObjectTypeReadState typeReadState = populateTypeStateWith(1);
+        assertEquals(1, typeReadState.numShards());
+
+        HollowObjectTypeDataElements[] splitBy4 = splitter.split(typeReadState.currentDataElements()[0], 4);
+        assertEquals(-1, splitBy4[1].maxOrdinal);
+        assertEquals(-1, splitBy4[3].maxOrdinal);
+
+        HollowObjectTypeDataElementsJoiner joiner = new HollowObjectTypeDataElementsJoiner();
+        HollowObjectTypeDataElements joined = joiner.join(new HollowObjectTypeDataElements[]{splitBy4[1], splitBy4[3]});
+
+        assertEquals(-1, joined.maxOrdinal);
+    }
+
     // manually invoked
     // @Test
     public void testSplittingAndJoiningWithSnapshotBlob() throws Exception {

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitJoinTest.java
@@ -1,0 +1,81 @@
+package com.netflix.hollow.core.read.engine.object;
+
+import static org.junit.Assert.assertEquals;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.fs.HollowFilesystemBlobRetriever;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.tools.checksum.HollowChecksum;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HollowObjectTypeDataElementsSplitJoinTest extends AbstractHollowObjectTypeDataElementsSplitJoinTest {
+
+    @Override
+    protected void initializeTypeStates() {
+        writeStateEngine.setTargetMaxTypeShardSize(4 * 1000 * 1024);
+        writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+    }
+
+    @Test
+    public void testSplitThenJoin() throws IOException {
+        HollowObjectTypeDataElementsSplitter splitter = new HollowObjectTypeDataElementsSplitter();
+        HollowObjectTypeDataElementsJoiner joiner = new HollowObjectTypeDataElementsJoiner();
+
+        for (int numRecords=0;numRecords<1*1000;numRecords++) {
+            HollowObjectTypeReadState typeReadState = populateTypeStateWith(numRecords);
+            assertEquals(1, typeReadState.numShards());
+            assertDataUnchanged(numRecords);
+            HollowChecksum origChecksum = typeReadState.getChecksum(typeReadState.getSchema());
+
+            for (int numSplits : new int[]{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}) {
+                HollowObjectTypeDataElements[] splitElements = splitter.split(typeReadState.currentDataElements()[0], numSplits);
+                HollowObjectTypeDataElements joinedElements = joiner.join(splitElements);
+                typeReadState.setCurrentData(joinedElements);
+
+                assertDataUnchanged(numRecords);
+                HollowChecksum resultChecksum = typeReadState.getChecksum(typeReadState.getSchema());
+                assertEquals(origChecksum, resultChecksum);
+            }
+        }
+    }
+
+    // manually invoked
+    // @Test
+    public void testSplittingAndJoiningWithVms() throws Exception {
+
+        String blobPath = null; // dir where snapshot blob exists for e.g. "/tmp/";
+        long v = 0l; // snapshot version for e.g. 20230915162636001l;
+        String objectTypeWithOneShard = null; // type name corresponding to an Object type with single shard for e.g. "Movie";
+        int numSplits = 2;
+
+        if (blobPath==null || v==0l || objectTypeWithOneShard==null) {
+            throw new IllegalArgumentException("These arguments need to be specified");
+        }
+        HollowFilesystemBlobRetriever hollowBlobRetriever = new HollowFilesystemBlobRetriever(Paths.get(blobPath));
+        HollowConsumer c = HollowConsumer.withBlobRetriever(hollowBlobRetriever).build();
+        c.triggerRefreshTo(v);
+        HollowReadStateEngine readStateEngine = c.getStateEngine();
+
+        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) readStateEngine.getTypeState(objectTypeWithOneShard);
+        HollowSchema origSchema = typeState.getSchema();
+        HollowChecksum originalChecksum = typeState.getChecksum(origSchema);
+
+        assertEquals(1, typeState.numShards());
+
+        HollowObjectTypeDataElementsSplitter splitter = new HollowObjectTypeDataElementsSplitter();
+        HollowObjectTypeDataElements[] splitElements = splitter.split(typeState.currentDataElements()[0], numSplits);
+
+        HollowObjectTypeDataElementsJoiner joiner = new HollowObjectTypeDataElementsJoiner();
+        HollowObjectTypeDataElements joinedElements = joiner.join(splitElements);
+
+        typeState.setCurrentData(joinedElements);
+        HollowChecksum newChecksum = typeState.getChecksum(origSchema);
+
+        Assert.assertEquals(originalChecksum, newChecksum);
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitterTest.java
@@ -1,0 +1,41 @@
+package com.netflix.hollow.core.read.engine.object;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HollowObjectTypeDataElementsSplitterTest extends AbstractHollowObjectTypeDataElementsSplitJoinTest {
+
+    @Test
+    public void testSplit() throws IOException {
+        HollowObjectTypeDataElementsSplitter splitter = new HollowObjectTypeDataElementsSplitter();
+
+        HollowObjectTypeReadState typeReadState = populateTypeStateWith(5);
+        assertEquals(1, typeReadState.numShards());
+        assertDataUnchanged(5);
+
+        HollowObjectTypeDataElements[] result1 = splitter.split(typeReadState.currentDataElements()[0], 1);
+        typeReadState.setCurrentData(result1[0]);
+        assertDataUnchanged(5);
+
+        HollowObjectTypeDataElements[] result8 = splitter.split(typeReadState.currentDataElements()[0], 8);
+        assertEquals(0, result8[0].maxOrdinal);  // for index that landed one record after split
+        assertEquals(-1, result8[7].maxOrdinal); // for index that landed no records after split
+
+        try {
+            splitter.split(typeReadState.currentDataElements()[0], 3);  // numSplits=3
+            Assert.fail();
+        } catch (IllegalStateException e) {
+            // expected, numSplits should be a power of 2
+        }
+
+        try {
+            splitter.split(typeReadState.currentDataElements()[0], 0);  // numSplits=0
+            Assert.fail();
+        } catch (IllegalStateException e) {
+            // expected, numSplits should be a power of 2
+        }
+    }
+}


### PR DESCRIPTION
This is 1 of 4 planned PRs for supporting dynamic type re-sharding:

- [X] utilities for splitting/joining Object types; limited to Object types in this step, extend to Map/Set/List in last step.
- [ ] consumer delta application reshards with O(shard size) extra space.
- [ ] producer-side numShards toggle and successful integrity check verification of delta/revdelta application.
- [ ] Extend resharding to Map,List, and Set types.
