### PR TITLE
bug fixed for null object hash value and string storage in object intern pool

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/read/HollowReadFieldUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/HollowReadFieldUtils.java
@@ -64,6 +64,9 @@ public class HollowReadFieldUtils {
     }
 
     public static int hashObject(Object value) {
+        if (value == null) {
+            return 0;
+        }
         if(value instanceof Integer) {
             return HollowReadFieldUtils.intHashCode((Integer)value);
         } else if(value instanceof String) {

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
@@ -83,7 +83,7 @@ public class ObjectInternPool {
 
     public String getString(long pointer) {
         ByteData byteData = ordinalMap.getByteData().getUnderlyingArray();
-        int length = byteData.get(pointer);
+        int length = VarInt.readVInt(byteData, pointer);
         byte[] bytes = new byte[length];
         for(int i=0;i<length;i++) {
             bytes[i] = byteData.get(pointer+1+i);


### PR DESCRIPTION
when object is null the hash value should be zero
the length of a string should be int instead of a byte