### PR TITLE
Add garbage collector aware recycler

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/memory/pool/ArraySegmentRecycler.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/pool/ArraySegmentRecycler.java
@@ -30,6 +30,10 @@ import com.netflix.hollow.core.memory.SegmentedLongArray;
 */
 public interface ArraySegmentRecycler {
 
+    int DEFAULT_LOG2_BYTE_ARRAY_SIZE = 11;
+
+    int DEFAULT_LOG2_LONG_ARRAY_SIZE = 8;
+
     public int getLog2OfByteSegmentSize();
 
     public int getLog2OfLongSegmentSize();

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/pool/GarbageCollectorAwareRecycler.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/pool/GarbageCollectorAwareRecycler.java
@@ -5,8 +5,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryManagerMXBean;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * A {@link ArraySegmentRecycler} that chooses the appropriate recycler based on the garbage collector in use.
@@ -27,7 +25,7 @@ public class GarbageCollectorAwareRecycler implements ArraySegmentRecycler {
         boolean isLowPause = ManagementFactory.getGarbageCollectorMXBeans()
                 .stream()
                 .map(MemoryManagerMXBean::getName)
-                .map(name -> name.split(" ")[0])
+                .map(name -> name.split(" ")[0]) // In the form '<GC> <Phase>', for instance 'PS Scavenge' or 'ZGC Major Pauses'
                 .distinct()
                 .findFirst()
                 .map(LOW_PAUSE_COLLECTORS::contains)

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/pool/GarbageCollectorAwareRecycler.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/pool/GarbageCollectorAwareRecycler.java
@@ -1,0 +1,61 @@
+package com.netflix.hollow.core.memory.pool;
+
+
+import java.lang.management.ManagementFactory;
+
+/**
+ * A {@link ArraySegmentRecycler} that chooses the appropriate recycler based on the garbage collector in use.
+ * </p>
+ * Specifically, when a low-pause collector is in use where promotion/evacuation pauses are no longer a concern,
+ * delegate to {@link WastefulRecycler}. Otherwise the default {@link RecyclingRecycler} is used.
+ */
+public class GarbageCollectorAwareRecycler implements ArraySegmentRecycler {
+    private final ArraySegmentRecycler delegate;
+
+    public GarbageCollectorAwareRecycler() {
+        this(DEFAULT_LOG2_BYTE_ARRAY_SIZE, DEFAULT_LOG2_LONG_ARRAY_SIZE);
+    }
+
+    public GarbageCollectorAwareRecycler(int log2OfByteSegmentSize, int log2OfLongSegmentSize) {
+        boolean isLowPause = ManagementFactory.getGarbageCollectorMXBeans()
+                .stream()
+                .anyMatch(bean -> bean.getName().startsWith("Shenandoah") || bean.getName().startsWith("ZGC"));
+        delegate = isLowPause ? new WastefulRecycler(log2OfByteSegmentSize, log2OfLongSegmentSize)
+                : new RecyclingRecycler(log2OfByteSegmentSize, log2OfLongSegmentSize);
+    }
+
+    @Override
+    public int getLog2OfByteSegmentSize() {
+        return delegate.getLog2OfByteSegmentSize();
+    }
+
+    @Override
+    public int getLog2OfLongSegmentSize() {
+        return delegate.getLog2OfLongSegmentSize();
+    }
+
+    @Override
+    public long[] getLongArray() {
+        return delegate.getLongArray();
+    }
+
+    @Override
+    public void recycleLongArray(long[] arr) {
+        delegate.recycleLongArray(arr);
+    }
+
+    @Override
+    public byte[] getByteArray() {
+        return delegate.getByteArray();
+    }
+
+    @Override
+    public void recycleByteArray(byte[] arr) {
+        delegate.recycleByteArray(arr);
+    }
+
+    @Override
+    public void swap() {
+        delegate.swap();
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/pool/GarbageCollectorAwareRecycler.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/pool/GarbageCollectorAwareRecycler.java
@@ -26,10 +26,7 @@ public class GarbageCollectorAwareRecycler implements ArraySegmentRecycler {
                 .stream()
                 .map(MemoryManagerMXBean::getName)
                 .map(name -> name.split(" ")[0]) // In the form '<GC> <Phase>', for instance 'PS Scavenge' or 'ZGC Major Pauses'
-                .distinct()
-                .findFirst()
-                .map(LOW_PAUSE_COLLECTORS::contains)
-                .orElse(false);
+                .anyMatch(LOW_PAUSE_COLLECTORS::contains);
         delegate = isLowPause ? new WastefulRecycler(log2OfByteSegmentSize, log2OfLongSegmentSize)
                 : new RecyclingRecycler(log2OfByteSegmentSize, log2OfLongSegmentSize);
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/pool/GarbageCollectorAwareRecycler.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/pool/GarbageCollectorAwareRecycler.java
@@ -5,7 +5,7 @@ import java.lang.management.ManagementFactory;
 
 /**
  * A {@link ArraySegmentRecycler} that chooses the appropriate recycler based on the garbage collector in use.
- * </p>
+ * <p>
  * Specifically, when a low-pause collector is in use where promotion/evacuation pauses are no longer a concern,
  * delegate to {@link WastefulRecycler}. Otherwise the default {@link RecyclingRecycler} is used.
  */

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/pool/RecyclingRecycler.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/pool/RecyclingRecycler.java
@@ -32,7 +32,7 @@ public class RecyclingRecycler implements ArraySegmentRecycler {
     private final Recycler<byte[]> byteSegmentRecycler;
 
     public RecyclingRecycler() {
-        this(11, 8);
+        this(DEFAULT_LOG2_BYTE_ARRAY_SIZE, DEFAULT_LOG2_LONG_ARRAY_SIZE);
     }
 
     public RecyclingRecycler(final int log2ByteArraySize, final int log2LongArraySize) {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
@@ -19,7 +19,7 @@ package com.netflix.hollow.core.read.engine;
 import com.netflix.hollow.api.error.SchemaNotFoundException;
 import com.netflix.hollow.core.HollowStateEngine;
 import com.netflix.hollow.core.memory.pool.ArraySegmentRecycler;
-import com.netflix.hollow.core.memory.pool.RecyclingRecycler;
+import com.netflix.hollow.core.memory.pool.GarbageCollectorAwareRecycler;
 import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
 import com.netflix.hollow.core.read.dataaccess.HollowTypeDataAccess;
 import com.netflix.hollow.core.read.engine.map.HollowMapTypeReadState;
@@ -66,11 +66,11 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
     private MissingDataHandler missingDataHandler = new DefaultMissingDataHandler();
 
     public HollowReadStateEngine() {
-        this(DefaultHashCodeFinder.INSTANCE, true, new RecyclingRecycler());
+        this(DefaultHashCodeFinder.INSTANCE, true, new GarbageCollectorAwareRecycler());
     }
 
     public HollowReadStateEngine(boolean listenToAllPopulatedOrdinals) {
-        this(DefaultHashCodeFinder.INSTANCE, listenToAllPopulatedOrdinals, new RecyclingRecycler());
+        this(DefaultHashCodeFinder.INSTANCE, listenToAllPopulatedOrdinals, new GarbageCollectorAwareRecycler());
     }
 
     public HollowReadStateEngine(ArraySegmentRecycler recycler) {
@@ -83,7 +83,7 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
 
     @Deprecated
     public HollowReadStateEngine(HollowObjectHashCodeFinder hashCodeFinder) {
-        this(hashCodeFinder, true, new RecyclingRecycler());
+        this(hashCodeFinder, true, new GarbageCollectorAwareRecycler());
     }
 
     @Deprecated


### PR DESCRIPTION
Testing against [this patch](https://github.com/Netflix/hollow/releases/tag/v7.6.8-rc.2) indicates that the pooling of byte arrays when using the modern, low-pause collectors is unnecessary, because there are no pauses for evacuation failures to cause an impact to application latency.

For a 2,500 second runtime, the baseline generational ZGC cluster:

<img width="1175" alt="images-genzgc-phases" src="https://github.com/Netflix/hollow/assets/1479220/1f2eabe2-3157-4278-bfa2-97c69d992fe6">

Versus generational ZGC w/ patch:

<img width="1167" alt="images-genzgc-hollow-wasteful-phases" src="https://github.com/Netflix/hollow/assets/1479220/6a341ba7-51c2-4342-a4c2-2edd114dcd1f">

Example of overhead:

![RecyclingRecycler](https://github.com/Netflix/hollow/assets/1479220/1044323c-c7fc-48cc-903b-ab17b4869539)
