### PR TITLE
sort stringified set elements with one field

### DIFF
--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
@@ -136,7 +136,7 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
                 htmlEscapingWriter.append("ERROR: Key " + key + " was not found!");
             } else if (ordinal != null && !ordinal.equals(ORDINAL_NONE)) {
                 HollowStringifier stringifier = "json".equals(req.getParameter("display"))
-                    ? new HollowRecordJsonStringifier() : new HollowRecordStringifier();
+                    ? new HollowRecordJsonStringifier(true, true, true) : new HollowRecordStringifier(false, false, true, true);
                 stringifier.stringify(htmlEscapingWriter, ui.getStateEngine(),
                     getTypeState(req).getSchema().getName(), ordinal);
             }

--- a/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HttpHandlerWithServletSupport.java
+++ b/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HttpHandlerWithServletSupport.java
@@ -305,7 +305,7 @@ public class HttpHandlerWithServletSupport implements HttpHandler {
         Map<String, String[]> parsePostData = new HashMap<>();
 
         try {
-            parsePostData.putAll(HttpUtils.parseQueryString(ex.getRequestURI().getQuery()));
+            parsePostData.putAll(HttpUtils.parseQueryString(ex.getRequestURI().getRawQuery()));
 
             // check if any postdata to parse
             parsePostData.putAll(HttpUtils.parsePostData(inBytes.length, is));

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/AbstractHollowRecordStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/AbstractHollowRecordStringifierTest.java
@@ -24,6 +24,7 @@ import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Set;
 
 /**
  * Code shared between HollowRecordStringifierTest and HollowRecordJsonStringifierTest.
@@ -73,6 +74,21 @@ public class AbstractHollowRecordStringifierTest {
         }
     }
 
+    static class TypeWithSetOfPrimitives {
+        private final Set<TypeWithPrimitive> values;
+
+        public TypeWithSetOfPrimitives(Set<TypeWithPrimitive> values) {
+            this.values = values;
+        }
+    }
+
+    static class TypeWithSetOfStrings {
+        private final Set<TypeWithString> values;
+
+        public TypeWithSetOfStrings(Set<TypeWithString> values) {
+            this.values = values;
+        }
+    }
 
     /**
      * Sends instances of a type through the HollowRecordStringifier. This concatenates records

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
@@ -206,8 +206,35 @@ public class HollowRecordJsonStringifierTest extends AbstractHollowRecordStringi
                 stringifyType(TypeWithString.class, true, false, new TypeWithString(testString)));
     }
 
+    @Test
+    public void testStringifySetOfPrimitives() throws IOException {
+        Assert.assertEquals("Set of primitives should be printed correctly",
+                "[3,200,1000]",
+                stringifyType(TypeWithSetOfPrimitives.class, false, false,
+                        new TypeWithSetOfPrimitives(
+                                new java.util.HashSet<>(Arrays.asList(
+                                        new TypeWithPrimitive(1000),
+                                        new TypeWithPrimitive(200),
+                                        new TypeWithPrimitive(3)
+                                )))));
+    }
+
+    @Test
+    public void testStringifySetOfStrings() throws IOException {
+        Assert.assertEquals("Set of strings should be printed correctly",
+                "[\"a\",\"b\",\"c\"]",
+                stringifyType(TypeWithSetOfStrings.class, false, false,
+                        new TypeWithSetOfStrings(
+                                new java.util.HashSet<>(Arrays.asList(
+                                        new TypeWithString("c"),
+                                        new TypeWithString("a"),
+                                        new TypeWithString("b")
+                                )))));
+    }
+
+
     private static <T> String stringifyType(Class<T> clazz, boolean prettyPrint, boolean expanded, T... instances) throws IOException {
-        HollowRecordJsonStringifier stringifier = new HollowRecordJsonStringifier(prettyPrint, !expanded);
+        HollowRecordJsonStringifier stringifier = new HollowRecordJsonStringifier(prettyPrint, !expanded, true);
         // HollowRecordJsonStringifier stringifier = expanded
         //    ? new HollowRecordJsonStringifier(prettyPrint, false) : new HollowRecordJsonStringifier();
         return stringifyType(clazz, stringifier, instances);

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordStringifierTest.java
@@ -135,6 +135,38 @@ public class HollowRecordStringifierTest extends AbstractHollowRecordStringifier
                         "\n]", writer.toString());
     }
 
+    @Test
+    public void testStringifySetOfPrimitives() throws IOException {
+        Assert.assertEquals("Set of primitives should be printed correctly",
+                "\n  e: 3\n" +
+                        "  e: 200\n" +
+                        "  e: 1000",
+                stringifyType(TypeWithSetOfPrimitives.class,
+                        new HollowRecordStringifier(false, false, true, true),
+                        new TypeWithSetOfPrimitives(
+                                new java.util.HashSet<>(Arrays.asList(
+                                        new TypeWithPrimitive(1000),
+                                        new TypeWithPrimitive(200),
+                                        new TypeWithPrimitive(3)
+                                )))));
+    }
+
+    @Test
+    public void testStringifySetOfStrings() throws IOException {
+        Assert.assertEquals("Set of strings should be printed correctly",
+                "\n  e: a\n" +
+                        "  e: b\n" +
+                        "  e: c",
+                stringifyType(TypeWithSetOfStrings.class,
+                        new HollowRecordStringifier(false, false, true, true),
+                        new TypeWithSetOfStrings(
+                                new java.util.HashSet<>(Arrays.asList(
+                                        new TypeWithString("c"),
+                                        new TypeWithString("a"),
+                                        new TypeWithString("b")
+                                )))));
+    }
+
     private static <T> String stringifyType(Class<T> clazz, boolean expanded, T... instances) throws IOException {
         HollowRecordStringifier stringifier = expanded
             ? new HollowRecordStringifier(true, true, false) : new HollowRecordStringifier();


### PR DESCRIPTION
Stringified set elements are now outputted in sorted order when each
element has exactly one field. Previously the output order was
determined by the element ordinals.

This change only affects the Hollow Explorer UI.