### PR TITLE
fix the log message of error message for reading optional part header

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobHeaderReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowBlobHeaderReader.java
@@ -78,7 +78,7 @@ public class HollowBlobHeaderReader {
         int headerVersion = in.readInt();
         if(headerVersion != HollowBlobOptionalPartHeader.HOLLOW_BLOB_PART_VERSION_HEADER) {
             throw new IOException("The HollowBlob optional part you are trying to read is incompatible. "
-                    + "The expected Hollow blob version was " + HollowBlobHeader.HOLLOW_BLOB_VERSION_HEADER
+                    + "The expected Hollow blob version was " + HollowBlobOptionalPartHeader.HOLLOW_BLOB_PART_VERSION_HEADER
                     + " but the actual version was " + headerVersion);
         }
 


### PR DESCRIPTION
We saw this type of error message in the log and this pr is to fix the log message

Caused by: java.io.IOException: The HollowBlob optional part you are trying to read is incompatible. The expected Hollow blob version was 1030 but the actual version was 1030

