### PR TITLE
Resharding: producer can toggle numShards for Object types in the course of a delta chain

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListener.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AbstractProducerMetricsListener.java
@@ -20,6 +20,7 @@ import com.netflix.hollow.api.producer.AbstractHollowProducerListener;
 import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import java.time.Duration;
+import java.util.Map;
 import java.util.OptionalLong;
 
 /**
@@ -87,9 +88,13 @@ public abstract class AbstractProducerMetricsListener extends AbstractHollowProd
 
         HollowReadStateEngine stateEngine = readState.getStateEngine();
         dataSizeBytes = stateEngine.calcApproxDataSize();
+        Map<String, Integer> numShardsPerType = stateEngine.numShardsPerType();
+        Map<String, Long> shardSizePerType = stateEngine.calcApproxShardSizePerType();
 
         announcementMetricsBuilder
                 .setDataSizeBytes(dataSizeBytes)
+                .setNumShardsPerType(numShardsPerType)
+                .setShardSizePerType(shardSizePerType)
                 .setIsAnnouncementSuccess(isAnnouncementSuccess)
                 .setAnnouncementDurationMillis(elapsed.toMillis());
         lastAnnouncementSuccessTimeNanoOptional.ifPresent(announcementMetricsBuilder::setLastAnnouncementSuccessTimeNano);

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AnnouncementMetrics.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/metrics/AnnouncementMetrics.java
@@ -16,11 +16,14 @@
  */
 package com.netflix.hollow.api.producer.metrics;
 
+import java.util.Map;
 import java.util.OptionalLong;
 
 public class AnnouncementMetrics {
 
     private long dataSizeBytes;                             // Heap footprint of announced blob in bytes
+    private Map<String, Integer> numShardsPerType;
+    private Map<String, Long> shardSizePerType;
     private long announcementDurationMillis;                // Announcement duration in ms, only applicable to completed cycles (skipped cycles dont announce)
     private boolean isAnnouncementSuccess;                  // true if announcement was successful, false if announcement failed
     private OptionalLong lastAnnouncementSuccessTimeNano;   // monotonic time of last successful announcement (no relation to wall clock), N/A until first successful announcement
@@ -28,6 +31,12 @@ public class AnnouncementMetrics {
 
     public long getDataSizeBytes() {
         return dataSizeBytes;
+    }
+    public Map<String, Integer> getNumShardsPerType() {
+        return numShardsPerType;
+    }
+    public Map<String, Long> getShardSizePerType() {
+        return shardSizePerType;
     }
     public long getAnnouncementDurationMillis() {
         return announcementDurationMillis;
@@ -41,6 +50,8 @@ public class AnnouncementMetrics {
 
     private AnnouncementMetrics(Builder builder) {
         this.dataSizeBytes = builder.dataSizeBytes;
+        this.numShardsPerType = builder.numShardsPerType;
+        this.shardSizePerType = builder.shardSizePerType;
         this.announcementDurationMillis = builder.announcementDurationMillis;
         this.isAnnouncementSuccess = builder.isAnnouncementSuccess;
         this.lastAnnouncementSuccessTimeNano = builder.lastAnnouncementSuccessTimeNano;
@@ -51,6 +62,8 @@ public class AnnouncementMetrics {
         private long announcementDurationMillis;
         private boolean isAnnouncementSuccess;
         private OptionalLong lastAnnouncementSuccessTimeNano;
+        private Map<String, Integer> numShardsPerType;
+        private Map<String, Long> shardSizePerType;
 
         public Builder() {
             lastAnnouncementSuccessTimeNano = OptionalLong.empty();
@@ -58,6 +71,14 @@ public class AnnouncementMetrics {
 
         public Builder setDataSizeBytes(long dataSizeBytes) {
             this.dataSizeBytes = dataSizeBytes;
+            return this;
+        }
+        public Builder setNumShardsPerType(Map<String, Integer> numShardsPerType) {
+            this.numShardsPerType = numShardsPerType;
+            return this;
+        }
+        public Builder setShardSizePerType(Map<String, Long> shardSizePerType) {
+            this.shardSizePerType = shardSizePerType;
             return this;
         }
         public Builder setAnnouncementDurationMillis(long announcementDurationMillis) {

--- a/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
@@ -48,6 +48,13 @@ public interface HollowStateEngine extends HollowDataset {
     String HEADER_TAG_SCHEMA_CHANGE = "hollow.schema.changedFromPriorVersion";
 
     /**
+     * A header tag indicating that num shards for a type has changed since the prior version. Its value encodes
+     * the type(s) that were re-sharded along with the before and after num shards in the fwd delta direction.
+     * For e.g. Movie:(2,4) Actor:(8,4)
+     */
+    String HEADER_TAG_TYPE_RESHARDING_INVOKED = "hollow.type.resharding.invoked";
+
+    /**
      * A header tag containing the hash of serialized hollow schema.
      */
     String HEADER_TAG_SCHEMA_HASH = "hollow.schema.hash";

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowReadStateEngine.java
@@ -176,6 +176,30 @@ public class HollowReadStateEngine implements HollowStateEngine, HollowDataAcces
                 .sum();
     }
 
+    /**
+     * @return the no. of shards for each type in the read state
+     */
+    public Map<String, Integer> numShardsPerType() {
+        Map<String, Integer> typeShards = new HashMap<>();
+        for (String type : this.getAllTypes()) {
+            HollowTypeReadState typeState = this.getTypeState(type);
+            typeShards.put(type, typeState.numShards());
+        }
+        return typeShards;
+    }
+
+    /**
+     * @return the approx heap footprint of a single shard in bytes, for each type in the read state
+     */
+    public Map<String, Long> calcApproxShardSizePerType() {
+        Map<String, Long> typeShardSizes = new HashMap<>();
+        for (String type : this.getAllTypes()) {
+            HollowTypeReadState typeState = this.getTypeState(type);
+            typeShardSizes.put(type, typeState.getApproximateShardSizeInBytes());
+        }
+        return typeShardSizes;
+    }
+
     @Override
     public HollowTypeDataAccess getTypeDataAccess(String type) {
         return typeStates.get(type);

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
@@ -193,7 +193,14 @@ public abstract class HollowTypeReadState implements HollowTypeDataAccess {
      * @return an approximate accounting of the current cost of the "ordinal holes" in this type state.
      */
     public abstract long getApproximateHoleCostInBytes();
-    
+
+    /**
+     * @return an approximate accounting of the current heap footprint occupied by each shard of this type state.
+     */
+    public long getApproximateShardSizeInBytes() {
+        return getApproximateHeapFootprintInBytes() / numShards();
+    }
+
     /**
      * @return The number of shards into which this type is split.  Sharding is transparent, so this has no effect on normal usage.
      */

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
@@ -112,7 +112,6 @@ public class HollowBlobWriter {
             partStreams.flush();
     }
 
-
     /**
      * Serialize the changes necessary to transition a consumer from the previous state
      * to the current state as a delta blob.
@@ -238,7 +237,7 @@ public class HollowBlobWriter {
                 HollowSchema schema = typeState.getSchema();
                 schema.writeTo(partStream);
 
-                writeNumShards(partStream, typeState.getNumShards());
+                writeNumShards(partStream, typeState.getRevNumShards());
 
                 typeState.writeReverseDelta(partStream);
             }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.hollow.core.write;
 
+import com.netflix.hollow.core.HollowStateEngine;
 import com.netflix.hollow.core.memory.ByteData;
 import com.netflix.hollow.core.memory.ByteDataArray;
 import com.netflix.hollow.core.memory.ThreadSafeBitSet;
@@ -26,8 +27,12 @@ import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class HollowObjectTypeWriteState extends HollowTypeWriteState {
+    private static final Logger LOG = Logger.getLogger(HollowObjectTypeWriteState.class.getName());
 
     /// statistics required for writing fixed length set data
     private FieldStatistics fieldStats;
@@ -35,6 +40,8 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
     /// data required for writing snapshot or delta
     private int maxOrdinal;
     private int maxShardOrdinal[];
+    private int revMaxShardOrdinal[];
+
     private FixedLengthElementArray fixedLengthLongArray[];
     private ByteDataArray varLengthByteArrays[][];
     private long recordBitOffset[];
@@ -46,14 +53,29 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
     public HollowObjectTypeWriteState(HollowObjectSchema schema) {
         this(schema, -1);
     }
-    
+
     public HollowObjectTypeWriteState(HollowObjectSchema schema, int numShards) {
         super(schema, numShards);
+    }
+
+    public HollowObjectTypeWriteState(HollowObjectSchema schema, int numShards, boolean isNumShardsPinned) {
+        super(schema, numShards, isNumShardsPinned);
     }
 
     @Override
     public HollowObjectSchema getSchema() {
         return (HollowObjectSchema)schema;
+    }
+
+    boolean allowTypeResharding() {
+        if (stateEngine.allowTypeResharding()) {
+            if (isNumShardsPinned()) {
+                LOG.warning("Type re-sharding feature was enabled but num shards is pinned (likely using the " +
+                        "HollowShardLargeType annotation in the data model). Proceeding with fixed num shards.");
+                return false;
+            }
+        }
+        return stateEngine.allowTypeResharding();
     }
 
     /**
@@ -76,20 +98,61 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
         }
 
         fieldStats.completeCalculations();
-        
-        if(numShards == -1) {
-            long projectedSizeOfType = ((long)fieldStats.getNumBitsPerRecord() * (maxOrdinal + 1)) / 8;
-            projectedSizeOfType += fieldStats.getTotalSizeOfAllVarLengthData();
-            
-            numShards = 1;
-            while(stateEngine.getTargetMaxTypeShardSize() * numShards < projectedSizeOfType) 
-                numShards *= 2;
+
+        if (numShards == -1) {
+            numShards = targetNumShards(maxOrdinal);
+            revNumShards = numShards;
+        } else {
+            revNumShards = numShards;
+            if (allowTypeResharding()) {
+                numShards = targetNumShards(maxOrdinal);
+                if (numShards != revNumShards) {    // re-sharding
+                    // limit numShards to 2x or .5x of prevShards per producer cycle
+                    numShards = numShards > revNumShards ? revNumShards * 2 : revNumShards / 2;
+
+                    LOG.info(String.format("Num shards for type %s changing from %s to %s", schema.getName(), revNumShards, numShards));
+                    addReshardingHeader(revNumShards, numShards);
+                }
+            }
         }
-        
-        maxShardOrdinal = new int[numShards];
-        int minRecordLocationsPerShard = (maxOrdinal + 1) / numShards; 
+
+        maxShardOrdinal = calcMaxShardOrdinal(maxOrdinal, numShards);
+        if (revNumShards > 0) {
+            revMaxShardOrdinal = calcMaxShardOrdinal(maxOrdinal, revNumShards);
+        }
+    }
+
+    private int targetNumShards(int maxOrdinal) {
+        long projectedSizeOfType = ((long)fieldStats.getNumBitsPerRecord() * (maxOrdinal + 1)) / 8;
+        projectedSizeOfType += fieldStats.getTotalSizeOfAllVarLengthData();
+
+        int targetNumShards = 1;
+        while(stateEngine.getTargetMaxTypeShardSize() * targetNumShards < projectedSizeOfType)
+            targetNumShards *= 2;
+
+        return targetNumShards;
+    }
+
+    /**
+     * A header tag indicating that num shards for a type has changed since the prior version. Its value encodes
+     * the type(s) that were re-sharded along with the before and after num shards in the fwd delta direction.
+     * For e.g. Movie:(2,4) Actor:(8,4)
+     */
+    private void addReshardingHeader(int prevNumShards, int newNumShards) {
+        String existing = stateEngine.getHeaderTag(HollowStateEngine.HEADER_TAG_TYPE_RESHARDING_INVOKED);
+        String appendTo = "";
+        if (existing != null) {
+            appendTo = existing + " ";
+        }
+        stateEngine.addHeaderTag(HollowStateEngine.HEADER_TAG_TYPE_RESHARDING_INVOKED, appendTo + schema.getName() + ":(" + prevNumShards + "," + newNumShards + ")");
+    }
+
+    int[] calcMaxShardOrdinal(int maxOrdinal, int numShards) {
+        int[] maxShardOrdinal = new int[numShards];
+        int minRecordLocationsPerShard = (maxOrdinal + 1) / numShards;
         for(int i=0;i<numShards;i++)
             maxShardOrdinal[i] = (i < ((maxOrdinal + 1) & (numShards - 1))) ? minRecordLocationsPerShard : minRecordLocationsPerShard - 1;
+        return maxShardOrdinal;
     }
 
     private void discoverObjectFieldStatisticsForRecord(FieldStatistics fieldStats, int ordinal) {
@@ -187,16 +250,15 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
             recordBitOffset[shardNumber] += numBitsPerRecord;
         }
     }
-    
-    @Override
+
     public void writeSnapshot(DataOutputStream os) throws IOException {
+        LOG.log(Level.FINE, String.format("Writing snapshot with num shards = %s, revNumShards = %s, max shard ordinals = %s", numShards, revNumShards, Arrays.toString(maxShardOrdinal)));
         /// for unsharded blobs, support pre v2.1.0 clients
         if(numShards == 1) {
             writeSnapshotShard(os, 0);
         } else {
             /// overall max ordinal
             VarInt.writeVInt(os, maxOrdinal);
-            
             for(int i=0;i<numShards;i++) {
                 writeSnapshotShard(os, i);
             }
@@ -204,7 +266,6 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
 
         /// Populated bits
         currentCyclePopulated.serializeBitsTo(os);
-        
         fixedLengthLongArray = null;
         varLengthByteArrays = null;
         recordBitOffset = null;
@@ -237,25 +298,27 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
 
     @Override
     public void calculateDelta() {
-        calculateDelta(previousCyclePopulated, currentCyclePopulated);
+        calculateDelta(previousCyclePopulated, currentCyclePopulated, numShards);
     }
 
     @Override
     public void writeDelta(DataOutputStream dos) throws IOException {
-        writeCalculatedDelta(dos);
+        LOG.log(Level.FINE, String.format("Writing delta with num shards = %s, max shard ordinals = %s", numShards, Arrays.toString(maxShardOrdinal)));
+        writeCalculatedDelta(dos, numShards, maxShardOrdinal);
     }
 
     @Override
     public void calculateReverseDelta() {
-        calculateDelta(currentCyclePopulated, previousCyclePopulated);
+        calculateDelta(currentCyclePopulated, previousCyclePopulated, revNumShards);
     }
 
     @Override
     public void writeReverseDelta(DataOutputStream dos) throws IOException {
-        writeCalculatedDelta(dos);
+        LOG.log(Level.FINE, String.format("Writing reversedelta with num shards = %s, max shard ordinals = %s", revNumShards, Arrays.toString(revMaxShardOrdinal)));
+        writeCalculatedDelta(dos, revNumShards, revMaxShardOrdinal);
     }
 
-    private void calculateDelta(ThreadSafeBitSet fromCyclePopulated, ThreadSafeBitSet toCyclePopulated) {
+    private void calculateDelta(ThreadSafeBitSet fromCyclePopulated, ThreadSafeBitSet toCyclePopulated, int numShards) {
         maxOrdinal = ordinalMap.maxOrdinal();
         int numBitsPerRecord = fieldStats.getNumBitsPerRecord();
 
@@ -302,16 +365,16 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
         }
     }
 
-    private void writeCalculatedDelta(DataOutputStream os) throws IOException {
+    private void writeCalculatedDelta(DataOutputStream os, int numShards, int[] maxShardOrdinal) throws IOException {
         /// for unsharded blobs, support pre v2.1.0 clients
         if(numShards == 1) {
-            writeCalculatedDeltaShard(os, 0);
+            writeCalculatedDeltaShard(os, 0, maxShardOrdinal);
         } else {
             /// overall max ordinal
             VarInt.writeVInt(os, maxOrdinal);
             
             for(int i=0;i<numShards;i++) {
-                writeCalculatedDeltaShard(os, i);
+                writeCalculatedDeltaShard(os, i, maxShardOrdinal);
             }
         }
         
@@ -322,7 +385,7 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
         recordBitOffset = null;
     }
 
-    private void writeCalculatedDeltaShard(DataOutputStream os, int shardNumber) throws IOException {
+    private void writeCalculatedDeltaShard(DataOutputStream os, int shardNumber, int[] maxShardOrdinal) throws IOException {
 
         /// 1) max ordinal
         VarInt.writeVInt(os, maxShardOrdinal[shardNumber]);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -44,6 +44,8 @@ public abstract class HollowTypeWriteState {
     protected final ByteArrayOrdinalMap ordinalMap;
     
     protected int numShards;
+    protected int revNumShards;
+    private int resetToLastNumShards;
 
     protected HollowSchema restoredSchema;
     protected ByteArrayOrdinalMap restoredMap;
@@ -55,17 +57,25 @@ public abstract class HollowTypeWriteState {
     private final ThreadLocal<ByteDataArray> serializedScratchSpace;
 
     protected HollowWriteStateEngine stateEngine;
-    
+
     private boolean wroteData = false;
 
+    private boolean isNumShardsPinned;  // if numShards is pinned using numShards annotation in data model
+
     public HollowTypeWriteState(HollowSchema schema, int numShards) {
+        this(schema, numShards, false);
+    }
+
+    public HollowTypeWriteState(HollowSchema schema, int numShards, boolean isNumShardsPinned) {
         this.schema = schema;
         this.ordinalMap = new ByteArrayOrdinalMap();
         this.serializedScratchSpace = new ThreadLocal<ByteDataArray>();
         this.currentCyclePopulated = new ThreadSafeBitSet();
         this.previousCyclePopulated = new ThreadSafeBitSet();
         this.numShards = numShards;
-        
+        this.isNumShardsPinned = isNumShardsPinned;
+        this.resetToLastNumShards = numShards;
+
         if(numShards != -1 && ((numShards & (numShards - 1)) != 0 || numShards <= 0))
             throw new IllegalArgumentException("Number of shards must be a power of 2!  Check configuration for type " + schema.getName());
     }
@@ -136,6 +146,7 @@ public abstract class HollowTypeWriteState {
      * Resets this write state to empty (i.e. as if prepareForNextCycle() had just been called)
      */
     public void resetToLastPrepareForNextCycle() {
+        numShards = resetToLastNumShards;
         if(restoredReadState == null) {
             currentCyclePopulated.clearAll();
             ordinalMap.compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards());
@@ -228,15 +239,24 @@ public abstract class HollowTypeWriteState {
         return schema;
     }
     
-    int getNumShards() {
+    public int getNumShards() {
         return numShards;
     }
-    
+
+    boolean isNumShardsPinned() {
+        return isNumShardsPinned;
+    }
+
+    int getRevNumShards() {
+        return revNumShards;
+    }
+
     public void setNumShards(int numShards) {
         if(this.numShards == -1) {
             this.numShards = numShards;
+            this.resetToLastNumShards = numShards;
         } else if(this.numShards != numShards) {
-            throw new IllegalStateException("The number of shards for type " + schema.getName() + " is already fixed to " + this.numShards + ".  Cannot reset to " + numShards + "."); 
+            throw new IllegalStateException("The number of shards for type " + schema.getName() + " is already fixed to " + this.numShards + ".  Cannot reset to " + numShards + ".");
         }
     }
 
@@ -262,6 +282,8 @@ public abstract class HollowTypeWriteState {
         restoredMap = null;
         restoredSchema = null;
         restoredReadState = null;
+
+        resetToLastNumShards = numShards; // -1 if first cycle else previous numShards. See {@code testNumShardsMaintainedWhenNoResharding}
     }
 
     public void prepareForWrite() {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -127,7 +127,12 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
         }
 
         HollowObjectTypeWriteState existingWriteState = (HollowObjectTypeWriteState) parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = existingWriteState != null ? existingWriteState : new HollowObjectTypeWriteState(schema, getNumShards(clazz));
+        if (existingWriteState != null) {
+            this.writeState = existingWriteState;
+        } else {
+            int numShardsByAnnotation = getNumShardsByAnnotation(clazz);
+            this.writeState = new HollowObjectTypeWriteState(schema, numShardsByAnnotation, numShardsByAnnotation == -1 ? false : true);
+        }
 
         this.assignedOrdinalFieldOffset = assignedOrdinalFieldOffset;
         this.hasAssignedOrdinalField = hasAssignedOrdinalField;
@@ -142,7 +147,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
         return primaryKey == null ? null : primaryKey.fields();
     }
     
-    private static int getNumShards(Class<?> clazz) {
+    private static int getNumShardsByAnnotation(Class<?> clazz) {
         HollowShardLargeType numShardsAnnotation = clazz.getAnnotation(HollowShardLargeType.class);
         if(numShardsAnnotation != null)
             return numShardsAnnotation.numShards();

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowIncrementalProducerTest.java
@@ -386,14 +386,18 @@ public class HollowIncrementalProducerTest {
 
     @Test
     public void continuesARestoredState() {
-        HollowProducer genesisProducer = createInMemoryProducer();
+        HollowProducer genesisProducer = createInMemoryProducerWithResharding();
 
         /// initialize the data -- classic producer creates the first state in the delta chain.
         long originalVersion = genesisProducer.runCycle(new Populator() {
             public void populate(WriteState state) throws Exception {
                 state.add(new TypeA(1, "one", 1));
+                state.add(new TypeA(2, "two", 2));
+                state.add(new TypeA(3, "three", 3));
+                state.add(new TypeA(4, "four", 4));
             }
         });
+        assertEquals(4, genesisProducer.getWriteEngine().getTypeState("String").getNumShards());
 
         /// now at some point in the future, we will start up and create a new classic producer
         /// to back the HollowIncrementalProducer.
@@ -407,9 +411,12 @@ public class HollowIncrementalProducerTest {
         /// now create our HollowIncrementalProducer
         HollowIncrementalProducer incrementalProducer = new HollowIncrementalProducer(backingProducer);
         incrementalProducer.restore(originalVersion, blobStore);
+        assertEquals(4, backingProducer.getWriteEngine().getTypeState("String").getNumShards());
 
         incrementalProducer.addOrModify(new TypeA(1, "one", 2));
         incrementalProducer.addOrModify(new TypeA(2, "two", 2));
+        incrementalProducer.addOrModify(new TypeA(3, "three", 3));
+        incrementalProducer.addOrModify(new TypeA(4, "four", 4));
         incrementalProducer.addOrModify(new TypeB(3, "three"));
 
         long version = incrementalProducer.runCycle();
@@ -1449,6 +1456,14 @@ public class HollowIncrementalProducerTest {
     private HollowProducer createInMemoryProducer() {
         return HollowProducer.withPublisher(blobStore)
                 .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+    }
+
+    private HollowProducer createInMemoryProducerWithResharding() {
+        return HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withTypeResharding(true)
+                .withTargetMaxTypeShardSize(8)
                 .build();
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
@@ -16,6 +16,9 @@
  */
 package com.netflix.hollow.api.producer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -33,22 +36,31 @@ import com.netflix.hollow.api.producer.HollowProducerListener.Status;
 import com.netflix.hollow.api.producer.enforcer.BasicSingleProducerEnforcer;
 import com.netflix.hollow.api.producer.enforcer.SingleProducerEnforcer;
 import com.netflix.hollow.api.producer.fs.HollowFilesystemAnnouncer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.api.producer.listener.VetoableListener;
 import com.netflix.hollow.core.HollowBlobHeader;
 import com.netflix.hollow.core.read.engine.HollowBlobHeaderReader;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.write.objectmapper.HollowInline;
 import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
+import com.netflix.hollow.test.InMemoryBlobStore;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Assert;
@@ -103,19 +115,19 @@ public class HollowProducerTest {
         long v1 = producer.runCycle(ws -> {
             ws.add(1);
         });
-        Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 1);
+        assertEquals(producer.getCycleCountWithPrimaryStatus(), 1);
         // Run cycle with no changes
         long v2 = producer.runCycle(ws -> {
             ws.add(1);
         });
-        Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 2);
+        assertEquals(producer.getCycleCountWithPrimaryStatus(), 2);
         long v3 = producer.runCycle(ws -> {
             ws.add(2);
         });
-        Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 3);
+        assertEquals(producer.getCycleCountWithPrimaryStatus(), 3);
 
-        Assert.assertEquals(v1, v2);
-        Assert.assertTrue(v3 > v2);
+        assertEquals(v1, v2);
+        assertTrue(v3 > v2);
     }
 
     @Test
@@ -136,16 +148,16 @@ public class HollowProducerTest {
         long v2 = producer.runCycle(ws -> {
             ws.add(1);
         });
-        Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 0);
+        assertEquals(producer.getCycleCountWithPrimaryStatus(), 0);
         // Run cycle as the primary producer
         enforcer.enable();
         long v3 = producer.runCycle(ws -> {
             ws.add(2);
         });
 
-        Assert.assertEquals(v1, v2);
-        Assert.assertTrue(v3 > v2);
-        Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 1);
+        assertEquals(v1, v2);
+        assertTrue(v3 > v2);
+        assertEquals(producer.getCycleCountWithPrimaryStatus(), 1);
     }
 
     @Test
@@ -167,12 +179,12 @@ public class HollowProducerTest {
                 ws.add(2);
             });
         } catch (IllegalStateException e) {
-            Assert.assertTrue(e instanceof HollowProducer.NotPrimaryMidCycleException);
-            Assert.assertEquals("Publish failed primary (aka leader) check", e.getMessage());
-            Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 2); // counted as cycle ran for the producer with primary status but lost status mid cycle. Doesn't matter as the next cycle result in a no-op.
+            assertTrue(e instanceof HollowProducer.NotPrimaryMidCycleException);
+            assertEquals("Publish failed primary (aka leader) check", e.getMessage());
+            assertEquals(producer.getCycleCountWithPrimaryStatus(), 2); // counted as cycle ran for the producer with primary status but lost status mid cycle. Doesn't matter as the next cycle result in a no-op.
             return;
         }
-        Assert.fail();
+        fail();
     }
 
     @Test
@@ -189,11 +201,11 @@ public class HollowProducerTest {
                 ws.add(1);
             });
         } catch (HollowProducer.NotPrimaryMidCycleException e) {
-            Assert.assertEquals("Announcement failed primary (aka leader) check", e.getMessage());
-            Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 1); // counted as cycle ran for producer with primary status
+            assertEquals("Announcement failed primary (aka leader) check", e.getMessage());
+            assertEquals(producer.getCycleCountWithPrimaryStatus(), 1); // counted as cycle ran for producer with primary status
             return;
         }
-        Assert.fail();
+        fail();
     }
 
     @Test
@@ -203,12 +215,12 @@ public class HollowProducerTest {
 
         try {
             producer.restore(fakeVersion, blobRetriever);
-            Assert.fail();
+            fail();
         } catch(Exception expected) { }
 
         Assert.assertNotNull(lastRestoreStatus);
-        Assert.assertEquals(Status.FAIL, lastRestoreStatus.getStatus());
-        Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 0);
+        assertEquals(Status.FAIL, lastRestoreStatus.getStatus());
+        assertEquals(producer.getCycleCountWithPrimaryStatus(), 0);
     }
 
     @Test
@@ -218,9 +230,9 @@ public class HollowProducerTest {
 
         producer.restore(version, blobRetriever);
         Assert.assertNotNull(lastRestoreStatus);
-        Assert.assertEquals(Status.SUCCESS, lastRestoreStatus.getStatus());
-        Assert.assertEquals("Version should be the same", version, lastRestoreStatus.getDesiredVersion());
-        Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 1);
+        assertEquals(Status.SUCCESS, lastRestoreStatus.getStatus());
+        assertEquals("Version should be the same", version, lastRestoreStatus.getDesiredVersion());
+        assertEquals(producer.getCycleCountWithPrimaryStatus(), 1);
     }
 
     @Test
@@ -229,11 +241,11 @@ public class HollowProducerTest {
         long version = testPublishV1(producer, 2, 10);
         HollowConsumer.HeaderBlob headerBlob = blobRetriever.retrieveHeaderBlob(version);
         Assert.assertNotNull(headerBlob);
-        Assert.assertEquals(version, headerBlob.getVersion());
+        assertEquals(version, headerBlob.getVersion());
         HollowBlobHeader header = new HollowBlobHeaderReader().readHeader(headerBlob.getInputStream());
         Assert.assertNotNull(header);
-        Assert.assertEquals(1, header.getSchemas().size());
-        Assert.assertEquals(schema, header.getSchemas().get(0));
+        assertEquals(1, header.getSchemas().size());
+        assertEquals(schema, header.getSchemas().get(0));
     }
 
     @Test
@@ -248,7 +260,7 @@ public class HollowProducerTest {
             long version = testPublishV1(producer, size, valueMultiplier);
             versions.add(version);
         }
-        Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 5);
+        assertEquals(producer.getCycleCountWithPrimaryStatus(), 5);
 
         System.out.println("\n\n------------ Restore and validate ------------\n");
         for (int i = 0; i < versions.size(); i++) {
@@ -293,7 +305,7 @@ public class HollowProducerTest {
         { // Publish V1
             HollowProducer producer = createProducer(tmpFolder, schema);
             v1 = testPublishV1(producer, sizeV1, valueMultiplierV1);
-            Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 1);
+            assertEquals(producer.getCycleCountWithPrimaryStatus(), 1);
         }
 
         // Publish V2;
@@ -325,7 +337,7 @@ public class HollowProducerTest {
             int valueFieldCount = 2;
             restoreAndAssert(producerV2, v3, sizeV3, valueMultiplierV3, valueFieldCount);
         }
-        Assert.assertEquals(producerV2.getCycleCountWithPrimaryStatus(), 2);
+        assertEquals(producerV2.getCycleCountWithPrimaryStatus(), 2);
     }
 
     @Test
@@ -336,18 +348,18 @@ public class HollowProducerTest {
         producer = createProducer(tmpFolder, schema);
         producer.restore(version + 1, blobRetriever);
         Assert.assertNotNull(lastRestoreStatus);
-        Assert.assertEquals(Status.SUCCESS, lastRestoreStatus.getStatus());
-        Assert.assertEquals("Should have reached correct version", version,
+        assertEquals(Status.SUCCESS, lastRestoreStatus.getStatus());
+        assertEquals("Should have reached correct version", version,
                 lastRestoreStatus.getVersionReached());
-        Assert.assertEquals("Should have correct desired version", version + 1,
+        assertEquals("Should have correct desired version", version + 1,
                 lastRestoreStatus.getDesiredVersion());
-        Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 0); // no cycle run
+        assertEquals(producer.getCycleCountWithPrimaryStatus(), 0); // no cycle run
     }
 
     @Test
     public void testRollsBackStateEngineOnPublishFailure() throws Exception {
         HollowProducer producer = spy(createProducer(tmpFolder, schema));
-        Assert.assertEquals("Should have no populated ordinals", 0,
+        assertEquals("Should have no populated ordinals", 0,
                 producer.getWriteEngine().getTypeState("TestPojo").getPopulatedBitSet().cardinality());
         doThrow(new RuntimeException("Publish failed")).when(producer).publish(
                 any(ProducerListenerSupport.ProducerListeners.class), any(Long.class), any(AbstractHollowProducer.Artifacts.class));
@@ -355,9 +367,9 @@ public class HollowProducerTest {
             producer.runCycle(newState -> newState.add(new TestPojoV1(1, 1)));
         } catch (RuntimeException e) { // expected
         }
-        Assert.assertEquals("Should still have no populated ordinals", 0,
+        assertEquals("Should still have no populated ordinals", 0,
                 producer.getWriteEngine().getTypeState("TestPojo").getPopulatedBitSet().cardinality());
-        Assert.assertEquals(producer.getCycleCountWithPrimaryStatus(), 1); // counted as cycle ran for producer with primary status
+        assertEquals(producer.getCycleCountWithPrimaryStatus(), 1); // counted as cycle ran for producer with primary status
     }
 
     private long testPublishV1(HollowProducer producer, final int size, final int valueMultiplier) {
@@ -367,7 +379,7 @@ public class HollowProducerTest {
             }
         });
         Assert.assertNotNull(lastProducerStatus);
-        Assert.assertEquals(Status.SUCCESS, lastProducerStatus.getStatus());
+        assertEquals(Status.SUCCESS, lastProducerStatus.getStatus());
         return lastProducerStatus.getVersion();
     }
 
@@ -378,7 +390,7 @@ public class HollowProducerTest {
             }
         });
         Assert.assertNotNull(lastProducerStatus);
-        Assert.assertEquals(Status.SUCCESS, lastProducerStatus.getStatus());
+        assertEquals(Status.SUCCESS, lastProducerStatus.getStatus());
         return lastProducerStatus.getVersion();
     }
 
@@ -389,12 +401,12 @@ public class HollowProducerTest {
     private void restoreAndAssert(HollowProducer producer, long version, int size, int valueMultiplier, int valueFieldCount) {
         ReadState readState = producer.restore(version, blobRetriever);
         Assert.assertNotNull(lastRestoreStatus);
-        Assert.assertEquals(Status.SUCCESS, lastRestoreStatus.getStatus());
-        Assert.assertEquals("Version should be the same", version, lastRestoreStatus.getDesiredVersion());
+        assertEquals(Status.SUCCESS, lastRestoreStatus.getStatus());
+        assertEquals("Version should be the same", version, lastRestoreStatus.getDesiredVersion());
 
         HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) readState.getStateEngine().getTypeState("TestPojo");
         BitSet populatedOrdinals = typeState.getPopulatedOrdinals();
-        Assert.assertEquals(size, populatedOrdinals.cardinality());
+        assertEquals(size, populatedOrdinals.cardinality());
 
         int ordinal = populatedOrdinals.nextSetBit(0);
         while (ordinal != -1) {
@@ -405,12 +417,375 @@ public class HollowProducerTest {
             for (int i = 0; i < valueFieldCount; i++) {
                 String valueFN = "v" + (i + 1);
                 int value = id * valueMultiplier;
-                Assert.assertEquals(valueFN, value, obj.getInt(valueFN));
+                assertEquals(valueFN, value, obj.getInt(valueFN));
             }
 
             ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
         }
         System.out.println("Asserted Correctness of version:" + version + "\n\n");
+    }
+
+    @Test
+    public void testReshardingObjectTypes() {
+        for (boolean allowResharding : Arrays.asList(true, false)) {
+            HollowProducer.Builder producerBuilder = HollowProducer.withPublisher(new FakeBlobPublisher()).withAnnouncer(new HollowFilesystemAnnouncer(tmpFolder.toPath()));
+            if (allowResharding)
+                    producerBuilder = producerBuilder.withTypeResharding(true);
+            HollowProducer producer = producerBuilder.withTargetMaxTypeShardSize(32).build();
+            producer.runCycle(ws -> {
+                // causes 2 shards for Integer at shard size 32
+                for (int i=0;i<50;i++) {
+                    Set<Long> set = new HashSet<>(Collections.singleton((long) i));
+                    ws.add(new HasNonObjectField(i, set));
+                }
+            });
+            assertEquals(2, producer.getWriteEngine().getTypeState("Integer").getNumShards());
+            int numShardsNonObjectType = producer.getWriteEngine().getTypeState("SetOfLong").getNumShards();
+            assertTrue(numShardsNonObjectType >= 1);
+            producer.runCycle(ws -> {
+
+                // 2x the data, causes 4 shards for Integer at shard size 32
+                // 2x the collection type, numShards should remain the same (until non object types support resharding)
+                for (int i=0;i<100;i++) {
+                    Set<Long> set = new HashSet<>(Collections.singleton((long) i));
+                    ws.add(new HasNonObjectField(i, set));
+                }
+            });
+            if (allowResharding) {
+                assertEquals(4, producer.getWriteEngine().getTypeState("Integer").getNumShards());
+            } else {
+                assertEquals(2, producer.getWriteEngine().getTypeState("Integer").getNumShards());
+            }
+            assertEquals(numShardsNonObjectType, producer.getWriteEngine().getTypeState("SetOfLong").getNumShards());
+
+            producer.runCycle(ws -> {
+                // still 4 shards, because ghost records
+                for (int i=0;i<50;i++) {
+                    Set<Long> set = new HashSet<>(Collections.singleton((long) i));
+                    ws.add(new HasNonObjectField(i, set));
+                }
+            });
+            producer.runCycle(ws -> {
+                // back to 2 shards for Integer
+                for (int i=0;i<49;i++) {    // one change in runCycle
+                    Set<Long> set = new HashSet<>(Collections.singleton((long) i));
+                    ws.add(new HasNonObjectField(i, set));
+                }
+            });
+            assertEquals(2, producer.getWriteEngine().getTypeState("Integer").getNumShards());
+        }
+    }
+
+    @Test
+    public void testDeltaChainWithMultipleReshardingInvocations() {
+
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+        int numCycles = 100;
+        int numRecordsMin = 1;
+        long v = 0;
+
+        HollowProducer p = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager)
+                .withTypeResharding(true).withTargetMaxTypeShardSize(32).build();
+
+        HollowConsumer c = HollowConsumer.withBlobRetriever(blobStore)
+                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
+                    @Override
+                    public boolean allowDoubleSnapshot() {
+                        return false;
+                    }
+                    @Override
+                    public int maxDeltasBeforeDoubleSnapshot() {
+                        return Integer.MAX_VALUE;
+                    }
+                })
+                .build();
+
+        long startVersion = 0;
+        Set<Integer> numShardsExercised = new HashSet<>();
+        for (int n = 0; n < numCycles; n ++) {
+            int numRecords = numRecordsMin + new Random().nextInt(100);
+            v = p.runCycle(state -> {
+                for (int i = 0; i < numRecords; i ++) {
+                    state.add(new TestPojoV1(i, i));
+                }
+            });
+            if (n == 0)
+                startVersion = v;
+
+            c.triggerRefreshTo(v);
+
+            numShardsExercised.add(c.getStateEngine().getTypeState("TestPojo").numShards());
+        }
+        long endVersion = v;
+
+        Assert.assertTrue(numShardsExercised.size() > 1);
+
+        c.triggerRefreshTo(startVersion);
+        assertEquals(startVersion, c.getCurrentVersionId());
+        c.triggerRefreshTo(endVersion);
+        assertEquals(endVersion, c.getCurrentVersionId());
+    }
+
+    @Test
+    public void testNumShardsMaintainedWhenNoResharding() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+        HollowProducer nonReshardingProducer1 = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager)
+                .withTypeResharding(false).withTargetMaxTypeShardSize(32).build();
+        long v1_1 = nonReshardingProducer1.runCycle(ws -> {
+            // causes 2 shards for Integer at shard size 32
+            for (int i=0;i<50;i++) {
+                ws.add(new TestPojoV1(i, i));
+            }
+        });
+        assertEquals(4, nonReshardingProducer1.getWriteEngine().getTypeState("TestPojo").getNumShards());
+
+        try {
+            long v1_2 = nonReshardingProducer1.runCycle(ws -> {
+                throw new RuntimeException("failed population");
+            });
+            fail("exception expected");
+        } catch (Exception e){
+        }
+
+        long v1_3 = nonReshardingProducer1.runCycle(ws -> {
+            for (int i=0;i<100;i++) {
+                ws.add(new TestPojoV1(i, i));
+            }
+        });
+        assertEquals(4, nonReshardingProducer1.getWriteEngine().getTypeState("TestPojo").getNumShards());
+
+        HollowProducer nonReshardingProducer2 = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager)
+                .withTypeResharding(false).withTargetMaxTypeShardSize(32).build();
+        nonReshardingProducer2.initializeDataModel(TestPojoV1.class);
+        assertEquals(-1, nonReshardingProducer2.getWriteEngine().getTypeState("TestPojo").getNumShards());
+        nonReshardingProducer2.restore(v1_1, blobStore);
+        assertEquals(4, nonReshardingProducer2.getWriteEngine().getTypeState("TestPojo").getNumShards());
+        try {
+            nonReshardingProducer2.runCycle(ws -> {
+                // causes 4 shards for Integer at shard size 32
+                throw new RuntimeException("failed population");
+            });
+            fail("exception expected");
+        } catch (Exception e){
+        }
+        assertEquals(4, nonReshardingProducer2.getWriteEngine().getTypeState("TestPojo").getNumShards());
+
+        nonReshardingProducer2.runCycle(ws -> {
+            // causes 4 shards for Integer at shard size 32
+            for (int i=0;i<100;i++) {
+                ws.add(new TestPojoV1(i, i));
+            }
+        });
+        assertEquals(4, nonReshardingProducer2.getWriteEngine().getTypeState("TestPojo").getNumShards());
+    }
+
+    @Test
+    public void testNumShardsMaintainedWhenNoResharding_WithNonObjectTypes() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+        HollowProducer nonReshardingProducer1 = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager)
+                .withTypeResharding(false).withTargetMaxTypeShardSize(32).build();
+        long v1 = nonReshardingProducer1.runCycle(ws -> {
+            // causes 2 shards for Integer at shard size 32
+            for (int i=0;i<50;i++) {
+                Set<Long> set = new HashSet<>(Collections.singleton((long) i));
+                ws.add(new HasNonObjectField(i, set));
+            }
+        });
+        assertEquals(4, nonReshardingProducer1.getWriteEngine().getTypeState("SetOfLong").getNumShards());
+
+        HollowProducer nonReshardingProducer2 = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager)
+                .withTypeResharding(false).withTargetMaxTypeShardSize(32).build();
+        nonReshardingProducer2.initializeDataModel(HasNonObjectField.class);
+        assertEquals(-1, nonReshardingProducer2.getWriteEngine().getTypeState("SetOfLong").getNumShards());
+        nonReshardingProducer2.restore(v1, blobStore);
+        assertEquals(4, nonReshardingProducer2.getWriteEngine().getTypeState("SetOfLong").getNumShards());
+        try {
+            nonReshardingProducer2.runCycle(ws -> {
+                // causes 4 shards for Integer at shard size 32
+                throw new RuntimeException("failed population");
+            });
+            fail("exception expected");
+        } catch (Exception e){
+        }
+        assertEquals(4, nonReshardingProducer2.getWriteEngine().getTypeState("SetOfLong").getNumShards());
+
+        nonReshardingProducer2.runCycle(ws -> {
+            // causes 4 shards for Integer at shard size 32
+            for (int i=0;i<500;i++) {
+                Set<Long> set = new HashSet<>(Collections.singleton((long) i));
+                ws.add(new HasNonObjectField(i, set));
+            }
+        });
+        assertEquals(4, nonReshardingProducer2.getWriteEngine().getTypeState("SetOfLong").getNumShards());
+    }
+
+    // @Test Disabled until producer allows both resharding and focusHolesInFewestShards features
+    public void testReshardingWithFocusHoleFillInFewestShards() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+        HollowProducer producer = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager)
+                .withTypeResharding(true).withTargetMaxTypeShardSize(64)
+                .withFocusHoleFillInFewestShards(true)
+                .build();
+        long v1 = producer.runCycle(state -> {
+            for(int i=1;i<=36;i++) {
+                add(state, "val" + i, i);
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withSkipTypeShardUpdateWithNoAdditions()
+                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
+                    @Override
+                    public boolean allowDoubleSnapshot() {
+                        return false;
+                    }
+                    @Override
+                    public int maxDeltasBeforeDoubleSnapshot() {
+                        return Integer.MAX_VALUE;
+                    }
+                })
+                .build();
+        consumer.triggerRefreshTo(v1);
+        Assert.assertEquals(4, consumer.getStateEngine().getTypeState("TestRec").numShards());
+
+        /// remove 4 from S0: 13, 21, 25, 29
+        /// remove 5 from S1:  6, 14, 18, 26, 30
+        /// remove 2 from S2: 11, 19
+        /// remove 1 from S3: 24
+        Set<Integer> removeSet = new HashSet<>(Arrays.asList(13, 21, 25, 29, 6, 14, 18, 26, 30, 11, 19, 24));
+        long v2 = producer.runCycle(state -> {
+            for(int i=1;i<=36;i++) {
+                if(!removeSet.contains(i))
+                    add(state, "val" + i, i);
+            }
+
+            add(state, "newval37", 37);
+        });
+        consumer.triggerRefreshTo(v2);
+        removeSet.add(5);
+
+        long v3 = producer.runCycle(state -> {
+            for(int i=1;i<=36;i++) {
+                if(!removeSet.contains(i))
+                    add(state, "val" + i, i);
+            }
+            add(state, "newval37", 37);
+            for(int i=1000;i<1005;i++) {
+                add(state, "bigval"+i, i);
+            }
+        });
+        consumer.triggerRefreshTo(v3);
+
+        /// all changes focused in shard 1
+        assertRecordOrdinal(consumer,  5, "bigval1000", 1000);
+        assertRecordOrdinal(consumer, 13, "bigval1001", 1001);
+        assertRecordOrdinal(consumer, 17, "bigval1002", 1002);
+        assertRecordOrdinal(consumer, 25, "bigval1003", 1003);
+        assertRecordOrdinal(consumer, 29, "bigval1004", 1004);
+
+        assertRecordOrdinal(consumer, 32, "val33", 33); // shard1
+        assertRecordOrdinal(consumer,  9, "val10", 10); // shard2
+        assertRecordOrdinal(consumer, 14, "val15", 15);
+        assertRecordOrdinal(consumer, 11, "val12", 12);
+
+        // numShards doubled to 8
+        assertEquals(8, consumer.getStateEngine().getTypeState("TestRec").numShards());
+        assertEquals(v3, consumer.getCurrentVersionId());
+
+        FailingValidationListener cycleFailingListener = new FailingValidationListener();
+        producer.addListener(cycleFailingListener);
+
+        // exercise resetToLastNumShards
+        try {
+            producer.runCycle(state -> {
+                add(state, "newVal", 9999);
+            });
+            fail("Cycle expected to fail at validation");
+        } catch (Exception e) {
+        }
+        try {
+            producer.runCycle(state -> {
+                add(state, "anotherNewVal", 9998);
+            });
+            fail("Cycle expected to fail at validation");
+        } catch (Exception e) {
+        }
+
+        producer.removeListener(cycleFailingListener);
+        long v4 = producer.runCycle(state -> {
+            for(int i=1;i<=36;i++) {
+                if(!removeSet.contains(i))
+                    add(state, "val" + i, i);
+            }
+
+            add(state, "newval37", 37);
+
+            for(int i=1000;i<1009;i++) {
+                add(state, "bigval"+i, i);
+            }
+        });
+        consumer.triggerRefreshTo(v4);
+
+        /// all changes focused in shard 0
+        assertRecordOrdinal(consumer,  4, "bigval1005", 1005);
+        assertRecordOrdinal(consumer, 12, "bigval1006", 1006);
+        assertRecordOrdinal(consumer, 20, "bigval1007", 1007);
+        assertRecordOrdinal(consumer, 28, "bigval1008", 1008);
+
+        assertRecordOrdinal(consumer, 32, "val33", 33); // shard1
+        assertRecordOrdinal(consumer,  9, "val10", 10); // shard2
+        assertRecordOrdinal(consumer, 14, "val15", 15);
+        assertRecordOrdinal(consumer, 11, "val12", 12);
+
+        assertEquals(8, consumer.getStateEngine().getTypeState("TestRec").numShards());
+        assertEquals(v4, consumer.getCurrentVersionId());
+
+        consumer.triggerRefreshTo(v1);
+        assertEquals(v1, consumer.getCurrentVersionId());
+
+        consumer.triggerRefreshTo(v4);
+        assertEquals(v4, consumer.getCurrentVersionId());
+        assertRecordOrdinal(consumer, 28, "bigval1008", 1008);
+        assertRecordOrdinal(consumer, 32, "val33", 33); // shard1
+        assertRecordOrdinal(consumer,  9, "val10", 10); // shard2
+        assertRecordOrdinal(consumer, 11, "val12", 12);
+    }
+
+    private void add(HollowProducer.WriteState state, String sVal, int iVal) {
+        TestRec rec = new TestRec(sVal, iVal);
+        state.add(rec);
+    }
+
+    private static class TestRec {
+        @HollowInline
+        private final String strVal;
+        private final int intVal;
+
+        public TestRec(String strVal, int intVal) {
+            this.strVal = strVal;
+            this.intVal = intVal;
+        }
+    }
+
+    private void assertRecordOrdinal(HollowConsumer consumer, int ordinal, String sVal, int iVal) {
+        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState)consumer.getStateEngine().getTypeState("TestRec");
+
+        Assert.assertEquals(iVal, typeState.readInt(ordinal, typeState.getSchema().getPosition("intVal")));
+        Assert.assertEquals(sVal, typeState.readString(ordinal, typeState.getSchema().getPosition("strVal")));
+    }
+
+    private static class HasNonObjectField {
+        public Integer objectField;
+        public Set<Long> nonObjectField;
+
+        public HasNonObjectField(int objectField, Set<Long> nonObjectField) {
+            this.objectField = objectField;
+            this.nonObjectField = nonObjectField;
+        }
     }
 
     @SuppressWarnings("unused")
@@ -449,6 +824,13 @@ public class HollowProducerTest {
         @Override
         public void onProducerRestoreComplete(RestoreStatus status, long elapsed, TimeUnit unit) {
             lastRestoreStatus = status;
+        }
+    }
+
+    private class FailingValidationListener extends AbstractHollowProducerListener implements VetoableListener {
+        @Override
+        public void onValidationStart(long version) {
+            throw new RuntimeException("This listener fails validation");
         }
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoinerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeDataElementsJoinerTest.java
@@ -77,82 +77,82 @@ public class HollowObjectTypeDataElementsJoinerTest extends AbstractHollowObject
         assertEquals(valBig, val1);
     }
 
-//    TODO: manually invoked, depends on producer side changes for supporting changing numShards in a delta chain
-//    @Test
-//    public void testLopsidedShards() {
-//        InMemoryBlobStore blobStore = new InMemoryBlobStore();
-//        HollowProducer p = HollowProducer.withPublisher(blobStore)
-//                .withBlobStager(new HollowInMemoryBlobStager())
-//                .build();
-//
-//        p.initializeDataModel(schema);
-//        int targetSize = 64;
-//        p.getWriteEngine().setTargetMaxTypeShardSize(targetSize);
-//        long v1 = oneRunCycle(p, new int[] {0, 1, 2, 3, 4, 5, 6, 7});
-//
-//        HollowConsumer c = HollowConsumer
-//                .withBlobRetriever(blobStore)
-//                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
-//                    @Override
-//                    public boolean allowDoubleSnapshot() {
-//                        return false;
-//                    }
-//
-//                    @Override
-//                    public int maxDeltasBeforeDoubleSnapshot() {
-//                        return Integer.MAX_VALUE;
-//                    }
-//                })
-//                .withSkipTypeShardUpdateWithNoAdditions()
-//                .build();
-//        c.triggerRefreshTo(v1);
-//
-//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
-//        assertEquals(true, c.getStateEngine().isSkipTypeShardUpdateWithNoAdditions());
-//
-//        long v2 = oneRunCycle(p, new int[] {0, 1, 2, 3, 5, 7});
-//        c.triggerRefreshTo(v2);
-//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
-//
-//        long v3 = oneRunCycle(p, new int[] { 0, 1, 3, 5}); // drop to 1 ordinal per shard, skipTypeShardWithNoAdds will make it so that maxOrdinal is adjusted
-//        c.triggerRefreshTo(v3);
-//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
-//
-//        long v4 = oneRunCycle(p, new int[] { 0, 1, 2, 3}); // now add another ordinal to one shard, maxOrdinals will be lopsided
-//        c.triggerRefreshTo(v4);
-//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
-//
-//        readStateEngine = c.getStateEngine();
-//        assertDataUnchanged(3);
-//
-//        long v5 = oneRunCycle(p, new int[] {0, 1});
-//
-//        // assert lopsided shards before join
-//        assertEquals(2, ((HollowObjectTypeReadState) c.getStateEngine().getTypeState("TestObject")).shardsVolatile.shards[0].dataElements.maxOrdinal);
-//        assertEquals(3, ((HollowObjectTypeReadState) c.getStateEngine().getTypeState("TestObject")).shardsVolatile.shards[1].dataElements.maxOrdinal);
-//        c.triggerRefreshTo(v5);
-//        assertEquals(1, c.getStateEngine().getTypeState("TestObject").numShards()); // joined to 1 shard
-//        readStateEngine = c.getStateEngine();
-//        assertDataUnchanged(2);
-//
-//        long v6 = oneRunCycle(p, new int[] {0, 1, 2, 3, 4, 5 });
-//        c.triggerRefreshTo(v6);
-//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards()); // split to 2 shards
-//
-//        long v7 = oneRunCycle(p, new int[] {8, 9});
-//        c.triggerRefreshTo(v7);
-//        assertEquals(4, c.getStateEngine().getTypeState("TestObject").numShards()); // still 2 shards
-//
-//        long v8 = oneRunCycle(p, new int[] {8});
-//        c.triggerRefreshTo(v8);
-//        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards()); // down to 1 shard
-//
-//        c.triggerRefreshTo(v1);
-//        assertEquals(v1, c.getCurrentVersionId());
-//
-//        c.triggerRefreshTo(v8);
-//        assertEquals(v8, c.getCurrentVersionId());
-//    }
+    @Test
+    public void testLopsidedShards() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowProducer p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withTypeResharding(true)
+                .build();
+
+        p.initializeDataModel(schema);
+        int targetSize = 64;
+        p.getWriteEngine().setTargetMaxTypeShardSize(targetSize);
+        long v1 = oneRunCycle(p, new int[] {0, 1, 2, 3, 4, 5, 6, 7});
+
+        HollowConsumer c = HollowConsumer
+                .withBlobRetriever(blobStore)
+                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
+                    @Override
+                    public boolean allowDoubleSnapshot() {
+                        return false;
+                    }
+
+                    @Override
+                    public int maxDeltasBeforeDoubleSnapshot() {
+                        return Integer.MAX_VALUE;
+                    }
+                })
+                .withSkipTypeShardUpdateWithNoAdditions()
+                .build();
+        c.triggerRefreshTo(v1);
+
+        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
+        assertEquals(true, c.getStateEngine().isSkipTypeShardUpdateWithNoAdditions());
+
+        long v2 = oneRunCycle(p, new int[] {0, 1, 2, 3, 5, 7});
+        c.triggerRefreshTo(v2);
+        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
+
+        long v3 = oneRunCycle(p, new int[] { 0, 1, 3, 5}); // drop to 1 ordinal per shard, skipTypeShardWithNoAdds will make it so that maxOrdinal is adjusted
+        c.triggerRefreshTo(v3);
+        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
+
+        long v4 = oneRunCycle(p, new int[] { 0, 1, 2, 3}); // now add another ordinal to one shard, maxOrdinals will be lopsided
+        c.triggerRefreshTo(v4);
+        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards());
+
+        readStateEngine = c.getStateEngine();
+        assertDataUnchanged(3);
+
+        long v5 = oneRunCycle(p, new int[] {0, 1});
+
+        // assert lopsided shards before join
+        assertEquals(2, ((HollowObjectTypeReadState) c.getStateEngine().getTypeState("TestObject")).shardsVolatile.shards[0].dataElements.maxOrdinal);
+        assertEquals(3, ((HollowObjectTypeReadState) c.getStateEngine().getTypeState("TestObject")).shardsVolatile.shards[1].dataElements.maxOrdinal);
+        c.triggerRefreshTo(v5);
+        assertEquals(1, c.getStateEngine().getTypeState("TestObject").numShards()); // joined to 1 shard
+        readStateEngine = c.getStateEngine();
+        assertDataUnchanged(2);
+
+        long v6 = oneRunCycle(p, new int[] {0, 1, 2, 3, 4, 5 });
+        c.triggerRefreshTo(v6);
+        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards()); // split to 2 shards
+
+        long v7 = oneRunCycle(p, new int[] {8, 9});
+        c.triggerRefreshTo(v7);
+        assertEquals(4, c.getStateEngine().getTypeState("TestObject").numShards()); // still 2 shards
+
+        long v8 = oneRunCycle(p, new int[] {8});
+        c.triggerRefreshTo(v8);
+        assertEquals(2, c.getStateEngine().getTypeState("TestObject").numShards()); // down to 1 shard
+
+        c.triggerRefreshTo(v1);
+        assertEquals(v1, c.getCurrentVersionId());
+
+        c.triggerRefreshTo(v8);
+        assertEquals(v8, c.getCurrentVersionId());
+    }
 
     private long oneRunCycle(HollowProducer p, int recordIds[]) {
         return p.runCycle(state -> {

--- a/hollow/src/test/java/com/netflix/hollow/core/write/HollowObjectTypeWriteStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/HollowObjectTypeWriteStateTest.java
@@ -1,0 +1,209 @@
+package com.netflix.hollow.core.write;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import com.netflix.hollow.core.write.objectmapper.HollowShardLargeType;
+import com.netflix.hollow.test.InMemoryBlobStore;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class HollowObjectTypeWriteStateTest {
+
+    @Test
+    public void testCalcMaxShardOrdinal() {
+        HollowObjectSchema testSchema = new HollowObjectSchema("Test", 1);
+        testSchema.addField("test1", HollowObjectSchema.FieldType.INT);
+        HollowObjectTypeWriteState testState = new HollowObjectTypeWriteState(testSchema);
+
+        assertTrue(Arrays.equals(new int[] {-1, -1, -1, -1}, testState.calcMaxShardOrdinal(-1, 4)));
+        assertTrue(Arrays.equals(new int[] {0, -1, -1, -1}, testState.calcMaxShardOrdinal(0, 4)));
+        assertTrue(Arrays.equals(new int[] {0, 0, -1, -1}, testState.calcMaxShardOrdinal(1, 4)));
+        assertTrue(Arrays.equals(new int[] {0, 0, 0, 0}, testState.calcMaxShardOrdinal(3, 4)));
+        assertTrue(Arrays.equals(new int[] {1, 1, 1, 1}, testState.calcMaxShardOrdinal(7, 4)));
+    }
+
+
+    @Test
+    public void testReverseDeltaNumShardsWhenNewType() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+
+        HollowProducer p1 = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager).withTargetMaxTypeShardSize(32).build();
+        p1.initializeDataModel(String.class);
+        long v1 = p1.runCycle(ws -> {
+            ws.add("A");
+        });
+
+        HollowProducer p2 = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager).withTargetMaxTypeShardSize(32).build();
+        p2.initializeDataModel(String.class, Long.class);
+        p2.restore(v1, blobStore);
+        long v2 = p2.runCycle(ws -> {
+            ws.add("A");
+            ws.add("B");
+            for (int i=0; i<50; i++) {
+                ws.add(new Long(i));
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
+                    @Override
+                    public boolean allowDoubleSnapshot() {
+                        return false;
+                    }
+                    @Override
+                    public int maxDeltasBeforeDoubleSnapshot() {
+                        return Integer.MAX_VALUE;
+                    }
+                })
+                .build();
+        consumer.triggerRefreshTo(v2);
+        assertEquals(2, consumer.getStateEngine().getTypeState("Long").numShards());
+
+        consumer.triggerRefreshTo(v1);    // reverse delta transition for new type with customNumShards
+        assertEquals(v1, consumer.getCurrentVersionId());
+        assertEquals(2, consumer.getStateEngine().getTypeState("Long").numShards());
+    }
+
+    @Test
+    public void testReverseDeltaNumShardsWhenTypeDropsToZeroRecords() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+
+        HollowProducer p1 = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager)
+                .withTypeResharding(true).withTargetMaxTypeShardSize(32).build();
+        p1.initializeDataModel(String.class, Long.class);
+        long v1 = p1.runCycle(ws -> {
+            // override cycle start time with a strictly incrementing count to work around clock skew
+            ws.add("A");
+            for (int i=0; i<50; i++) { // results in 2 shards at shard size 32
+                ws.add(new Long(i));
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
+                    @Override
+                    public boolean allowDoubleSnapshot() {
+                        return false;
+                    }
+                    @Override
+                    public int maxDeltasBeforeDoubleSnapshot() {
+                        return Integer.MAX_VALUE;
+                    }
+                })
+                .build();
+        consumer.triggerRefreshTo(v1);
+        assertEquals(v1, consumer.getCurrentVersionId());
+        assertEquals(2, consumer.getStateEngine().getTypeState("Long").numShards());
+
+        long v2 = p1.runCycle(ws -> {
+            ws.add("A");
+        });
+        consumer.triggerRefreshTo(v2);
+        assertEquals(v2, consumer.getCurrentVersionId());
+        assertEquals(2, consumer.getStateEngine().getTypeState("Long").numShards()); // Long type has a ghost record
+
+        long v3 = p1.runCycle(ws -> {
+            // override cycle start time with a strictly incrementing count to work around clock skew
+            ws.add("A");
+            ws.add("B");
+        });
+        consumer.triggerRefreshTo(v3);
+        assertEquals(v3, consumer.getCurrentVersionId());
+        assertEquals(2, consumer.getStateEngine().getTypeState("Long").numShards()); // Long type dropped all records
+
+        long v4 = p1.runCycle(ws -> {
+            // override cycle start time with a strictly incrementing count to work around clock skew
+            ws.add("A");
+            for (int i=0; i<50; i++) { // results in 2 shards at shard size 32
+                ws.add(new Long(i));
+            }
+        });
+        consumer.triggerRefreshTo(v4);
+        assertEquals(v4, consumer.getCurrentVersionId());
+        assertEquals(2, consumer.getStateEngine().getTypeState("Long").numShards()); // Long type has 1 record again
+    }
+
+    @Test
+    public void testNoReshardingIfNumShardsPinnedByAnnotation() {
+        HollowWriteStateEngine wse = new HollowWriteStateEngine();
+        new HollowObjectMapper(wse).initializeTypeState(TypeWithPinnedNumShards.class);
+        HollowObjectTypeWriteState typeWriteState = (HollowObjectTypeWriteState) wse.getTypeState("TypeWithPinnedNumShards");
+        assertFalse(typeWriteState.allowTypeResharding());
+    }
+
+    @Test
+    public void testRestoreNumShardsButDoNotPin() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+
+        HollowProducer p1 = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager)
+                .withTargetMaxTypeShardSize(32).build();
+        p1.initializeDataModel(Long.class);
+        long v1 = p1.runCycle(ws -> {
+            // override cycle start time with a strictly incrementing count to work around clock skew
+            for (int i=0; i<50; i++) { // results in 2 shards at shard size 32
+                ws.add(new Long(i));
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
+                    @Override
+                    public boolean allowDoubleSnapshot() {
+                        return false;
+                    }
+                    @Override
+                    public int maxDeltasBeforeDoubleSnapshot() {
+                        return Integer.MAX_VALUE;
+                    }
+                })
+                .build();
+        consumer.triggerRefreshTo(v1);
+        assertEquals(v1, consumer.getCurrentVersionId());
+        assertEquals(2, consumer.getStateEngine().getTypeState("Long").numShards());
+
+        HollowProducer p2 = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager)
+                .withTypeResharding(true).withTargetMaxTypeShardSize(32).build();
+        p2.initializeDataModel(Long.class);
+        p2.restore(v1, blobStore);
+        assertEquals(2, p2.getWriteEngine().getTypeState("Long").numShards);
+        assertFalse(p2.getWriteEngine().getTypeState("Long").isNumShardsPinned());
+
+        long v2 = p2.runCycle(ws -> {
+            for (int i=0; i<100; i++) { // results in 2 shards at shard size 32
+                ws.add(new Long(i));
+            }
+        });
+
+        HollowConsumer consumer2 = HollowConsumer.withBlobRetriever(blobStore)
+                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
+                    @Override
+                    public boolean allowDoubleSnapshot() {
+                        return false;
+                    }
+                    @Override
+                    public int maxDeltasBeforeDoubleSnapshot() {
+                        return Integer.MAX_VALUE;
+                    }
+                })
+                .build();
+        consumer2.triggerRefreshTo(v2);
+        int newNumShards = consumer2.getStateEngine().getTypeState("Long").numShards();
+        assertEquals(v2, consumer2.getCurrentVersionId());
+        assertEquals(4, newNumShards);
+    }
+
+    @HollowShardLargeType(numShards=4)
+    private static class TypeWithPinnedNumShards {
+        private int value;
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/write/HollowWriteStateEngineTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/HollowWriteStateEngineTest.java
@@ -1,7 +1,9 @@
 package com.netflix.hollow.core.write;
 
 import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_PRODUCER_TO_VERSION;
+import static com.netflix.hollow.core.HollowStateEngine.HEADER_TAG_TYPE_RESHARDING_INVOKED;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.producer.HollowProducer;
@@ -64,5 +66,64 @@ public class HollowWriteStateEngineTest {
         assertEquals("2", consumer.getStateEngine().getHeaderTag(TEST_TAG));
         assertEquals(String.valueOf(version2), consumer.getStateEngine().getHeaderTag(HEADER_TAG_PRODUCER_TO_VERSION));
 
+    }
+
+    @Test
+    public void testHeaderTagsWhenResharding() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+
+        HollowProducer producer = HollowProducer.withPublisher(blobStore).withBlobStager(blobStager)
+                .withTypeResharding(true).withTargetMaxTypeShardSize(32)
+                .build();
+        long v1 = producer.runCycle(ws -> {
+            // causes 2 shards for Integer at shard size 32
+            for (int i=0;i<50;i++) {
+                ws.add(i);
+            }
+        });
+        assertEquals(2, producer.getWriteEngine().getTypeState("Integer").getNumShards());
+        long v2 = producer.runCycle(ws -> {
+            // 2x the data, causes 4 shards for Integer at shard size 32
+            for (int i=0;i<100;i++) {
+                ws.add(i);
+            }
+
+        });
+        assertEquals(4, producer.getWriteEngine().getTypeState("Integer").getNumShards());
+        long v3 = producer.runCycle(ws -> {
+            // remain at 4 shards for Integer
+            for (int i=0;i<99;i++) {
+                ws.add(i);
+            }
+
+        });
+        assertEquals(4, producer.getWriteEngine().getTypeState("Integer").getNumShards());
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore)
+                .withDoubleSnapshotConfig(new HollowConsumer.DoubleSnapshotConfig() {
+                    @Override
+                    public boolean allowDoubleSnapshot() {
+                        return false;
+                    }
+                    @Override
+                    public int maxDeltasBeforeDoubleSnapshot() {
+                        return Integer.MAX_VALUE;
+                    }
+                })
+                .build();
+
+        consumer.triggerRefreshTo(v1);
+        assertEquals(2, consumer.getStateEngine().getTypeState("Integer").numShards());
+        assertNull(consumer.getStateEngine().getHeaderTag(HEADER_TAG_TYPE_RESHARDING_INVOKED));
+
+        consumer.triggerRefreshTo(v2);
+        assertEquals(v2, consumer.getCurrentVersionId());
+        assertEquals(4, consumer.getStateEngine().getTypeState("Integer").numShards());
+        assertEquals("Integer:(2,4)", consumer.getStateEngine().getHeaderTag(HEADER_TAG_TYPE_RESHARDING_INVOKED));
+
+        consumer.triggerRefreshTo(v3);
+        assertEquals(v3, consumer.getCurrentVersionId());
+        assertEquals(4, consumer.getStateEngine().getTypeState("Integer").numShards());
+        assertEquals(false, consumer.getStateEngine().getHeaderTags().containsKey(HEADER_TAG_TYPE_RESHARDING_INVOKED));
     }
 }


### PR DESCRIPTION
Opt-in feature, requires consumers to be on recent library version that supports applying varying numShards in a delta transition. A header tag in blob headers (also propagated into announcement metadata) provides observability into when and which types are resharded.

This is 3 of 4 planned PRs for supporting dynamic type re-sharding:

- [X] [PR#642](https://github.com/Netflix/hollow/pull/642) <s>utilities for splitting/joining Object types; limited to Object types in this step, extend to Map/Set/List in last step</s> 
- [X] [PR#644](https://github.com/Netflix/hollow/pull/644) <s>consumer delta application reshards with O(shard size) extra space</s> 
- [X] (this PR) producer-side numShards toggle and signaling
- [ ] Extend resharding to Map,List, and Set types

