### PR TITLE
chore: make FlatRecordTraversalNode concurrent safe

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
@@ -19,13 +19,11 @@ package com.netflix.hollow.core.write.objectmapper;
 import com.netflix.hollow.api.objects.HollowRecord;
 import com.netflix.hollow.api.objects.generic.GenericHollowList;
 import com.netflix.hollow.core.schema.HollowListSchema;
-import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.util.IntList;
 import com.netflix.hollow.core.write.HollowListTypeWriteState;
 import com.netflix.hollow.core.write.HollowListWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalListNode;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalNode;
@@ -34,7 +32,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class HollowListTypeMapper extends HollowTypeMapper {
@@ -129,25 +126,11 @@ public class HollowListTypeMapper extends HollowTypeMapper {
     }
 
     @Override
-    protected Object parseFlatRecord(HollowSchema recordSchema, FlatRecordReader reader, Map<Integer, Object> parsedObjects) {
-        List<Object> collection = new ArrayList<>();
-
-        int size = reader.readCollectionSize();
-        for (int i = 0; i < size; i++) {
-            int ordinal = reader.readOrdinal();
-            Object element = parsedObjects.get(ordinal);
-            collection.add(element);
-        }
-
-        return collection;
-    }
-
-    @Override
-    protected Object parseFlatRecordTraversalNode(FlatRecordTraversalNode node) {
+    protected Object parseFlatRecord(FlatRecordTraversalNode node) {
         List<Object> collection = new ArrayList<>();
 
         for (FlatRecordTraversalNode elementNode : (FlatRecordTraversalListNode) node) {
-            Object element = elementMapper.parseFlatRecordTraversalNode(elementNode);
+            Object element = elementMapper.parseFlatRecord(elementNode);
             collection.add(element);
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -19,14 +19,12 @@ package com.netflix.hollow.core.write.objectmapper;
 import com.netflix.hollow.api.objects.HollowRecord;
 import com.netflix.hollow.api.objects.generic.GenericHollowMap;
 import com.netflix.hollow.core.schema.HollowMapSchema;
-import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.write.HollowMapTypeWriteState;
 import com.netflix.hollow.core.write.HollowMapWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalMapNode;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalNode;
@@ -142,31 +140,13 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
     }
 
     @Override
-    protected Object parseFlatRecord(HollowSchema recordSchema, FlatRecordReader reader, Map<Integer, Object> parsedObjects) {
-        Map<Object, Object> collection = new HashMap<>();
-
-        int size = reader.readCollectionSize();
-        int keyOrdinal = 0;
-        for (int i = 0; i < size; i++) {
-            int keyOrdinalDelta = reader.readOrdinal();
-            int valueOrdinal = reader.readOrdinal();
-            keyOrdinal += keyOrdinalDelta;
-            Object key = parsedObjects.get(keyOrdinal);
-            Object value = parsedObjects.get(valueOrdinal);
-            collection.put(key, value);
-        }
-
-        return collection;
-    }
-
-    @Override
-    protected Object parseFlatRecordTraversalNode(FlatRecordTraversalNode node) {
+    protected Object parseFlatRecord(FlatRecordTraversalNode node) {
         FlatRecordTraversalMapNode mapNode = (FlatRecordTraversalMapNode) node;
         Map<Object, Object> collection = new HashMap<>();
 
         for (Map.Entry<FlatRecordTraversalNode, FlatRecordTraversalNode> entry : mapNode.entrySet()) {
-            Object key = keyMapper.parseFlatRecordTraversalNode(entry.getKey());
-            Object value = valueMapper.parseFlatRecordTraversalNode(entry.getValue());
+            Object key = keyMapper.parseFlatRecord(entry.getKey());
+            Object value = valueMapper.parseFlatRecord(entry.getValue());
             collection.put(key, value);
         }
         return collection;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectMapper.java
@@ -100,28 +100,13 @@ public class HollowObjectMapper {
         if (typeMapper == null) {
             throw new IllegalArgumentException("No type mapper found for schema " + schemaName);
         }
-        Object obj = typeMapper.parseFlatRecordTraversalNode(node);
+        Object obj = typeMapper.parseFlatRecord(node);
         return (T) obj;
     }
 
     public <T> T readFlat(FlatRecord record) {
-        FlatRecordReader recordReader = new FlatRecordReader(record);
-
-        int ordinal = 0;
-        Map<Integer, Object> parsedObjects = new HashMap<>();
-        while(recordReader.hasMore()) {
-            HollowSchema schema = recordReader.readSchema();
-            HollowTypeMapper mapper = typeMappers.get(schema.getName());
-            if (mapper == null) {
-                recordReader.skipSchema(schema);
-            } else {
-                Object obj = mapper.parseFlatRecord(schema, recordReader, parsedObjects);
-                parsedObjects.put(ordinal, obj);
-            }
-            ordinal++;
-        }
-
-        return (T) parsedObjects.get(ordinal - 1);
+        FlatRecordTraversalNode node = new FlatRecordTraversalObjectNode(record);
+        return readFlat(node);
     }
     
     /**

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -18,7 +18,6 @@ package com.netflix.hollow.core.write.objectmapper;
 
 import com.netflix.hollow.api.objects.HollowRecord;
 import com.netflix.hollow.api.objects.generic.GenericHollowSet;
-import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.write.HollowSetTypeWriteState;
@@ -26,7 +25,6 @@ import com.netflix.hollow.core.write.HollowSetWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalNode;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalSetNode;
@@ -34,8 +32,6 @@ import com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatReco
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
 
 public class HollowSetTypeMapper extends HollowTypeMapper {
@@ -121,26 +117,10 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
     }
 
     @Override
-    protected Object parseFlatRecord(HollowSchema recordSchema, FlatRecordReader reader, Map<Integer, Object> parsedObjects) {
-        Set<Object> collection = new HashSet<>();
-
-        int size = reader.readCollectionSize();
-        int ordinal = 0;
-        for (int i = 0; i < size; i++) {
-            int ordinalDelta = reader.readOrdinal();
-            ordinal += ordinalDelta;
-            Object element = parsedObjects.get(ordinal);
-            collection.add(element);
-        }
-
-        return collection;
-    }
-
-    @Override
-    protected Object parseFlatRecordTraversalNode(FlatRecordTraversalNode node) {
+    protected Object parseFlatRecord(FlatRecordTraversalNode node) {
         Set<Object> collection = new HashSet<>();
         for (FlatRecordTraversalNode elementNode : (FlatRecordTraversalSetNode) node) {
-            collection.add(elementMapper.parseFlatRecordTraversalNode(elementNode));
+            collection.add(elementMapper.parseFlatRecord(elementNode));
         }
         return collection;
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowTypeMapper.java
@@ -18,11 +18,9 @@ package com.netflix.hollow.core.write.objectmapper;
 
 import com.netflix.hollow.api.objects.HollowRecord;
 import com.netflix.hollow.core.memory.ByteDataArray;
-import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordWriter;
 import com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalNode;
 
@@ -47,10 +45,8 @@ public abstract class HollowTypeMapper {
     protected abstract int writeFlat(Object obj, FlatRecordWriter flatRecordWriter);
 
     protected abstract Object parseHollowRecord(HollowRecord record);
-    
-    protected abstract Object parseFlatRecord(HollowSchema schema, FlatRecordReader reader, Map<Integer, Object> parsedObjects);
 
-    protected abstract Object parseFlatRecordTraversalNode(FlatRecordTraversalNode node);
+    protected abstract Object parseFlatRecord(FlatRecordTraversalNode node);
     
     protected abstract HollowWriteRecord newWriteRecord();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordOrdinalReader.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/FlatRecordOrdinalReader.java
@@ -1,0 +1,342 @@
+package com.netflix.hollow.core.write.objectmapper.flatrecords;
+
+import com.netflix.hollow.core.memory.encoding.VarInt;
+import com.netflix.hollow.core.memory.encoding.ZigZag;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.util.IntList;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+
+public class FlatRecordOrdinalReader {
+  private final FlatRecord record;
+  private final IntList ordinalOffsets = new IntList();
+
+  public FlatRecordOrdinalReader(FlatRecord record) {
+    this.record = record;
+    populateOrdinalOffset();
+  }
+
+  private void populateOrdinalOffset() {
+    int offset = record.dataStartByte;
+    while (offset < record.dataEndByte) {
+      ordinalOffsets.add(offset);
+      offset += sizeOfOrdinal(ordinalOffsets.size() - 1);
+    }
+  }
+
+  private int getOrdinalOffset(int ordinal) {
+    return ordinalOffsets.get(ordinal);
+  }
+
+  public int getOrdinalCount() {
+    return ordinalOffsets.size();
+  }
+
+  public HollowSchema readSchema(int ordinal) {
+    int schemaId = VarInt.readVInt(record.data, getOrdinalOffset(ordinal));
+    return record.schemaIdMapper.getSchema(schemaId);
+  }
+
+  public int readSize(int ordinal) {
+    int offset = getOrdinalOffset(ordinal);
+
+    int schemaId = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(schemaId);
+
+    HollowSchema schema = record.schemaIdMapper.getSchema(schemaId);
+    if (schema.getSchemaType() != HollowSchema.SchemaType.LIST &&
+        schema.getSchemaType() != HollowSchema.SchemaType.SET &&
+        schema.getSchemaType() != HollowSchema.SchemaType.MAP) {
+      throw new IllegalArgumentException(String.format("Ordinal %d is not a LIST, SET, or MAP type (found %s)", ordinal, schema.getSchemaType()));
+    }
+
+    return VarInt.readVInt(record.data, offset);
+  }
+
+  public void readListElementsInto(int ordinal, int[] elements) {
+    int offset = getOrdinalOffset(ordinal);
+
+    int schemaId = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(schemaId);
+
+    HollowSchema schema = record.schemaIdMapper.getSchema(schemaId);
+    if (schema.getSchemaType() != HollowSchema.SchemaType.LIST) {
+      throw new IllegalArgumentException(String.format("Ordinal %d is not a LIST type (found %s)", ordinal, schema.getSchemaType()));
+    }
+
+    int size = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(size);
+
+    for (int i = 0; i < size; i++) {
+      elements[i] = VarInt.readVInt(record.data, offset);
+      offset += VarInt.sizeOfVInt(elements[i]);
+    }
+  }
+
+  public void readSetElementsInto(int ordinal, int[] elements) {
+    int offset = getOrdinalOffset(ordinal);
+
+    int schemaId = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(schemaId);
+
+    HollowSchema schema = record.schemaIdMapper.getSchema(schemaId);
+    if (schema.getSchemaType() != HollowSchema.SchemaType.SET) {
+      throw new IllegalArgumentException(String.format("Ordinal %d is not a SET type (found %s)", ordinal, schema.getSchemaType()));
+    }
+
+    int size = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(size);
+
+    int elementOrdinal = 0;
+    for (int i = 0; i < size; i++) {
+      int elementOrdinalDelta = VarInt.readVInt(record.data, offset);
+      offset += VarInt.sizeOfVInt(elementOrdinalDelta);
+      elementOrdinal += elementOrdinalDelta;
+      elements[i] = elementOrdinal;
+    }
+  }
+
+  public void readMapElementsInto(int ordinal, int[] keys, int[] values) {
+    int offset = getOrdinalOffset(ordinal);
+
+    int schemaId = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(schemaId);
+
+    HollowSchema schema = record.schemaIdMapper.getSchema(schemaId);
+    if (schema.getSchemaType() != HollowSchema.SchemaType.MAP) {
+      throw new IllegalArgumentException(String.format("Ordinal %d is not a MAP type (found %s)", ordinal, schema.getSchemaType()));
+    }
+
+    int size = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(size);
+
+    int keyOrdinal = 0;
+    for (int i = 0; i < size; i++) {
+      int keyOrdinalDelta = VarInt.readVInt(record.data, offset);
+      offset += VarInt.sizeOfVInt(keyOrdinalDelta);
+      keyOrdinal += keyOrdinalDelta;
+      keys[i] = keyOrdinal;
+      values[i] = VarInt.readVInt(record.data, offset);
+      offset += VarInt.sizeOfVInt(values[i]);
+    }
+  }
+
+  public int readFieldReference(int ordinal, String field) {
+    int offset = skipToField(ordinal, HollowObjectSchema.FieldType.REFERENCE, field);
+    if (offset == -1) {
+      return -1;
+    }
+
+    if (VarInt.readVNull(record.data, offset)) {
+      return -1;
+    }
+
+    return VarInt.readVInt(record.data, offset);
+  }
+
+  public Boolean readFieldBoolean(int ordinal, String field) {
+    int offset = skipToField(ordinal, HollowObjectSchema.FieldType.BOOLEAN, field);
+    if (offset == -1) {
+      return null;
+    }
+
+    if (VarInt.readVNull(record.data, offset)) {
+      return null;
+    }
+
+    int value = record.data.get(offset);
+    return value == 1 ? Boolean.TRUE : Boolean.FALSE;
+  }
+
+  public int readFieldInt(int ordinal, String field) {
+    int offset = skipToField(ordinal, HollowObjectSchema.FieldType.INT, field);
+    if (offset == -1) {
+      return Integer.MIN_VALUE;
+    }
+
+    if (VarInt.readVNull(record.data, offset)) {
+      return Integer.MIN_VALUE;
+    }
+
+    int value = VarInt.readVInt(record.data, offset);
+    return ZigZag.decodeInt(value);
+  }
+
+  public long readFieldLong(int ordinal, String field) {
+    int offset = skipToField(ordinal, HollowObjectSchema.FieldType.LONG, field);
+    if (offset == -1) {
+      return Long.MIN_VALUE;
+    }
+
+    if (VarInt.readVNull(record.data, offset)) {
+      return Long.MIN_VALUE;
+    }
+
+    long value = VarInt.readVLong(record.data, offset);
+    return ZigZag.decodeLong(value);
+  }
+
+  public float readFieldFloat(int ordinal, String field) {
+    int offset = skipToField(ordinal, HollowObjectSchema.FieldType.FLOAT, field);
+    if (offset == -1) {
+      return Float.NaN;
+    }
+
+    int value = record.data.readIntBits(offset);
+    if (value == HollowObjectWriteRecord.NULL_FLOAT_BITS) {
+      return Float.NaN;
+    }
+
+    return Float.intBitsToFloat(value);
+  }
+
+  public double readFieldDouble(int ordinal, String field) {
+    int offset = skipToField(ordinal, HollowObjectSchema.FieldType.DOUBLE, field);
+    if (offset == -1) {
+      return Double.NaN;
+    }
+
+    long value = record.data.readLongBits(offset);
+    if (value == HollowObjectWriteRecord.NULL_DOUBLE_BITS) {
+      return Double.NaN;
+    }
+
+    return Double.longBitsToDouble(value);
+  }
+
+  public String readFieldString(int ordinal, String field) {
+    int offset = skipToField(ordinal, HollowObjectSchema.FieldType.STRING, field);
+    if (offset == -1) {
+      return null;
+    }
+
+    if (VarInt.readVNull(record.data, offset)) {
+        return null;
+    }
+
+    int length = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(length);
+
+    int cLength = VarInt.countVarIntsInRange(record.data, offset, length);
+    char[] s = new char[cLength];
+    for (int i = 0; i < cLength; i++) {
+      int charValue = VarInt.readVInt(record.data, offset);
+      s[i] = (char) charValue;
+      offset += VarInt.sizeOfVInt(charValue);
+    }
+
+    return new String(s);
+  }
+
+  public byte[] readFieldBytes(int ordinal, String field) {
+    int offset = skipToField(ordinal, HollowObjectSchema.FieldType.BYTES, field);
+    if (offset == -1) {
+      return null;
+    }
+
+    if (VarInt.readVNull(record.data, offset)) {
+        return null;
+    }
+
+    int length = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(length);
+
+    byte[] b = new byte[length];
+    for (int i = 0; i < length; i++) {
+      b[i] = record.data.get(offset++);
+    }
+
+    return b;
+  }
+
+  private int skipToField(int ordinal, HollowObjectSchema.FieldType fieldType, String field) {
+    int offset = getOrdinalOffset(ordinal);
+
+    int schemaId = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(schemaId);
+
+    HollowSchema schema = record.schemaIdMapper.getSchema(schemaId);
+    if (schema.getSchemaType() != HollowSchema.SchemaType.OBJECT) {
+      throw new IllegalArgumentException(String.format("Ordinal %d is not an OBJECT type (found %s)", ordinal, schema.getSchemaType()));
+    }
+    HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
+
+    int fieldIndex = objectSchema.getPosition(field);
+    if (fieldIndex == -1) {
+      return -1;
+    }
+
+    if (fieldType != objectSchema.getFieldType(fieldIndex)) {
+      throw new IllegalArgumentException(String.format("Field %s is not of type %s", field, fieldType));
+    }
+
+    for (int i = 0; i < fieldIndex; i++) {
+      offset += sizeOfFieldValue(objectSchema.getFieldType(i), offset);
+    }
+
+    return offset;
+  }
+
+  private int sizeOfOrdinal(int ordinal) {
+    int offset = getOrdinalOffset(ordinal);
+    int start = offset;
+
+    int schemaId = VarInt.readVInt(record.data, offset);
+    offset += VarInt.sizeOfVInt(schemaId);
+
+    HollowSchema schema = record.schemaIdMapper.getSchema(schemaId);
+    switch (schema.getSchemaType()) {
+      case OBJECT: {
+        HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
+        for (int i = 0; i < objectSchema.numFields(); i++) {
+          offset += sizeOfFieldValue(objectSchema.getFieldType(i), offset);
+        }
+        break;
+      }
+      case LIST:
+      case SET: {
+        int size = VarInt.readVInt(record.data, offset);
+        offset += VarInt.sizeOfVInt(size);
+        for (int i = 0; i < size; i++) {
+          offset += VarInt.nextVLongSize(record.data, offset);
+        }
+        break;
+      }
+      case MAP: {
+        int size = VarInt.readVInt(record.data, offset);
+        offset += VarInt.sizeOfVInt(size);
+        for (int i = 0; i < size; i++) {
+          offset += VarInt.nextVLongSize(record.data, offset); // key
+          offset += VarInt.nextVLongSize(record.data, offset); // value
+        }
+        break;
+      }
+    }
+
+    return offset - start;
+  }
+
+  private int sizeOfFieldValue(HollowObjectSchema.FieldType fieldType, int offset) {
+    switch (fieldType) {
+      case INT:
+      case LONG:
+      case REFERENCE:
+        return VarInt.nextVLongSize(record.data, offset);
+      case BYTES:
+      case STRING:
+        if (VarInt.readVNull(record.data, offset)) {
+          return 1;
+        }
+        int fieldLength = VarInt.readVInt(record.data, offset);
+        return VarInt.sizeOfVInt(fieldLength) + fieldLength;
+      case BOOLEAN:
+        return 1;
+      case DOUBLE:
+        return 8;
+      case FLOAT:
+        return 4;
+      default:
+        throw new IllegalArgumentException("Unsupported field type: " + fieldType);
+    }
+  }
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalListNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalListNode.java
@@ -2,59 +2,35 @@ package com.netflix.hollow.core.write.objectmapper.flatrecords.traversal;
 
 import com.netflix.hollow.core.schema.HollowListSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.util.IntList;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordOrdinalReader;
 
 import java.util.AbstractList;
 import java.util.Map;
 
 public class FlatRecordTraversalListNode extends AbstractList<FlatRecordTraversalNode> implements FlatRecordTraversalNode {
-  private FlatRecordReader reader;
-  private IntList ordinalPositions;
-  private HollowListSchema schema;
-  private int[] elementOrdinals;
+  private final FlatRecordOrdinalReader reader;
+  private final HollowListSchema schema;
+  private final int[] elementOrdinals;
+
   private Map<String, HollowObjectSchema> commonSchemaMap;
 
-  @Override
-  public void reposition(FlatRecordReader reader, IntList ordinalPositions, int ordinal) {
+  public FlatRecordTraversalListNode(FlatRecordOrdinalReader reader, HollowListSchema schema, int ordinal) {
     this.reader = reader;
-    this.ordinalPositions = ordinalPositions;
+    this.schema = schema;
 
-    reader.resetTo(ordinalPositions.get(ordinal));
-    schema = (HollowListSchema) reader.readSchema();
-
-    int size = reader.readCollectionSize();
+    int size = reader.readSize(ordinal);
     elementOrdinals = new int[size];
-    for (int i = 0; i < size; i++) {
-      elementOrdinals[i] = reader.readOrdinal();
-    }
+    reader.readListElementsInto(ordinal, elementOrdinals);
+  }
+
+  @Override
+  public HollowListSchema getSchema() {
+    return schema;
   }
 
   @Override
   public void setCommonSchema(Map<String, HollowObjectSchema> commonSchema) {
     this.commonSchemaMap = commonSchema;
-  }
-
-  @Override
-  public int hashCode() {
-    int hashCode = 1;
-    for (FlatRecordTraversalNode e : this) {
-      FlatRecordTraversalObjectNode objectNode = (FlatRecordTraversalObjectNode) e;
-      if (objectNode != null && commonSchemaMap.containsKey(objectNode.getSchema().getName())) {
-        objectNode.setCommonSchema(commonSchemaMap);
-        hashCode = 31 * hashCode + objectNode.hashCode();
-      }
-      else if (objectNode == null) {
-        hashCode = 31 * hashCode;
-      }
-    }
-    return hashCode;
-  }
-
-
-  @Override
-  public HollowListSchema getSchema() {
-    return schema;
   }
 
   public FlatRecordTraversalObjectNode getObject(int index) {
@@ -82,11 +58,27 @@ public class FlatRecordTraversalListNode extends AbstractList<FlatRecordTraversa
     if (elementOrdinal == -1) {
       return null;
     }
-    return createAndRepositionNode(reader, ordinalPositions, elementOrdinal);
+    return createNode(reader, elementOrdinal);
   }
 
   @Override
   public int size() {
     return elementOrdinals.length;
+  }
+
+  @Override
+  public int hashCode() {
+    int hashCode = 1;
+    for (FlatRecordTraversalNode e : this) {
+      FlatRecordTraversalObjectNode objectNode = (FlatRecordTraversalObjectNode) e;
+      if (objectNode != null && commonSchemaMap.containsKey(objectNode.getSchema().getName())) {
+        objectNode.setCommonSchema(commonSchemaMap);
+        hashCode = 31 * hashCode + objectNode.hashCode();
+      }
+      else if (objectNode == null) {
+        hashCode = 31 * hashCode;
+      }
+    }
+    return hashCode;
   }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalListNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalListNode.java
@@ -10,12 +10,14 @@ import java.util.Map;
 public class FlatRecordTraversalListNode extends AbstractList<FlatRecordTraversalNode> implements FlatRecordTraversalNode {
   private final FlatRecordOrdinalReader reader;
   private final HollowListSchema schema;
+  private final int ordinal;
   private final int[] elementOrdinals;
 
   private Map<String, HollowObjectSchema> commonSchemaMap;
 
   public FlatRecordTraversalListNode(FlatRecordOrdinalReader reader, HollowListSchema schema, int ordinal) {
     this.reader = reader;
+    this.ordinal = ordinal;
     this.schema = schema;
 
     int size = reader.readSize(ordinal);
@@ -26,6 +28,11 @@ public class FlatRecordTraversalListNode extends AbstractList<FlatRecordTraversa
   @Override
   public HollowListSchema getSchema() {
     return schema;
+  }
+
+  @Override
+  public int getOrdinal() {
+    return ordinal;
   }
 
   @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalMapNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalMapNode.java
@@ -13,6 +13,7 @@ import java.util.Set;
 public class FlatRecordTraversalMapNode extends AbstractMap<FlatRecordTraversalNode, FlatRecordTraversalNode> implements FlatRecordTraversalNode {
     private final FlatRecordOrdinalReader reader;
     private final HollowMapSchema schema;
+    private final int ordinal;
     private final int[] keyOrdinals;
     private final int[] valueOrdinals;
 
@@ -21,6 +22,7 @@ public class FlatRecordTraversalMapNode extends AbstractMap<FlatRecordTraversalN
     public FlatRecordTraversalMapNode(FlatRecordOrdinalReader reader, HollowMapSchema schema, int ordinal) {
         this.reader = reader;
         this.schema = schema;
+        this.ordinal = ordinal;
 
         int size = reader.readSize(ordinal);
         keyOrdinals = new int[size];
@@ -31,6 +33,11 @@ public class FlatRecordTraversalMapNode extends AbstractMap<FlatRecordTraversalN
     @Override
     public HollowMapSchema getSchema() {
         return schema;
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ordinal;
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalMapNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalMapNode.java
@@ -2,73 +2,40 @@ package com.netflix.hollow.core.write.objectmapper.flatrecords.traversal;
 
 import com.netflix.hollow.core.schema.HollowMapSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.util.IntList;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordOrdinalReader;
 
 import java.util.AbstractMap;
 import java.util.AbstractSet;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 public class FlatRecordTraversalMapNode extends AbstractMap<FlatRecordTraversalNode, FlatRecordTraversalNode> implements FlatRecordTraversalNode {
-    private FlatRecordReader reader;
-    private IntList ordinalPositions;
-    private HollowMapSchema schema;
-    private int[] keyOrdinals;
-    private int[] valueOrdinals;
+    private final FlatRecordOrdinalReader reader;
+    private final HollowMapSchema schema;
+    private final int[] keyOrdinals;
+    private final int[] valueOrdinals;
+
     private Map<String, HollowObjectSchema> commonSchemaMap;
 
-    @Override
-    public void reposition(FlatRecordReader reader, IntList ordinalPositions, int ordinal) {
+    public FlatRecordTraversalMapNode(FlatRecordOrdinalReader reader, HollowMapSchema schema, int ordinal) {
         this.reader = reader;
-        this.ordinalPositions = ordinalPositions;
+        this.schema = schema;
 
-        reader.resetTo(ordinalPositions.get(ordinal));
-        schema = (HollowMapSchema) reader.readSchema();
-
-        int size = reader.readCollectionSize();
+        int size = reader.readSize(ordinal);
         keyOrdinals = new int[size];
         valueOrdinals = new int[size];
-        int keyOrdinal = 0;
-        for (int i = 0; i < size; i++) {
-            keyOrdinal += reader.readOrdinal();
-            keyOrdinals[i] = keyOrdinal;
-            valueOrdinals[i] = reader.readOrdinal();
-        }
-    }
-
-    @Override
-    public void setCommonSchema(Map<String, HollowObjectSchema> commonSchema) {
-        this.commonSchemaMap = commonSchema;
-    }
-
-    @Override
-    public int hashCode() {
-        int h = 0;
-        Iterator<Entry<FlatRecordTraversalNode,FlatRecordTraversalNode>> i = entrySet().iterator();
-        while (i.hasNext()) {
-            Entry<FlatRecordTraversalNode, FlatRecordTraversalNode> e = i.next();
-            FlatRecordTraversalNode key = e.getKey();
-            FlatRecordTraversalNode value = e.getValue();
-            if(commonSchemaMap.containsKey(key.getSchema().getName())) {
-                key.setCommonSchema(commonSchemaMap);
-                h += (key == null ? 0 : key.hashCode());
-            }
-            if(commonSchemaMap.containsKey(value.getSchema().getName())) {
-                value.setCommonSchema(commonSchemaMap);
-                h += (value == null ? 0 : value.hashCode());
-            }
-        }
-        return h;
+        reader.readMapElementsInto(ordinal, keyOrdinals, valueOrdinals);
     }
 
     @Override
     public HollowMapSchema getSchema() {
         return schema;
+    }
+
+    @Override
+    public void setCommonSchema(Map<String, HollowObjectSchema> commonSchema) {
+        this.commonSchemaMap = commonSchema;
     }
 
     @Override
@@ -114,7 +81,7 @@ public class FlatRecordTraversalMapNode extends AbstractMap<FlatRecordTraversalN
                     if (keyOrdinal == -1) {
                         return null;
                     }
-                    return (K) createAndRepositionNode(reader, ordinalPositions, keyOrdinal);
+                    return (K) createNode(reader, keyOrdinal);
                 }
 
                 @Override
@@ -122,7 +89,7 @@ public class FlatRecordTraversalMapNode extends AbstractMap<FlatRecordTraversalN
                     if (valueOrdinal == -1) {
                         return null;
                     }
-                    return (V) createAndRepositionNode(reader, ordinalPositions, valueOrdinal);
+                    return (V) createNode(reader, valueOrdinal);
                 }
 
                 @Override
@@ -132,31 +99,22 @@ public class FlatRecordTraversalMapNode extends AbstractMap<FlatRecordTraversalN
             };
         }
     }
-    private static class MapEntry {
-        private final int key;
-        private final int value;
 
-        public MapEntry(int key, int value) {
-            this.key = key;
-            this.value = value;
+    @Override
+    public int hashCode() {
+        int h = 0;
+        for (Entry<FlatRecordTraversalNode, FlatRecordTraversalNode> e : entrySet()) {
+            FlatRecordTraversalNode key = e.getKey();
+            FlatRecordTraversalNode value = e.getValue();
+            if (commonSchemaMap.containsKey(key.getSchema().getName())) {
+                key.setCommonSchema(commonSchemaMap);
+                h += key.hashCode();
+            }
+            if (commonSchemaMap.containsKey(value.getSchema().getName())) {
+                value.setCommonSchema(commonSchemaMap);
+                h += value.hashCode();
+            }
         }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) return true;
-            if (!(o instanceof MapEntry)) return false;
-            MapEntry other = (MapEntry) o;
-            return key == other.key && value == other.value;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(key, value);
-        }
-
-        @Override
-        public String toString() {
-            return "MapEntry(" + key + ", " + value + ")";
-        }
+        return h;
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalNode.java
@@ -13,6 +13,8 @@ import java.util.Map;
  * An abstraction that allows for the traversal of a flat record from the root type to a specific sub-path.
  */
 public interface FlatRecordTraversalNode {
+  int getOrdinal();
+
   HollowSchema getSchema();
 
   void setCommonSchema(Map<String, HollowObjectSchema> commonSchema);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalNode.java
@@ -1,9 +1,11 @@
 package com.netflix.hollow.core.write.objectmapper.flatrecords.traversal;
 
+import com.netflix.hollow.core.schema.HollowListSchema;
+import com.netflix.hollow.core.schema.HollowMapSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
-import com.netflix.hollow.core.util.IntList;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
+import com.netflix.hollow.core.schema.HollowSetSchema;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordOrdinalReader;
 
 import java.util.Map;
 
@@ -15,31 +17,19 @@ public interface FlatRecordTraversalNode {
 
   void setCommonSchema(Map<String, HollowObjectSchema> commonSchema);
 
-  void reposition(FlatRecordReader reader, IntList ordinalPositions, int ordinal);
-
-  default FlatRecordTraversalNode createAndRepositionNode(FlatRecordReader reader, IntList ordinalPositions, int ordinal) {
-    reader.pointer = ordinalPositions.get(ordinal);
-    HollowSchema schema = reader.readSchema();
-
-    FlatRecordTraversalNode node;
+  default FlatRecordTraversalNode createNode(FlatRecordOrdinalReader reader, int ordinal) {
+    HollowSchema schema = reader.readSchema(ordinal);
     switch (schema.getSchemaType()) {
       case OBJECT:
-        node = new FlatRecordTraversalObjectNode();
-        break;
+        return new FlatRecordTraversalObjectNode(reader, (HollowObjectSchema) schema, ordinal);
       case LIST:
-        node = new FlatRecordTraversalListNode();
-        break;
+        return new FlatRecordTraversalListNode(reader, (HollowListSchema) schema, ordinal);
       case SET:
-        node = new FlatRecordTraversalSetNode();
-        break;
+        return new FlatRecordTraversalSetNode(reader, (HollowSetSchema) schema, ordinal);
       case MAP:
-        node = new FlatRecordTraversalMapNode();
-        break;
+        return new FlatRecordTraversalMapNode(reader, (HollowMapSchema) schema, ordinal);
       default:
         throw new IllegalArgumentException("Unsupported schema type: " + schema.getSchemaType());
     }
-
-    node.reposition(reader, ordinalPositions, ordinal);
-    return node;
   }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalObjectNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalObjectNode.java
@@ -17,8 +17,8 @@ public class FlatRecordTraversalObjectNode implements FlatRecordTraversalNode {
 
   public FlatRecordTraversalObjectNode(FlatRecordOrdinalReader reader, HollowObjectSchema schema, int ordinal) {
     this.reader = reader;
-    this.ordinal = ordinal;
     this.schema = schema;
+    this.ordinal = ordinal;
   }
 
   public FlatRecordTraversalObjectNode(FlatRecord rec) {
@@ -30,6 +30,11 @@ public class FlatRecordTraversalObjectNode implements FlatRecordTraversalNode {
   @Override
   public HollowObjectSchema getSchema() {
     return schema;
+  }
+
+  @Override
+  public int getOrdinal() {
+    return ordinal;
   }
 
   @Override
@@ -60,7 +65,7 @@ public class FlatRecordTraversalObjectNode implements FlatRecordTraversalNode {
     }
 
     if (fieldType != HollowObjectSchema.FieldType.REFERENCE) {
-      throw new IllegalArgumentException("Cannot get child for non-reference field");
+      throw new IllegalArgumentException("Cannot get child for non-reference field: " + field);
     }
 
     int refOrdinal = reader.readFieldReference(ordinal, field);
@@ -93,7 +98,7 @@ public class FlatRecordTraversalObjectNode implements FlatRecordTraversalNode {
       case BYTES:
         return reader.readFieldBytes(ordinal, field);
       case REFERENCE:
-        throw new IllegalArgumentException("Cannot get leaf value for reference field");
+        throw new IllegalArgumentException("Cannot get leaf value for reference field: " + field);
     }
     return null;
   }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalObjectNodeEquality.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalObjectNodeEquality.java
@@ -6,8 +6,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 public class FlatRecordTraversalObjectNodeEquality {
-
-    private static Map<String, HollowObjectSchema> commonSchemaCache = new HashMap<>();
+    private static final Map<String, HollowObjectSchema> commonSchemaCache = new HashMap<>();
 
     public static boolean equals(FlatRecordTraversalObjectNode left, FlatRecordTraversalObjectNode right) {
         if (left == null && right == null) {
@@ -138,5 +137,4 @@ public class FlatRecordTraversalObjectNodeEquality {
                 }
         }
     }
-
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalSetNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalSetNode.java
@@ -11,12 +11,14 @@ import java.util.Map;
 public class FlatRecordTraversalSetNode extends AbstractSet<FlatRecordTraversalNode> implements FlatRecordTraversalNode {
   private final FlatRecordOrdinalReader reader;
   private final HollowSetSchema schema;
+  private final int ordinal;
   private final int[] elementOrdinals;
 
   private Map<String, HollowObjectSchema> commonSchemaMap;
 
   public FlatRecordTraversalSetNode(FlatRecordOrdinalReader reader, HollowSetSchema schema, int ordinal) {
     this.reader = reader;
+    this.ordinal = ordinal;
     this.schema = schema;
 
     int size = reader.readSize(ordinal);
@@ -27,6 +29,11 @@ public class FlatRecordTraversalSetNode extends AbstractSet<FlatRecordTraversalN
   @Override
   public HollowSetSchema getSchema() {
     return schema;
+  }
+
+  @Override
+  public int getOrdinal() {
+    return ordinal;
   }
 
   @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalSetNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/flatrecords/traversal/FlatRecordTraversalSetNode.java
@@ -2,64 +2,38 @@ package com.netflix.hollow.core.write.objectmapper.flatrecords.traversal;
 
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSetSchema;
-import com.netflix.hollow.core.util.IntList;
-import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordReader;
+import com.netflix.hollow.core.write.objectmapper.flatrecords.FlatRecordOrdinalReader;
 
 import java.util.AbstractSet;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class FlatRecordTraversalSetNode extends AbstractSet<FlatRecordTraversalNode> implements FlatRecordTraversalNode {
-  private FlatRecordReader reader;
-  private IntList ordinalPositions;
-  private HollowSetSchema schema;
-  private int[] elementOrdinals;
+  private final FlatRecordOrdinalReader reader;
+  private final HollowSetSchema schema;
+  private final int[] elementOrdinals;
 
   private Map<String, HollowObjectSchema> commonSchemaMap;
-  @Override
-  public void reposition(FlatRecordReader reader, IntList ordinalPositions, int ordinal) {
+
+  public FlatRecordTraversalSetNode(FlatRecordOrdinalReader reader, HollowSetSchema schema, int ordinal) {
     this.reader = reader;
-    this.ordinalPositions = ordinalPositions;
+    this.schema = schema;
 
-    reader.resetTo(ordinalPositions.get(ordinal));
-    schema = (HollowSetSchema) reader.readSchema();
-
-    int size = reader.readCollectionSize();
+    int size = reader.readSize(ordinal);
     elementOrdinals = new int[size];
-    int elementOrdinal = 0;
-    for (int i = 0; i < size; i++) {
-      elementOrdinal += reader.readOrdinal();
-      elementOrdinals[i] = elementOrdinal;
-    }
+    reader.readSetElementsInto(ordinal, elementOrdinals);
   }
 
-  @Override
-  public void setCommonSchema(Map<String, HollowObjectSchema> commonSchema) {
-    this.commonSchemaMap = commonSchema;
-  }
   @Override
   public HollowSetSchema getSchema() {
     return schema;
   }
 
   @Override
-  public int hashCode() {
-    int h = 0;
-    Iterator<FlatRecordTraversalNode> i = iterator();
-    while (i.hasNext()) {
-      FlatRecordTraversalNode obj = i.next();
-      if (obj != null && commonSchemaMap.containsKey(obj.getSchema().getName()))
-        obj.setCommonSchema(commonSchemaMap);
-        h += obj.hashCode();
-    }
-    return h;
+  public void setCommonSchema(Map<String, HollowObjectSchema> commonSchema) {
+    this.commonSchemaMap = commonSchema;
   }
+
   public Iterator<FlatRecordTraversalObjectNode> objects() {
     return new IteratorImpl<>();
   }
@@ -86,6 +60,18 @@ public class FlatRecordTraversalSetNode extends AbstractSet<FlatRecordTraversalN
     return elementOrdinals.length;
   }
 
+  @Override
+  public int hashCode() {
+    int h = 0;
+    for (FlatRecordTraversalNode obj : this) {
+      if (obj != null && commonSchemaMap.containsKey(obj.getSchema().getName())) {
+        obj.setCommonSchema(commonSchemaMap);
+        h += obj.hashCode();
+      }
+    }
+    return h;
+  }
+
   private class IteratorImpl<T extends FlatRecordTraversalNode> implements Iterator<T> {
     private int index = 0;
 
@@ -100,7 +86,7 @@ public class FlatRecordTraversalSetNode extends AbstractSet<FlatRecordTraversalN
       if (elementOrdinal == -1) {
         return null;
       }
-      return (T) createAndRepositionNode(reader, ordinalPositions, elementOrdinal);
+      return (T) createNode(reader, elementOrdinal);
     }
   }
 }


### PR DESCRIPTION
The `FlatRecordTraversalNode` implementations now rely on `FlatRecordOrdinalReader` for traversing the FlatRecord instead of `FlatRecordReader`. i've implemented `FlatRecordOrdinalReader` in such a way that the Node can call into it concurrently without stepping on each other (in other words, it makes the Nodes concurrent safe).

i plan to eventually move most of the existing uses of `FlatRecordReader` to `FlatRecordOrdinalReader` as time allows.