### PR TITLE
fix: Wrapped getResourceAsStream in try() (#487)

### DIFF
--- a/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HollowUIRouter.java
+++ b/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HollowUIRouter.java
@@ -121,9 +121,9 @@ public abstract class HollowUIRouter extends HttpServlet {
                 resp.setContentType("image/png");
             }
 
-            InputStream is = this.getClass().getResourceAsStream("/" + resourceName);
-
-            IOUtils.copy(is, resp.getOutputStream());
+            try (InputStream is = this.getClass().getResourceAsStream("/" + resourceName)) {
+                IOUtils.copy(is, resp.getOutputStream());
+            }
             return true;
         } catch(Exception e){
             return false;


### PR DESCRIPTION
Streams should be closed before they go out of scope