### PR TITLE
change consumer to read metadata in blob header for version number

### DIFF
--- a/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestBlobRetriever.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestBlobRetriever.java
@@ -28,10 +28,10 @@ import java.util.Map;
  * memory.
  */
 public class TestBlobRetriever implements BlobRetriever {
-    private final Map<Long, Blob> snapshots = new HashMap<>();
-    private final Map<Long, Blob> deltas = new HashMap<>();
-    private final Map<Long, Blob> reverseDeltas = new HashMap<>();
-    private final Map<Long, HeaderBlob> headers = new HashMap<>();
+    protected final Map<Long, Blob> snapshots = new HashMap<>();
+    protected final Map<Long, Blob> deltas = new HashMap<>();
+    protected final Map<Long, Blob> reverseDeltas = new HashMap<>();
+    protected final Map<Long, HeaderBlob> headers = new HashMap<>();
 
     @Override
     public HeaderBlob retrieveHeaderBlob(long desiredVersion) {
@@ -60,7 +60,7 @@ public class TestBlobRetriever implements BlobRetriever {
     }
 
     // so blob can be reused
-    private void resetStream(Blob b) {
+    protected void resetStream(Blob b) {
         try {
             if (b!= null && b.getInputStream() != null) {
                 b.getInputStream().reset();

--- a/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestBlobRetrieverWithNearestSnapshotMatch.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/consumer/TestBlobRetrieverWithNearestSnapshotMatch.java
@@ -1,0 +1,42 @@
+package com.netflix.hollow.test.consumer;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class TestBlobRetrieverWithNearestSnapshotMatch extends TestBlobRetriever {
+
+    @Override
+    public HollowConsumer.Blob retrieveSnapshotBlob(long desiredVersion) {
+        long version = findNearestSnapshotVersion(desiredVersion);
+        HollowConsumer.Blob b = snapshots.get(version);
+        resetStream(b);
+        return b;
+    }
+
+
+    private long findNearestSnapshotVersion(long desiredVersion) {
+        List<Long> snapshotVersions = new ArrayList<>();
+        snapshotVersions.addAll(snapshots.keySet());
+        Collections.sort(snapshotVersions);
+        int start = 0;
+        int end = snapshotVersions.size() - 1;
+        int mid = 0;
+        while (start + 1< end) {
+            mid = (start + end) / 2;
+            if (mid < desiredVersion) {
+                start = mid;
+            } else if (mid > desiredVersion){
+                end = mid;
+            } else {
+                return snapshotVersions.get(mid);
+            }
+        }
+        if (end <= desiredVersion) {
+            return snapshotVersions.get(end);
+        }
+        return snapshotVersions.get(start);
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.hollow.api.client;
 
+import static com.netflix.hollow.core.HollowConstants.VERSION_NONE;
 import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_SCHEMA_HASH;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
@@ -119,7 +120,7 @@ public class HollowClientUpdater {
     public synchronized boolean updateTo(HollowConsumer.VersionInfo requestedVersionInfo) throws Throwable {
         long requestedVersion = requestedVersionInfo.getVersion();
         if (requestedVersion == getCurrentVersionId()) {
-            if (requestedVersion == HollowConstants.VERSION_NONE && hollowDataHolderVolatile == null) {
+            if (requestedVersion == VERSION_NONE && hollowDataHolderVolatile == null) {
                 LOG.warning("No versions to update to, initializing to empty state");
                 // attempting to refresh, but no available versions - initialize to empty state
                 hollowDataHolderVolatile = newHollowDataHolder();
@@ -148,16 +149,17 @@ public class HollowClientUpdater {
                 ? planner.planInitializingUpdate(requestedVersion)
                 : planner.planUpdate(hollowDataHolderVolatile.getCurrentVersion(), requestedVersion,
                         doubleSnapshotConfig.allowDoubleSnapshot());
+            boolean isInitialUpdate = getCurrentVersionId() == VERSION_NONE;
 
             for (HollowConsumer.RefreshListener listener : localListeners)
                 if (listener instanceof HollowConsumer.TransitionAwareRefreshListener)
                     ((HollowConsumer.TransitionAwareRefreshListener)listener).transitionsPlanned(beforeVersion, requestedVersion, updatePlan.isSnapshotPlan(), updatePlan.getTransitionSequence());
 
-            if (updatePlan.destinationVersion() == HollowConstants.VERSION_NONE
+            if (updatePlan.destinationVersion() == VERSION_NONE
                     && requestedVersion != HollowConstants.VERSION_LATEST) {
                 String msg = String.format("Could not create an update plan for version %s, because "
                         + "that version or any qualifying previous versions could not be retrieved.", requestedVersion);
-                if (beforeVersion != HollowConstants.VERSION_NONE) {
+                if (beforeVersion != VERSION_NONE) {
                     msg += String.format(" Consumer will remain at current version %s until next update attempt.", beforeVersion);
                 }
                 throw new IllegalArgumentException(msg);
@@ -185,7 +187,7 @@ public class HollowClientUpdater {
                          * Also note that hollowDataHolderVolatile only changes for snapshot plans,
                          * and it is only for snapshot plans that HollowDataHolder#initializeAPI is
                          * called. */
-                        newDh.update(updatePlan, localListeners, () -> hollowDataHolderVolatile = newDh);
+                        newDh.update(updatePlan, localListeners, () -> hollowDataHolderVolatile = newDh, isInitialUpdate);
                     } catch (Throwable t) {
                         // If the update plan failed then revert back to the old holder
                         hollowDataHolderVolatile = oldDh;
@@ -194,7 +196,7 @@ public class HollowClientUpdater {
                     forceDoubleSnapshot = false;
                 }
             } else {    // 0 snapshot and 1+ delta transitions
-                hollowDataHolderVolatile.update(updatePlan, localListeners, () -> {});
+                hollowDataHolderVolatile.update(updatePlan, localListeners, () -> {}, isInitialUpdate);
             }
 
             for(HollowConsumer.RefreshListener refreshListener : localListeners)
@@ -245,7 +247,7 @@ public class HollowClientUpdater {
     public long getCurrentVersionId() {
         HollowDataHolder hollowDataHolderLocal = hollowDataHolderVolatile;
         return hollowDataHolderLocal != null ? hollowDataHolderLocal.getCurrentVersion()
-            : HollowConstants.VERSION_NONE;
+            : VERSION_NONE;
     }
 
     public void forceDoubleSnapshotNextUpdate() {
@@ -256,7 +258,7 @@ public class HollowClientUpdater {
      * Whether or not a snapshot plan should be created. Visible for testing.
      */
     boolean shouldCreateSnapshotPlan(HollowConsumer.VersionInfo incomingVersionInfo) {
-        if (getCurrentVersionId() == HollowConstants.VERSION_NONE
+        if (getCurrentVersionId() == VERSION_NONE
         || (forceDoubleSnapshot && doubleSnapshotConfig.allowDoubleSnapshot())) {
             return true;
         }

--- a/hollow/src/main/java/com/netflix/hollow/api/error/VersionMismatchException.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/error/VersionMismatchException.java
@@ -1,0 +1,21 @@
+package com.netflix.hollow.api.error;
+
+public class VersionMismatchException extends HollowException {
+    private final long expectedVersion;
+
+    private final long actualVersion;
+
+    public VersionMismatchException(long expectedVersion, long actualVersion) {
+        super("toVersion in blob did not match toVersion requested in transition; actualToVersion=" + actualVersion + ", expectedToVersion=" + expectedVersion);
+        this.expectedVersion = expectedVersion;
+        this.actualVersion = actualVersion;
+    }
+
+    public long getExpectedVersion() {
+        return expectedVersion;
+    }
+
+    public long getActualVersion() {
+        return actualVersion;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobReader.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.hollow.core.read.engine;
 
+import com.netflix.hollow.api.error.VersionMismatchException;
 import com.netflix.hollow.core.HollowBlobHeader;
 import com.netflix.hollow.core.HollowBlobOptionalPartHeader;
 import com.netflix.hollow.core.memory.MemoryMode;
@@ -43,6 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 import java.util.logging.Logger;
+
+import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_PRODUCER_TO_VERSION;
 
 /**
  * A HollowBlobReader is used to populate and update data in a {@link HollowReadStateEngine}, via the consumption
@@ -149,7 +152,8 @@ public class HollowBlobReader {
         if(optionalParts != null)
             optionalPartInputs = optionalParts.getInputsByPartName(in.getMemoryMode());
 
-        HollowBlobHeader header = readHeader(in, false);
+        HollowBlobHeader header = headerReader.readHeader(in);
+        applyHeader(header, false);
         List<HollowBlobOptionalPartHeader> partHeaders = readPartHeaders(header, optionalPartInputs, in.getMemoryMode());
         List<HollowSchema> allSchemas = combineSchemas(header, partHeaders);
 
@@ -218,12 +222,24 @@ public class HollowBlobReader {
     }
 
     public void applyDelta(HollowBlobInput in, OptionalBlobPartInput optionalParts) throws IOException {
+        applyDelta(in, optionalParts, 0, false);
+    }
+    public void applyDelta(HollowBlobInput in, OptionalBlobPartInput optionalParts, long expectedVersion, boolean isInitialUpdate) throws IOException {
         validateMemoryMode(in.getMemoryMode());
         Map<String, HollowBlobInput> optionalPartInputs = null;
         if(optionalParts != null)
             optionalPartInputs = optionalParts.getInputsByPartName(in.getMemoryMode());
-
-        HollowBlobHeader header = readHeader(in, true);
+        HollowBlobHeader header = headerReader.readHeader(in);
+        if (expectedVersion != 0 && !isInitialUpdate) {
+            String to_version_tag = header.getHeaderTags().get(HEADER_TAG_PRODUCER_TO_VERSION);
+            if (to_version_tag != null) {
+                long to_version = Long.parseLong(to_version_tag);
+                if (expectedVersion != to_version) {
+                    throw new VersionMismatchException(expectedVersion, to_version);
+                }
+            }
+        }
+        applyHeader(header, true);
         List<HollowBlobOptionalPartHeader> partHeaders = readPartHeaders(header, optionalPartInputs, in.getMemoryMode());
         notifyBeginUpdate();
 
@@ -258,16 +274,13 @@ public class HollowBlobReader {
         notifyEndUpdate();
     }
 
-    private HollowBlobHeader readHeader(HollowBlobInput in, boolean isDelta) throws IOException {
-        HollowBlobHeader header = headerReader.readHeader(in);
-
+    private void applyHeader(HollowBlobHeader header, boolean isDelta) throws IOException {
         if(isDelta && header.getOriginRandomizedTag() != stateEngine.getCurrentRandomizedTag())
             throw new IOException("Attempting to apply a delta to a state from which it was not originated!");
 
         stateEngine.setCurrentRandomizedTag(header.getDestinationRandomizedTag());
         stateEngine.setOriginRandomizedTag(header.getOriginRandomizedTag());
         stateEngine.setHeaderTags(header.getHeaderTags());
-        return header;
     }
 
     private List<HollowBlobOptionalPartHeader> readPartHeaders(HollowBlobHeader header, Map<String, HollowBlobInput> inputsByPartName, MemoryMode mode) throws IOException {

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.api.client;
 
 import static com.netflix.hollow.core.HollowConstants.VERSION_LATEST;
 import static com.netflix.hollow.core.HollowConstants.VERSION_NONE;
+import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_PRODUCER_TO_VERSION;
 import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_SCHEMA_HASH;
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
@@ -30,6 +31,7 @@ import static org.mockito.Mockito.when;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.api.error.VersionMismatchException;
 import com.netflix.hollow.api.metrics.HollowConsumerMetrics;
 import com.netflix.hollow.core.HollowStateEngine;
 import com.netflix.hollow.core.memory.MemoryMode;
@@ -43,9 +45,11 @@ import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.test.HollowWriteStateEngineBuilder;
 import com.netflix.hollow.test.consumer.TestBlob;
 import com.netflix.hollow.test.consumer.TestBlobRetriever;
+import com.netflix.hollow.test.consumer.TestBlobRetrieverWithNearestSnapshotMatch;
 import com.netflix.hollow.test.consumer.TestHollowConsumer;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -55,6 +59,8 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -259,6 +265,61 @@ public class HollowClientUpdaterTest {
         HollowObjectWriteRecord rec = new HollowObjectWriteRecord((HollowObjectSchema) stateEngine.getSchema("Actor"));
         rec.setInt("id", id);
         stateEngine.add("Actor", rec);
+    }
+
+    @Test
+    public void testReadBlobVersionInitialInconsistent() throws IOException {
+        testReadBlobVersion(2, 3, 1,  true);
+    }
+
+    @Test
+    public void testReadBlobVersionNotInitialInconsistent() throws IOException {
+        testReadBlobVersion(2, 3, 1,  false);
+    }
+
+    private void testReadBlobVersion(long metadataDesiredVersion1,
+                                     long blobDesiredVersion1,
+                                     long snapshotVersion,
+                                     boolean isInitialUpdate) throws IOException {
+        TestBlobRetrieverWithNearestSnapshotMatch testBlobRetriever = new TestBlobRetrieverWithNearestSnapshotMatch();
+        TestHollowConsumer testHollowConsumer = (new TestHollowConsumer.Builder())
+                .withBlobRetriever(testBlobRetriever)
+                .build();
+        HollowWriteStateEngine stateEngine = new HollowWriteStateEngine();
+        HollowBlobWriter writer = new HollowBlobWriter(stateEngine);
+
+        HollowObjectSchema movieSchema = new HollowObjectSchema("Movie", 1, "id");
+        movieSchema.addField("id", HollowObjectSchema.FieldType.INT);
+        stateEngine.addTypeState(new HollowObjectTypeWriteState(movieSchema));
+        addMovie(stateEngine, 1);
+        stateEngine.prepareForWrite();
+        ByteArrayOutputStream baos_v1 = new ByteArrayOutputStream();
+        writer.writeSnapshot(baos_v1);
+        testBlobRetriever.addSnapshot(snapshotVersion, new TestBlob(1,new ByteArrayInputStream(baos_v1.toByteArray())));
+
+        if (isInitialUpdate) {
+            stateEngine.prepareForNextCycle();
+            ByteArrayOutputStream baos_delta = new ByteArrayOutputStream();
+            stateEngine.addHeaderTag(HEADER_TAG_PRODUCER_TO_VERSION, String.valueOf(blobDesiredVersion1));
+            addMovie(stateEngine, 2);
+            stateEngine.prepareForWrite();
+            writer.writeDelta(baos_delta);
+            testBlobRetriever.addDelta(snapshotVersion, new TestBlob(snapshotVersion, metadataDesiredVersion1, new ByteArrayInputStream(baos_delta.toByteArray())));
+            testHollowConsumer.triggerRefreshTo(metadataDesiredVersion1);
+            assertEquals(metadataDesiredVersion1, testHollowConsumer.getCurrentVersionId());
+        } else {
+            expectedException.expect(VersionMismatchException.class);
+            testHollowConsumer.triggerRefreshTo(snapshotVersion);
+            stateEngine.prepareForNextCycle();
+            ByteArrayOutputStream baos_delta = new ByteArrayOutputStream();
+            stateEngine.addHeaderTag(HEADER_TAG_PRODUCER_TO_VERSION, String.valueOf(blobDesiredVersion1));
+            addMovie(stateEngine, 2);
+            stateEngine.prepareForWrite();
+            writer.writeDelta(baos_delta);
+            testBlobRetriever.addDelta(snapshotVersion, new TestBlob(snapshotVersion, metadataDesiredVersion1, new ByteArrayInputStream(baos_delta.toByteArray())));
+            testHollowConsumer.triggerRefreshTo(metadataDesiredVersion1);
+            assertEquals(snapshotVersion, testHollowConsumer.getCurrentVersionId());
+        }
     }
 
     private TestHollowConsumer schemaChangeSubject(HollowWriteStateEngine stateEngine, boolean doubleSnapshotOnSchemaChange,


### PR DESCRIPTION
When the consumer apply a delta transition, it will check the blob version in blob metadata. If this is a transition happen during the app start up, keep the existing behavior, otherwise, throw an exception when there is a mismatch of blob metadata to version and delta to version.