### PR TITLE
fix npe with using drop noSingleProducerEnforcer on HollowProducer.Builder

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -892,7 +892,6 @@ public class HollowProducer extends AbstractHollowProducer {
         }
 
         public B noSingleProducerEnforcer() {
-            this.singleProducerEnforcer = null;
             return (B) this;
         }
 


### PR DESCRIPTION
The error was
```
java.lang.NullPointerException: Cannot invoke "com.netflix.hollow.api.producer.enforcer.SingleProducerEnforcer.isPrimary()" because "this.singleProducerEnforcer" is null
        at com.netflix.hollow.api.producer.AbstractHollowProducer.runCycle(AbstractHollowProducer.java:351)
        at com.netflix.hollow.api.producer.HollowProducer.runCycle(HollowProducer.java:242)
        at 
```