### PR TITLE
handle null pkeys in explorer ui

### DIFF
--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/BrowseSelectedTypePage.java
@@ -167,6 +167,15 @@ public class BrowseSelectedTypePage extends HollowExplorerPage {
                     delimiterEscapedKeyBuilder.append(MULTI_FIELD_KEY_DELIMITER);
                 }
 
+                if (curOrdinal == ORDINAL_NONE) {
+                    // Handle the case where the field is null, display "null"
+                    // as the key so the user can take action on it, while still
+                    // rendering the key's non-null fields.
+                    keyBuilder.append("null");
+                    delimiterEscapedKeyBuilder.append("null");
+                    continue;
+                }
+
                 Object fieldValueObject = HollowReadFieldUtils.fieldValueObject(curState, curOrdinal, fieldPathIndexes[i][fieldPathIndexes[i].length - 1]);
                 keyBuilder.append(fieldValueObject);
                 if (fieldValueObject instanceof String) {


### PR DESCRIPTION
Null primary keys are not supported, however when a null primary key is present, browsing a selected type in the Hollow Explorer UI will fail with an OOB exception.

Handle null primary keys so that they are still displayed in the selected type page, with "NULL" substituted in-place of missing fields.