### PR TITLE
Support byte[] in @HollowPrimaryKey for ObjectInternPool in HollowHistoryUI

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiff.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/HollowDiff.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
  *
  */
 public class HollowDiff {
-    private final EnumSet<FieldType> SINGLE_FIELD_SUPPORTED_TYPES = EnumSet.of(FieldType.INT, FieldType.LONG, FieldType.DOUBLE, FieldType.STRING, FieldType.FLOAT, FieldType.BOOLEAN);
+    private final EnumSet<FieldType> SINGLE_FIELD_SUPPORTED_TYPES = EnumSet.of(FieldType.INT, FieldType.LONG, FieldType.DOUBLE, FieldType.STRING, FieldType.FLOAT, FieldType.BOOLEAN, FieldType.BYTES);
 
     private final Logger log = Logger.getLogger(HollowDiff.class.getName());
     private final HollowReadStateEngine fromStateEngine;

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
@@ -121,6 +121,11 @@ public class ObjectInternPool {
             for (byte b : ((String) objectToIntern).getBytes()) {
                 buf.write(b);
             }
+        } else if(objectToIntern instanceof byte[]) {
+            VarInt.writeVInt(buf, ((byte[]) objectToIntern).length);
+            for (byte b : ((byte[]) objectToIntern)) {
+                buf.write(b);
+            }
         } else if(objectToIntern instanceof Boolean) {
             int valToWrite = (boolean) objectToIntern ? 1 : 0;
             VarInt.writeVInt(buf, valToWrite);

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/ObjectInternPool.java
@@ -49,6 +49,8 @@ public class ObjectInternPool {
                 return getLong(pointer);
             case STRING:
                 return getString(pointer);
+            case BYTES:
+                return getBytes(pointer);
             default:
                 throw new IllegalArgumentException("Unknown type " + type);
         }
@@ -82,13 +84,17 @@ public class ObjectInternPool {
     }
 
     public String getString(long pointer) {
+        return new String(getBytes(pointer));
+    }
+
+    public byte[] getBytes(long pointer) {
         ByteData byteData = ordinalMap.getByteData().getUnderlyingArray();
         int length = VarInt.readVInt(byteData, pointer);
         byte[] bytes = new byte[length];
         for(int i=0;i<length;i++) {
             bytes[i] = byteData.get(pointer+1+i);
         }
-        return new String(bytes);
+        return bytes;
     }
 
     public int writeAndGetOrdinal(Object objectToIntern) {

--- a/hollow/src/main/java/com/netflix/hollow/tools/util/SearchUtils.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/util/SearchUtils.java
@@ -58,7 +58,8 @@ public class SearchUtils {
                     key[i] = Float.parseFloat(fields[i]);
                     break;
                 case BYTES:
-                    throw new IllegalArgumentException("Primary key contains a field of type BYTES");
+                    key[i] = fields[i];
+                    break;
             }
         }
         return key;

--- a/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/util/ObjectInternPoolTest.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.hollow.tools.util;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 
@@ -160,6 +161,32 @@ public class ObjectInternPoolTest {
 
         assertEquals(string3Ordinal, string4Ordinal);
         assertEquals(retrievedString2, "I can do this all day");
+    }
+
+    @Test
+    public void testBytes() {
+        byte[] bytesObj1 = "I am Groot".getBytes();
+        byte[] bytesObj2 = "I am Groot".getBytes();
+        byte[] bytesObj3 = "I can do this all day".getBytes();
+        byte[] bytesObj4 = "I can do this all day".getBytes();
+
+        int bytes1Ordinal = internPool.writeAndGetOrdinal(bytesObj1);
+        int bytes2Ordinal = internPool.writeAndGetOrdinal(bytesObj2);
+        internPool.prepareForRead();
+
+        byte[] retrievedString1 = (byte[]) internPool.getObject(bytes1Ordinal, FieldType.BYTES);
+
+        assertEquals(bytes1Ordinal, bytes2Ordinal);
+        assertArrayEquals(retrievedString1, "I am Groot".getBytes());
+
+        int bytes3Ordinal = internPool.writeAndGetOrdinal(bytesObj3);
+        int bytes4Ordinal = internPool.writeAndGetOrdinal(bytesObj4);
+        internPool.prepareForRead();
+
+        byte[] retrievedBytes2 = (byte[]) internPool.getObject(bytes3Ordinal, FieldType.BYTES);
+
+        assertEquals(bytes3Ordinal, bytes4Ordinal);
+        assertArrayEquals(retrievedBytes2, "I can do this all day".getBytes());
     }
 
     @Test


### PR DESCRIPTION
This PR is a follow-up to my [previous attempt](https://github.com/Netflix/hollow/pull/664)  to resolve an `IllegalArgumentException` encountered when interning `byte[]` objects in Hollow which was subsequently reverted due to [unforeseen issues](https://github.com/Netflix/hollow/pull/668). As suggested by @Sunjeet, proposed solution has now been implemented and tested.

**Changes Made:**
- Applied the patch suggested by @Sunjeet, adding support for `byte[]` interning within `ObjectInternPool`.
- Conducted thorough testing to confirm the fix addresses the issue without adverse effects on Hollow's functionality.

**Acknowledgements:**
Special thanks to @Sunjeet

**Original description:**
When loading states with `byte[]` as the primary key in Hollow, the `ObjectInternPool` throws an `IllegalArgumentException`. This issue occurs because the current implementation of `ObjectInternPool` does not support interning objects of type `byte[]`, which is needed by `HollowHistoryUI`.

The proposed solution extends the `ObjectInternPool` functionality to handle `byte[]` effectively, allowing `HollowHistoryUI` to intern these objects without errors.

Current implementation throws exception:

```
Caused by: java.lang.IllegalArgumentException: Cannot intern object of type [B
	at com.netflix.hollow.tools.util.ObjectInternPool.writeAndGetOrdinal(ObjectInternPool.java:123)
	at com.netflix.hollow.tools.history.keyindex.HollowOrdinalMapper.storeFieldObjects(HollowOrdinalMapper.java:182)
	at com.netflix.hollow.tools.history.keyindex.HollowOrdinalMapper.storeNewRecord(HollowOrdinalMapper.java:168)
	at com.netflix.hollow.tools.history.keyindex.HollowHistoryTypeKeyIndex.writeKeyObject(HollowHistoryTypeKeyIndex.java:159)
	at com.netflix.hollow.tools.history.keyindex.HollowHistoryTypeKeyIndex.populateAllCurrentRecordKeysIntoIndex(HollowHistoryTypeKeyIndex.java:153)
	at com.netflix.hollow.tools.history.keyindex.HollowHistoryTypeKeyIndex.update(HollowHistoryTypeKeyIndex.java:126)
	at com.netflix.hollow.tools.history.keyindex.HollowHistoryKeyIndex.lambda$updateTypeIndexes$0(HollowHistoryKeyIndex.java:143)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
```