### PR TITLE
throw null ptr exception when constructing null pkey idx

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -625,12 +625,20 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         HollowObjectTypeReadState typeState = this.typeState;
         HollowObjectSchema schema = typeState.getSchema();
 
+        int parentOrdinal = ordinal;
         int lastFieldPath = fieldPathIndexes[fieldIdx].length - 1;
         for(int i=0;i<lastFieldPath;i++) {
             int fieldPosition = fieldPathIndexes[fieldIdx][i];
             ordinal = typeState.readOrdinal(ordinal, fieldPosition);
             typeState = (HollowObjectTypeReadState) schema.getReferencedTypeState(fieldPosition); //This causes an incompatibility with object longevity.
             schema = typeState.getSchema();
+        }
+
+        if (ordinal == ORDINAL_NONE) {
+            HollowObjectSchema parentSchema =  this.typeState.getSchema();
+            throw new NullPointerException("Cannot hash null field " +
+                    parentSchema.getFieldName(fieldIdx) + " in type " +
+                    parentSchema.getName() + " at ordinal " + parentOrdinal);
         }
 
         int hashCode = HollowReadFieldUtils.fieldHashCode(typeState, ordinal, fieldPathIndexes[fieldIdx][lastFieldPath]);

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndexTest.java
@@ -335,6 +335,19 @@ public class HollowPrimaryKeyIndexTest extends AbstractStateEngineTest {
         Assert.assertEquals(0, validPki.getMatchingOrdinal(1L));
     }
 
+
+    @Test
+    public void testNullPKeyIdx() throws IOException {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+        mapper.add(new TypeNullPKey());
+        roundTripSnapshot();
+
+        try {
+            HollowPrimaryKeyIndex invalidPkIdx = new HollowPrimaryKeyIndex(this.readStateEngine, "TypeNullPKey", "id");
+            fail("Index on type with null fields is expected to fail construction");
+        } catch (NullPointerException e) {}
+    }
+
     private static void addDataForDupTesting(HollowWriteStateEngine writeStateEngine, int a1Start, double a2, int size) {
         TypeB typeB = new TypeB("commonTypeB");
         HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
@@ -377,6 +390,15 @@ public class HollowPrimaryKeyIndexTest extends AbstractStateEngineTest {
         public TypeB(String b1, boolean isDuplicate) {
             this.b1 = b1;
             this.isDuplicate = isDuplicate;
+        }
+    }
+
+    @HollowPrimaryKey(fields = {"id"})
+    private static class TypeNullPKey {
+        private final Long id;
+
+        public TypeNullPKey() {
+            this.id = null;
         }
     }
 


### PR DESCRIPTION
When constructing a primary key index where a referenced key field
contains a null value, an array out of bounds exception would be thrown:

```
java.lang.ArrayIndexOutOfBoundsException: 0
```

Now, throw a null pointer exception instead, with information detailing
the type, field and ordinal:

```
java.lang.NullPointerException: Cannot hash null field id in type Movie at ordinal 0
```