### PR TITLE
fix: Use thread-safe datastructure in SimultaneousExecutor

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/util/SimultaneousExecutor.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/SimultaneousExecutor.java
@@ -234,11 +234,6 @@ public class SimultaneousExecutor extends ThreadPoolExecutor {
      * Await successful completion of all submitted tasks. Throw exception of the first failed task
      * if 1 or more tasks failed.
      *
-     * If tasks are being submitted concurrently from other threads while
-     * this method executes, the iteration over futures is weakly consistent and may not include
-     * all concurrently submitted tasks. Ideally this method should be called after all the tasks are 
-     * submitted.
-     *
      * After this call completes, the thread pool will be shut down.
      *
      * @throws ExecutionException if a computation threw an
@@ -258,6 +253,11 @@ public class SimultaneousExecutor extends ThreadPoolExecutor {
      * if 1 or more tasks failed.
      *
      * After this call completes, the thread pool will <i>not</i> be shut down and can be reused.
+     * 
+     * If tasks are being submitted concurrently from other threads while
+     * this method executes, the iteration over futures is weakly consistent and may not include
+     * all concurrently submitted tasks. Ideally this method should be called after all the tasks are 
+     * submitted.
      *
      * @throws ExecutionException if a computation threw an
      * exception

--- a/hollow/src/main/java/com/netflix/hollow/core/util/SimultaneousExecutor.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/SimultaneousExecutor.java
@@ -18,8 +18,6 @@ package com.netflix.hollow.core.util;
 
 import static com.netflix.hollow.core.util.Threads.daemonThread;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
@@ -31,10 +29,11 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
- *
  * A convenience wrapper around ThreadPoolExecutor. Provides sane defaults to
  * constructor arguments and allows for awaitUninterruptibly().
- *
+ * 
+ * <p><strong>Internal Use:</strong> This class is intended for internal framework use and
+ * is not meant for external consumption.
  */
 public class SimultaneousExecutor extends ThreadPoolExecutor {
 
@@ -234,6 +233,11 @@ public class SimultaneousExecutor extends ThreadPoolExecutor {
     /**
      * Await successful completion of all submitted tasks. Throw exception of the first failed task
      * if 1 or more tasks failed.
+     *
+     * <p><strong>Note:</strong> If tasks are being submitted concurrently from other threads while
+     * this method executes, the iteration over futures is weakly consistent and may not include
+     * all concurrently submitted tasks. Ideally this method should be called after all the tasks are 
+     * submitted.
      *
      * After this call completes, the thread pool will be shut down.
      *

--- a/hollow/src/main/java/com/netflix/hollow/core/util/SimultaneousExecutor.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/SimultaneousExecutor.java
@@ -21,6 +21,7 @@ import static com.netflix.hollow.core.util.Threads.daemonThread;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -39,7 +40,7 @@ public class SimultaneousExecutor extends ThreadPoolExecutor {
 
     private static final String DEFAULT_THREAD_NAME = "simultaneous-executor";
 
-    private final List<Future<?>> futures = new ArrayList<Future<?>>();
+    private final ConcurrentLinkedQueue<Future<?>> futures = new ConcurrentLinkedQueue<>();
 
     /**
      * Creates an executor with a thread per processor.
@@ -260,11 +261,10 @@ public class SimultaneousExecutor extends ThreadPoolExecutor {
      * while waiting
      */
     public void awaitSuccessfulCompletionOfCurrentTasks() throws InterruptedException, ExecutionException {
-        for(Future<?> f : futures) {
+        Future<?> f;
+        while ((f = futures.poll()) != null) {
             f.get();
         }
-
-        futures.clear();
     }
 
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/util/SimultaneousExecutor.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/SimultaneousExecutor.java
@@ -234,7 +234,7 @@ public class SimultaneousExecutor extends ThreadPoolExecutor {
      * Await successful completion of all submitted tasks. Throw exception of the first failed task
      * if 1 or more tasks failed.
      *
-     * <p><strong>Note:</strong> If tasks are being submitted concurrently from other threads while
+     * If tasks are being submitted concurrently from other threads while
      * this method executes, the iteration over futures is weakly consistent and may not include
      * all concurrently submitted tasks. Ideally this method should be called after all the tasks are 
      * submitted.

--- a/hollow/src/main/java/com/netflix/hollow/core/util/SimultaneousExecutor.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/SimultaneousExecutor.java
@@ -32,8 +32,8 @@ import java.util.concurrent.TimeUnit;
  * A convenience wrapper around ThreadPoolExecutor. Provides sane defaults to
  * constructor arguments and allows for awaitUninterruptibly().
  * 
- * <p><strong>Internal Use:</strong> This class is intended for internal framework use and
- * is not meant for external consumption.
+ * <p><strong>Internal Use:</strong> This class is intended for internal 
+ * framework use and is not meant for external consumption.
  */
 public class SimultaneousExecutor extends ThreadPoolExecutor {
 
@@ -254,10 +254,9 @@ public class SimultaneousExecutor extends ThreadPoolExecutor {
      *
      * After this call completes, the thread pool will <i>not</i> be shut down and can be reused.
      * 
-     * If tasks are being submitted concurrently from other threads while
-     * this method executes, the iteration over futures is weakly consistent and may not include
-     * all concurrently submitted tasks. Ideally this method should be called after all the tasks are 
-     * submitted.
+     * If tasks are being submitted concurrently from other threads while this method executes, 
+     * the iteration over futures is weakly consistent and may not include all concurrently submitted 
+     * tasks. Ideally this method should be called after all the tasks are submitted.
      *
      * @throws ExecutionException if a computation threw an
      * exception


### PR DESCRIPTION
Fixed potential thread-safety issue by using ConcurrentLinkedQueue instead of ArrayList.