### PR TITLE
Consumer delta application supports re-sharding for Object type

### DIFF
--- a/hollow-perf/src/jmh/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateDeltaTransitionBenchmark.java
+++ b/hollow-perf/src/jmh/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateDeltaTransitionBenchmark.java
@@ -1,0 +1,182 @@
+package com.netflix.hollow.core.read.engine.object;
+
+
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Thread)
+@BenchmarkMode({Mode.All})
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 7, time = 1)
+@Measurement(iterations = 7, time = 1)
+@Fork(1)
+/**
+ * Runs delta transitions in the background while benchmarking reads. Re-sharding in delta transitions can be toggled with a param.
+ */
+public class HollowObjectTypeReadStateDeltaTransitionBenchmark {
+    HollowWriteStateEngine writeStateEngine;
+    HollowReadStateEngine readStateEngine;
+    HollowObjectTypeDataAccess dataAccess;
+    HollowObjectMapper objectMapper;
+
+    @Param({ "500" })
+    int countStrings;
+
+    @Param({ "2000" })
+    int deltaChanges;
+
+    @Param({ "true" })
+    boolean isReshardingEnabled;
+
+    @Param({ "100000" })
+    int countStringsDb;
+
+    ArrayList<Integer> readOrder;
+
+    @Param({ "1" })
+    int shardSizeMBs;
+
+    @Param({ "5", "25", "50", "150", "1000" })
+    int maxStringLength;
+
+    ExecutorService refreshExecutor;
+    Future<?> reshardingFuture;
+    CountDownLatch doneBenchmark;
+
+    @Setup
+    public void setUp() throws ExecutionException, InterruptedException {
+        final List<String> readStrings = new ArrayList<>();
+        final Set<Integer> readKeys = new HashSet<>();
+        refreshExecutor = Executors.newSingleThreadExecutor();
+
+        refreshExecutor.submit(() -> {
+            Random r = new Random();
+            writeStateEngine = new HollowWriteStateEngine();
+            writeStateEngine.setTargetMaxTypeShardSize((long) shardSizeMBs * 1000l * 1000l);
+            objectMapper = new HollowObjectMapper(writeStateEngine);
+            objectMapper.initializeTypeState(String.class);
+
+            readOrder = new ArrayList<>(countStrings);
+            for (int i = 0; i < countStrings; i++) {
+                readOrder.add(r.nextInt(countStringsDb));
+            }
+            readKeys.addAll(readOrder);
+
+            for (int i = 0; i < countStringsDb; i++) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("string_");
+                sb.append(i);
+                sb.append("_");
+                int thisStringLength = r.nextInt(maxStringLength) - sb.length() + 1;
+                for (int j = 0; j < thisStringLength; j++) {
+                    sb.append((char) (r.nextInt(26) + 'a'));
+                }
+                String s = sb.toString();
+                objectMapper.add(s);
+                if (readKeys.contains(i)) {
+                    readStrings.add(s);
+                }
+            }
+
+            readStateEngine = new HollowReadStateEngine();
+            try {
+                StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine, null);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            dataAccess = (HollowObjectTypeDataAccess) readStateEngine.getTypeDataAccess("String", 0);
+        }).get();
+
+        doneBenchmark = new CountDownLatch(1);
+        reshardingFuture = refreshExecutor.submit(() -> {
+            Random r = new Random();
+            long origShardSize = shardSizeMBs * 1000 * 1000;
+            long newShardSize = origShardSize;
+            do {
+                for (int i=0; i<readStrings.size(); i++) {
+                    objectMapper.add(readStrings.get(i));
+                }
+                for (int i = 0; i < deltaChanges; i++) {
+                    int changeKey = r.nextInt(countStringsDb);
+                    if (readKeys.contains(changeKey)) {
+                        continue;
+                    }
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("string_");
+                    sb.append(changeKey);
+                    sb.append("_");
+                    int thisStringLength = r.nextInt(maxStringLength) - sb.length() + 1;
+                    for (int j = 0; j < thisStringLength; j++) {
+                        sb.append((char) (r.nextInt(26) + 'a'));
+                    }
+                    objectMapper.add(sb.toString());
+                }
+
+                try {
+                    if (isReshardingEnabled) {
+                        if (newShardSize == origShardSize) {
+                            newShardSize = origShardSize / 10;
+                        } else {
+                            newShardSize = origShardSize;
+                        }
+                        writeStateEngine.setTargetMaxTypeShardSize(newShardSize);
+                    }
+                    StateEngineRoundTripper.roundTripDelta(writeStateEngine, readStateEngine);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            } while (doneBenchmark.getCount() > 0);
+        });
+    }
+
+    @TearDown
+    public void tearDown() {
+        doneBenchmark.countDown();
+        reshardingFuture.cancel(true);
+        refreshExecutor.shutdown();
+        try {
+            if (!refreshExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+                refreshExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            refreshExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Benchmark
+    public void testReadString(Blackhole bh) {
+        for (int j : readOrder) {
+            String result = dataAccess.readString(j, 0);
+            bh.consume(result);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -365,10 +365,9 @@ public class HollowBlobReader {
         HollowSchema schema = HollowSchema.readFrom(in);
 
         int numShards = readNumShards(in);
-
         HollowTypeReadState typeState = stateEngine.getTypeState(schema.getName());
         if(typeState != null) {
-            typeState.applyDelta(in, schema, stateEngine.getMemoryRecycler());
+            typeState.applyDelta(in, schema, stateEngine.getMemoryRecycler(), numShards);
         } else {
             discardDelta(in, schema, numShards);
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -331,7 +331,7 @@ public class HollowBlobReader {
             } else {
                 HollowObjectSchema unfilteredSchema = (HollowObjectSchema)schema;
                 HollowObjectSchema filteredSchema = unfilteredSchema.filterSchema(filter);
-                populateTypeStateSnapshot(in, new HollowObjectTypeReadState(stateEngine, memoryMode, filteredSchema, unfilteredSchema, numShards));
+                populateTypeStateSnapshotWithNumShards(in, new HollowObjectTypeReadState(stateEngine, memoryMode, filteredSchema, unfilteredSchema), numShards);
             }
         } else if (schema instanceof HollowListSchema) {
             if(!filter.includes(typeName)) {
@@ -359,6 +359,15 @@ public class HollowBlobReader {
     private void populateTypeStateSnapshot(HollowBlobInput in, HollowTypeReadState typeState) throws IOException {
         stateEngine.addTypeState(typeState);
         typeState.readSnapshot(in, stateEngine.getMemoryRecycler());
+    }
+
+    private void populateTypeStateSnapshotWithNumShards(HollowBlobInput in, HollowTypeReadState typeState, int numShards) throws IOException {
+        if (numShards<=0 || ((numShards&(numShards-1))!=0)) {
+            throw new IllegalArgumentException("Number of shards must be a power of 2!");
+        }
+
+        stateEngine.addTypeState(typeState);
+        typeState.readSnapshot(in, stateEngine.getMemoryRecycler(), numShards);
     }
 
     private String readTypeStateDelta(HollowBlobInput in) throws IOException {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
@@ -123,6 +123,8 @@ public abstract class HollowTypeReadState implements HollowTypeDataAccess {
 
     public abstract void readSnapshot(HollowBlobInput in, ArraySegmentRecycler recycler) throws IOException;
 
+    public abstract void readSnapshot(HollowBlobInput in, ArraySegmentRecycler recycler, int numShards) throws IOException;
+
     public abstract void applyDelta(HollowBlobInput in, HollowSchema deltaSchema, ArraySegmentRecycler memoryRecycler, int deltaNumShards) throws IOException;
 
     protected boolean shouldReshard(int currNumShards, int deltaNumShards) {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
@@ -122,7 +122,12 @@ public abstract class HollowTypeReadState implements HollowTypeDataAccess {
     public abstract int maxOrdinal();
 
     public abstract void readSnapshot(HollowBlobInput in, ArraySegmentRecycler recycler) throws IOException;
-    public abstract void applyDelta(HollowBlobInput in, HollowSchema schema, ArraySegmentRecycler memoryRecycler) throws IOException;
+
+    public abstract void applyDelta(HollowBlobInput in, HollowSchema deltaSchema, ArraySegmentRecycler memoryRecycler, int deltaNumShards) throws IOException;
+
+    protected boolean shouldReshard(int currNumShards, int deltaNumShards) {
+        return currNumShards!=0 && deltaNumShards!=0 && currNumShards!=deltaNumShards;
+    }
 
     public HollowSchema getSchema() {
         return schema;

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -91,7 +91,11 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
     }
 
     @Override
-    public void applyDelta(HollowBlobInput in, HollowSchema schema, ArraySegmentRecycler memoryRecycler) throws IOException {
+    public void applyDelta(HollowBlobInput in, HollowSchema schema, ArraySegmentRecycler memoryRecycler, int deltaNumShards) throws IOException {
+        if (shouldReshard(shards.length, deltaNumShards)) {
+            throw new UnsupportedOperationException("Dynamic type sharding not supported for " + schema.getName()
+                    + ". Current numShards=" + shards.length + ", delta numShards=" + deltaNumShards);
+        }
         if(shards.length > 1)
             maxOrdinal = VarInt.readVInt(in);
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -74,6 +74,11 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
     }
 
     @Override
+    public void readSnapshot(HollowBlobInput in, ArraySegmentRecycler memoryRecycler, int numShards) throws IOException {
+        throw new UnsupportedOperationException("This type does not yet support numShards specification when reading snapshot");
+    }
+
+    @Override
     public void readSnapshot(HollowBlobInput in, ArraySegmentRecycler memoryRecycler) throws IOException {
         if(shards.length > 1)
             maxOrdinal = VarInt.readVInt(in);

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -98,7 +98,11 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     }
 
     @Override
-    public void applyDelta(HollowBlobInput in, HollowSchema schema, ArraySegmentRecycler memoryRecycler) throws IOException {
+    public void applyDelta(HollowBlobInput in, HollowSchema schema, ArraySegmentRecycler memoryRecycler, int deltaNumShards) throws IOException {
+        if (shouldReshard(shards.length, deltaNumShards)) {
+            throw new UnsupportedOperationException("Dynamic type sharding not supported for " + schema.getName()
+                    + ". Current numShards=" + shards.length + ", delta numShards=" + deltaNumShards);
+        }
         if(shards.length > 1)
             maxOrdinal = VarInt.readVInt(in);
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -81,6 +81,11 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     }
 
     @Override
+    public void readSnapshot(HollowBlobInput in, ArraySegmentRecycler memoryRecycler, int numShards) throws IOException {
+        throw new UnsupportedOperationException("This type does not yet support numShards specification when reading snapshot");
+    }
+
+    @Override
     public void readSnapshot(HollowBlobInput in, ArraySegmentRecycler memoryRecycler) throws IOException {
         if(shards.length > 1)
             maxOrdinal = VarInt.readVInt(in);

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectDeltaApplicator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectDeltaApplicator.java
@@ -16,6 +16,10 @@
  */
 package com.netflix.hollow.core.read.engine.object;
 
+import static com.netflix.hollow.core.read.engine.object.HollowObjectTypeDataElements.writeNullField;
+import static com.netflix.hollow.core.read.engine.object.HollowObjectTypeDataElements.writeNullFixedLengthField;
+import static com.netflix.hollow.core.read.engine.object.HollowObjectTypeDataElements.writeNullVarLengthField;
+
 import com.netflix.hollow.core.memory.SegmentedByteArray;
 import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
 import com.netflix.hollow.core.memory.encoding.GapEncodedVariableLengthIntegerReader;
@@ -175,7 +179,7 @@ class HollowObjectDeltaApplicator {
                     long readStartBit = currentFromStateReadFixedLengthStartBit + from.bitOffsetPerField[fieldIndex];
                     copyRecordField(fieldIndex, fieldIndex, from, readStartBit, currentWriteFixedLengthStartBit, currentFromStateReadVarLengthDataPointers, currentWriteVarLengthDataPointers, removeData);
                 } else if(target.varLengthData[fieldIndex] != null) {
-                	writeNullVarLengthField(fieldIndex, currentWriteFixedLengthStartBit, currentWriteVarLengthDataPointers);
+                	writeNullVarLengthField(target, fieldIndex, currentWriteFixedLengthStartBit, currentWriteVarLengthDataPointers);
                 }
             }
             currentWriteFixedLengthStartBit += target.bitsPerField[fieldIndex];
@@ -193,7 +197,7 @@ class HollowObjectDeltaApplicator {
 
     private void addFromDelta(boolean removeData, int fieldIndex, int deltaFieldIndex) {
         if(deltaFieldIndex == -1) {
-            writeNullField(fieldIndex, currentWriteFixedLengthStartBit, currentWriteVarLengthDataPointers);
+            writeNullField(target, fieldIndex, currentWriteFixedLengthStartBit, currentWriteVarLengthDataPointers);
         } else {
             long readStartBit = currentDeltaStateReadFixedLengthStartBit + delta.bitOffsetPerField[deltaFieldIndex];
             copyRecordField(fieldIndex, deltaFieldIndex, delta, readStartBit, currentWriteFixedLengthStartBit, currentDeltaReadVarLengthDataPointers, currentWriteVarLengthDataPointers, false);
@@ -214,7 +218,7 @@ class HollowObjectDeltaApplicator {
 
         if(target.varLengthData[fieldIndex] != null) {
             if((readValue & (1L << (copyFromData.bitsPerField[fromFieldIndex] - 1))) != 0) {
-                writeNullVarLengthField(fieldIndex, currentWriteFixedLengthStartBit, currentWriteVarLengthDataPointers);
+                writeNullVarLengthField(target, fieldIndex, currentWriteFixedLengthStartBit, currentWriteVarLengthDataPointers);
             } else {
                 long readStart = currentReadVarLengthDataPointers[fieldIndex];
                 long length = readValue - readStart;
@@ -228,28 +232,9 @@ class HollowObjectDeltaApplicator {
             }
         } else if(!removeData) {
             if(readValue == copyFromData.nullValueForField[fromFieldIndex])
-                writeNullFixedLengthField(fieldIndex, currentWriteFixedLengthStartBit);
+                writeNullFixedLengthField(target, fieldIndex, currentWriteFixedLengthStartBit);
             else
                 target.fixedLengthData.setElementValue(currentWriteFixedLengthStartBit, target.bitsPerField[fieldIndex], readValue);
         }
     }
-
-    private void writeNullField(int fieldIndex, long currentWriteFixedLengthStartBit, long[] currentWriteVarLengthDataPointers) {
-        if(target.varLengthData[fieldIndex] != null) {
-            writeNullVarLengthField(fieldIndex, currentWriteFixedLengthStartBit, currentWriteVarLengthDataPointers);
-        } else {
-            writeNullFixedLengthField(fieldIndex, currentWriteFixedLengthStartBit);
-        }
-    }
-
-    private void writeNullVarLengthField(int fieldIndex, long currentWriteFixedLengthStartBit, long[] currentWriteVarLengthDataPointers) {
-        long writeValue = (1L << (target.bitsPerField[fieldIndex] - 1)) | currentWriteVarLengthDataPointers[fieldIndex];
-        target.fixedLengthData.setElementValue(currentWriteFixedLengthStartBit, target.bitsPerField[fieldIndex], writeValue);
-    }
-
-    private void writeNullFixedLengthField(int fieldIndex, long currentWriteFixedLengthStartBit) {
-        target.fixedLengthData.setElementValue(currentWriteFixedLengthStartBit, target.bitsPerField[fieldIndex], target.nullValueForField[fieldIndex]);
-    }
-
-
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -511,17 +511,26 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
         HollowObjectTypeReadStateShard shard;
-        HollowObjectTypeReadStateShard.VarLenStats stats;
         byte[] result;
+        int numBitsForField;
+        long currentBitOffset;
+        long endByte;
+        long startByte;
+        int shardOrdinal;
 
         do {
             do {
                 shardsHolder = this.shardsVolatile;
                 shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-                stats = shard.readVarLenStats(ordinal >> shard.shardOrdinalShift, fieldIndex);
+                shardOrdinal = ordinal >> shard.shardOrdinalShift;
+
+                numBitsForField = shard.dataElements.bitsPerField[fieldIndex];
+                currentBitOffset = shard.fieldOffset(shardOrdinal, fieldIndex);
+                endByte = shard.dataElements.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
+                startByte = shardOrdinal != 0 ? shard.dataElements.fixedLengthData.getElementValue(currentBitOffset - shard.dataElements.bitsPerRecord, numBitsForField) : 0;
             } while (readWasUnsafe(shardsHolder));
 
-            result = shard.readBytes(stats, fieldIndex);
+            result = shard.readBytes(startByte, endByte, numBitsForField, fieldIndex);
         } while (readWasUnsafe(shardsHolder));
 
         return result;
@@ -533,17 +542,26 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
         HollowObjectTypeReadStateShard shard;
-        HollowObjectTypeReadStateShard.VarLenStats stats;
         String result;
+        int numBitsForField;
+        long currentBitOffset;
+        long endByte;
+        long startByte;
+        int shardOrdinal;
 
         do {
             do {
                 shardsHolder = this.shardsVolatile;
                 shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-                stats = shard.readVarLenStats(ordinal >> shard.shardOrdinalShift, fieldIndex);
+                shardOrdinal = ordinal >> shard.shardOrdinalShift;
+
+                numBitsForField = shard.dataElements.bitsPerField[fieldIndex];
+                currentBitOffset = shard.fieldOffset(shardOrdinal, fieldIndex);
+                endByte = shard.dataElements.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
+                startByte = shardOrdinal != 0 ? shard.dataElements.fixedLengthData.getElementValue(currentBitOffset - shard.dataElements.bitsPerRecord, numBitsForField) : 0;
             } while(readWasUnsafe(shardsHolder));
 
-            result = shard.readString(stats, fieldIndex);
+            result = shard.readString(startByte, endByte, numBitsForField, fieldIndex);
         } while(readWasUnsafe(shardsHolder));
 
         return result;
@@ -555,17 +573,26 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
         HollowObjectTypeReadStateShard shard;
-        HollowObjectTypeReadStateShard.VarLenStats stats;
         boolean result;
+        int numBitsForField;
+        long currentBitOffset;
+        long endByte;
+        long startByte;
+        int shardOrdinal;
 
         do {
             do {
                 shardsHolder = this.shardsVolatile;
                 shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-                stats = shard.readVarLenStats(ordinal >> shard.shardOrdinalShift, fieldIndex);
+                shardOrdinal = ordinal >> shard.shardOrdinalShift;
+
+                numBitsForField = shard.dataElements.bitsPerField[fieldIndex];
+                currentBitOffset = shard.fieldOffset(shardOrdinal, fieldIndex);
+                endByte = shard.dataElements.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
+                startByte = shardOrdinal != 0 ? shard.dataElements.fixedLengthData.getElementValue(currentBitOffset - shard.dataElements.bitsPerRecord, numBitsForField) : 0;
             } while(readWasUnsafe(shardsHolder));
 
-            result = shard.isStringFieldEqual(stats, fieldIndex, testValue);
+            result = shard.isStringFieldEqual(startByte, endByte, numBitsForField, fieldIndex, testValue);
         } while(readWasUnsafe(shardsHolder));
 
         return result;
@@ -577,17 +604,26 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
         HollowObjectTypeReadStateShard shard;
-        HollowObjectTypeReadStateShard.VarLenStats stats;
         int hashCode;
+        int numBitsForField;
+        long currentBitOffset;
+        long endByte;
+        long startByte;
+        int shardOrdinal;
 
         do {
             do {
                 shardsHolder = this.shardsVolatile;
                 shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-                stats = shard.readVarLenStats(ordinal >> shard.shardOrdinalShift, fieldIndex);
+                shardOrdinal = ordinal >> shard.shardOrdinalShift;
+
+                numBitsForField = shard.dataElements.bitsPerField[fieldIndex];
+                currentBitOffset = shard.fieldOffset(shardOrdinal, fieldIndex);
+                endByte = shard.dataElements.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
+                startByte = shardOrdinal != 0 ? shard.dataElements.fixedLengthData.getElementValue(currentBitOffset - shard.dataElements.bitsPerRecord, numBitsForField) : 0;
             } while(readWasUnsafe(shardsHolder));
 
-            hashCode = shard.findVarLengthFieldHashCode(stats, fieldIndex);
+            hashCode = shard.findVarLengthFieldHashCode(startByte, endByte, numBitsForField, fieldIndex);
         } while(readWasUnsafe(shardsHolder));
 
         return hashCode;

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -34,6 +34,7 @@ import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.tools.checksum.HollowChecksum;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.BitSet;
 
 /**
@@ -44,9 +45,33 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
     private final HollowObjectSchema unfilteredSchema;
     private final HollowObjectSampler sampler;
 
-    private final int shardNumberMask;
-    private final int shardOrdinalShift;
-    private final HollowObjectTypeReadStateShard shards[];
+    static class ShardsHolder {
+        final HollowObjectTypeReadStateShard shards[];
+        final int shardNumberMask;
+
+        private ShardsHolder(HollowSchema schema, int numShards) {
+            HollowObjectTypeReadStateShard[] shards = new HollowObjectTypeReadStateShard[numShards];
+            int shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(numShards);
+            for(int i=0; i<numShards; i++) {
+                shards[i] = new HollowObjectTypeReadStateShard((HollowObjectSchema) schema, shardOrdinalShift);
+            }
+            this.shards = shards;
+            this.shardNumberMask = numShards - 1;
+        }
+
+        private ShardsHolder(HollowSchema schema, HollowObjectTypeDataElements[] dataElements, int[] shardOrdinalShifts) {
+            int numShards = dataElements.length;
+            HollowObjectTypeReadStateShard[] shards = new HollowObjectTypeReadStateShard[numShards];
+            for (int i=0; i<numShards; i++) {
+                shards[i] = new HollowObjectTypeReadStateShard((HollowObjectSchema) schema, shardOrdinalShifts[i]);
+                shards[i].setCurrentData(dataElements[i]);
+            }
+            this.shards = shards;
+            this.shardNumberMask = numShards - 1;
+        }
+    }
+
+    volatile ShardsHolder shardsVolatile;
 
     private int maxOrdinal;
 
@@ -58,17 +83,12 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         super(fileEngine, memoryMode, schema);
         this.sampler = new HollowObjectSampler(schema, DisabledSamplingDirector.INSTANCE);
         this.unfilteredSchema = unfilteredSchema;
-        this.shardNumberMask = numShards - 1;
-        this.shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(numShards);
-        
+
+        int shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(numShards);
         if(numShards < 1 || 1 << shardOrdinalShift != numShards)
             throw new IllegalArgumentException("Number of shards must be a power of 2!");
-        
-        HollowObjectTypeReadStateShard shards[] = new HollowObjectTypeReadStateShard[numShards];
-        for(int i=0;i<shards.length;i++)
-            shards[i] = new HollowObjectTypeReadStateShard(schema);
-        
-        this.shards = shards;
+
+        this.shardsVolatile = new ShardsHolder(schema, numShards);
     }
 
     @Override
@@ -83,35 +103,38 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
     @Override
     public void readSnapshot(HollowBlobInput in, ArraySegmentRecycler memoryRecycler) throws IOException {
-        if(shards.length > 1)
+        if(shardsVolatile.shards.length > 1)
             maxOrdinal = VarInt.readVInt(in);
 
-        for(int i=0;i<shards.length;i++) {
+        for(int i=0; i<shardsVolatile.shards.length; i++) {
             HollowObjectTypeDataElements snapshotData = new HollowObjectTypeDataElements(getSchema(), memoryMode, memoryRecycler);
             snapshotData.readSnapshot(in, unfilteredSchema);
-            shards[i].setCurrentData(snapshotData);
+            shardsVolatile.shards[i].setCurrentData(snapshotData);
         }
 
-        if(shards.length == 1)
-            maxOrdinal = shards[0].currentDataElements().maxOrdinal;
+        if(shardsVolatile.shards.length == 1)
+            maxOrdinal = shardsVolatile.shards[0].currentDataElements().maxOrdinal;
 
         SnapshotPopulatedOrdinalsReader.readOrdinals(in, stateListeners);
     }
-    
+
     @Override
-    public void applyDelta(HollowBlobInput in, HollowSchema deltaSchema, ArraySegmentRecycler memoryRecycler) throws IOException {
-        if(shards.length > 1)
+    public void applyDelta(HollowBlobInput in, HollowSchema deltaSchema, ArraySegmentRecycler memoryRecycler, int deltaNumShards) throws IOException {
+        if (shouldReshard(shardsVolatile.shards.length, deltaNumShards)) {
+            reshard(deltaNumShards);
+        }
+        if(shardsVolatile.shards.length > 1)
             maxOrdinal = VarInt.readVInt(in);
 
-        for(int i=0;i<shards.length;i++) {
+        for(int i=0; i<shardsVolatile.shards.length; i++) {
             HollowObjectTypeDataElements deltaData = new HollowObjectTypeDataElements((HollowObjectSchema)deltaSchema, memoryMode, memoryRecycler);
             deltaData.readDelta(in);
             if(stateEngine.isSkipTypeShardUpdateWithNoAdditions() && deltaData.encodedAdditions.isEmpty()) {
 
                 if(!deltaData.encodedRemovals.isEmpty())
-                    notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+                    notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shardsVolatile.shards.length);
 
-                HollowObjectTypeDataElements currentData = shards[i].currentDataElements();
+                HollowObjectTypeDataElements currentData = shardsVolatile.shards[i].currentDataElements();
                 GapEncodedVariableLengthIntegerReader oldRemovals = currentData.encodedRemovals == null ? GapEncodedVariableLengthIntegerReader.EMPTY_READER : currentData.encodedRemovals;
                 if(oldRemovals.isEmpty()) {
                     currentData.encodedRemovals = deltaData.encodedRemovals;
@@ -127,10 +150,10 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
                 deltaData.encodedAdditions.destroy();
             } else {
                 HollowObjectTypeDataElements nextData = new HollowObjectTypeDataElements(getSchema(), memoryMode, memoryRecycler);
-                HollowObjectTypeDataElements oldData = shards[i].currentDataElements();
+                HollowObjectTypeDataElements oldData = shardsVolatile.shards[i].currentDataElements();
                 nextData.applyDelta(oldData, deltaData);
-                shards[i].setCurrentData(nextData);
-                notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shards.length);
+                shardsVolatile.shards[i].setCurrentData(nextData);
+                notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shardsVolatile.shards.length);
                 deltaData.encodedAdditions.destroy();
                 oldData.destroy();
             }
@@ -138,8 +161,173 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             stateEngine.getMemoryRecycler().swap();
         }
 
-        if(shards.length == 1)
-            maxOrdinal = shards[0].currentDataElements().maxOrdinal;
+        if(shardsVolatile.shards.length == 1)
+            maxOrdinal = shardsVolatile.shards[0].currentDataElements().maxOrdinal;
+    }
+
+    /**
+     * Given old and new numShards, this method returns the shard resizing multiplier.
+     */
+    static int shardingFactor(int oldNumShards, int newNumShards) {
+        if (newNumShards <= 0 || oldNumShards <= 0 || newNumShards == oldNumShards) {
+            throw new IllegalStateException("Invalid shard resizing, oldNumShards=" + oldNumShards + ", newNumShards=" + newNumShards);
+        }
+
+        boolean isNewGreater = newNumShards > oldNumShards;
+        int dividend = isNewGreater ? newNumShards : oldNumShards;
+        int divisor = isNewGreater ? oldNumShards : newNumShards;
+
+        if (dividend % divisor != 0) {
+            throw new IllegalStateException("Invalid shard resizing, oldNumShards=" + oldNumShards + ", newNumShards=" + newNumShards);
+        }
+        return dividend / divisor;
+    }
+
+    /**
+     * Reshards this type state to the desired shard count using O(shard size) space while supporting concurrent reads
+     * into the underlying data elements.
+     *
+     * @param newNumShards The desired number of shards
+     */
+    void reshard(int newNumShards) {
+        int prevNumShards = shardsVolatile.shards.length;
+        int shardingFactor = shardingFactor(prevNumShards, newNumShards);
+        HollowObjectTypeDataElements[] newDataElements;
+        int[] shardOrdinalShifts;
+
+        if (newNumShards>prevNumShards) { // split existing shards
+            // Step 1:  Grow the number of shards. Each original shard will result in N child shards where N is the sharding factor.
+            // The child shards will reference into the existing data elements as-is, and reuse existing shardOrdinalShift.
+            // However since the shards array is resized, a read will map into the new shard index, as a result a subset of
+            // ordinals in each shard will be accessed. In the next "splitting" step, the data elements in these new shards
+            // will be filtered to only retain the subset of ordinals that are actually accessed.
+            //
+            // This is an atomic update to shardsVolatile: full construction happens-before the store to shardsVolatile,
+            // in other words a fully constructed object as visible to this thread will be visible to other threads that
+            // load the new shardsVolatile.
+            shardsVolatile = expandWithOriginalDataElements(shardsVolatile, shardingFactor);
+
+            // Step 2: Split each original data element into N child data elements where N is the sharding factor.
+            // Then update each of the N child shards with the respective split of data element, this will be
+            // sufficient to serve all reads into this shard. Once all child shards for a pre-split parent
+            // shard have been assigned the split data elements, the parent data elements can be discarded.
+            for(int i=0; i<prevNumShards; i++) {
+                HollowObjectTypeDataElements originalDataElements = shardsVolatile.shards[i].currentDataElements();
+
+                shardsVolatile = splitDataElementsForOneShard(shardsVolatile, i, prevNumShards, shardingFactor);
+
+                destroyOriginalDataElements(originalDataElements);
+            }
+            // Re-sharding done.
+            // shardsVolatile now contains newNumShards shards where each shard contains
+            // a split of original data elements.
+
+        } else { // join existing shards
+            // Step 1: Join N data elements to create one, where N is the sharding factor. Then update each of the
+            //         N shards to reference the joined result, but with a new shardOrdinalShift.
+            //         Reads will continue to reference the same shard index as before, but the new shardOrdinalShift
+            //         will help these reads land at the right ordinal in the joined shard. When all N old shards
+            //         corresponding to one new shard have been updated, the N pre-join data elements can be destroyed.
+            for (int i=0; i<newNumShards; i++) {
+                HollowObjectTypeDataElements destroyCandidates[] = joinCandidates(shardsVolatile.shards, i, shardingFactor);
+
+                shardsVolatile = joinDataElementsForOneShard(shardsVolatile, i, shardingFactor);  // atomic update to shardsVolatile
+
+                for (int j = 0; j < shardingFactor; j ++) {
+                    destroyOriginalDataElements(destroyCandidates[j]);
+                };
+            }
+
+            // Step 2: Resize the shards array to only keep the first newNumShards shards.
+            newDataElements = new HollowObjectTypeDataElements[shardsVolatile.shards.length];
+            shardOrdinalShifts = new int[shardsVolatile.shards.length];
+            copyShardElements(shardsVolatile, newDataElements, shardOrdinalShifts);
+            shardsVolatile = new ShardsHolder(schema,
+                    Arrays.copyOfRange(newDataElements, 0, newNumShards),
+                    Arrays.copyOfRange(shardOrdinalShifts, 0, newNumShards));
+            // Re-sharding done.
+            // shardsVolatile now contains newNumShards shards where each shard contains
+            // a join of original data elements.
+        }
+    }
+
+    private void copyShardElements(ShardsHolder from, HollowObjectTypeDataElements[] newDataElements, int[] shardOrdinalShifts) {
+        for (int i=0; i<from.shards.length; i++) {
+            newDataElements[i] = from.shards[i].currentDataElements();
+            shardOrdinalShifts[i] = from.shards[i].shardOrdinalShift;
+        }
+    }
+
+    private HollowObjectTypeDataElements[] joinCandidates(HollowObjectTypeReadStateShard[] shards, int indexIntoShards, int shardingFactor) {
+        HollowObjectTypeDataElements[] result = new HollowObjectTypeDataElements[shardingFactor];
+        int newNumShards = shards.length / shardingFactor;
+        for (int i=0; i<shardingFactor; i++) {
+            result[i] = shards[indexIntoShards + (newNumShards*i)].currentDataElements();
+        };
+        return result;
+    }
+
+    ShardsHolder joinDataElementsForOneShard(ShardsHolder shardsHolder, int currentIndex, int shardingFactor) {
+        int newNumShards = shardsHolder.shards.length / shardingFactor;
+        int newShardOrdinalShift = 31 - Integer.numberOfLeadingZeros(newNumShards);
+
+        HollowObjectTypeDataElements[] joinCandidates = joinCandidates(shardsHolder.shards, currentIndex, shardingFactor);
+
+        HollowObjectTypeDataElementsJoiner joiner = new HollowObjectTypeDataElementsJoiner();
+        HollowObjectTypeDataElements joined = joiner.join(joinCandidates);
+
+        HollowObjectTypeDataElements[] newDataElements = new HollowObjectTypeDataElements[shardsHolder.shards.length];
+        int[] shardOrdinalShifts = new int[shardsHolder.shards.length];
+        copyShardElements(shardsHolder, newDataElements, shardOrdinalShifts);
+
+        for (int i=0; i<shardingFactor; i++) {
+            newDataElements[currentIndex + (newNumShards*i)] = joined;
+            shardOrdinalShifts[currentIndex + (newNumShards*i)] = newShardOrdinalShift;
+        };
+        return new ShardsHolder(schema, newDataElements, shardOrdinalShifts);
+    }
+
+    ShardsHolder expandWithOriginalDataElements(ShardsHolder shardsHolder, int shardingFactor) {
+        int prevNumShards = shardsHolder.shards.length;
+        int newNumShards = prevNumShards * shardingFactor;
+        HollowObjectTypeDataElements[] newDataElements = new HollowObjectTypeDataElements[newNumShards];
+        int[] shardOrdinalShifts = new int[newNumShards];
+
+        for(int i=0; i<prevNumShards; i++) {
+            for (int j=0; j<shardingFactor; j++) {
+                newDataElements[i+(prevNumShards*j)] = shardsHolder.shards[i].currentDataElements();
+                shardOrdinalShifts[i+(prevNumShards*j)] = 31 - Integer.numberOfLeadingZeros(prevNumShards);
+            }
+        }
+        return new ShardsHolder(schema, newDataElements, shardOrdinalShifts);
+    }
+
+    ShardsHolder splitDataElementsForOneShard(ShardsHolder shardsHolder, int currentIndex, int prevNumShards, int shardingFactor) {
+        int newNumShards = shardsHolder.shards.length;
+        int newShardOrdinalShift = 31 - Integer.numberOfLeadingZeros(newNumShards);
+
+        HollowObjectTypeDataElements dataElementsToSplit = shardsHolder.shards[currentIndex].currentDataElements();
+
+        HollowObjectTypeDataElementsSplitter splitter = new HollowObjectTypeDataElementsSplitter();
+        HollowObjectTypeDataElements[] splits = splitter.split(dataElementsToSplit, shardingFactor);
+
+        HollowObjectTypeDataElements[] newDataElements = new HollowObjectTypeDataElements[shardsHolder.shards.length];
+        int[] shardOrdinalShifts = new int[shardsHolder.shards.length];
+        copyShardElements(shardsHolder, newDataElements, shardOrdinalShifts);
+
+        for (int i = 0; i < shardingFactor; i ++) {
+            newDataElements[currentIndex + (prevNumShards*i)] = splits[i];
+            shardOrdinalShifts[currentIndex + (prevNumShards*i)] = newShardOrdinalShift;
+        }
+
+        return new ShardsHolder(schema, newDataElements, shardOrdinalShifts);
+    }
+
+    private void destroyOriginalDataElements(HollowObjectTypeDataElements dataElements) {
+        dataElements.destroy();
+        if (dataElements.encodedRemovals != null) {
+            dataElements.encodedRemovals.destroy();
+        }
     }
 
     public static void discardSnapshot(HollowBlobInput in, HollowObjectSchema schema, int numShards) throws IOException {
@@ -159,67 +347,155 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
     @Override
     public boolean isNull(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].isNull(ordinal >> shardOrdinalShift, fieldIndex);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        boolean result;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            result = shard.isNull(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(shardsHolder != this.shardsVolatile);
+        return result;
     }
 
     @Override
     public int readOrdinal(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].readOrdinal(ordinal >> shardOrdinalShift, fieldIndex);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        int result;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            result = shard.readOrdinal(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(shardsHolder != this.shardsVolatile);
+        return result;
     }
 
     @Override
     public int readInt(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].readInt(ordinal >> shardOrdinalShift, fieldIndex);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        int result;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            result = shard.readInt(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(shardsHolder != this.shardsVolatile);
+        return result;
     }
 
     @Override
     public float readFloat(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].readFloat(ordinal >> shardOrdinalShift, fieldIndex);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        float result;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            result = shard.readFloat(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(shardsHolder != this.shardsVolatile);
+        return result;
     }
 
     @Override
     public double readDouble(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].readDouble(ordinal >> shardOrdinalShift, fieldIndex);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        double result;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            result = shard.readDouble(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(shardsHolder != this.shardsVolatile);
+        return result;
     }
 
     @Override
     public long readLong(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].readLong(ordinal >> shardOrdinalShift, fieldIndex);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        long result;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            result = shard.readLong(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(shardsHolder != this.shardsVolatile);
+        return result;
     }
 
     @Override
     public Boolean readBoolean(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].readBoolean(ordinal >> shardOrdinalShift, fieldIndex);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        Boolean result;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            result = shard.readBoolean(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(shardsHolder != this.shardsVolatile);
+        return result;
     }
 
     @Override
     public byte[] readBytes(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].readBytes(ordinal >> shardOrdinalShift, fieldIndex);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        byte[] result;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            result = shard.readBytes(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(shardsHolder != this.shardsVolatile);
+        return result;
     }
 
     @Override
     public String readString(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].readString(ordinal >> shardOrdinalShift, fieldIndex);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        String result;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            result = shard.readString(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(shardsHolder != this.shardsVolatile);
+        return result;
     }
 
     @Override
     public boolean isStringFieldEqual(int ordinal, int fieldIndex, String testValue) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].isStringFieldEqual(ordinal >> shardOrdinalShift, fieldIndex, testValue);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        boolean result;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            result = shard.isStringFieldEqual(ordinal >> shard.shardOrdinalShift, fieldIndex, testValue);
+        } while(shardsHolder != this.shardsVolatile);
+        return result;
     }
 
     @Override
     public int findVarLengthFieldHashCode(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
-        return shards[ordinal & shardNumberMask].findVarLengthFieldHashCode(ordinal >> shardOrdinalShift, fieldIndex);
+        HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        int hashCode;
+
+        do {
+            shardsHolder = this.shardsVolatile;
+            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            hashCode = shard.findVarLengthFieldHashCode(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(shardsHolder != this.shardsVolatile);
+        return hashCode;
     }
 
     /**
@@ -228,6 +504,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
      * @return the number of bits required for the field
      */
     public int bitsRequiredForField(String fieldName) {
+        final HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
         int maxBitsRequiredForField = shards[0].bitsRequiredForField(fieldName);
         
         for(int i=1;i<shards.length;i++) {
@@ -246,6 +523,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
     @Override
     protected void invalidate() {
+        HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
         stateListeners = EMPTY_LISTENERS;
         for(int i=0;i<shards.length;i++)
             shards[i].invalidate();
@@ -265,8 +543,9 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
     public void ignoreUpdateThreadForSampling(Thread t) {
         sampler.setUpdateThread(t);
     }
-    
+
     HollowObjectTypeDataElements[] currentDataElements() {
+        final HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
         HollowObjectTypeDataElements currentDataElements[] = new HollowObjectTypeDataElements[shards.length];
         
         for(int i=0;i<shards.length;i++)
@@ -277,27 +556,33 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
     @Override
     protected void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema) {
+        final ShardsHolder shardsHolder = this.shardsVolatile;
+        final HollowObjectTypeReadStateShard[] shards = shardsHolder.shards;
+        int shardNumberMask = shardsHolder.shardNumberMask;
         if(!(withSchema instanceof HollowObjectSchema))
             throw new IllegalArgumentException("HollowObjectTypeReadState can only calculate checksum with a HollowObjectSchema: " + getSchema().getName());
 
         BitSet populatedOrdinals = getPopulatedOrdinals();
-        
-        for(int i=0;i<shards.length;i++)
-            shards[i].applyToChecksum(checksum, withSchema, populatedOrdinals, i, shards.length);
+
+        for(int i=0;i<shards.length;i++) {
+            shards[i].applyToChecksum(checksum, withSchema, populatedOrdinals, i, shardNumberMask);
+        }
     }
 
 	@Override
 	public long getApproximateHeapFootprintInBytes() {
+        final HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
 	    long totalApproximateHeapFootprintInBytes = 0;
 	    
 	    for(int i=0;i<shards.length;i++)
-	        totalApproximateHeapFootprintInBytes += shards[i].getApproximateHeapFootprintInBytes();
+            totalApproximateHeapFootprintInBytes += shards[i].getApproximateHeapFootprintInBytes();
 	    
 	    return totalApproximateHeapFootprintInBytes;
 	}
 	
 	@Override
 	public long getApproximateHoleCostInBytes() {
+        final HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
 	    long totalApproximateHoleCostInBytes = 0;
 	    
 	    BitSet populatedOrdinals = getPopulatedOrdinals();
@@ -309,6 +594,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 	}
 	
 	void setCurrentData(HollowObjectTypeDataElements data) {
+        HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
 	    if(shards.length > 1)
 	        throw new UnsupportedOperationException("Cannot directly set data on sharded type state");
 	    shards[0].setCurrentData(data);
@@ -317,7 +603,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
     @Override
     public int numShards() {
-        return shards.length;
+        return this.shardsVolatile.shards.length;
     }
 	
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -56,14 +56,9 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         final HollowObjectTypeReadStateShard shards[];
         final int shardNumberMask;
 
-        private ShardsHolder(HollowSchema schema, HollowObjectTypeDataElements[] dataElements, int[] shardOrdinalShifts) {
-            int numShards = dataElements.length;
-            HollowObjectTypeReadStateShard[] shards = new HollowObjectTypeReadStateShard[numShards];
-            for (int i=0; i<numShards; i++) {
-                shards[i] = new HollowObjectTypeReadStateShard((HollowObjectSchema) schema, dataElements[i], shardOrdinalShifts[i]);
-            }
-            this.shards = shards;
-            this.shardNumberMask = numShards - 1;
+        private ShardsHolder(HollowObjectTypeReadStateShard[] fromShards) {
+            this.shards = fromShards;
+            this.shardNumberMask = fromShards.length - 1;
         }
 
         private ShardsHolder(HollowObjectTypeReadStateShard[] oldShards, HollowObjectTypeReadStateShard newShard, int newShardIndex) {
@@ -93,8 +88,8 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         this.sampler = new HollowObjectSampler(schema, DisabledSamplingDirector.INSTANCE);
         this.unfilteredSchema = schema;
 
-        int shardOrdinalShift = 0;
-        this.shardsVolatile = new ShardsHolder(schema, new HollowObjectTypeDataElements[] {dataElements}, new int[] {shardOrdinalShift});
+        HollowObjectTypeReadStateShard newShard = new HollowObjectTypeReadStateShard(schema, dataElements, 0);
+        this.shardsVolatile = new ShardsHolder(new HollowObjectTypeReadStateShard[] {newShard});
         this.maxOrdinal = dataElements.maxOrdinal;
     }
 
@@ -118,15 +113,14 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         if(numShards > 1)
             maxOrdinal = VarInt.readVInt(in);
 
-        HollowObjectTypeDataElements[] snapshotData = new HollowObjectTypeDataElements[numShards];
-        int shardOrdinalShifts[] = new int[numShards];
+        HollowObjectTypeReadStateShard[] newShards = new HollowObjectTypeReadStateShard[numShards];
+        int shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(numShards);
         for(int i=0; i<numShards; i++) {
-            snapshotData[i] = new HollowObjectTypeDataElements(getSchema(), memoryMode, memoryRecycler);
-            snapshotData[i].readSnapshot(in, unfilteredSchema);
-            shardOrdinalShifts[i] = 31 - Integer.numberOfLeadingZeros(numShards);
+            HollowObjectTypeDataElements shardDataElements = new HollowObjectTypeDataElements(getSchema(), memoryMode, memoryRecycler);
+            shardDataElements.readSnapshot(in, unfilteredSchema);
+            newShards[i] = new HollowObjectTypeReadStateShard(getSchema(), shardDataElements, shardOrdinalShift);
         }
-
-        shardsVolatile = new ShardsHolder(getSchema(), snapshotData, shardOrdinalShifts);
+        shardsVolatile = new ShardsHolder(newShards);
 
         if(shardsVolatile.shards.length == 1)
             maxOrdinal = shardsVolatile.shards[0].dataElements.maxOrdinal;
@@ -261,9 +255,8 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             newDataElements = new HollowObjectTypeDataElements[shardsVolatile.shards.length];
             shardOrdinalShifts = new int[shardsVolatile.shards.length];
             copyShardElements(shardsVolatile, newDataElements, shardOrdinalShifts);
-            shardsVolatile = new ShardsHolder(schema,
-                    Arrays.copyOfRange(newDataElements, 0, newNumShards),
-                    Arrays.copyOfRange(shardOrdinalShifts, 0, newNumShards));
+            shardsVolatile = new ShardsHolder(Arrays.copyOfRange(shardsVolatile.shards, 0, newNumShards));
+
             // Re-sharding done.
             // shardsVolatile now contains newNumShards shards where each shard contains
             // a join of original data elements.
@@ -290,56 +283,43 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         int newNumShards = shardsHolder.shards.length / shardingFactor;
         int newShardOrdinalShift = 31 - Integer.numberOfLeadingZeros(newNumShards);
 
-        HollowObjectTypeDataElements[] joinCandidates = joinCandidates(shardsHolder.shards, currentIndex, shardingFactor);
-
         HollowObjectTypeDataElementsJoiner joiner = new HollowObjectTypeDataElementsJoiner();
+        HollowObjectTypeDataElements[] joinCandidates = joinCandidates(shardsHolder.shards, currentIndex, shardingFactor);
         HollowObjectTypeDataElements joined = joiner.join(joinCandidates);
 
-        HollowObjectTypeDataElements[] newDataElements = new HollowObjectTypeDataElements[shardsHolder.shards.length];
-        int[] shardOrdinalShifts = new int[shardsHolder.shards.length];
-        copyShardElements(shardsHolder, newDataElements, shardOrdinalShifts);
-
+        HollowObjectTypeReadStateShard[] newShards = Arrays.copyOf(shardsHolder.shards, shardsHolder.shards.length);
         for (int i=0; i<shardingFactor; i++) {
-            newDataElements[currentIndex + (newNumShards*i)] = joined;
-            shardOrdinalShifts[currentIndex + (newNumShards*i)] = newShardOrdinalShift;
-        };
-        return new ShardsHolder(schema, newDataElements, shardOrdinalShifts);
+            newShards[currentIndex + (newNumShards*i)] = new HollowObjectTypeReadStateShard(getSchema(), joined, newShardOrdinalShift);
+        }
+        return new ShardsHolder(newShards);
     }
 
     ShardsHolder expandWithOriginalDataElements(ShardsHolder shardsHolder, int shardingFactor) {
         int prevNumShards = shardsHolder.shards.length;
         int newNumShards = prevNumShards * shardingFactor;
-        HollowObjectTypeDataElements[] newDataElements = new HollowObjectTypeDataElements[newNumShards];
-        int[] shardOrdinalShifts = new int[newNumShards];
+        HollowObjectTypeReadStateShard[] newShards = new HollowObjectTypeReadStateShard[newNumShards];
 
         for(int i=0; i<prevNumShards; i++) {
             for (int j=0; j<shardingFactor; j++) {
-                newDataElements[i+(prevNumShards*j)] = shardsHolder.shards[i].dataElements;
-                shardOrdinalShifts[i+(prevNumShards*j)] = 31 - Integer.numberOfLeadingZeros(prevNumShards);
+                newShards[i+(prevNumShards*j)] = shardsHolder.shards[i];
             }
         }
-        return new ShardsHolder(schema, newDataElements, shardOrdinalShifts);
+        return new ShardsHolder(newShards);
     }
 
     ShardsHolder splitDataElementsForOneShard(ShardsHolder shardsHolder, int currentIndex, int prevNumShards, int shardingFactor) {
         int newNumShards = shardsHolder.shards.length;
         int newShardOrdinalShift = 31 - Integer.numberOfLeadingZeros(newNumShards);
 
-        HollowObjectTypeDataElements dataElementsToSplit = shardsHolder.shards[currentIndex].dataElements;
-
         HollowObjectTypeDataElementsSplitter splitter = new HollowObjectTypeDataElementsSplitter();
+        HollowObjectTypeDataElements dataElementsToSplit = shardsHolder.shards[currentIndex].dataElements;
         HollowObjectTypeDataElements[] splits = splitter.split(dataElementsToSplit, shardingFactor);
 
-        HollowObjectTypeDataElements[] newDataElements = new HollowObjectTypeDataElements[shardsHolder.shards.length];
-        int[] shardOrdinalShifts = new int[shardsHolder.shards.length];
-        copyShardElements(shardsHolder, newDataElements, shardOrdinalShifts);
-
+        HollowObjectTypeReadStateShard[] newShards = Arrays.copyOf(shardsHolder.shards, shardsHolder.shards.length);
         for (int i = 0; i < shardingFactor; i ++) {
-            newDataElements[currentIndex + (prevNumShards*i)] = splits[i];
-            shardOrdinalShifts[currentIndex + (prevNumShards*i)] = newShardOrdinalShift;
+            newShards[currentIndex + (prevNumShards*i)] = new HollowObjectTypeReadStateShard(getSchema(), splits[i], newShardOrdinalShift);
         }
-
-        return new ShardsHolder(schema, newDataElements, shardOrdinalShifts);
+        return new ShardsHolder(newShards);
     }
 
     private void destroyOriginalDataElements(HollowObjectTypeDataElements dataElements) {
@@ -375,7 +355,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             shardsHolder = this.shardsVolatile;
             shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
             fixedLengthValue = shard.isNull(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(readWasUnsafe(shardsHolder));
+        } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
         switch(((HollowObjectSchema) schema).getFieldType(fieldIndex)) {
             case BYTES:
@@ -403,7 +383,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             shardsHolder = this.shardsVolatile;
             shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
             refOrdinal = shard.readOrdinal(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(readWasUnsafe(shardsHolder));
+        } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
         if(refOrdinal == shard.dataElements.nullValueForField[fieldIndex])
             return ORDINAL_NONE;
@@ -422,7 +402,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             shardsHolder = this.shardsVolatile;
             shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
             value = shard.readInt(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(readWasUnsafe(shardsHolder));
+        } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
         if(value == shard.dataElements.nullValueForField[fieldIndex])
             return Integer.MIN_VALUE;
@@ -441,7 +421,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             shardsHolder = this.shardsVolatile;
             shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
             value = shard.readFloat(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(readWasUnsafe(shardsHolder));
+        } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
         if(value == HollowObjectWriteRecord.NULL_FLOAT_BITS)
             return Float.NaN;
@@ -460,7 +440,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             shardsHolder = this.shardsVolatile;
             shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
             value = shard.readDouble(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(readWasUnsafe(shardsHolder));
+        } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
         if(value == HollowObjectWriteRecord.NULL_DOUBLE_BITS)
             return Double.NaN;
@@ -479,7 +459,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             shardsHolder = this.shardsVolatile;
             shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
             value = shard.readLong(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(readWasUnsafe(shardsHolder));
+        } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
         if(value == shard.dataElements.nullValueForField[fieldIndex])
             return Long.MIN_VALUE;
@@ -498,7 +478,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             shardsHolder = this.shardsVolatile;
             shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
             value = shard.readBoolean(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(readWasUnsafe(shardsHolder));
+        } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
         if(value == shard.dataElements.nullValueForField[fieldIndex])
             return null;
@@ -528,10 +508,10 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
                 currentBitOffset = shard.fieldOffset(shardOrdinal, fieldIndex);
                 endByte = shard.dataElements.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
                 startByte = shardOrdinal != 0 ? shard.dataElements.fixedLengthData.getElementValue(currentBitOffset - shard.dataElements.bitsPerRecord, numBitsForField) : 0;
-            } while (readWasUnsafe(shardsHolder));
+            } while (readWasUnsafe(shardsHolder, ordinal, shard));
 
             result = shard.readBytes(startByte, endByte, numBitsForField, fieldIndex);
-        } while (readWasUnsafe(shardsHolder));
+        } while (readWasUnsafe(shardsHolder, ordinal, shard));
 
         return result;
     }
@@ -559,10 +539,10 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
                 currentBitOffset = shard.fieldOffset(shardOrdinal, fieldIndex);
                 endByte = shard.dataElements.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
                 startByte = shardOrdinal != 0 ? shard.dataElements.fixedLengthData.getElementValue(currentBitOffset - shard.dataElements.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(shardsHolder));
+            } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
             result = shard.readString(startByte, endByte, numBitsForField, fieldIndex);
-        } while(readWasUnsafe(shardsHolder));
+        } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
         return result;
     }
@@ -590,10 +570,10 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
                 currentBitOffset = shard.fieldOffset(shardOrdinal, fieldIndex);
                 endByte = shard.dataElements.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
                 startByte = shardOrdinal != 0 ? shard.dataElements.fixedLengthData.getElementValue(currentBitOffset - shard.dataElements.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(shardsHolder));
+            } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
             result = shard.isStringFieldEqual(startByte, endByte, numBitsForField, fieldIndex, testValue);
-        } while(readWasUnsafe(shardsHolder));
+        } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
         return result;
     }
@@ -621,15 +601,15 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
                 currentBitOffset = shard.fieldOffset(shardOrdinal, fieldIndex);
                 endByte = shard.dataElements.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
                 startByte = shardOrdinal != 0 ? shard.dataElements.fixedLengthData.getElementValue(currentBitOffset - shard.dataElements.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(shardsHolder));
+            } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
             hashCode = shard.findVarLengthFieldHashCode(startByte, endByte, numBitsForField, fieldIndex);
-        } while(readWasUnsafe(shardsHolder));
+        } while(readWasUnsafe(shardsHolder, ordinal, shard));
 
         return hashCode;
     }
 
-    private boolean readWasUnsafe(ShardsHolder shardsHolder) {
+    private boolean readWasUnsafe(ShardsHolder shardsHolder, int ordinal, HollowObjectTypeReadStateShard shard) {
         // Use a load (acquire) fence to constrain the compiler reordering prior plain loads so
         // that they cannot "float down" below the volatile load of shardsVolatile.
         // This ensures data is checked against current shard holder *after* optimistic calculations
@@ -657,7 +637,14 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         // [Comment credit: Paul Sandoz]
         //
         HollowUnsafeHandle.getUnsafe().loadFence();
-        return shardsHolder != shardsVolatile;
+        ShardsHolder currShardsHolder = shardsVolatile;
+        // Validate against the underlying shard so that, during a delta application that involves re-sharding the worst
+        // case no. of times a read will be invalidatedis 3: when shards are expanded or truncated, when a shard is affected
+        // by a split or join, and finally when delta is applied to a shard. If only shardsHolder was checked here, the
+        // worst-case scenario could lead to read invalidation (numShards+2) times: once for shards expansion/truncation, o
+        // nce for split/join on any shard, and then once when delta is applied.
+        return shardsHolder != currShardsHolder
+            && (shard != currShardsHolder.shards[ordinal & currShardsHolder.shardNumberMask]);
     }
 
     /**
@@ -688,11 +675,11 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         stateListeners = EMPTY_LISTENERS;
         HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
         int numShards = shards.length;
-        HollowObjectTypeDataElements[] nullDataElements = new HollowObjectTypeDataElements[numShards];
-        int[] shardOridnalShifts = new int[numShards];
-        for (int i=0;i<numShards;i++)
-            shardOridnalShifts[i] = shards[i].shardOrdinalShift;
-        this.shardsVolatile = new ShardsHolder(getSchema(), nullDataElements, shardOridnalShifts);
+        HollowObjectTypeReadStateShard[] newShards = new HollowObjectTypeReadStateShard[numShards];
+        for (int i=0;i<numShards;i++) {
+            newShards[i] = new HollowObjectTypeReadStateShard(getSchema(), null, shards[i].shardOrdinalShift);
+        }
+        this.shardsVolatile = new ShardsHolder(newShards);
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -16,13 +16,17 @@
  */
 package com.netflix.hollow.core.read.engine.object;
 
+import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
+
 import com.netflix.hollow.api.sampling.DisabledSamplingDirector;
 import com.netflix.hollow.api.sampling.HollowObjectSampler;
 import com.netflix.hollow.api.sampling.HollowSampler;
 import com.netflix.hollow.api.sampling.HollowSamplingDirector;
+import com.netflix.hollow.core.memory.HollowUnsafeHandle;
 import com.netflix.hollow.core.memory.MemoryMode;
 import com.netflix.hollow.core.memory.encoding.GapEncodedVariableLengthIntegerReader;
 import com.netflix.hollow.core.memory.encoding.VarInt;
+import com.netflix.hollow.core.memory.encoding.ZigZag;
 import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
 import com.netflix.hollow.core.read.HollowBlobInput;
 import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
@@ -32,6 +36,7 @@ import com.netflix.hollow.core.read.engine.SnapshotPopulatedOrdinalsReader;
 import com.netflix.hollow.core.read.filter.HollowFilterConfig;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
 import com.netflix.hollow.tools.checksum.HollowChecksum;
 import java.io.IOException;
 import java.util.Arrays;
@@ -44,51 +49,53 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
     private final HollowObjectSchema unfilteredSchema;
     private final HollowObjectSampler sampler;
+    private int maxOrdinal;
+    volatile ShardsHolder shardsVolatile;
 
     static class ShardsHolder {
         final HollowObjectTypeReadStateShard shards[];
         final int shardNumberMask;
 
-        private ShardsHolder(HollowSchema schema, int numShards) {
-            HollowObjectTypeReadStateShard[] shards = new HollowObjectTypeReadStateShard[numShards];
-            int shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(numShards);
-            for(int i=0; i<numShards; i++) {
-                shards[i] = new HollowObjectTypeReadStateShard((HollowObjectSchema) schema, shardOrdinalShift);
-            }
-            this.shards = shards;
-            this.shardNumberMask = numShards - 1;
-        }
-
         private ShardsHolder(HollowSchema schema, HollowObjectTypeDataElements[] dataElements, int[] shardOrdinalShifts) {
             int numShards = dataElements.length;
             HollowObjectTypeReadStateShard[] shards = new HollowObjectTypeReadStateShard[numShards];
             for (int i=0; i<numShards; i++) {
-                shards[i] = new HollowObjectTypeReadStateShard((HollowObjectSchema) schema, shardOrdinalShifts[i]);
-                shards[i].setCurrentData(dataElements[i]);
+                shards[i] = new HollowObjectTypeReadStateShard((HollowObjectSchema) schema, dataElements[i], shardOrdinalShifts[i]);
+            }
+            this.shards = shards;
+            this.shardNumberMask = numShards - 1;
+        }
+
+        private ShardsHolder(HollowObjectTypeReadStateShard[] oldShards, HollowObjectTypeReadStateShard newShard, int newShardIndex) {
+            int numShards = oldShards.length;
+            HollowObjectTypeReadStateShard[] shards = new HollowObjectTypeReadStateShard[numShards];
+            for (int i=0; i<numShards; i++) {
+                if (i == newShardIndex) {
+                    shards[i] = newShard;
+                } else {
+                    shards[i] = oldShards[i];
+                }
             }
             this.shards = shards;
             this.shardNumberMask = numShards - 1;
         }
     }
 
-    volatile ShardsHolder shardsVolatile;
-
-    private int maxOrdinal;
-
-    public HollowObjectTypeReadState(HollowReadStateEngine fileEngine, HollowObjectSchema schema) {
-        this(fileEngine, MemoryMode.ON_HEAP, schema, schema, 1);
-    }
-
-    public HollowObjectTypeReadState(HollowReadStateEngine fileEngine, MemoryMode memoryMode, HollowObjectSchema schema, HollowObjectSchema unfilteredSchema, int numShards) {
+    public HollowObjectTypeReadState(HollowReadStateEngine fileEngine, MemoryMode memoryMode, HollowObjectSchema schema, HollowObjectSchema unfilteredSchema) {
         super(fileEngine, memoryMode, schema);
         this.sampler = new HollowObjectSampler(schema, DisabledSamplingDirector.INSTANCE);
         this.unfilteredSchema = unfilteredSchema;
+        this.shardsVolatile = null;
+    }
 
-        int shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(numShards);
-        if(numShards < 1 || 1 << shardOrdinalShift != numShards)
-            throw new IllegalArgumentException("Number of shards must be a power of 2!");
+    public HollowObjectTypeReadState(HollowObjectSchema schema, HollowObjectTypeDataElements dataElements) {
+        super(null, MemoryMode.ON_HEAP, schema);
+        this.sampler = new HollowObjectSampler(schema, DisabledSamplingDirector.INSTANCE);
+        this.unfilteredSchema = schema;
 
-        this.shardsVolatile = new ShardsHolder(schema, numShards);
+        int shardOrdinalShift = 0;
+        this.shardsVolatile = new ShardsHolder(schema, new HollowObjectTypeDataElements[] {dataElements}, new int[] {shardOrdinalShift});
+        this.maxOrdinal = dataElements.maxOrdinal;
     }
 
     @Override
@@ -103,17 +110,26 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
     @Override
     public void readSnapshot(HollowBlobInput in, ArraySegmentRecycler memoryRecycler) throws IOException {
-        if(shardsVolatile.shards.length > 1)
+        throw new IllegalStateException("Object type read state requires numShards when reading snapshot");
+    }
+
+    @Override
+    public void readSnapshot(HollowBlobInput in, ArraySegmentRecycler memoryRecycler, int numShards) throws IOException {
+        if(numShards > 1)
             maxOrdinal = VarInt.readVInt(in);
 
-        for(int i=0; i<shardsVolatile.shards.length; i++) {
-            HollowObjectTypeDataElements snapshotData = new HollowObjectTypeDataElements(getSchema(), memoryMode, memoryRecycler);
-            snapshotData.readSnapshot(in, unfilteredSchema);
-            shardsVolatile.shards[i].setCurrentData(snapshotData);
+        HollowObjectTypeDataElements[] snapshotData = new HollowObjectTypeDataElements[numShards];
+        int shardOrdinalShifts[] = new int[numShards];
+        for(int i=0; i<numShards; i++) {
+            snapshotData[i] = new HollowObjectTypeDataElements(getSchema(), memoryMode, memoryRecycler);
+            snapshotData[i].readSnapshot(in, unfilteredSchema);
+            shardOrdinalShifts[i] = 31 - Integer.numberOfLeadingZeros(numShards);
         }
 
+        shardsVolatile = new ShardsHolder(getSchema(), snapshotData, shardOrdinalShifts);
+
         if(shardsVolatile.shards.length == 1)
-            maxOrdinal = shardsVolatile.shards[0].currentDataElements().maxOrdinal;
+            maxOrdinal = shardsVolatile.shards[0].dataElements.maxOrdinal;
 
         SnapshotPopulatedOrdinalsReader.readOrdinals(in, stateListeners);
     }
@@ -134,7 +150,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
                 if(!deltaData.encodedRemovals.isEmpty())
                     notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shardsVolatile.shards.length);
 
-                HollowObjectTypeDataElements currentData = shardsVolatile.shards[i].currentDataElements();
+                HollowObjectTypeDataElements currentData = shardsVolatile.shards[i].dataElements;
                 GapEncodedVariableLengthIntegerReader oldRemovals = currentData.encodedRemovals == null ? GapEncodedVariableLengthIntegerReader.EMPTY_READER : currentData.encodedRemovals;
                 if(oldRemovals.isEmpty()) {
                     currentData.encodedRemovals = deltaData.encodedRemovals;
@@ -150,9 +166,12 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
                 deltaData.encodedAdditions.destroy();
             } else {
                 HollowObjectTypeDataElements nextData = new HollowObjectTypeDataElements(getSchema(), memoryMode, memoryRecycler);
-                HollowObjectTypeDataElements oldData = shardsVolatile.shards[i].currentDataElements();
+                HollowObjectTypeDataElements oldData = shardsVolatile.shards[i].dataElements;
                 nextData.applyDelta(oldData, deltaData);
-                shardsVolatile.shards[i].setCurrentData(nextData);
+
+                HollowObjectTypeReadStateShard newShard = new HollowObjectTypeReadStateShard(getSchema(), nextData, shardsVolatile.shards[i].shardOrdinalShift);
+                shardsVolatile = new ShardsHolder(shardsVolatile.shards, newShard, i);
+
                 notifyListenerAboutDeltaChanges(deltaData.encodedRemovals, deltaData.encodedAdditions, i, shardsVolatile.shards.length);
                 deltaData.encodedAdditions.destroy();
                 oldData.destroy();
@@ -162,7 +181,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         }
 
         if(shardsVolatile.shards.length == 1)
-            maxOrdinal = shardsVolatile.shards[0].currentDataElements().maxOrdinal;
+            maxOrdinal = shardsVolatile.shards[0].dataElements.maxOrdinal;
     }
 
     /**
@@ -212,7 +231,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
             // sufficient to serve all reads into this shard. Once all child shards for a pre-split parent
             // shard have been assigned the split data elements, the parent data elements can be discarded.
             for(int i=0; i<prevNumShards; i++) {
-                HollowObjectTypeDataElements originalDataElements = shardsVolatile.shards[i].currentDataElements();
+                HollowObjectTypeDataElements originalDataElements = shardsVolatile.shards[i].dataElements;
 
                 shardsVolatile = splitDataElementsForOneShard(shardsVolatile, i, prevNumShards, shardingFactor);
 
@@ -253,7 +272,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
     private void copyShardElements(ShardsHolder from, HollowObjectTypeDataElements[] newDataElements, int[] shardOrdinalShifts) {
         for (int i=0; i<from.shards.length; i++) {
-            newDataElements[i] = from.shards[i].currentDataElements();
+            newDataElements[i] = from.shards[i].dataElements;
             shardOrdinalShifts[i] = from.shards[i].shardOrdinalShift;
         }
     }
@@ -262,7 +281,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         HollowObjectTypeDataElements[] result = new HollowObjectTypeDataElements[shardingFactor];
         int newNumShards = shards.length / shardingFactor;
         for (int i=0; i<shardingFactor; i++) {
-            result[i] = shards[indexIntoShards + (newNumShards*i)].currentDataElements();
+            result[i] = shards[indexIntoShards + (newNumShards*i)].dataElements;
         };
         return result;
     }
@@ -295,7 +314,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
         for(int i=0; i<prevNumShards; i++) {
             for (int j=0; j<shardingFactor; j++) {
-                newDataElements[i+(prevNumShards*j)] = shardsHolder.shards[i].currentDataElements();
+                newDataElements[i+(prevNumShards*j)] = shardsHolder.shards[i].dataElements;
                 shardOrdinalShifts[i+(prevNumShards*j)] = 31 - Integer.numberOfLeadingZeros(prevNumShards);
             }
         }
@@ -306,7 +325,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         int newNumShards = shardsHolder.shards.length;
         int newShardOrdinalShift = 31 - Integer.numberOfLeadingZeros(newNumShards);
 
-        HollowObjectTypeDataElements dataElementsToSplit = shardsHolder.shards[currentIndex].currentDataElements();
+        HollowObjectTypeDataElements dataElementsToSplit = shardsHolder.shards[currentIndex].dataElements;
 
         HollowObjectTypeDataElementsSplitter splitter = new HollowObjectTypeDataElementsSplitter();
         HollowObjectTypeDataElements[] splits = splitter.split(dataElementsToSplit, shardingFactor);
@@ -347,155 +366,262 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
     @Override
     public boolean isNull(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
-        boolean result;
+        HollowObjectTypeReadStateShard shard;
+        long fixedLengthValue;
 
         do {
             shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            result = shard.isNull(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(shardsHolder != this.shardsVolatile);
-        return result;
+            shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            fixedLengthValue = shard.isNull(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(readWasUnsafe(shardsHolder));
+
+        switch(((HollowObjectSchema) schema).getFieldType(fieldIndex)) {
+            case BYTES:
+            case STRING:
+                int numBits = shard.dataElements.bitsPerField[fieldIndex];
+                return (fixedLengthValue & (1L << (numBits - 1))) != 0;
+            case FLOAT:
+                return (int)fixedLengthValue == HollowObjectWriteRecord.NULL_FLOAT_BITS;
+            case DOUBLE:
+                return fixedLengthValue == HollowObjectWriteRecord.NULL_DOUBLE_BITS;
+            default:
+                return fixedLengthValue == shard.dataElements.nullValueForField[fieldIndex];
+        }
     }
 
     @Override
     public int readOrdinal(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
-        int result;
+        HollowObjectTypeReadStateShard shard;
+        long refOrdinal;
 
         do {
             shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            result = shard.readOrdinal(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(shardsHolder != this.shardsVolatile);
-        return result;
+            shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            refOrdinal = shard.readOrdinal(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(readWasUnsafe(shardsHolder));
+
+        if(refOrdinal == shard.dataElements.nullValueForField[fieldIndex])
+            return ORDINAL_NONE;
+        return (int)refOrdinal;
     }
 
     @Override
     public int readInt(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
-        int result;
+        HollowObjectTypeReadStateShard shard;
+        long value;
 
         do {
             shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            result = shard.readInt(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(shardsHolder != this.shardsVolatile);
-        return result;
+            shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            value = shard.readInt(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(readWasUnsafe(shardsHolder));
+
+        if(value == shard.dataElements.nullValueForField[fieldIndex])
+            return Integer.MIN_VALUE;
+        return ZigZag.decodeInt((int)value);
     }
 
     @Override
     public float readFloat(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
-        float result;
+        HollowObjectTypeReadStateShard shard;
+        int value;
 
         do {
             shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            result = shard.readFloat(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(shardsHolder != this.shardsVolatile);
-        return result;
+            shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            value = shard.readFloat(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(readWasUnsafe(shardsHolder));
+
+        if(value == HollowObjectWriteRecord.NULL_FLOAT_BITS)
+            return Float.NaN;
+        return Float.intBitsToFloat(value);
     }
 
     @Override
     public double readDouble(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
-        double result;
+        HollowObjectTypeReadStateShard shard;
+        long value;
 
         do {
             shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            result = shard.readDouble(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(shardsHolder != this.shardsVolatile);
-        return result;
+            shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            value = shard.readDouble(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(readWasUnsafe(shardsHolder));
+
+        if(value == HollowObjectWriteRecord.NULL_DOUBLE_BITS)
+            return Double.NaN;
+        return Double.longBitsToDouble(value);
     }
 
     @Override
     public long readLong(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
-        long result;
+        HollowObjectTypeReadStateShard shard;
+        long value;
 
         do {
             shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            result = shard.readLong(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(shardsHolder != this.shardsVolatile);
-        return result;
+            shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            value = shard.readLong(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(readWasUnsafe(shardsHolder));
+
+        if(value == shard.dataElements.nullValueForField[fieldIndex])
+            return Long.MIN_VALUE;
+        return ZigZag.decodeLong(value);
     }
 
     @Override
     public Boolean readBoolean(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
-        Boolean result;
+        HollowObjectTypeReadStateShard shard;
+        long value;
 
         do {
             shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            result = shard.readBoolean(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(shardsHolder != this.shardsVolatile);
-        return result;
+            shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+            value = shard.readBoolean(ordinal >> shard.shardOrdinalShift, fieldIndex);
+        } while(readWasUnsafe(shardsHolder));
+
+        if(value == shard.dataElements.nullValueForField[fieldIndex])
+            return null;
+        return value == 1 ? Boolean.TRUE : Boolean.FALSE;
     }
 
     @Override
     public byte[] readBytes(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        HollowObjectTypeReadStateShard shard;
+        HollowObjectTypeReadStateShard.VarLenStats stats;
         byte[] result;
 
         do {
-            shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            result = shard.readBytes(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(shardsHolder != this.shardsVolatile);
+            do {
+                shardsHolder = this.shardsVolatile;
+                shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+                stats = shard.readVarLenStats(ordinal >> shard.shardOrdinalShift, fieldIndex);
+            } while (readWasUnsafe(shardsHolder));
+
+            result = shard.readBytes(stats, fieldIndex);
+        } while (readWasUnsafe(shardsHolder));
+
         return result;
     }
 
     @Override
     public String readString(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        HollowObjectTypeReadStateShard shard;
+        HollowObjectTypeReadStateShard.VarLenStats stats;
         String result;
 
         do {
-            shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            result = shard.readString(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(shardsHolder != this.shardsVolatile);
+            do {
+                shardsHolder = this.shardsVolatile;
+                shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+                stats = shard.readVarLenStats(ordinal >> shard.shardOrdinalShift, fieldIndex);
+            } while(readWasUnsafe(shardsHolder));
+
+            result = shard.readString(stats, fieldIndex);
+        } while(readWasUnsafe(shardsHolder));
+
         return result;
     }
 
     @Override
     public boolean isStringFieldEqual(int ordinal, int fieldIndex, String testValue) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        HollowObjectTypeReadStateShard shard;
+        HollowObjectTypeReadStateShard.VarLenStats stats;
         boolean result;
 
         do {
-            shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            result = shard.isStringFieldEqual(ordinal >> shard.shardOrdinalShift, fieldIndex, testValue);
-        } while(shardsHolder != this.shardsVolatile);
+            do {
+                shardsHolder = this.shardsVolatile;
+                shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+                stats = shard.readVarLenStats(ordinal >> shard.shardOrdinalShift, fieldIndex);
+            } while(readWasUnsafe(shardsHolder));
+
+            result = shard.isStringFieldEqual(stats, fieldIndex, testValue);
+        } while(readWasUnsafe(shardsHolder));
+
         return result;
     }
 
     @Override
     public int findVarLengthFieldHashCode(int ordinal, int fieldIndex) {
         sampler.recordFieldAccess(fieldIndex);
+
         HollowObjectTypeReadState.ShardsHolder shardsHolder;
+        HollowObjectTypeReadStateShard shard;
+        HollowObjectTypeReadStateShard.VarLenStats stats;
         int hashCode;
 
         do {
-            shardsHolder = this.shardsVolatile;
-            HollowObjectTypeReadStateShard shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
-            hashCode = shard.findVarLengthFieldHashCode(ordinal >> shard.shardOrdinalShift, fieldIndex);
-        } while(shardsHolder != this.shardsVolatile);
+            do {
+                shardsHolder = this.shardsVolatile;
+                shard = shardsHolder.shards[ordinal & shardsHolder.shardNumberMask];
+                stats = shard.readVarLenStats(ordinal >> shard.shardOrdinalShift, fieldIndex);
+            } while(readWasUnsafe(shardsHolder));
+
+            hashCode = shard.findVarLengthFieldHashCode(stats, fieldIndex);
+        } while(readWasUnsafe(shardsHolder));
+
         return hashCode;
+    }
+
+    private boolean readWasUnsafe(ShardsHolder shardsHolder) {
+        // Use a load (acquire) fence to constrain the compiler reordering prior plain loads so
+        // that they cannot "float down" below the volatile load of shardsVolatile.
+        // This ensures data is checked against current shard holder *after* optimistic calculations
+        // have been performed on data.
+        //
+        // Note: the Java Memory Model allows for the reordering of plain loads and stores
+        // before a volatile load (those plain loads and stores can "float down" below the
+        // volatile load), but forbids the reordering of plain loads after a volatile load
+        // (those plain loads are not allowed to "float above" the volatile load).
+        // Similar reordering also applies to plain loads and stores and volatile stores.
+        // In effect the ordering of volatile loads and stores is retained and plain loads
+        // and stores can be shuffled around and grouped together, which increases
+        // optimization opportunities.
+        // This is why locks can be coarsened; plain loads and stores may enter the lock region
+        // from above (float down the acquire) or below (float above the release) but existing
+        // loads and stores may not exit (a "lock roach motel" and why there is almost universal
+        // misunderstanding of, and many misguided attempts to optimize, the infamous double
+        // checked locking idiom).
+        //
+        // Note: the fence provides stronger ordering guarantees than a corresponding non-plain
+        // load or store since the former affects all prior or subsequent loads and stores,
+        // whereas the latter is scoped to the particular load or store.
+        //
+        // For more details see http://gee.cs.oswego.edu/dl/html/j9mm.html
+        // [Comment credit: Paul Sandoz]
+        //
+        HollowUnsafeHandle.getUnsafe().loadFence();
+        return shardsHolder != shardsVolatile;
     }
 
     /**
@@ -523,10 +649,14 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
     @Override
     protected void invalidate() {
-        HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
         stateListeners = EMPTY_LISTENERS;
-        for(int i=0;i<shards.length;i++)
-            shards[i].invalidate();
+        HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
+        int numShards = shards.length;
+        HollowObjectTypeDataElements[] nullDataElements = new HollowObjectTypeDataElements[numShards];
+        int[] shardOridnalShifts = new int[numShards];
+        for (int i=0;i<numShards;i++)
+            shardOridnalShifts[i] = shards[i].shardOrdinalShift;
+        this.shardsVolatile = new ShardsHolder(getSchema(), nullDataElements, shardOridnalShifts);
     }
 
     @Override
@@ -546,12 +676,9 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 
     HollowObjectTypeDataElements[] currentDataElements() {
         final HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
-        HollowObjectTypeDataElements currentDataElements[] = new HollowObjectTypeDataElements[shards.length];
-        
-        for(int i=0;i<shards.length;i++)
-            currentDataElements[i] = shards[i].currentDataElements();
-        
-        return currentDataElements;
+        return Arrays.stream(shards)
+                .map(shard -> shard.dataElements)
+                .toArray(HollowObjectTypeDataElements[]::new);
     }
 
     @Override
@@ -565,7 +692,7 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         BitSet populatedOrdinals = getPopulatedOrdinals();
 
         for(int i=0;i<shards.length;i++) {
-            shards[i].applyToChecksum(checksum, withSchema, populatedOrdinals, i, shardNumberMask);
+            shards[i].applyShardToChecksum(checksum, withSchema, populatedOrdinals, i, shardNumberMask);
         }
     }
 
@@ -591,14 +718,6 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 	        totalApproximateHoleCostInBytes += shards[i].getApproximateHoleCostInBytes(populatedOrdinals, i, shards.length);
         
 	    return totalApproximateHoleCostInBytes;
-	}
-	
-	void setCurrentData(HollowObjectTypeDataElements data) {
-        HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
-	    if(shards.length > 1)
-	        throw new UnsupportedOperationException("Cannot directly set data on sharded type state");
-	    shards[0].setCurrentData(data);
-	    maxOrdinal = data.maxOrdinal;
 	}
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
@@ -42,7 +42,7 @@ class HollowObjectTypeReadStateShard {
         this.dataElements = dataElements;
     }
 
-    public long isNull(int ordinal, int fieldIndex) {
+    public long readValue(int ordinal, int fieldIndex) {
         long bitOffset = fieldOffset(ordinal, fieldIndex);
         int numBitsForField = dataElements.bitsPerField[fieldIndex];
         return numBitsForField <= 56 ?

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
@@ -36,11 +36,13 @@ import java.util.List;
 class HollowObjectTypeReadStateShard {
 
     private volatile HollowObjectTypeDataElements currentDataVolatile;
+    final int shardOrdinalShift;
 
     private final HollowObjectSchema schema;
     
-    HollowObjectTypeReadStateShard(HollowObjectSchema schema) {
+    HollowObjectTypeReadStateShard(HollowObjectSchema schema, int shardOrdinalShift) {
         this.schema = schema;
+        this.shardOrdinalShift = shardOrdinalShift;
     }
 
     public boolean isNull(int ordinal, int fieldIndex) {
@@ -391,7 +393,7 @@ class HollowObjectTypeReadStateShard {
         this.currentDataVolatile = data;
     }
 
-    protected void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema, BitSet populatedOrdinals, int shardNumber, int numShards) {
+    protected void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema, BitSet populatedOrdinals, int shardNumber, int shardNumberMask) {
         if(!(withSchema instanceof HollowObjectSchema))
             throw new IllegalArgumentException("HollowObjectTypeReadState can only calculate checksum with a HollowObjectSchema: " + schema.getName());
 
@@ -410,8 +412,8 @@ class HollowObjectTypeReadStateShard {
         HollowObjectTypeDataElements currentData = currentDataVolatile;
         int ordinal = populatedOrdinals.nextSetBit(0);
         while(ordinal != ORDINAL_NONE) {
-            if((ordinal & (numShards - 1)) == shardNumber) {
-                int shardOrdinal = ordinal / numShards;
+            if((ordinal & shardNumberMask) == shardNumber) {
+                int shardOrdinal = ordinal >> shardOrdinalShift;
                 checksum.applyInt(ordinal);
                 for(int i=0;i<fieldIndexes.length;i++) {
                     int fieldIdx = fieldIndexes[i];
@@ -449,7 +451,7 @@ class HollowObjectTypeReadStateShard {
         
         return requiredBytes;
     }
-    
+
     public long getApproximateHoleCostInBytes(BitSet populatedOrdinals, int shardNumber, int numShards) {
         HollowObjectTypeDataElements currentData = currentDataVolatile;
         long holeBits = 0;

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
@@ -19,13 +19,10 @@ package com.netflix.hollow.core.read.engine.object;
 import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
 
 import com.netflix.hollow.core.memory.ByteData;
-import com.netflix.hollow.core.memory.HollowUnsafeHandle;
 import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.memory.encoding.VarInt;
-import com.netflix.hollow.core.memory.encoding.ZigZag;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
-import com.netflix.hollow.core.write.HollowObjectWriteRecord;
 import com.netflix.hollow.tools.checksum.HollowChecksum;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,268 +31,149 @@ import java.util.Collections;
 import java.util.List;
 
 class HollowObjectTypeReadStateShard {
-
-    private volatile HollowObjectTypeDataElements currentDataVolatile;
+    final HollowObjectTypeDataElements dataElements;
     final int shardOrdinalShift;
 
     private final HollowObjectSchema schema;
-    
-    HollowObjectTypeReadStateShard(HollowObjectSchema schema, int shardOrdinalShift) {
+
+    HollowObjectTypeReadStateShard(HollowObjectSchema schema, HollowObjectTypeDataElements dataElements, int shardOrdinalShift) {
         this.schema = schema;
         this.shardOrdinalShift = shardOrdinalShift;
+        this.dataElements = dataElements;
     }
 
-    public boolean isNull(int ordinal, int fieldIndex) {
-        HollowObjectTypeDataElements currentData;
-        long fixedLengthValue;
-
-        do {
-            currentData = this.currentDataVolatile;
-
-            long bitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-            int numBitsForField = currentData.bitsPerField[fieldIndex];
-
-            fixedLengthValue = numBitsForField <= 56 ?
-                    currentData.fixedLengthData.getElementValue(bitOffset, numBitsForField)
-                    : currentData.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
-        } while(readWasUnsafe(currentData));
-
-        switch(schema.getFieldType(fieldIndex)) {
-        case BYTES:
-        case STRING:
-            int numBits = currentData.bitsPerField[fieldIndex];
-            return (fixedLengthValue & (1L << (numBits - 1))) != 0;
-        case FLOAT:
-            return (int)fixedLengthValue == HollowObjectWriteRecord.NULL_FLOAT_BITS;
-        case DOUBLE:
-            return fixedLengthValue == HollowObjectWriteRecord.NULL_DOUBLE_BITS;
-        default:
-            return fixedLengthValue == currentData.nullValueForField[fieldIndex];
-        }
+    public long isNull(int ordinal, int fieldIndex) {
+        long bitOffset = fieldOffset(ordinal, fieldIndex);
+        int numBitsForField = dataElements.bitsPerField[fieldIndex];
+        return numBitsForField <= 56 ?
+                dataElements.fixedLengthData.getElementValue(bitOffset, numBitsForField)
+                : dataElements.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
     }
 
-    public int readOrdinal(int ordinal, int fieldIndex) {
-        HollowObjectTypeDataElements currentData;
-        long refOrdinal;
-
-        do {
-            currentData = this.currentDataVolatile;
-            refOrdinal = readFixedLengthFieldValue(currentData, ordinal, fieldIndex);
-        } while(readWasUnsafe(currentData));
-
-        if(refOrdinal == currentData.nullValueForField[fieldIndex])
-            return ORDINAL_NONE;
-        return (int)refOrdinal;
+    public long readOrdinal(int ordinal, int fieldIndex) {
+        return readFixedLengthFieldValue(ordinal, fieldIndex);
     }
 
-    public int readInt(int ordinal, int fieldIndex) {
-        HollowObjectTypeDataElements currentData;
-        long value;
-
-        do {
-            currentData = this.currentDataVolatile;
-            value = readFixedLengthFieldValue(currentData, ordinal, fieldIndex);
-        } while(readWasUnsafe(currentData));
-
-        if(value == currentData.nullValueForField[fieldIndex])
-            return Integer.MIN_VALUE;
-        return ZigZag.decodeInt((int)value);
+    public long readInt(int ordinal, int fieldIndex) {
+        return readFixedLengthFieldValue(ordinal, fieldIndex);
     }
 
-    public float readFloat(int ordinal, int fieldIndex) {
-        HollowObjectTypeDataElements currentData;
-        int value;
-
-        do {
-            currentData = this.currentDataVolatile;
-            value = (int)readFixedLengthFieldValue(currentData, ordinal, fieldIndex);
-        } while(readWasUnsafe(currentData));
-
-        if(value == HollowObjectWriteRecord.NULL_FLOAT_BITS)
-            return Float.NaN;
-        return Float.intBitsToFloat(value);
+    public int readFloat(int ordinal, int fieldIndex) {
+        return (int)readFixedLengthFieldValue(ordinal, fieldIndex);
     }
 
-    public double readDouble(int ordinal, int fieldIndex) {
-        HollowObjectTypeDataElements currentData;
-        long value;
-
-        do {
-            currentData = this.currentDataVolatile;
-            long bitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-            value = currentData.fixedLengthData.getLargeElementValue(bitOffset, 64, -1L);
-        } while(readWasUnsafe(currentData));
-
-        if(value == HollowObjectWriteRecord.NULL_DOUBLE_BITS)
-            return Double.NaN;
-        return Double.longBitsToDouble(value);
+    public long readDouble(int ordinal, int fieldIndex) {
+        long bitOffset = fieldOffset(ordinal, fieldIndex);
+        return dataElements.fixedLengthData.getLargeElementValue(bitOffset, 64, -1L);
     }
 
     public long readLong(int ordinal, int fieldIndex) {
-        HollowObjectTypeDataElements currentData;
-        long value;
-
-        do {
-            currentData = this.currentDataVolatile;
-            long bitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-            int numBitsForField = currentData.bitsPerField[fieldIndex];
-            value = currentData.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
-        } while(readWasUnsafe(currentData));
-
-        if(value == currentData.nullValueForField[fieldIndex])
-            return Long.MIN_VALUE;
-        return ZigZag.decodeLong(value);
+        long bitOffset = fieldOffset(ordinal, fieldIndex);
+        int numBitsForField = dataElements.bitsPerField[fieldIndex];
+        return dataElements.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
     }
 
-    public Boolean readBoolean(int ordinal, int fieldIndex) {
-        HollowObjectTypeDataElements currentData;
-        long value;
-
-        do {
-            currentData = this.currentDataVolatile;
-            value = readFixedLengthFieldValue(currentData, ordinal, fieldIndex);
-        } while(readWasUnsafe(currentData));
-
-        if(value == currentData.nullValueForField[fieldIndex])
-            return null;
-        return value == 1 ? Boolean.TRUE : Boolean.FALSE;
+    public long readBoolean(int ordinal, int fieldIndex) {
+        return readFixedLengthFieldValue(ordinal, fieldIndex);
     }
 
-    private long readFixedLengthFieldValue(HollowObjectTypeDataElements currentData, int ordinal, int fieldIndex) {
-        long bitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-        int numBitsForField = currentData.bitsPerField[fieldIndex];
+    private long readFixedLengthFieldValue(int ordinal, int fieldIndex) {
+        long bitOffset = fieldOffset(ordinal, fieldIndex);
+        int numBitsForField = dataElements.bitsPerField[fieldIndex];
 
-        long value = currentData.fixedLengthData.getElementValue(bitOffset, numBitsForField);
+        long value = dataElements.fixedLengthData.getElementValue(bitOffset, numBitsForField);
 
         return value;
     }
 
-    public byte[] readBytes(int ordinal, int fieldIndex) {
-        HollowObjectTypeDataElements currentData;
+    static class VarLenStats {
+        final int numBitsForField;
+        final long startByte;
+        final long endByte;
+
+        public VarLenStats(int numBitsForField, long startByte, long endByte) {
+            this.numBitsForField = numBitsForField;
+            this.startByte = startByte;
+            this.endByte = endByte;
+        }
+    }
+
+    VarLenStats readVarLenStats(int ordinal, int fieldIndex) {
+        int numBitsForField = dataElements.bitsPerField[fieldIndex];
+        long currentBitOffset = fieldOffset(ordinal, fieldIndex);
+
+        long endByte = dataElements.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
+        long startByte = ordinal != 0 ? dataElements.fixedLengthData.getElementValue(currentBitOffset - dataElements.bitsPerRecord, numBitsForField) : 0;
+
+        return new VarLenStats(numBitsForField, startByte, endByte);
+    }
+
+    public byte[] readBytes(VarLenStats stats, int fieldIndex) {
         byte[] result;
 
-        do {
-            int numBitsForField;
-            long endByte;
-            long startByte;
+        int numBitsForField = stats.numBitsForField;
+        long startByte = stats.startByte;
+        long endByte = stats.endByte;
 
-            do {
-                currentData = this.currentDataVolatile;
+        if((endByte & (1L << numBitsForField - 1)) != 0)
+            return null;
 
-                numBitsForField = currentData.bitsPerField[fieldIndex];
-                long currentBitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-                endByte = currentData.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
-                startByte = ordinal != 0 ? currentData.fixedLengthData.getElementValue(currentBitOffset - currentData.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(currentData));
+        startByte &= (1L << numBitsForField - 1) - 1;
 
-            if((endByte & (1L << numBitsForField - 1)) != 0)
-                return null;
+        int length = (int)(endByte - startByte);
 
-            startByte &= (1L << numBitsForField - 1) - 1;
-
-            int length = (int)(endByte - startByte);
-            result = new byte[length];
-            for(int i=0;i<length;i++)
-                result[i] = currentData.varLengthData[fieldIndex].get(startByte + i);
-
-        } while(readWasUnsafe(currentData));
+        result = new byte[length];
+        for(int i=0;i<length;i++)
+            result[i] = dataElements.varLengthData[fieldIndex].get(startByte + i);
 
         return result;
     }
 
-    public String readString(int ordinal, int fieldIndex) {
-        HollowObjectTypeDataElements currentData;
-        String result;
+    public String readString(VarLenStats stats, int fieldIndex) {
+        int numBitsForField = stats.numBitsForField;
+        long startByte = stats.startByte;
+        long endByte = stats.endByte;
 
-        do {
-            int numBitsForField;
-            long endByte;
-            long startByte;
+        if((endByte & (1L << numBitsForField - 1)) != 0)
+            return null;
 
-            do {
-                currentData = this.currentDataVolatile;
+        startByte &= (1L << numBitsForField - 1) - 1;
 
-                numBitsForField = currentData.bitsPerField[fieldIndex];
-                long currentBitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-                endByte = currentData.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
-                startByte = ordinal != 0 ? currentData.fixedLengthData.getElementValue(currentBitOffset - currentData.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(currentData));
+        int length = (int)(endByte - startByte);
 
-            if((endByte & (1L << numBitsForField - 1)) != 0)
-                return null;
-
-            startByte &= (1L << numBitsForField - 1) - 1;
-
-            int length = (int)(endByte - startByte);
-
-            result = readString(currentData.varLengthData[fieldIndex], startByte, length);
-        } while(readWasUnsafe(currentData));
-
-        return result;
+        return readString(dataElements.varLengthData[fieldIndex], startByte, length);
     }
 
-    public boolean isStringFieldEqual(int ordinal, int fieldIndex, String testValue) {
-        HollowObjectTypeDataElements currentData;
-        boolean result;
+    public boolean isStringFieldEqual(VarLenStats stats, int fieldIndex, String testValue) {
+        int numBitsForField = stats.numBitsForField;
+        long startByte = stats.startByte;
+        long endByte = stats.endByte;
 
-        do {
-            int numBitsForField;
-            long endByte;
-            long startByte;
+        if((endByte & (1L << numBitsForField - 1)) != 0)
+            return testValue == null;
+        if(testValue == null)
+            return false;
 
-            do {
-                currentData = this.currentDataVolatile;
+        startByte &= (1L << numBitsForField - 1) - 1;
 
-                numBitsForField = currentData.bitsPerField[fieldIndex];
+        int length = (int)(endByte - startByte);
 
-                long currentBitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-                endByte = currentData.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
-                startByte = ordinal != 0 ? currentData.fixedLengthData.getElementValue(currentBitOffset - currentData.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(currentData));
-
-            if((endByte & (1L << numBitsForField - 1)) != 0)
-                return testValue == null;
-            if(testValue == null)
-                return false;
-
-            startByte &= (1L << numBitsForField - 1) - 1;
-
-            int length = (int)(endByte - startByte);
-
-            result = testStringEquality(currentData.varLengthData[fieldIndex], startByte, length, testValue);
-        } while(readWasUnsafe(currentData));
-
-        return result;
+        return testStringEquality(dataElements.varLengthData[fieldIndex], startByte, length, testValue);
     }
 
-    public int findVarLengthFieldHashCode(int ordinal, int fieldIndex) {
-        HollowObjectTypeDataElements currentData;
-        int hashCode;
-        do {
-            int numBitsForField;
-            long endByte;
-            long startByte;
+    public int findVarLengthFieldHashCode(VarLenStats stats, int fieldIndex) {
+        int numBitsForField = stats.numBitsForField;
+        long startByte = stats.startByte;
+        long endByte = stats.endByte;
 
-            do {
-                currentData = this.currentDataVolatile;
+        if((endByte & (1L << numBitsForField - 1)) != 0)
+            return -1;
 
-                numBitsForField = currentData.bitsPerField[fieldIndex];
-                long currentBitOffset = fieldOffset(currentData, ordinal, fieldIndex);
-                endByte = currentData.fixedLengthData.getElementValue(currentBitOffset, numBitsForField);
-                startByte = ordinal != 0 ? currentData.fixedLengthData.getElementValue(currentBitOffset - currentData.bitsPerRecord, numBitsForField) : 0;
-            } while(readWasUnsafe(currentData));
+        startByte &= (1L << numBitsForField - 1) - 1;
 
-            if((endByte & (1L << numBitsForField - 1)) != 0)
-                return -1;
+        int length = (int)(endByte - startByte);
 
-            startByte &= (1L << numBitsForField - 1) - 1;
-
-            int length = (int)(endByte - startByte);
-
-            hashCode = HashCodes.hashCode(currentData.varLengthData[fieldIndex], startByte, length);
-        } while(readWasUnsafe(currentData));
-
-        return hashCode;
+        return HashCodes.hashCode(dataElements.varLengthData[fieldIndex], startByte, length);
     }
 
     /**
@@ -303,19 +181,15 @@ class HollowObjectTypeReadStateShard {
      */
     public int bitsRequiredForField(String fieldName) {
         int fieldIndex = schema.getPosition(fieldName);
-        return fieldIndex == -1 ? 0 : currentDataVolatile.bitsPerField[fieldIndex];
+        return fieldIndex == -1 ? 0 : dataElements.bitsPerField[fieldIndex];
     }
 
-    private long fieldOffset(HollowObjectTypeDataElements currentData, int ordinal, int fieldIndex) {
-        return ((long)currentData.bitsPerRecord * ordinal) + currentData.bitOffsetPerField[fieldIndex];
+    private long fieldOffset(int ordinal, int fieldIndex) {
+        return ((long)dataElements.bitsPerRecord * ordinal) + dataElements.bitOffsetPerField[fieldIndex];
     }
 
     /**
      * Decode a String as a series of VarInts, one per character.<p>
-     *
-     * @param str
-     * @param out
-     * @return
      */
     private static final ThreadLocal<char[]> chararr = ThreadLocal.withInitial(() -> new char[100]);
 
@@ -352,52 +226,12 @@ class HollowObjectTypeReadStateShard {
         return position == endPosition && count == testValue.length();
     }
 
-    void invalidate() {
-        setCurrentData(null);
-    }
-
-    HollowObjectTypeDataElements currentDataElements() {
-        return currentDataVolatile;
-    }
-
-    private boolean readWasUnsafe(HollowObjectTypeDataElements data) {
-        // Use a load (acquire) fence to constrain the compiler reordering prior plain loads so
-        // that they cannot "float down" below the volatile load of currentDataVolatile.
-        // This ensures data is checked against currentData *after* optimistic calculations
-        // have been performed on data.
-        //
-        // Note: the Java Memory Model allows for the reordering of plain loads and stores
-        // before a volatile load (those plain loads and stores can "float down" below the
-        // volatile load), but forbids the reordering of plain loads after a volatile load
-        // (those plain loads are not allowed to "float above" the volatile load).
-        // Similar reordering also applies to plain loads and stores and volatile stores.
-        // In effect the ordering of volatile loads and stores is retained and plain loads
-        // and stores can be shuffled around and grouped together, which increases
-        // optimization opportunities.
-        // This is why locks can be coarsened; plain loads and stores may enter the lock region
-        // from above (float down the acquire) or below (float above the release) but existing
-        // loads and stores may not exit (a "lock roach motel" and why there is almost universal
-        // misunderstanding of, and many misguided attempts to optimize, the infamous double
-        // checked locking idiom).
-        //
-        // Note: the fence provides stronger ordering guarantees than a corresponding non-plain
-        // load or store since the former affects all prior or subsequent loads and stores,
-        // whereas the latter is scoped to the particular load or store.
-        //
-        // For more details see http://gee.cs.oswego.edu/dl/html/j9mm.html
-        HollowUnsafeHandle.getUnsafe().loadFence();
-        return data != currentDataVolatile;
-    }
-
-    void setCurrentData(HollowObjectTypeDataElements data) {
-        this.currentDataVolatile = data;
-    }
-
-    protected void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema, BitSet populatedOrdinals, int shardNumber, int shardNumberMask) {
+    protected void applyShardToChecksum(HollowChecksum checksum, HollowSchema withSchema, BitSet populatedOrdinals, int shardNumber, int shardNumberMask) {
         if(!(withSchema instanceof HollowObjectSchema))
             throw new IllegalArgumentException("HollowObjectTypeReadState can only calculate checksum with a HollowObjectSchema: " + schema.getName());
 
         HollowObjectSchema commonSchema = schema.findCommonSchema((HollowObjectSchema)withSchema);
+        VarLenStats stats;
 
         List<String> commonFieldNames = new ArrayList<String>();
         for(int i=0;i<commonSchema.numFields();i++)
@@ -409,7 +243,6 @@ class HollowObjectTypeReadStateShard {
             fieldIndexes[i] = schema.getPosition(commonFieldNames.get(i));
         }
 
-        HollowObjectTypeDataElements currentData = currentDataVolatile;
         int ordinal = populatedOrdinals.nextSetBit(0);
         while(ordinal != ORDINAL_NONE) {
             if((ordinal & shardNumberMask) == shardNumber) {
@@ -418,18 +251,19 @@ class HollowObjectTypeReadStateShard {
                 for(int i=0;i<fieldIndexes.length;i++) {
                     int fieldIdx = fieldIndexes[i];
                     if(!schema.getFieldType(fieldIdx).isVariableLength()) {
-                        long bitOffset = fieldOffset(currentData, shardOrdinal, fieldIdx);
-                        int numBitsForField = currentData.bitsPerField[fieldIdx];
+                        long bitOffset = fieldOffset(shardOrdinal, fieldIdx);
+                        int numBitsForField = dataElements.bitsPerField[fieldIdx];
                         long fixedLengthValue = numBitsForField <= 56 ?
-                                currentData.fixedLengthData.getElementValue(bitOffset, numBitsForField)
-                                : currentData.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
+                                dataElements.fixedLengthData.getElementValue(bitOffset, numBitsForField)
+                                : dataElements.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
     
-                        if(fixedLengthValue == currentData.nullValueForField[fieldIdx])
+                        if(fixedLengthValue == dataElements.nullValueForField[fieldIdx])
                             checksum.applyInt(Integer.MAX_VALUE);
                         else
                             checksum.applyLong(fixedLengthValue);
                     } else {
-                        checksum.applyInt(findVarLengthFieldHashCode(shardOrdinal, fieldIdx));
+                        stats = readVarLenStats(shardOrdinal, fieldIdx);
+                        checksum.applyInt(findVarLengthFieldHashCode(stats, fieldIdx));
                     }
                 }
             }
@@ -439,27 +273,25 @@ class HollowObjectTypeReadStateShard {
     }
 
     public long getApproximateHeapFootprintInBytes() {
-        HollowObjectTypeDataElements currentData = currentDataVolatile;
-        long bitsPerFixedLengthData = (long)currentData.bitsPerRecord * (currentData.maxOrdinal + 1);
+        long bitsPerFixedLengthData = (long)dataElements.bitsPerRecord * (dataElements.maxOrdinal + 1);
         
         long requiredBytes = bitsPerFixedLengthData / 8;
         
-        for(int i=0;i<currentData.varLengthData.length;i++) {
-            if(currentData.varLengthData[i] != null)
-                requiredBytes += currentData.varLengthData[i].size();
+        for(int i=0;i<dataElements.varLengthData.length;i++) {
+            if(dataElements.varLengthData[i] != null)
+                requiredBytes += dataElements.varLengthData[i].size();
         }
         
         return requiredBytes;
     }
 
     public long getApproximateHoleCostInBytes(BitSet populatedOrdinals, int shardNumber, int numShards) {
-        HollowObjectTypeDataElements currentData = currentDataVolatile;
         long holeBits = 0;
         
         int holeOrdinal = populatedOrdinals.nextClearBit(0);
-        while(holeOrdinal <= currentData.maxOrdinal) {
+        while(holeOrdinal <= dataElements.maxOrdinal) {
             if((holeOrdinal & (numShards - 1)) == shardNumber)
-                holeBits += currentData.bitsPerRecord;
+                holeBits += dataElements.bitsPerRecord;
             
             holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -99,7 +99,11 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
     }
 
     @Override
-    public void applyDelta(HollowBlobInput in, HollowSchema schema, ArraySegmentRecycler memoryRecycler) throws IOException {
+    public void applyDelta(HollowBlobInput in, HollowSchema schema, ArraySegmentRecycler memoryRecycler, int deltaNumShards) throws IOException {
+        if (shouldReshard(shards.length, deltaNumShards)) {
+            throw new UnsupportedOperationException("Dynamic type sharding not supported for " + schema.getName()
+                    + ". Current numShards=" + shards.length + ", delta numShards=" + deltaNumShards);
+        }
         if(shards.length > 1)
             maxOrdinal = VarInt.readVInt(in);
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -82,6 +82,11 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
     }
 
     @Override
+    public void readSnapshot(HollowBlobInput in, ArraySegmentRecycler memoryRecycler, int numShards) throws IOException {
+        throw new UnsupportedOperationException("This type does not yet support numShards specification when reading snapshot");
+    }
+
+    @Override
     public void readSnapshot(HollowBlobInput in, ArraySegmentRecycler memoryRecycler) throws IOException {
         if(shards.length > 1)
             maxOrdinal = VarInt.readVInt(in);

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/AbstractHollowObjectTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/AbstractHollowObjectTypeDataElementsSplitJoinTest.java
@@ -92,11 +92,14 @@ public class AbstractHollowObjectTypeDataElementsSplitJoinTest extends AbstractS
     }
 
     protected void assertDataUnchanged(int numRecords) {
+        assertDataUnchanged((HollowObjectTypeReadState) readStateEngine.getTypeState("TestObject"), numRecords);
+    }
+
+    protected void assertDataUnchanged(HollowObjectTypeReadState typeState, int numRecords) {
         for(int i=0;i<numRecords;i++) {
-            GenericHollowObject obj = new GenericHollowObject(readStateEngine, "TestObject", i);
+            GenericHollowObject obj = new GenericHollowObject(typeState, i);
             assertEquals(i, obj.getLong("longField"));
             assertEquals("Value"+i, obj.getString("stringField"));
-            HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) readStateEngine.getTypeState("TestObject");
             assertEquals((double)i, obj.getDouble("doubleField"), 0);
             if (typeState.getSchema().numFields() == 4) {   // filtered
                 assertEquals(i, obj.getInt("intField"));

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoinerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoinerTest.java
@@ -28,13 +28,13 @@ public class HollowObjectTypeDataElementsJoinerTest extends AbstractHollowObject
         assertEquals(1, typeReadState.numShards());
 
         HollowObjectTypeReadState typeReadStateSharded = populateTypeStateWith(5);
-        assertDataUnchanged(5);
+        assertDataUnchanged(typeReadStateSharded, 5);
         assertEquals(8, typeReadStateSharded.numShards());
 
         HollowObjectTypeDataElements joinedDataElements = joiner.join(typeReadStateSharded.currentDataElements());
 
-        typeReadState.setCurrentData(joinedDataElements);
-        assertDataUnchanged(5);
+        typeReadState = new HollowObjectTypeReadState(typeReadState.getSchema(), joinedDataElements);
+        assertDataUnchanged(typeReadState, 5);
 
         try {
             joiner.join(mockObjectTypeState.currentDataElements());
@@ -128,8 +128,8 @@ public class HollowObjectTypeDataElementsJoinerTest extends AbstractHollowObject
 //        long v5 = oneRunCycle(p, new int[] {0, 1});
 //
 //        // assert lopsided shards before join
-//        assertEquals(2, ((HollowObjectTypeReadState) c.getStateEngine().getTypeState("TestObject")).shardsVolatile.shards[0].currentDataElements().maxOrdinal);
-//        assertEquals(3, ((HollowObjectTypeReadState) c.getStateEngine().getTypeState("TestObject")).shardsVolatile.shards[1].currentDataElements().maxOrdinal);
+//        assertEquals(2, ((HollowObjectTypeReadState) c.getStateEngine().getTypeState("TestObject")).shardsVolatile.shards[0].dataElements.maxOrdinal);
+//        assertEquals(3, ((HollowObjectTypeReadState) c.getStateEngine().getTypeState("TestObject")).shardsVolatile.shards[1].dataElements.maxOrdinal);
 //        c.triggerRefreshTo(v5);
 //        assertEquals(1, c.getStateEngine().getTypeState("TestObject").numShards()); // joined to 1 shard
 //        readStateEngine = c.getStateEngine();

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitJoinTest.java
@@ -10,7 +10,7 @@ import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
 import com.netflix.hollow.tools.checksum.HollowChecksum;
 import java.io.IOException;
 import java.nio.file.Paths;
-import org.junit.Assert;
+import java.util.BitSet;
 import org.junit.Test;
 
 public class HollowObjectTypeDataElementsSplitJoinTest extends AbstractHollowObjectTypeDataElementsSplitJoinTest {
@@ -29,19 +29,32 @@ public class HollowObjectTypeDataElementsSplitJoinTest extends AbstractHollowObj
         for (int numRecords=0;numRecords<1*1000;numRecords++) {
             HollowObjectTypeReadState typeReadState = populateTypeStateWith(numRecords);
             assertEquals(1, typeReadState.numShards());
-            assertDataUnchanged(numRecords);
-            HollowChecksum origChecksum = typeReadState.getChecksum(typeReadState.getSchema());
+            assertDataUnchanged(typeReadState, numRecords);
 
             for (int numSplits : new int[]{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}) {
                 HollowObjectTypeDataElements[] splitElements = splitter.split(typeReadState.currentDataElements()[0], numSplits);
                 HollowObjectTypeDataElements joinedElements = joiner.join(splitElements);
-                typeReadState.setCurrentData(joinedElements);
+                HollowObjectTypeReadState resultTypeReadState = new HollowObjectTypeReadState(typeReadState.getSchema(), joinedElements);
 
-                assertDataUnchanged(numRecords);
-                HollowChecksum resultChecksum = typeReadState.getChecksum(typeReadState.getSchema());
-                assertEquals(origChecksum, resultChecksum);
+                assertDataUnchanged(resultTypeReadState, numRecords);
+                assertChecksumUnchanged(resultTypeReadState, typeReadState, typeReadState.getPopulatedOrdinals());
             }
         }
+    }
+
+    private void assertChecksumUnchanged(HollowObjectTypeReadState newTypeState, HollowObjectTypeReadState origTypeState, BitSet populatedOrdinals) {
+        HollowChecksum origCksum = new HollowChecksum();
+        HollowChecksum newCksum = new HollowChecksum();
+
+        for(int i=0;i<origTypeState.numShards();i++) {
+            origTypeState.shardsVolatile.shards[i].applyShardToChecksum(origCksum, origTypeState.getSchema(), populatedOrdinals, i, origTypeState.shardsVolatile.shardNumberMask);
+        }
+
+        for(int i=0;i<newTypeState.numShards();i++) {
+            newTypeState.shardsVolatile.shards[i].applyShardToChecksum(newCksum, newTypeState.getSchema(), populatedOrdinals, i, newTypeState.shardsVolatile.shardNumberMask);
+        }
+
+        assertEquals(newCksum, origCksum);
     }
 
     @Test
@@ -53,16 +66,14 @@ public class HollowObjectTypeDataElementsSplitJoinTest extends AbstractHollowObj
         for (int numRecords=0;numRecords<1*1000;numRecords++) {
             HollowObjectTypeReadState typeReadState = populateTypeStateWithFilter(numRecords);
             assertEquals(1, typeReadState.numShards());
-            assertDataUnchanged(numRecords);
-            HollowChecksum origChecksum = typeReadState.getChecksum(typeReadState.getSchema());
+            assertDataUnchanged(typeReadState, numRecords);
 
             HollowObjectTypeDataElements[] splitElements = splitter.split(typeReadState.currentDataElements()[0], numSplits);
             HollowObjectTypeDataElements joinedElements = joiner.join(splitElements);
-            typeReadState.setCurrentData(joinedElements);
+            HollowObjectTypeReadState resultTypeReadState = new HollowObjectTypeReadState(typeReadState.getSchema(), joinedElements);
 
-            assertDataUnchanged(numRecords);
-            HollowChecksum resultChecksum = typeReadState.getChecksum(typeReadState.getSchema());
-            assertEquals(origChecksum, resultChecksum);
+            assertDataUnchanged(resultTypeReadState, numRecords);
+            assertChecksumUnchanged(resultTypeReadState, typeReadState, typeReadState.getPopulatedOrdinals());
         }
     }
 
@@ -102,7 +113,6 @@ public class HollowObjectTypeDataElementsSplitJoinTest extends AbstractHollowObj
 
         HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) readStateEngine.getTypeState(objectTypeWithOneShard);
         HollowSchema origSchema = typeState.getSchema();
-        HollowChecksum originalChecksum = typeState.getChecksum(origSchema);
 
         assertEquals(1, typeState.numShards());
 
@@ -112,9 +122,8 @@ public class HollowObjectTypeDataElementsSplitJoinTest extends AbstractHollowObj
         HollowObjectTypeDataElementsJoiner joiner = new HollowObjectTypeDataElementsJoiner();
         HollowObjectTypeDataElements joinedElements = joiner.join(splitElements);
 
-        typeState.setCurrentData(joinedElements);
-        HollowChecksum newChecksum = typeState.getChecksum(origSchema);
+        HollowObjectTypeReadState resultTypeState = new HollowObjectTypeReadState(typeState.getSchema(), joinedElements);
 
-        Assert.assertEquals(originalChecksum, newChecksum);
+        assertChecksumUnchanged(resultTypeState, typeState, typeState.getPopulatedOrdinals());
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsSplitterTest.java
@@ -14,11 +14,11 @@ public class HollowObjectTypeDataElementsSplitterTest extends AbstractHollowObje
 
         HollowObjectTypeReadState typeReadState = populateTypeStateWith(5);
         assertEquals(1, typeReadState.numShards());
-        assertDataUnchanged(5);
+        assertDataUnchanged(typeReadState, 5);
 
         HollowObjectTypeDataElements[] result1 = splitter.split(typeReadState.currentDataElements()[0], 1);
-        typeReadState.setCurrentData(result1[0]);
-        assertDataUnchanged(5);
+        typeReadState = new HollowObjectTypeReadState(typeReadState.getSchema(), result1[0]);
+        assertDataUnchanged(typeReadState, 5);
 
         HollowObjectTypeDataElements[] result8 = splitter.split(typeReadState.currentDataElements()[0], 8);
         assertEquals(0, result8[0].maxOrdinal);  // for index that landed one record after split

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateTest.java
@@ -1,0 +1,233 @@
+package com.netflix.hollow.core.read.engine.object;
+
+import static com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState.shardingFactor;
+import static junit.framework.TestCase.assertEquals;
+
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.core.memory.MemoryMode;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import java.util.Random;
+import java.util.function.Supplier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HollowObjectTypeReadStateTest extends AbstractHollowObjectTypeDataElementsSplitJoinTest {
+    @Override
+    protected void initializeTypeStates() {
+        writeStateEngine.setTargetMaxTypeShardSize(4 * 100 * 1024);
+        writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+    }
+
+    @Test
+    public void testMappingAnOrdinalToAShardAndBack() {
+        int maxOrdinal = 1000;
+        int numShards = 4;
+        int minRecordLocationsPerShard = (maxOrdinal + 1) / numShards;
+        int[][] shardOrdinals = new int[numShards][];
+        for(int i=0;i<numShards;i++) {
+            int maxShardOrdinal = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minRecordLocationsPerShard : minRecordLocationsPerShard - 1;
+            shardOrdinals[i] = new int[maxShardOrdinal + 1];
+        }
+
+        int shardNumberMask = numShards - 1;
+        int shardOrdinalShift = 31 - Integer.numberOfLeadingZeros(numShards);
+
+        for (int ordinal=0; ordinal<=maxOrdinal; ordinal++) {
+            int shardIndex = ordinal & shardNumberMask;
+            int shardOrdinal = ordinal >> shardOrdinalShift;
+            shardOrdinals[shardIndex][shardOrdinal] = ordinal;
+        }
+
+        for (int shardIndex=0; shardIndex<numShards; shardIndex++) {
+            for (int shardOrdinal=0; shardOrdinal<shardOrdinals[shardIndex].length; shardOrdinal++) {
+                int ordinal = (shardOrdinal * numShards) + shardIndex;
+                assertEquals(shardOrdinals[shardIndex][shardOrdinal], ordinal);
+            }
+        }
+    }
+
+    @Test
+    public void testShardingFactor() {
+        assertEquals(2, shardingFactor(1, 2));
+        assertEquals(2, shardingFactor(2, 1));
+
+        assertEquals(2, shardingFactor(4, 2));
+        assertEquals(2, shardingFactor(2, 4));
+
+        assertEquals(16, shardingFactor(1, 16));
+        assertEquals(16, shardingFactor(32, 2));
+
+        assertIllegalStateException(() -> shardingFactor(0, 1));
+        assertIllegalStateException(() -> shardingFactor(2, 0));
+        assertIllegalStateException(() -> shardingFactor(1, 1));
+        assertIllegalStateException(() -> shardingFactor(1, -1));
+        assertIllegalStateException(() -> shardingFactor(2, 3));
+    }
+
+    @Test
+    public void testResharding() throws Exception {
+
+        for (int shardingFactor : new int[]{2, 4, 8, 16})   // 32, 64, 128, 256, 512, 1024...
+        {
+            for(int numRecords=1;numRecords<=100000;numRecords+=new Random().nextInt(1000))
+            {
+                HollowObjectTypeReadState objectTypeReadState = populateTypeStateWith(numRecords);
+                assertDataUnchanged(numRecords);
+
+                // Splitting shards
+                {
+                    int prevShardCount = objectTypeReadState.numShards();
+                    int newShardCount = shardingFactor * prevShardCount;
+                    objectTypeReadState.reshard(newShardCount);
+
+                    assertEquals(newShardCount, objectTypeReadState.numShards());
+                    assertEquals(newShardCount, shardingFactor * prevShardCount);
+                }
+                assertDataUnchanged(numRecords);
+
+                // Joining shards
+                {
+                    int prevShardCount = objectTypeReadState.numShards();
+                    int newShardCount = prevShardCount / shardingFactor;
+                    objectTypeReadState.reshard(newShardCount);
+
+                    assertEquals(newShardCount, objectTypeReadState.numShards());
+                    assertEquals(shardingFactor * newShardCount, prevShardCount);
+                }
+                assertDataUnchanged(numRecords);
+            }
+        }
+    }
+
+    @Test
+    public void testReshardingWithFilter() throws Exception {
+
+        for (int shardingFactor : new int[]{2, 64})
+        {
+            for(int numRecords=1;numRecords<=100000;numRecords+=new Random().nextInt(10000))
+            {
+                HollowObjectTypeReadState objectTypeReadState = populateTypeStateWithFilter(numRecords);
+                assertDataUnchanged(numRecords);
+
+                // Splitting shards
+                {
+                    int prevShardCount = objectTypeReadState.numShards();
+                    int newShardCount = shardingFactor * prevShardCount;
+                    objectTypeReadState.reshard(newShardCount);
+
+                    assertEquals(newShardCount, objectTypeReadState.numShards());
+                    assertEquals(newShardCount, shardingFactor * prevShardCount);
+                }
+                assertDataUnchanged(numRecords);
+
+                // Joining shards
+                {
+                    int prevShardCount = objectTypeReadState.numShards();
+                    int newShardCount = prevShardCount / shardingFactor;
+                    objectTypeReadState.reshard(newShardCount);
+
+                    assertEquals(newShardCount, objectTypeReadState.numShards());
+                    assertEquals(shardingFactor * newShardCount, prevShardCount);
+                }
+                assertDataUnchanged(numRecords);
+            }
+        }
+    }
+
+    @Test
+    public void testReshardingIntermediateStages_expandWithOriginalDataElements() throws Exception {
+        for (int shardingFactor : new int[]{2, 4}) {
+            for(int numRecords=1;numRecords<=100000;numRecords+=new Random().nextInt(5000))
+            {
+                HollowObjectTypeReadState expectedTypeState = populateTypeStateWith(numRecords);
+
+                HollowObjectTypeReadState.ShardsHolder original = expectedTypeState.shardsVolatile;
+                HollowObjectTypeReadState.ShardsHolder expanded = expectedTypeState.expandWithOriginalDataElements(original, shardingFactor);
+
+                HollowObjectTypeReadState actualTypeState = new HollowObjectTypeReadState(readStateEngine, MemoryMode.ON_HEAP, schema, schema,
+                        expanded.shards.length);
+                actualTypeState.shardsVolatile = expanded;
+
+                assertEquals(shardingFactor * expectedTypeState.numShards(), actualTypeState.numShards());
+                assertDataUnchanged(actualTypeState, numRecords);
+            }
+        }
+    }
+
+    @Test
+    public void testReshardingIntermediateStages_splitDataElementsForOneShard() throws Exception {
+        for (int shardingFactor : new int[]{2, 4}) {
+            for(int numRecords=1;numRecords<=100000;numRecords+=new Random().nextInt(5000))
+            {
+                HollowObjectTypeReadState typeState = populateTypeStateWith(numRecords);
+
+                HollowObjectTypeReadState.ShardsHolder originalShardsHolder = typeState.shardsVolatile;
+                int originalNumShards = typeState.numShards();
+
+                // expand shards
+                typeState.shardsVolatile = typeState.expandWithOriginalDataElements(originalShardsHolder, shardingFactor);
+
+                for(int i=0; i<originalNumShards; i++) {
+                    HollowObjectTypeDataElements originalDataElements = typeState.shardsVolatile.shards[i].currentDataElements();
+
+                    typeState.shardsVolatile = typeState.splitDataElementsForOneShard(typeState.shardsVolatile, i, originalNumShards, shardingFactor);
+
+                    assertEquals(shardingFactor * originalNumShards, typeState.numShards());
+                    assertDataUnchanged(typeState, numRecords);   // as each original shard is processed
+
+                    originalDataElements.destroy();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testReshardingIntermediateStages_joinDataElementsForOneShard() throws Exception {
+        for (int shardingFactor : new int[]{2, 4, 8}) {
+            for (int numRecords = 75000; numRecords <= 100000; numRecords += new Random().nextInt(1000)) {
+                HollowObjectTypeReadState typeState = populateTypeStateWith(numRecords);
+
+                HollowObjectTypeReadState.ShardsHolder originalShardsHolder = typeState.shardsVolatile;
+                int originalNumShards = typeState.numShards();
+                assertEquals(8, originalNumShards);
+
+                int newNumShards = originalNumShards / shardingFactor;
+                for (int i=0; i<newNumShards; i++) {
+                    HollowObjectTypeDataElements dataElementsToJoin[] = new HollowObjectTypeDataElements[shardingFactor];
+                    for (int j=0; j<shardingFactor; j++) {
+                        dataElementsToJoin[j] = originalShardsHolder.shards[i + (newNumShards*j)].currentDataElements();
+                    };
+
+                    typeState.shardsVolatile = typeState.joinDataElementsForOneShard(typeState.shardsVolatile, i, shardingFactor);
+
+                    for (int j = 0; j < shardingFactor; j ++) {
+                        dataElementsToJoin[j].destroy();
+                    };
+
+                    assertEquals(originalNumShards, typeState.numShards()); // numShards remains unchanged
+                    assertDataUnchanged(typeState, numRecords);   // as each original shard is processed
+                }
+            }
+        }
+    }
+
+    private void assertDataUnchanged(HollowObjectTypeReadState actualTypeState, int numRecords) {
+        for(int i=0;i<numRecords;i++) {
+
+            GenericHollowObject obj = new GenericHollowObject(actualTypeState , i);
+            Assert.assertEquals(i, obj.getLong("longField"));
+            Assert.assertEquals("Value"+i, obj.getString("stringField"));
+            Assert.assertEquals(i, obj.getInt("intField"));
+            Assert.assertEquals((double)i, obj.getDouble("doubleField"), 0);
+        }
+    }
+
+    private void assertIllegalStateException(Supplier<Integer> invocation) {
+        try {
+            invocation.get();
+            Assert.fail();
+        } catch (IllegalStateException e) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
This is 2 of 4 planned PRs for supporting dynamic type re-sharding:

- [X] [PR#642](https://github.com/Netflix/hollow/pull/642) <s>utilities for splitting/joining Object types; limited to Object types in this step, extend to Map/Set/List in last step</s> 
- [X] consumer delta application reshards with O(shard size) extra space (this PR) 
- [ ] producer-side numShards toggle and signaling
- [ ] Extend resharding to Map,List, and Set types


### Benchmarking with jmh
Benchmark 1: No significant regression for consumers when resharding isn't invoked, avg is upto 6% worse [`Baseline.json` vs. `PR.json`] 

Benchmark 2: Read performance during delta transition with resharding vs. without resharding:  avg is upto 6% worse again [`PR_withDeltaTransitionsNoResharding.json` vs. `PR_withDeltaTransitionsWithResharding.json`]

[Baseline.json](https://github.com/Netflix/hollow/files/13090264/Baseline.json)
[PR.json](https://github.com/Netflix/hollow/files/13090267/PR.json)
[PR_withDeltaTransitionsNoResharding.json](https://github.com/Netflix/hollow/files/13090292/PR_withDeltaTransitionsNoResharding.json)
[PR_withDeltaTransitionsWithResharding.json](https://github.com/Netflix/hollow/files/13090294/PR_withDeltaTransitionsWithResharding.json)

