### PR TITLE
Codegen- option to generate a schema doc

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/AbstractHollowAPIGeneratorBuilder.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/AbstractHollowAPIGeneratorBuilder.java
@@ -36,7 +36,6 @@ public abstract class AbstractHollowAPIGeneratorBuilder<B extends AbstractHollow
     protected boolean parameterizeAllClassNames = false;
     protected boolean useErgonomicShortcuts = false;
     protected Path destinationPath;
-
     protected CodeGeneratorConfig config = new CodeGeneratorConfig();
 
     protected abstract G instantiateGenerator();
@@ -138,6 +137,20 @@ public abstract class AbstractHollowAPIGeneratorBuilder<B extends AbstractHollow
 
     public B withDestination(Path destinationPath) {
         this.destinationPath = destinationPath;
+        return getBuilder();
+    }
+
+    /**
+     * Enable meta info (e.g. schema doc) and specify the path where it is to be generated.
+     * @param metaInfoPath location for meta info
+     * @return this builder
+     */
+    public B withMetaInfo(String metaInfoPath) {
+        return withMetaInfo(Paths.get(metaInfoPath));
+    }
+
+    public B withMetaInfo(Path metaInfoPath) {
+        config.setMetaInfoPath(metaInfoPath);
         return getBuilder();
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/CodeGeneratorConfig.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/CodeGeneratorConfig.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.hollow.api.codegen;
 
+import java.nio.file.Path;
+
 public class CodeGeneratorConfig {
     private String classPostfix = "";
     private String getterPrefix = "";
@@ -27,6 +29,22 @@ public class CodeGeneratorConfig {
     private boolean useHollowPrimitiveTypes = false;
     private boolean restrictApiToFieldType = false;
     private boolean useVerboseToString = false;
+
+    private boolean useMetaInfo = false;
+    private Path metaInfoPath;
+
+    public void setMetaInfoPath(Path metaInfoPath) {
+        this.useMetaInfo = true;
+        this.metaInfoPath = metaInfoPath;
+    }
+
+    public boolean isUseMetaInfo() {
+        return useMetaInfo;
+    }
+
+    public Path getMetaInfoPath() {
+        return metaInfoPath;
+    }
 
     public CodeGeneratorConfig() {}
 
@@ -134,6 +152,8 @@ public class CodeGeneratorConfig {
         result = prime * result + (useHollowPrimitiveTypes ? 1231 : 1237);
         result = prime * result + (usePackageGrouping ? 1231 : 1237);
         result = prime * result + (useVerboseToString ? 1231 : 1237);
+        result = prime * result + (useMetaInfo ? 1231 : 1237);
+        result = prime * result + ((metaInfoPath == null) ? 0 : metaInfoPath.hashCode());
         return result;
     }
 
@@ -170,6 +190,13 @@ public class CodeGeneratorConfig {
             return false;
         if (useVerboseToString != other.useVerboseToString)
             return false;
+        if (useMetaInfo != other.useMetaInfo)
+            return false;
+        if (metaInfoPath == null) {
+            if (other.metaInfoPath != null)
+                return false;
+        } else if (!metaInfoPath.equals(other.metaInfoPath))
+            return false;
         return true;
     }
 
@@ -194,6 +221,10 @@ public class CodeGeneratorConfig {
         builder.append(restrictApiToFieldType);
         builder.append(", useVerboseToString=");
         builder.append(useVerboseToString);
+        builder.append(", useMetaInfo=");
+        builder.append(useMetaInfo);
+        builder.append(", metaInfoPath=");
+        builder.append(metaInfoPath);
         builder.append("]");
         return builder.toString();
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.hollow.api.codegen;
 
+import static com.netflix.hollow.api.codegen.HollowAPIGenerator.SCHEMA_DOC_SUFFIX;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.hollowFactoryClassname;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.hollowObjectProviderName;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.lowercase;
@@ -112,6 +113,10 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
             }
         }
         builder.append(" {\n\n");
+
+        if (config.isUseMetaInfo()) {
+            builder.append("    public static final String SCHEMA_DOC = \"" + packageName + "." + className + SCHEMA_DOC_SUFFIX + "\";\n\n");
+        }
 
         builder.append("    private final HollowObjectCreationSampler objectCreationSampler;\n\n");
 

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -1,8 +1,47 @@
 package com.netflix.hollow.api.codegen;
 
+import static org.junit.Assert.assertEquals;
+
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchemaParser;
+import com.netflix.hollow.core.schema.SimpleHollowDataset;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
 import org.junit.Test;
 
 public class HollowAPIGeneratorTest extends AbstractHollowAPIGeneratorTest {
+
+    @Test
+    public void assertMetaInfoAtCustomLocation() throws Exception {
+        runGenerator("API", "codegen.api", MyClass.class, b -> b.withMetaInfo("meta-info"));
+        assertNonEmptyFileExists(Paths.get("meta-info"));
+    }
+
+    @Test
+    public void testSchemaDocAtCustomLocation() throws Exception {
+        runGenerator("MyClassTestAPI", "codegen.api", MyClass.class,
+                builder -> builder.withMetaInfo(tmpFolder + "/" + "resources/META-INF/hollow"));
+        assertNonEmptyFileExists(Paths.get(tmpFolder, "resources/META-INF/hollow/codegen.api.MyClassTestAPI.schema"));
+    }
+
+    @Test
+    public void testSchemaDocContents() throws Exception {
+        runGenerator("MyClassTestAPI", "codegen.api", MyClass.class, b -> b.withMetaInfo(Paths.get(sourceFolder)));
+        assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen.api.MyClassTestAPI.schema"));
+
+        List<HollowSchema> expected = SimpleHollowDataset.fromClassDefinitions(MyClass.class).getSchemas();
+        try (InputStream input = new FileInputStream(sourceFolder + "/" + "codegen.api.MyClassTestAPI.schema")) {
+            List<HollowSchema> actual = HollowSchemaParser.parseCollectionOfSchemas(new BufferedReader(new InputStreamReader(input)));
+            assertEquals(expected.size(), actual.size());
+            assertEquals(new HashSet(expected), new HashSet(actual));
+        }
+    }
 
     @Test
     public void generatesFileUsingDestinationPath() throws Exception {
@@ -13,7 +52,7 @@ public class HollowAPIGeneratorTest extends AbstractHollowAPIGeneratorTest {
     public void testGenerateWithPostfix() throws Exception {
         runGenerator("MyClassTestAPI", "codegen.api", MyClass.class,
                 builder -> builder.withClassPostfix("Generated"));
-        assertNonEmptyFileExists("codegen/api/StringGenerated.java");
+        assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen/api/StringGenerated.java"));
         assertClassHasHollowTypeName("codegen.api.MyClassGenerated", "MyClass");
     }
 
@@ -21,7 +60,7 @@ public class HollowAPIGeneratorTest extends AbstractHollowAPIGeneratorTest {
     public void testGenerateWithPostfixAndPackageGrouping() throws Exception {
         runGenerator("MyClassTestAPI", "codegen.api", MyClass.class,
                 builder -> builder.withClassPostfix("Generated").withPackageGrouping());
-        assertNonEmptyFileExists("codegen/api/core/StringGenerated.java");
+        assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen/api/core/StringGenerated.java"));
     }
 
     @Test
@@ -43,6 +82,7 @@ public class HollowAPIGeneratorTest extends AbstractHollowAPIGeneratorTest {
     }
 
     @SuppressWarnings("unused")
+    @HollowPrimaryKey(fields = "id")
     private static class MyClass {
         int id;
         String foo;

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIGeneratorTest.java
@@ -4,6 +4,7 @@ import com.netflix.hollow.api.codegen.AbstractHollowAPIGeneratorTest;
 import com.netflix.hollow.api.codegen.HollowCodeGenerationCompileUtil;
 import com.netflix.hollow.core.schema.SimpleHollowDataset;
 import java.io.File;
+import java.nio.file.Paths;
 import org.junit.Test;
 
 public class HollowPerformanceAPIGeneratorTest extends AbstractHollowAPIGeneratorTest {
@@ -16,9 +17,9 @@ public class HollowPerformanceAPIGeneratorTest extends AbstractHollowAPIGenerato
   @Test
   public void testGeneratedFilesArePlacedInPackageDirectory() throws Exception {
     runGenerator("API", "codegen.api", MyClass.class);
-    assertNonEmptyFileExists("codegen/api/MyClassPerfAPI.java");
-    assertNonEmptyFileExists("codegen/api/StringPerfAPI.java");
-    assertNonEmptyFileExists("codegen/api/API.java");
+    assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen/api/MyClassPerfAPI.java"));
+    assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen/api/StringPerfAPI.java"));
+    assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen/api/API.java"));
   }
 
   private void runGenerator(String apiClassName, String packageName, Class<?> clazz) throws Exception {


### PR DESCRIPTION
Option to generate a schema doc at a specified path, could be used on consumer side simply as reference or to initialize consumer for tests