### PR TITLE
Upgrade to Gradle 8.5 and Nebula OSS 11.5.0

### DIFF
--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -17,6 +17,10 @@ jobs:
     name: CI with Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v1
+      - name: Setup git user
+        run: |
+          git config --global user.name "Netflix OSS Maintainers"
+          git config --global user.email "netflixoss@netflix.com"
       - name: Setup jdk
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Setup git user
+        run: |
+          git config --global user.name "Netflix OSS Maintainers"
+          git config --global user.email "netflixoss@netflix.com"
       - name: Setup jdk 8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -12,6 +12,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Setup git user
+        run: |
+          git config --global user.name "Netflix OSS Maintainers"
+          git config --global user.email "netflixoss@netflix.com"
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.netflix.nebula.netflixoss' version '11.1.1'
+  id 'com.netflix.nebula.netflixoss' version '11.5.0'
 }
 
 subprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip


### PR DESCRIPTION
This upgrades Hollow to Gradle 8.5 and Nebula OSS 11.5.0

This version of Nebula OSS contains latest `nebula.release` with a fix to support composite builds https://github.com/nebula-plugins/nebula-release-plugin/releases/tag/v19.0.1

This should unblock composite builds while we roll this fix for internal projects at Netflix 