### PR TITLE
fix: if the max ordinal for a map value is zero then reserve 1 bit for it instead of nothing

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
@@ -134,7 +134,7 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
         }
 
         bitsPerKeyElement = 64 - Long.numberOfLeadingZeros(maxKeyOrdinal + 1);
-        bitsPerValueElement = 64 - Long.numberOfLeadingZeros(maxValueOrdinal);
+        bitsPerValueElement = maxValueOrdinal == 0 ? 1 : 64 - Long.numberOfLeadingZeros(maxValueOrdinal);
 
         bitsPerMapSizeValue = 64 - Long.numberOfLeadingZeros(maxMapSize);
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
@@ -185,7 +185,7 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
         }
 
         long bitsPerKeyElement = 64 - Long.numberOfLeadingZeros(maxKeyOrdinal + 1);
-        long bitsPerValueElement = 64 - Long.numberOfLeadingZeros(maxValueOrdinal);
+        long bitsPerValueElement = maxValueOrdinal == 0 ? 1 : 64 - Long.numberOfLeadingZeros(maxValueOrdinal);
         long bitsPerMapSizeValue = 64 - Long.numberOfLeadingZeros(maxMapSize);
         long bitsPerMapPointer = 64 - Long.numberOfLeadingZeros(totalOfMapBuckets);
         


### PR DESCRIPTION
Currently, when a Map is written where all the keys reference the same value ordinal and that ordinal is zero then we don't reserve any space for the value ordinal. when a map entry is hashed into the last bucket, it overflows when trying to set the value in the data array.