### PR TITLE
doc: refreshing an index

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -273,6 +273,7 @@ HollowConsumer consumer = ...;
 consumer.triggerRefresh();
 
 UniqueKeyIndex<Movie, Integer> idx = Movie.uniqueIndex(consumer);
+consumer.addRefreshListener(idx);  // tell index to listen for consumer updates
 ```
 
 This index can be held in memory and then used in conjunction with the generated Hollow API to retrieve Movie records by 
@@ -288,7 +289,7 @@ Which outputs:
 Found Movie: Beasts of No Nation
 ```
 
-In our generated API, each type annotated with `@HollowPrimaryLey` has a static method to obtain a `UniqueIndex`.  For
+In our generated API, each type annotated with `@HollowPrimaryKey` has a static method to obtain a `UniqueIndex`.  For
 primary keys with multiple fields a _bean_ class is also generated to hold key values.
 
 A `UniqueIndex` may be also created explicitly to index by any field, or multiple fields.

--- a/docs/indexing-querying.md
+++ b/docs/indexing-querying.md
@@ -46,7 +46,7 @@ Once we have loaded a dataset into a `HollowConsumer`, we can use the `Movie` in
 
 HollowConsumer consumer = ...;
 
-MoviePrimaryKeyIndex idx = new MoviePrimaryKeyIndex(consumer);
+MoviePrimaryKeyIndex idx = new MoviePrimaryKeyIndex(consumer, true); // param isListenToDataRefresh set to true
 
 int knownMovieId = ...;
 
@@ -54,7 +54,7 @@ Movie movie = idx.findMatch(knownMovieId);
 
 ```
 
-Just as the `HollowConsumer` will automatically stay up-to-date as your dataset updates, a primary key index will also stay up-to-date with the `HollowConsumer` with which it is backed.
+Note that keeping the primary key index up-to-date with the `HollowConsumer` data state changes is optional.
 
 !!! hint "Share Indexes"
     Queries to indexes are thread-safe.  We should create each of the indexes we need only once, and share them everywhere they are needed.
@@ -138,7 +138,7 @@ for(ActorRole role : idx.findActorRoleMatches(knownActorId, knownMovieTitle)) {
 ```
 Similarly, if we want to include an enum type like releaseCountry in the fields, then its field path in the index construction can be specified as `releaseCountry._name`. Note, in field paths, an enum type is treated slightly differently from a String reference type which is expanded using `.value`.
 
-## Prefix Index
+## Prefix Index (experimental)
 
 A prefix index is used for indexing string values to records containing them. Prefix index in hollow also supports partial matching of string values enabling quick development of features like auto-complete, spell-checkers and others. In order to create a new prefix index, use this class by providing the following arguments in the constructor:
 - An instance of `HollowReadStateEngine`
@@ -163,7 +163,11 @@ while(ordinal != HollowOrdinalIterator.NO_MORE_ORDINAL)
 ```
 The above code will print out all the movie titles that begin with the letter "A". Field path could be a reference to an `OBJECT`, `LIST`, or a `SET`, it has to ultimately lead to a String type.
 
-You can also keep this index updated when a new delta blob is received on the consumer. When a new delta is available, a new prefix is built completely from scratch. While a new prefix index is being built, the current index can continue to answer queries. The implementation of the index takes care of swapping the new updated index with old one. In order to keep your index updated with delta changes, use the following:
+You can also keep this index updated when a new delta blob is received on the consumer. 
+When a new delta is available, a new prefix is built completely from scratch. 
+While a new prefix index is being built, the current index can continue to answer queries. 
+The implementation of the index takes care of swapping the new updated index with old one. 
+In order to keep your index updated with delta changes, use the following:
 
 ```java
 // add the index object as listener for delta updates for type "Movie".
@@ -173,7 +177,7 @@ prefixIndex.listenForDeltaUpdates();
 prefixIndex.detachFromDeltaUpdates();
 
 ```
-
+Also see section on [Keeping an index up-to-date](diving-deeper.md#keeping-an-index-up-to-date)
 
 ## Field Paths
 

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -225,6 +225,11 @@ public class HollowHashIndex implements HollowTypeStateListener {
      * <p>
      * In order to prevent memory leaks, if this method is called and the index is no longer needed, call detachFromDeltaUpdates() before
      * discarding the index.
+     * <p>
+     * Note that this index does not listen on snapshot update. If a snapshot update occurs this index will
+     * NOT return the latest data in the consumer and after 2 updates it could start returning corrupt results.
+     * If double-snapshot updates are expected the caller must detach this index instance and initialize a new one. See
+     * implementation of {@link com.netflix.hollow.api.consumer.index.UniqueKeyIndex} for a reference implementation.
      */
     public void listenForDeltaUpdates() {
         if (typeState == null) {

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrefixIndex.java
@@ -48,6 +48,10 @@ import java.util.logging.Logger;
  * </ul><p>
  * Includes methods for getting stats on memory usage and query performance.
  */
+/**
+ * @deprecated experimental, discontinued due to memory efficiency concerns. Could try multiple lookups into UniqueKeyIndex instead.
+ */
+@Deprecated
 public class HollowPrefixIndex implements HollowTypeStateListener {
     private static final Logger LOG = Logger.getLogger(HollowPrefixIndex.class.getName());
 

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
@@ -313,6 +313,18 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
 
         // an iterator doesn't update itself if it was retrieved prior to an update being applied
         assertIteratorContainsAll(preUpdateIterator, 4, 5);
+
+        // snapshot updates don't update HollowHashIndex subscribed using listenForDeltaUpdates
+        mapper.add(new TypeA(5, 5.1d, new TypeB("five")));
+        roundTripSnapshot();
+        Assert.assertNull("Double snapshots not expected to update index subscribed using listenForDeltaUpdates",
+                index.findMatches(5));
+
+        // after a snapshot, subsequent delta updates don't update the original index
+        mapper.add(new TypeA(6, 6.1d, new TypeB("six")));
+        roundTripDelta();
+        Assert.assertNull("Original index subscribed using listenForDeltaUpdates not expected to refresh on " +
+                "deltas after incurring a double snapshot", index.findMatches(6));
     }
     
     @Test


### PR DESCRIPTION
* document gotcha around use of `listenForDeltaUpdates`
* unit test for HollowHashIndex with `listenForDeltaUpdates` does not listen for double snapshots 
