### PR TITLE
Resharding: producer can reshard only from within runCycle

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobWriter.java
@@ -56,7 +56,7 @@ public class HollowBlobWriter {
     }
 
     public void writeHeader(OutputStream os, ProducerOptionalBlobPartConfig.OptionalBlobPartOutputStreams partStreams) throws IOException {
-        stateEngine.prepareForWrite();
+        stateEngine.prepareForWrite(true);
 
         DataOutputStream dos = new DataOutputStream(os);
         HollowBlobHeaderWrapper hollowBlobHeaderWrapper = buildHeader(partStreams, stateEngine.getSchemas(), false);
@@ -72,7 +72,7 @@ public class HollowBlobWriter {
         if(partStreams != null)
             partStreamsByType = partStreams.getStreamsByType();
 
-        stateEngine.prepareForWrite();
+        stateEngine.prepareForWrite(true);
 
         DataOutputStream dos = new DataOutputStream(os);
         HollowBlobHeaderWrapper hollowBlobHeaderWrapper = buildHeader(partStreams, stateEngine.getSchemas(), false);
@@ -132,7 +132,7 @@ public class HollowBlobWriter {
         if(partStreams != null)
             partStreamsByType = partStreams.getStreamsByType();
 
-        stateEngine.prepareForWrite();
+        stateEngine.prepareForWrite(true);
 
         if(stateEngine.isRestored())
             stateEngine.ensureAllNecessaryStatesRestored();
@@ -200,7 +200,7 @@ public class HollowBlobWriter {
         if(partStreams != null)
             partStreamsByType = partStreams.getStreamsByType();
 
-        stateEngine.prepareForWrite();
+        stateEngine.prepareForWrite(true);
 
         if(stateEngine.isRestored())
             stateEngine.ensureAllNecessaryStatesRestored();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
@@ -59,11 +59,11 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
     }
 
     @Override
-    public void prepareForWrite() {
-        super.prepareForWrite();
+    public void prepareForWrite(boolean canReshard) {
+        super.prepareForWrite(canReshard);
 
         maxOrdinal = ordinalMap.maxOrdinal();
-        gatherShardingStats(maxOrdinal);
+        gatherShardingStats(maxOrdinal, canReshard);
         gatherStatistics(numShards != revNumShards);
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
@@ -68,11 +68,11 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
     }
 
     @Override
-    public void prepareForWrite() {
-        super.prepareForWrite();
+    public void prepareForWrite(boolean canReshard) {
+        super.prepareForWrite(canReshard);
 
         maxOrdinal = ordinalMap.maxOrdinal();
-        gatherShardingStats(maxOrdinal);
+        gatherShardingStats(maxOrdinal, canReshard);
         gatherStatistics(numShards != revNumShards);
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
@@ -66,12 +66,12 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
      *
      */
     @Override
-    public void prepareForWrite() {
-        super.prepareForWrite();
+    public void prepareForWrite(boolean canReshard) {
+        super.prepareForWrite(canReshard);
 
         maxOrdinal = ordinalMap.maxOrdinal();
         gatherFieldStats();
-        gatherShardingStats(maxOrdinal);
+        gatherShardingStats(maxOrdinal, canReshard);
     }
 
     private void gatherFieldStats() {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
@@ -67,11 +67,11 @@ public class HollowSetTypeWriteState extends HollowTypeWriteState {
     }
 
     @Override
-    public void prepareForWrite() {
-        super.prepareForWrite();
+    public void prepareForWrite(boolean canReshard) {
+        super.prepareForWrite(canReshard);
 
         maxOrdinal = ordinalMap.maxOrdinal();
-        gatherShardingStats(maxOrdinal);
+        gatherShardingStats(maxOrdinal, canReshard);
         gatherStatistics(numShards != revNumShards);
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -291,7 +291,7 @@ public abstract class HollowTypeWriteState {
         resetToLastNumShards = numShards; // -1 if first cycle else previous numShards. See {@code testNumShardsMaintainedWhenNoResharding}
     }
 
-    public void prepareForWrite() {
+    public void prepareForWrite(boolean canReshard) {
         /// write all of the unused objects to the current ordinalMap, without updating the current cycle bitset,
         /// this way we can do a reverse delta.
         if(isRestored() && !wroteData) {
@@ -437,13 +437,13 @@ public abstract class HollowTypeWriteState {
         return isAllowed;
     }
 
-    protected void gatherShardingStats(int maxOrdinal) {
+    public void gatherShardingStats(int maxOrdinal, boolean canReshard) {
         if(numShards == -1) {
             numShards = typeStateNumShards(maxOrdinal);
             revNumShards = numShards;
         } else {
             revNumShards = numShards;
-            if (allowTypeResharding()) {
+            if (canReshard && allowTypeResharding()) {
                 numShards = typeStateNumShards(maxOrdinal);
                 if (numShards != revNumShards) {    // re-sharding
                     // limit numShards to 2x or .5x of prevShards per producer cycle
@@ -454,7 +454,6 @@ public abstract class HollowTypeWriteState {
                 }
             }
         }
-
         maxShardOrdinal = calcMaxShardOrdinal(maxOrdinal, numShards);
         if (revNumShards > 0) {
             revMaxShardOrdinal = calcMaxShardOrdinal(maxOrdinal, revNumShards);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
@@ -189,7 +189,8 @@ public class HollowWriteStateEngine implements HollowStateEngine {
     /**
      * Transition from the "adding records" phase of a cycle to the "writing" phase of a cycle.
      */
-    public void prepareForWrite() {
+    public void prepareForWrite() { prepareForWrite(false); }
+    protected void prepareForWrite(boolean canReshard) {
 
         if(!preparedForNextCycle)  // this call should be a no-op if we are already prepared for write
             return;
@@ -203,7 +204,7 @@ public class HollowWriteStateEngine implements HollowStateEngine {
                 executor.execute(new Runnable() {
                     @Override
                     public void run() {
-                        typeStateEntry.getValue().prepareForWrite();
+                        typeStateEntry.getValue().prepareForWrite(canReshard);
                     }
                 });
             }


### PR DESCRIPTION
Incr hollow continue-after-restore was triggereing resharding twice in the first runCycle- once when restore calls HollowWriteStateCreator::populateUsingReadEngine which in turns calls prepareForWrite, then again after adding records and triggering populateUsingReadEngine from within runCylce. 

With this change resharding is only invoked in prepareForWrite called from within runCycle.