### PR TITLE
Include header that contains lookup key search box in History state page

### DIFF
--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/pages/HistoryStatePage.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/pages/HistoryStatePage.java
@@ -121,11 +121,4 @@ public class HistoryStatePage extends HistoryPage {
         }
         return -1;
     }
-
-	@Override
-	protected boolean includeHeaderAndFooter() {
-		return false;
-	}
-    
-
 }


### PR DESCRIPTION
This PR enables the `Lookup Key` search box in History state page, in response to an internal user voice. This helps users to easily navigate to the types they are interested in.