### PR TITLE
fix: consumer init to an announced version should only retrieve snapshots corresponding to announced versions

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowClientUpdater.java
@@ -76,7 +76,7 @@ public class HollowClientUpdater {
                                HollowMetricsCollector<HollowConsumerMetrics> metricsCollector) {
         this(transitionCreator, refreshListeners, apiFactory, doubleSnapshotConfig, hashCodeFinder, memoryMode,
                 objectLongevityConfig, objectLongevityDetector, metrics, metricsCollector,
-                null, HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE);
+                HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE);
     }
 
     public HollowClientUpdater(HollowConsumer.BlobRetriever transitionCreator,
@@ -89,7 +89,6 @@ public class HollowClientUpdater {
                                HollowConsumer.ObjectLongevityDetector objectLongevityDetector,
                                HollowConsumerMetrics metrics,
                                HollowMetricsCollector<HollowConsumerMetrics> metricsCollector,
-                               HollowConsumer.AnnouncementWatcher announcementWatcher,
                                HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier) {
         this.planner = new HollowUpdatePlanner(transitionCreator, doubleSnapshotConfig, updatePlanBlobVerifier);
         this.failedTransitionTracker = new FailedTransitionTracker();

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlan.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlan.java
@@ -30,7 +30,7 @@ import java.util.List;
  */
 public class HollowUpdatePlan implements Iterable<HollowConsumer.Blob> {
 
-    public static HollowUpdatePlan DO_NOTHING = new HollowUpdatePlan(Collections.<HollowConsumer.Blob>emptyList());
+    public static HollowUpdatePlan DO_NOTHING = new HollowUpdatePlan(Collections.emptyList());
 
     private final List<HollowConsumer.Blob> transitions;
 
@@ -39,7 +39,7 @@ public class HollowUpdatePlan implements Iterable<HollowConsumer.Blob> {
     }
 
     public HollowUpdatePlan() {
-        this.transitions = new ArrayList<HollowConsumer.Blob>();
+        this.transitions = new ArrayList();
     }
 
     public boolean isSnapshotPlan() {
@@ -97,5 +97,20 @@ public class HollowUpdatePlan implements Iterable<HollowConsumer.Blob> {
     @Override
     public Iterator<HollowConsumer.Blob> iterator() {
         return transitions.iterator();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+        if (transitions!= null) {
+            for (int i=0; i<transitions.size(); i++) {
+                HollowConsumer.Blob blob = transitions.get(i);
+                result.append(blob.getBlobType()).append(" to ").append(blob.getToVersion());
+                if (i < transitions.size()-1) {
+                    result.append(", ");
+                }
+            }
+        }
+        return result.toString();
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlanner.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowUpdatePlanner.java
@@ -18,69 +18,96 @@ package com.netflix.hollow.api.client;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.core.HollowConstants;
+import java.util.logging.Logger;
 
 /**
  * The HollowUpdatePlanner defines the logic responsible for interacting with a {@link HollowBlobRetriever} 
  * to create a {@link HollowUpdatePlan}.
  */
 public class HollowUpdatePlanner {
+    private static final Logger LOG = Logger.getLogger(HollowUpdatePlanner.class.getName());
 
     private final HollowConsumer.BlobRetriever transitionCreator;
     private final HollowConsumer.DoubleSnapshotConfig doubleSnapshotConfig;
+    private final HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier;
     
     @Deprecated
     public HollowUpdatePlanner(HollowBlobRetriever blobRetriever) {
         this(HollowClientConsumerBridge.consumerBlobRetrieverFor(blobRetriever));
     }
-    
+
     public HollowUpdatePlanner(HollowConsumer.BlobRetriever blobRetriever) {
-        this(blobRetriever, new HollowConsumer.DoubleSnapshotConfig() {
-            @Override
-            public int maxDeltasBeforeDoubleSnapshot() {
-                return 32;
-            }
-            
-            @Override
-            public boolean allowDoubleSnapshot() {
-                return true;
-            }
-        });
+        this(blobRetriever, HollowConsumer.DoubleSnapshotConfig.DEFAULT_CONFIG);
     }
 
     public HollowUpdatePlanner(HollowConsumer.BlobRetriever transitionCreator, HollowConsumer.DoubleSnapshotConfig doubleSnapshotConfig) {
+        this(transitionCreator, doubleSnapshotConfig, HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE);
+    }
+
+    /**
+     * @param transitionCreator A blob retriever implementation
+     * @param doubleSnapshotConfig Double snapshot config
+     * @param updatePlanBlobVerifier Update plan config
+     */
+    public HollowUpdatePlanner(HollowConsumer.BlobRetriever transitionCreator,
+                               HollowConsumer.DoubleSnapshotConfig doubleSnapshotConfig,
+                               HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier) {
         this.transitionCreator = transitionCreator;
         this.doubleSnapshotConfig = doubleSnapshotConfig;
+        this.updatePlanBlobVerifier = updatePlanBlobVerifier;
+    }
+
+    /**
+     * @deprecated use {@link #planInitializingUpdate(HollowConsumer.VersionInfo)} instead.
+     */
+    @Deprecated
+    public HollowUpdatePlan planInitializingUpdate(long desiredVersion) throws Exception {
+        return planInitializingUpdate(new HollowConsumer.VersionInfo(desiredVersion));
     }
 
     /**
      * @return the sequence of steps necessary to initialize a hollow state engine to a given state.
-     * @param desiredVersion - The version to which the hollow state engine should be updated once the resultant steps are applied.
+     * @param desiredVersionInfo - The version to which the hollow state engine should be updated once the resultant steps are applied.
      * @throws Exception if the plan cannot be initialized
      */
-    public HollowUpdatePlan planInitializingUpdate(long desiredVersion) throws Exception {
-        return planUpdate(HollowConstants.VERSION_NONE, desiredVersion, true);
+    public HollowUpdatePlan planInitializingUpdate(HollowConsumer.VersionInfo desiredVersionInfo) throws Exception {
+        return planUpdate(HollowConstants.VERSION_NONE, desiredVersionInfo, true);
     }
 
     /**
+     * @deprecated use {@link #planUpdate(long, HollowConsumer.VersionInfo, boolean)} instead.
+     */
+    @Deprecated
+    public HollowUpdatePlan planUpdate(long currentVersion, long desiredVersion, boolean allowSnapshot) throws Exception {
+        return planUpdate(currentVersion, new HollowConsumer.VersionInfo(desiredVersion), allowSnapshot);
+    }
+
+    /**
+     * Create an update plan from the current version to the desired version.
+     * If the desired version was announced, and if announcement watcher impl has been initialized, the update plan config
+     * will default to snapshot plans only retrieving a snapshot version that was successfully announced.
+     *
      * @param currentVersion - The current version of the hollow state engine, or HollowConstants.VERSION_NONE if not yet initialized
-     * @param desiredVersion - The version to which the hollow state engine should be updated once the resultant steps are applied.
+     * @param desiredVersionInfo - The version info to which the hollow state engine should be updated once the resultant steps are applied.
      * @param allowSnapshot  - Allow a snapshot plan to be created if the destination version is not reachable
      * @return the sequence of steps necessary to bring a hollow state engine up to date.
      * @throws Exception if the plan cannot be updated
      */
-    public HollowUpdatePlan planUpdate(long currentVersion, long desiredVersion, boolean allowSnapshot) throws Exception {
+    public HollowUpdatePlan planUpdate(long currentVersion, HollowConsumer.VersionInfo desiredVersionInfo, boolean allowSnapshot) throws Exception {
+        long desiredVersion = desiredVersionInfo.getVersion();
+
         if(desiredVersion == currentVersion)
             return HollowUpdatePlan.DO_NOTHING;
 
         if (currentVersion == HollowConstants.VERSION_NONE)
-            return snapshotPlan(desiredVersion);
+            return snapshotPlan(desiredVersionInfo);
 
         HollowUpdatePlan deltaPlan = deltaPlan(currentVersion, desiredVersion, doubleSnapshotConfig.maxDeltasBeforeDoubleSnapshot());
 
         long deltaDestinationVersion = deltaPlan.destinationVersion(currentVersion);
 
         if(deltaDestinationVersion != desiredVersion && allowSnapshot) {
-            HollowUpdatePlan snapshotPlan = snapshotPlan(desiredVersion);
+            HollowUpdatePlan snapshotPlan = snapshotPlan(desiredVersionInfo);
             long snapshotDestinationVersion = snapshotPlan.destinationVersion(currentVersion);
 
             if(snapshotDestinationVersion == desiredVersion
@@ -97,16 +124,16 @@ public class HollowUpdatePlanner {
      * Returns an update plan that if executed will update the client to a version that is either equal to or as close to but
      * less than the desired version as possible. This plan normally contains one snapshot transition and zero or more delta
      * transitions but if no previous versions were found then an empty plan, {@code HollowUpdatePlan.DO_NOTHING}, is returned.
-     *
-     * @param desiredVersion The desired version to which the client wishes to update to, or update to as close to as possible but lesser than this version
+     * @param desiredVersionInfo Version info for the desired version to which the client wishes to update to, or update to as close to as possible but lesser than this version
      * @return An update plan containing 1 snapshot transition and 0+ delta transitions if requested versions were found,
      *         or an empty plan, {@code HollowUpdatePlan.DO_NOTHING}, if no previous versions were found
      */
-    private HollowUpdatePlan snapshotPlan(long desiredVersion) {
+    private HollowUpdatePlan snapshotPlan(HollowConsumer.VersionInfo desiredVersionInfo) {
         HollowUpdatePlan plan = new HollowUpdatePlan();
-        long nearestPreviousSnapshotVersion = includeNearestSnapshot(plan, desiredVersion);
+        long desiredVersion = desiredVersionInfo.getVersion();
+        long nearestPreviousSnapshotVersion = includeNearestSnapshot(plan, desiredVersionInfo);
 
-        // The includeNearestSnapshot function returns a snapshot version that is less than or equal to the desired version
+        // The includeNearestSnapshot function returns a  snapshot version that is less than or equal to the desired version
         if(nearestPreviousSnapshotVersion > desiredVersion)
             return HollowUpdatePlan.DO_NOTHING;
 
@@ -182,14 +209,63 @@ public class HollowUpdatePlanner {
         return HollowConstants.VERSION_NONE;
     }
 
-    private long includeNearestSnapshot(HollowUpdatePlan plan, long desiredVersion) {
+    private long includeNearestSnapshot(HollowUpdatePlan plan, HollowConsumer.VersionInfo desiredVersionInfo) {
+        long desiredVersion = desiredVersionInfo.getVersion();
         HollowConsumer.Blob transition = transitionCreator.retrieveSnapshotBlob(desiredVersion);
-        if(transition != null) {
-            plan.add(transition);
-            return transition.getToVersion();
-        }
+        if (transition != null) {
+            // exact match with desired version
+            if (transition.getToVersion() == desiredVersion) {
+                plan.add(transition);
+                return transition.getToVersion();
+            }
 
+            // else if update is to an announced version then add only announced versions to plan
+            if (updatePlanBlobVerifier != null
+                && updatePlanBlobVerifier.announcementVerificationEnabled()
+                && desiredVersionInfo.wasAnnounced() != null
+                && desiredVersionInfo.wasAnnounced().isPresent()
+                && desiredVersionInfo.wasAnnounced().get()) {
+
+                int lookback = 1;
+                int maxLookback = updatePlanBlobVerifier.announcementVerificationMaxLookback();
+                HollowConsumer.AnnouncementWatcher announcementWatcher = updatePlanBlobVerifier.announcementWatcher();
+                while (lookback <= maxLookback) {
+                    HollowConsumer.AnnouncementStatus announcementStatus = announcementWatcher == null
+                            ? HollowConsumer.AnnouncementStatus.UNKNOWN : announcementWatcher.getVersionAnnouncementStatus(transition.getToVersion());
+
+                    if (announcementStatus == null
+                     || announcementStatus.equals(HollowConsumer.AnnouncementStatus.UNKNOWN)
+                     || announcementStatus.equals(HollowConsumer.AnnouncementStatus.ANNOUNCED)) {
+                        // backwards compatibility
+                        if (announcementStatus == HollowConsumer.AnnouncementStatus.UNKNOWN) {
+                            if (announcementWatcher == null) {
+                                LOG.warning("HollowUpdatePlanner was not initialized with an announcement watcher so it does not support getVersionAnnouncementStatus. " +
+                                        "Consumer will continue with the update but runs the risk of consuming a snapshot version that was not announced");
+                            } else {
+                                LOG.warning(String.format("Announcement watcher impl bound (%s) to HollowUpdatePlanner does not support getVersionAnnouncementStatus. " +
+                                        "Consumer will continue with the update but runs the risk of consuming a snapshot version that was not announced", announcementWatcher.getClass().getName()));
+                            }
+                        } else if (announcementStatus == null) {
+                            LOG.warning(String.format("Expecting a valid announcement stats for version(%s), but Announcement watcher impl (%s) " +
+                                    "returned null", transition.getToVersion(), announcementWatcher.getClass().getName()));
+                        }
+                        plan.add(transition);
+                        return transition.getToVersion();
+                    }
+                    lookback ++;
+                    desiredVersion = transition.getToVersion() - 1; // try the next highest snapshot version less than the previous one
+                    transition = transitionCreator.retrieveSnapshotBlob(desiredVersion);
+                    if (transition == null) {
+                        break;
+                    }
+                }
+                LOG.warning("No past snapshot found within lookback period that corresponded to an announced version, maxLookback configured to " + maxLookback);
+            } else {
+                // if desired version is either not an announced version, or unknown whether it is an announced version (e.g. backwards compatibility)
+                plan.add(transition);
+                return transition.getToVersion();
+            }
+        }
         return HollowConstants.VERSION_LATEST;
     }
-
 }

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -200,7 +200,6 @@ public class HollowConsumer {
                 builder.objectLongevityDetector,
                 metrics,
                 builder.metricsCollector,
-                builder.announcementWatcher,
                 builder.updatePlanBlobVerifier);
         updater.setFilter(builder.typeFilter);
         if(builder.skipTypeShardUpdateWithNoAdditions)

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -199,7 +199,9 @@ public class HollowConsumer {
                 builder.objectLongevityConfig,
                 builder.objectLongevityDetector,
                 metrics,
-                builder.metricsCollector);
+                builder.metricsCollector,
+                builder.announcementWatcher,
+                builder.updatePlanBlobVerifier);
         updater.setFilter(builder.typeFilter);
         if(builder.skipTypeShardUpdateWithNoAdditions)
             updater.setSkipShardUpdateWithNoAdditions(true);
@@ -629,23 +631,32 @@ public class HollowConsumer {
     }
 
     /**
-     * This class holds an announced version, its pinned status and the announcement metadata.
-     * isPinned and announcementMetadata fields are empty unless they are populated by the AnnouncementWatcher.
+     * This class holds a version, its pinned status, associated metadata, and whether the version corresponds to an announcement.
+     * isPinned, announcementMetadata, and wasAnnounced are optional, and poopulated only when known (for e.g. by an announcement
+     * watcher implementation).
+     * {@code isPinned} powers detection of forked delta chains- a producer is not expected to regress to an older version unless it is pinned.
+     * {@code announcementMetdata} powers consumer-side features like auto double-snapshot on schema change that rely on producer setting a tag in announcement metadata.
+     * {@code wasAnnounced} powers a verification in the consumer update plan computation- when updating to an announced version only announced snapshots should be retrieved.
      * */
     public static class VersionInfo {
         long version;
         Optional<Boolean> isPinned;
         Optional<Map<String, String>> announcementMetadata;
+        Optional<Boolean> wasAnnounced;
 
         public VersionInfo(long version) {
             this(version, Optional.empty(), Optional.empty());
         }
 
         public VersionInfo(long version, Optional<Map<String, String>> announcementMetadata, Optional<Boolean> isPinned) {
+            this(version, announcementMetadata, isPinned, Optional.empty());
+        }
+
+        public VersionInfo(long version, Optional<Map<String, String>> announcementMetadata, Optional<Boolean> isPinned, Optional<Boolean> wasAnnounced) {
             this.version = version;
             this.announcementMetadata = announcementMetadata;
             this.isPinned = isPinned;
-
+            this.wasAnnounced = wasAnnounced;
         }
 
         public long getVersion() {
@@ -658,6 +669,10 @@ public class HollowConsumer {
 
         public Optional<Boolean> isPinned() {
             return isPinned;
+        }
+
+        public Optional<Boolean> wasAnnounced() {
+            return wasAnnounced;
         }
     }
 
@@ -692,8 +707,29 @@ public class HollowConsumer {
          * @return versionInfo - the latest announced version, its pinned status and announcement metadata.
          */
         default VersionInfo getLatestVersionInfo() {
-            return new VersionInfo(getLatestVersion(), Optional.empty(), Optional.empty());
+            return new VersionInfo(getLatestVersion(), Optional.empty(), Optional.empty(), Optional.of(true));
         }
+
+        /**
+         * Returns the status corresponding to if the given version was announced.
+         * @param version Namespace version
+         * @return
+         *  AnnouncementStatus.ANNOUNCED - version was announced
+         *  AnnouncementStatus.NOT_ANNOUNCED - no announcement was found for the version
+         *  AnnouncementStatus.NOT_SUPPORTED - impl does not support this method
+         */
+        default AnnouncementStatus getVersionAnnouncementStatus(long version) {
+            return AnnouncementStatus.UNKNOWN;
+        }
+    }
+
+    /**
+     * This enum captures whether a version corresponds to a previously announced version or not.
+     */
+    public enum AnnouncementStatus {
+        ANNOUNCED,
+        NOT_ANNOUNCED,
+        UNKNOWN
     }
 
     public interface DoubleSnapshotConfig {
@@ -713,6 +749,40 @@ public class HollowConsumer {
             @Override
             public boolean allowDoubleSnapshot() {
                 return true;
+            }
+        };
+    }
+
+    public interface UpdatePlanBlobVerifier {
+        // If the update plan computation requires a snapshot transition and a snapshot matching the desired version is
+        // not found, then the next-highest look back snapshot version is retrieved instead. By returning true from this
+        // method, any look back snapshots will be discarded if they did not correspond to an announced version, and then
+        // the next-highest look back snapshot will be attempted, and so on. This will repeat until an "announced" snapshot
+        // is found, or max lookback versions is breached (see {@code announcementVerificationMaxLookback}).
+        boolean announcementVerificationEnabled();
+
+        // Specifies how many past snapshot versions can be looked up if announcementVerificationEnabled is true,
+        // and an exact snapshot version matching with the update plan desired version could not be retrieved. Multiple
+        // lookups may be required in order to retrieve one that corresponds to an announced version.
+        int announcementVerificationMaxLookback();
+
+        // Announcemnet watcher impl for verifying that a retrieved blob had a corresponding announcement
+        AnnouncementWatcher announcementWatcher();
+
+        UpdatePlanBlobVerifier DEFAULT_INSTANCE = new UpdatePlanBlobVerifier() {
+            @Override
+            public boolean announcementVerificationEnabled() {
+                return false;
+            }
+
+            @Override
+            public int announcementVerificationMaxLookback() {
+                return 1;
+            }
+
+            @Override
+            public AnnouncementWatcher announcementWatcher() {
+                return null;
             }
         };
     }
@@ -1077,6 +1147,7 @@ public class HollowConsumer {
         protected HollowAPIFactory apiFactory = HollowAPIFactory.DEFAULT_FACTORY;
         protected HollowObjectHashCodeFinder hashCodeFinder = new DefaultHashCodeFinder();
         protected HollowConsumer.DoubleSnapshotConfig doubleSnapshotConfig = DoubleSnapshotConfig.DEFAULT_CONFIG;
+        protected UpdatePlanBlobVerifier updatePlanBlobVerifier = UpdatePlanBlobVerifier.DEFAULT_INSTANCE;
         protected HollowConsumer.ObjectLongevityConfig objectLongevityConfig = ObjectLongevityConfig.DEFAULT_CONFIG;
         protected HollowConsumer.ObjectLongevityDetector objectLongevityDetector = ObjectLongevityDetector.DEFAULT_DETECTOR;
         protected File localBlobStoreDir = null;
@@ -1298,6 +1369,11 @@ public class HollowConsumer {
 
         public B withDoubleSnapshotConfig(HollowConsumer.DoubleSnapshotConfig doubleSnapshotConfig) {
             this.doubleSnapshotConfig = doubleSnapshotConfig;
+            return (B)this;
+        }
+
+        public B withUpdatePlanVerifier(UpdatePlanBlobVerifier updatePlanBlobVerifier) {
+            this.updatePlanBlobVerifier = updatePlanBlobVerifier;
             return (B)this;
         }
 

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
@@ -91,7 +91,7 @@ public class HollowClientUpdaterTest {
         MemoryMode memoryMode = MemoryMode.ON_HEAP;
 
         subject = new HollowClientUpdater(retriever, emptyList(), apiFactory, snapshotConfig,null, memoryMode,
-                objectLongevityConfig, objectLongevityDetector, metrics, null, announcementWatcher, updatePlanBlobVerifier);
+                objectLongevityConfig, objectLongevityDetector, metrics, null, updatePlanBlobVerifier);
     }
 
     @Test

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowClientUpdaterTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,6 +47,7 @@ import com.netflix.hollow.test.consumer.TestBlobRetriever;
 import com.netflix.hollow.test.consumer.TestHollowConsumer;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -69,6 +71,9 @@ public class HollowClientUpdaterTest {
     private HollowConsumer.ObjectLongevityConfig objectLongevityConfig;
     private HollowConsumer.ObjectLongevityDetector objectLongevityDetector;
     private HollowAPIFactory apiFactory;
+    private HollowConsumer.AnnouncementWatcher announcementWatcher;
+    private HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier;
+    private HollowConsumer.Blob blob;
 
     @Before
     public void setUp() {
@@ -78,10 +83,15 @@ public class HollowClientUpdaterTest {
         objectLongevityConfig = mock(HollowConsumer.ObjectLongevityConfig.class);
         objectLongevityDetector = mock(HollowConsumer.ObjectLongevityDetector.class);
         metrics = mock(HollowConsumerMetrics.class);
+        announcementWatcher = mock(HollowConsumer.AnnouncementWatcher.class);
+        updatePlanBlobVerifier = mock(HollowConsumer.UpdatePlanBlobVerifier.class);
+        blob = mock(HollowConsumer.Blob.class);
+
+        when(updatePlanBlobVerifier.announcementVerificationEnabled()).thenReturn(false);
         MemoryMode memoryMode = MemoryMode.ON_HEAP;
 
-        subject = new HollowClientUpdater(retriever, emptyList(), apiFactory, snapshotConfig,
-                null, memoryMode, objectLongevityConfig, objectLongevityDetector, metrics, null);
+        subject = new HollowClientUpdater(retriever, emptyList(), apiFactory, snapshotConfig,null, memoryMode,
+                objectLongevityConfig, objectLongevityDetector, metrics, null, announcementWatcher, updatePlanBlobVerifier);
     }
 
     @Test
@@ -141,14 +151,11 @@ public class HollowClientUpdaterTest {
         assertFalse(subject.getInitialLoad().isCompletedExceptionally());
     }
 
-    @Test
-    public void testInitialLoadSucceedsThenBadUpdatePlan_throwsException() throws Throwable {
-        // much setup
+    private HollowConsumer.Blob fakeSnapshotBlob() throws IOException {
         // 1. construct a real-ish snapshot blob
         HollowWriteStateEngine stateEngine = new HollowWriteStateEngineBuilder()
                 .add("hello")
                 .build();
-        // TODO(timt): DRY with TestHollowConsumer::addSnapshot
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         new HollowBlobWriter(stateEngine).writeSnapshot(os);
         ByteArrayInputStream is = new ByteArrayInputStream(os.toByteArray());
@@ -158,7 +165,14 @@ public class HollowClientUpdaterTest {
                 .thenReturn(true);
         when(blob.getInputStream())
                 .thenReturn(is);
-        // 3. return fake snapshot when asked
+        return blob;
+    }
+
+    @Test
+    public void testInitialLoadSucceedsThenBadUpdatePlan_throwsException() throws Throwable {
+        blob = fakeSnapshotBlob();
+
+        // return fake snapshot when asked
         when(retriever.retrieveSnapshotBlob(anyLong()))
                 .thenReturn(blob);
 
@@ -175,6 +189,131 @@ public class HollowClientUpdaterTest {
                 + "version or any qualifying previous versions could not be retrieved. Consumer will remain at current "
                 + "version %s until next update attempt.", v, subject.getCurrentVersionId()));
         subject.updateTo(v);
+    }
+
+    @Test
+    public void testInitToUnannouncedVersion_ExactSnapshot() throws Throwable {
+        long v1 = 123;
+
+        blob = fakeSnapshotBlob();
+        when(blob.getToVersion()).thenReturn(v1);
+        when(retriever.retrieveSnapshotBlob(anyLong())).thenReturn(blob);
+        when(updatePlanBlobVerifier.announcementVerificationEnabled()).thenReturn(true);
+        when(updatePlanBlobVerifier.announcementWatcher()).thenReturn(announcementWatcher);
+        when(announcementWatcher.getVersionAnnouncementStatus(anyLong())).thenReturn(HollowConsumer.AnnouncementStatus.NOT_ANNOUNCED);
+        when(snapshotConfig.allowDoubleSnapshot()).thenReturn(false);
+
+        subject.updateTo(v1);
+        assertTrue(subject.getInitialLoad().isDone());
+    }
+
+    @Test
+    public void testInitToUnannouncedVersion_LookbackSnapshotNotAnnounced() throws Throwable {
+        long v1 = 123;
+
+        blob = fakeSnapshotBlob();
+        when(blob.getToVersion()).thenReturn(v1);
+        when(retriever.retrieveSnapshotBlob(anyLong())).thenReturn(blob);
+        when(updatePlanBlobVerifier.announcementVerificationEnabled()).thenReturn(true);
+        when(updatePlanBlobVerifier.announcementVerificationMaxLookback()).thenReturn(1);
+        when(updatePlanBlobVerifier.announcementWatcher()).thenReturn(announcementWatcher);
+        when(announcementWatcher.getVersionAnnouncementStatus(anyLong())).thenReturn(HollowConsumer.AnnouncementStatus.NOT_ANNOUNCED);
+        when(snapshotConfig.allowDoubleSnapshot()).thenReturn(false);
+
+        try {
+            subject.updateTo(new HollowConsumer.VersionInfo(v1+1, Optional.empty(), Optional.empty(), Optional.of(true)));
+            fail(); // expected to throw
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalArgumentException);
+        }
+    }
+
+    @Test
+    public void testInitToAnnouncedVersion_LookbackSnapshot() throws Throwable {
+        long v1 = 123;
+
+        blob = fakeSnapshotBlob();
+        when(blob.getToVersion()).thenReturn(v1);
+        when(retriever.retrieveSnapshotBlob(anyLong())).thenReturn(blob);
+        when(updatePlanBlobVerifier.announcementVerificationEnabled()).thenReturn(true);
+        when(updatePlanBlobVerifier.announcementVerificationMaxLookback()).thenReturn(1);
+        when(updatePlanBlobVerifier.announcementWatcher()).thenReturn(announcementWatcher);
+        when(announcementWatcher.getVersionAnnouncementStatus(anyLong())).thenReturn(HollowConsumer.AnnouncementStatus.ANNOUNCED);
+        when(snapshotConfig.allowDoubleSnapshot()).thenReturn(false);
+
+        subject.updateTo(new HollowConsumer.VersionInfo(v1+1, Optional.empty(), Optional.empty(), Optional.of(true)));
+        assertTrue(subject.getInitialLoad().isDone());
+    }
+
+    @Test
+    public void testInitToAnnouncedVersion_MultipleLookbackSnapshot() throws Throwable {
+        long v1 = 123;
+        HollowConsumer.Blob blob1 = fakeSnapshotBlob();
+        HollowConsumer.Blob blob2 = fakeSnapshotBlob();
+
+        when(blob1.getToVersion()).thenReturn(v1+1);
+        when(blob2.getToVersion()).thenReturn(v1);
+
+        when(retriever.retrieveSnapshotBlob(anyLong())).thenReturn(blob1).thenReturn(blob2);
+        when(updatePlanBlobVerifier.announcementVerificationEnabled()).thenReturn(true);
+        when(updatePlanBlobVerifier.announcementVerificationMaxLookback()).thenReturn(1);
+        when(updatePlanBlobVerifier.announcementWatcher()).thenReturn(announcementWatcher);
+        when(announcementWatcher.getVersionAnnouncementStatus(eq(v1+1))).thenReturn(HollowConsumer.AnnouncementStatus.NOT_ANNOUNCED);
+        when(announcementWatcher.getVersionAnnouncementStatus(eq(v1))).thenReturn(HollowConsumer.AnnouncementStatus.ANNOUNCED);
+        when(snapshotConfig.allowDoubleSnapshot()).thenReturn(false);
+
+        when(updatePlanBlobVerifier.announcementVerificationMaxLookback()).thenReturn(2);
+        subject.updateTo(new HollowConsumer.VersionInfo(v1+2, Optional.empty(), Optional.empty(), Optional.of(true)));
+        assertTrue(subject.getInitialLoad().isDone());
+
+    }
+
+    @Test
+    public void testInitToAnnouncementUnknownVersion_LookbackSnapshotNotAnnounced() throws Throwable {
+        long v1 = 123;
+
+        blob = fakeSnapshotBlob();
+        when(blob.getToVersion()).thenReturn(v1);
+        when(retriever.retrieveSnapshotBlob(anyLong())).thenReturn(blob);
+        when(updatePlanBlobVerifier.announcementVerificationEnabled()).thenReturn(true);
+        when(updatePlanBlobVerifier.announcementVerificationMaxLookback()).thenReturn(1);
+        when(updatePlanBlobVerifier.announcementWatcher()).thenReturn(announcementWatcher);
+        when(announcementWatcher.getVersionAnnouncementStatus(anyLong())).thenReturn(HollowConsumer.AnnouncementStatus.NOT_ANNOUNCED);
+        when(snapshotConfig.allowDoubleSnapshot()).thenReturn(false);
+
+        subject.updateTo(new HollowConsumer.VersionInfo(v1+1, Optional.empty(), Optional.empty(), Optional.empty()));
+        assertTrue(subject.getInitialLoad().isDone());
+    }
+
+    @Test
+    public void testInitToAnnouncementUnknownVersion_ExactSnapshot() throws Throwable {
+        long v1 = 123;
+
+        blob = fakeSnapshotBlob();
+        when(blob.getToVersion()).thenReturn(v1);
+        when(retriever.retrieveSnapshotBlob(anyLong())).thenReturn(blob);
+        when(updatePlanBlobVerifier.announcementVerificationEnabled()).thenReturn(true);
+        when(updatePlanBlobVerifier.announcementWatcher()).thenReturn(announcementWatcher);
+        when(snapshotConfig.allowDoubleSnapshot()).thenReturn(false);
+        when(announcementWatcher.getVersionAnnouncementStatus(anyLong())).thenReturn(HollowConsumer.AnnouncementStatus.UNKNOWN);
+
+        subject.updateTo(v1);
+        assertTrue(subject.getInitialLoad().isDone());
+    }
+
+    @Test
+    public void testSnapshotAnnounceCheckDisabled_LookbackSnapshot() throws Throwable {
+        long v1 = 123;
+
+        blob = fakeSnapshotBlob();
+        when(blob.getToVersion()).thenReturn(v1);
+        when(retriever.retrieveSnapshotBlob(anyLong())).thenReturn(blob);
+        when(updatePlanBlobVerifier.announcementVerificationEnabled()).thenReturn(false);
+        when(announcementWatcher.getVersionAnnouncementStatus(anyLong())).thenReturn(HollowConsumer.AnnouncementStatus.UNKNOWN);
+        when(snapshotConfig.allowDoubleSnapshot()).thenReturn(true);
+
+        subject.updateTo(v1+1);
+        assertTrue(subject.getInitialLoad().isDone());
     }
 
     @Test

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowUpdatePlannerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowUpdatePlannerTest.java
@@ -55,7 +55,7 @@ public class HollowUpdatePlannerTest {
         addMockDelta(4, 5);
         addMockDelta(5, 6);
 
-        HollowUpdatePlan plan = planner.planInitializingUpdate(5);
+        HollowUpdatePlan plan = planner.planInitializingUpdate(new HollowConsumer.VersionInfo(5));
 
         Assert.assertEquals(plan.numTransitions(), 5);
 
@@ -175,7 +175,7 @@ public class HollowUpdatePlannerTest {
         addMockDelta(0, 3);
         addMockDelta(3, 6);
 
-        HollowUpdatePlan plan = planner.planInitializingUpdate(5);
+        HollowUpdatePlan plan = planner.planInitializingUpdate(new HollowConsumer.VersionInfo(5));
 
         Assert.assertEquals(plan.numTransitions(), 2);
 


### PR DESCRIPTION
### The bug
```
1. A producer announces V0, 
2. Then starts failing validations, so it publishes a snapshot for V1 which is not announced due to validation failure,
3. Then later on announces V2 but with no corresponding snapshot because numStatesBetweenSnapshot is not met,
4. And later on announces Vn with a corresponding snapshot.

Then a consumer starting between 3 and 4 will attempt to initialize to the latest announcement V2 but will initialize to V1 -thus initializing to a version that wasn’t announced because it failed validation.
```
### Impact
* Risk of consumers landing on a version of data that was not announced (described above)
* Consumer can fail to recover from forked delta chains using double-snapshot until a snapshot on the new delta chain is announced.

### Fix
Introduced a `UpdatePlanVerifier` that can be configured when building a consumer instance to enable this verification. If enabled, a consumer update is triggered to an announced version (as indicated in the trigger refresh to version info), the update plan computation will verify that retrieved snapshot blobs were also announced- until it finds an announced snapshot or exhausts configured max lookback attempts.
