### PR TITLE
Fix NullPointerException in HistoryUI  for empty 'from' and 'to' objects

### DIFF
--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diffview/effigy/pairer/HollowEffigyFieldPairer.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diffview/effigy/pairer/HollowEffigyFieldPairer.java
@@ -55,10 +55,12 @@ public abstract class HollowEffigyFieldPairer {
         }
 
         private boolean calculateIsDiff() {
-            if((from == null && to != null) || (from != null && to == null))
-                return true;
-            if(from.getValue() == null)
-                return to.getValue() != null;
+            if (from == null || to == null) {
+                return from != to;
+            }
+            if (from.getValue() == null || to.getValue() == null) {
+                return from.getValue() != to.getValue();
+            }
             if(isLeafNode())
                 return !from.getValue().equals(to.getValue());
             return false;

--- a/hollow-diff-ui/src/test/java/com/netflix/hollow/diffview/HollowEffigyFieldPairerTest.java
+++ b/hollow-diff-ui/src/test/java/com/netflix/hollow/diffview/HollowEffigyFieldPairerTest.java
@@ -1,0 +1,59 @@
+package com.netflix.hollow.diffview;
+
+import com.netflix.hollow.diffview.effigy.HollowRecordDiffUI;
+import com.netflix.hollow.history.ui.HollowHistoryUI;
+import com.netflix.hollow.tools.diff.HollowDiff;
+import com.netflix.hollow.tools.history.HollowHistory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class HollowEffigyFieldPairerTest {
+
+    @Test
+    public void testTheSameObjects() throws IOException {
+        HollowDiff diff = new FakeHollowDiffGenerator().createFakeDiff();
+
+        HollowRecordDiffUI diffUI = new HollowHistoryUI("", (HollowHistory) null);
+        HollowObjectDiffViewGenerator diffGenerator = new HollowObjectDiffViewGenerator(diff.getFromStateEngine(), diff.getToStateEngine(), diffUI, "TypeA", 0, 0);
+
+        HollowDiffViewRow diffViewRows = diffGenerator.getHollowDiffViewRows();
+        Assert.assertFalse(diffViewRows.getFieldPair().isDiff());
+    }
+
+    @Test
+    public void testFromEmpty() throws IOException {
+        HollowDiff diff = new FakeHollowDiffGenerator().createFakeDiff();
+
+        HollowRecordDiffUI diffUI = new HollowHistoryUI("", (HollowHistory) null);
+        HollowObjectDiffViewGenerator diffGenerator = new HollowObjectDiffViewGenerator(diff.getFromStateEngine(), diff.getToStateEngine(), diffUI, "TypeA", -1, 0);
+
+        HollowDiffViewRow diffViewRows = diffGenerator.getHollowDiffViewRows();
+        Assert.assertTrue(diffViewRows.getFieldPair().isDiff());
+    }
+
+    @Test
+    public void testToEmpty() throws IOException {
+        HollowDiff diff = new FakeHollowDiffGenerator().createFakeDiff();
+
+        HollowRecordDiffUI diffUI = new HollowHistoryUI("", (HollowHistory) null);
+        HollowObjectDiffViewGenerator diffGenerator = new HollowObjectDiffViewGenerator(diff.getFromStateEngine(), diff.getToStateEngine(), diffUI, "TypeA", 0, -1);
+
+        HollowDiffViewRow diffViewRows = diffGenerator.getHollowDiffViewRows();
+        Assert.assertTrue(diffViewRows.getFieldPair().isDiff());
+    }
+
+    @Test
+    public void testBothEmpty() throws IOException {
+        HollowDiff diff = new FakeHollowDiffGenerator().createFakeDiff();
+
+        HollowRecordDiffUI diffUI = new HollowHistoryUI("", (HollowHistory) null);
+        HollowObjectDiffViewGenerator diffGenerator = new HollowObjectDiffViewGenerator(diff.getFromStateEngine(), diff.getToStateEngine(), diffUI, "TypeA", -1, -1);
+
+        HollowDiffViewRow diffViewRows = diffGenerator.getHollowDiffViewRows();
+        Assert.assertFalse(diffViewRows.getFieldPair().isDiff());
+    }
+
+
+}


### PR DESCRIPTION
Encountered a `NullPointerException` in the HistoryUI when both `from` and `to` objects are empty. This crash is caused by attempting to invoke `getValue()` on a null `from` object within `EffigyFieldPair.calculateIsDiff()` method.

I've:
- Added better null checks in `calculateIsDiff()` to verify objects are not null before accessing their properties.
- Included a unit test that simulates the scenario of empty `from` and `to` versions, confirming the absence of `NullPointerException` post-fix.

Exception stack trace:

```
java.lang.NullPointerException: Cannot invoke "com.netflix.hollow.diffview.effigy.HollowEffigy$Field.getValue()" because "this.from" is null
	at com.netflix.hollow.diffview.effigy.pairer.HollowEffigyFieldPairer$EffigyFieldPair.calculateIsDiff(HollowEffigyFieldPairer.java:60)
	at com.netflix.hollow.diffview.effigy.pairer.HollowEffigyFieldPairer$EffigyFieldPair.<init>(HollowEffigyFieldPairer.java:53)
	at com.netflix.hollow.diffview.HollowObjectDiffViewGenerator.createRootRow(HollowObjectDiffViewGenerator.java:106)
	at com.netflix.hollow.diffview.HollowObjectDiffViewGenerator.getHollowDiffViewRows(HollowObjectDiffViewGenerator.java:68)
	at com.netflix.hollow.diffview.HollowHistoryViewProvider.getObjectView(HollowHistoryViewProvider.java:61)
	at com.netflix.hollow.diffview.HollowHistoryViewProvider.getObjectView(HollowHistoryViewProvider.java:39)
	at com.netflix.hollow.diffview.HollowHistoryViewProvider.getObjectView(HollowHistoryViewProvider.java:25)
	at com.netflix.hollow.history.ui.pages.HistoricalObjectDiffPage.setUpContext(HistoricalObjectDiffPage.java:49)
	at com.netflix.hollow.history.ui.pages.HistoryPage.render(HistoryPage.java:54)
	at com.netflix.hollow.history.ui.HollowHistoryUI.handle(HollowHistoryUI.java:209)
```