### PR TITLE
Fix: Escape control chars when stringifing JSON (#492)

### DIFF
--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
@@ -38,6 +38,8 @@ public class HollowRecordJsonStringifierTest extends AbstractHollowRecordStringi
         String msg = "String types should be printed correctly";
         Assert.assertEquals(msg, "\"foo\"",
                 stringifyType(TypeWithString.class, true, false, new TypeWithString("foo")));
+        Assert.assertEquals(msg, "\"\\\\/foo\\u000a\"",
+                stringifyType(TypeWithString.class, true, false, new TypeWithString("\\/foo\n")));
         Assert.assertEquals(msg, "{" + NEWLINE
                 + INDENT + "\"value\": {" + NEWLINE
                 + INDENT + INDENT + "\"value\": \"foo\"" + NEWLINE


### PR DESCRIPTION
As it was originally coded, this change assumes escaping is uncommon.  The string is scanned first for characters that require escaping (i.e \ " and control characters).  A single scan is performed checking for the presence of any of these three cases.  The type of characters found are accumulated and used to only replace those that were found in the string.

The presence of a given category/type of escape character is done using bit-wise operations to avoid comparisons for performance (testing a character this way is 12% faster with jdk11 on an m1).  