### PR TITLE
Improvements in failure handling of transition in update processes  

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowDataHolder.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowDataHolder.java
@@ -118,8 +118,12 @@ class HollowDataHolder {
         // such as when a new delta is published.
         // Note that a refresh listener may also induce a failed transition, likely unknowingly,
         // by throwing an exception.
-        if (doubleSnapshotConfig.allowDoubleSnapshot() && failedTransitionTracker.anyTransitionWasFailed(updatePlan)) {
-            throw new RuntimeException("Update plan contains known failing transition!");
+        if (!doubleSnapshotConfig.allowDoubleSnapshot() && failedTransitionTracker.anyTransitionWasFailed(updatePlan)) {
+            if (System.getProperty("STRICT_TRANSITION_FAILURE_HANDLING", "false").equalsIgnoreCase("true")) {
+                throw new RuntimeException("Update plan contains known failing transition!");
+            } else {
+                LOG.warning("Update plan contains known failing transition! This may cause stale data.");
+            }
         }
 
         if (updatePlan.isSnapshotPlan()) {


### PR DESCRIPTION
issue #566 

- Added a check to prevent updates when `doubleSnapshot` is disabled and a known failing transition exists.  
- Introduced the `STRICT_TRANSITION_FAILURE_HANDLING` system property:  
  - If set to true, an exception is thrown to prevent stale data.  
  - If set to false, a warning is logged instead.  
- To provide better control over transition failures and to avoid the consumers being stuck on stale data.  

 