### PR TITLE
support Composite Key Search for HollowHistory tooling

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/util/IntList.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/IntList.java
@@ -17,6 +17,9 @@
 package com.netflix.hollow.core.util;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * A list of primitive ints
@@ -104,6 +107,33 @@ public class IntList {
     public int hashCode() {
         int result = size;
         result = 31 * result + Arrays.hashCode(values);
+        return result;
+    }
+
+    public static Set<Integer> createSetFromIntList(IntList list) {
+        if (Objects.isNull(list)) {
+            return new HashSet<>();
+        }
+
+        HashSet<Integer> result = new HashSet<>(list.size());
+        int listSize = list.size();
+        for (int i = 0; i < listSize; ++i) {
+            result.add(list.get(i));
+        }
+
+        return result;
+    }
+
+    public static IntList createIntListFromSet(Set<Integer> set) {
+        if (Objects.isNull(set)) {
+            return new IntList(0);
+        }
+
+        IntList result = new IntList(set.size());
+        for (int value : set) {
+            result.add(value);
+        }
+
         return result;
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryKeyIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryKeyIndexTest.java
@@ -105,8 +105,15 @@ public class HollowHistoryKeyIndexTest extends AbstractStateEngineTest {
 
         Assert.assertEquals("2.2:two", keyIdx.getKeyDisplayString("A", 1));
 
-
         /// query returns all matching keys
+        assertResults(keyIdx, "A", "1.1:one", 0);
+        assertResults(keyIdx, "A", "3.3:one", 2);
+        assertResults(keyIdx, "A", "4.4:four", 3);
+        assertResults(keyIdx, "A", "5.5:five!", 4);
+        assertResults(keyIdx, "A", "5.5!:five!" );
+        assertResults(keyIdx, "A", "5.5:five!:" );
+        assertResults(keyIdx, "A", "5.5:");
+
         assertResults(keyIdx, "A", "one", 0, 2);
         assertResults(keyIdx, "A", "two", 1);
         assertResults(keyIdx, "A", "four", 3);
@@ -132,7 +139,6 @@ public class HollowHistoryKeyIndexTest extends AbstractStateEngineTest {
         Assert.assertEquals(expectedResults.length, actualResults.size());
 
         actualResults.sort();
-
         for(int i=0;i<expectedResults.length;i++) {
             Assert.assertEquals(expectedResults[i], actualResults.get(i));
         }


### PR DESCRIPTION
Prior to the change, searching composite primary key like `abc:efg` in History tooling page would fail to find the related changes.
User would search for either `abc` or `efg` to get a superset of modifications, then resolves to the browser's search tool for finding the exact record.
This change enables the user to search for modifications for the exact composite primary key.