### PR TITLE
add top level schema page in explorer ui

### DIFF
--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
@@ -21,8 +21,9 @@ import static com.netflix.hollow.ui.HollowDiffUtil.formatBytes;
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
-import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchemaUtil;
 import com.netflix.hollow.explorer.ui.HollowExplorerUI;
 import com.netflix.hollow.explorer.ui.model.TypeOverview;
 import com.netflix.hollow.ui.HollowUISession;
@@ -47,7 +48,7 @@ public class ShowAllTypesPage extends HollowExplorerPage {
         String sort = req.getParameter("sort") == null ? "primaryKey" : req.getParameter("sort");
         
         List<TypeOverview> typeOverviews = new ArrayList<TypeOverview>();
-        
+
         for(HollowTypeReadState typeState : ui.getStateEngine().getTypeStates()) {
             String typeName = typeState.getSchema().getName();
             BitSet populatedOrdinals = typeState.getPopulatedOrdinals();
@@ -58,7 +59,7 @@ public class ShowAllTypesPage extends HollowExplorerPage {
             long approxHeapFootprint = typeState.getApproximateHeapFootprintInBytes();
             HollowSchema schema = typeState.getSchema();
             int numShards = typeState.numShards();
-            
+
             typeOverviews.add(new TypeOverview(typeName, numRecords, numHoles, approxHoleFootprint, approxHeapFootprint, primaryKey, schema, numShards));
         }
 
@@ -109,6 +110,7 @@ public class ShowAllTypesPage extends HollowExplorerPage {
         ctx.put("totalHoleFootprint", totalApproximateHoleFootprint(typeOverviews));
         ctx.put("totalHeapFootprint", totalApproximateHeapFootprint(typeOverviews));
         ctx.put("typeOverviews", typeOverviews);
+        ctx.put("topLevelTypes", HollowSchemaUtil.getTopLevelTypes(ui.getStateEngine()));
     }
 
     @Override

--- a/hollow-explorer-ui/src/main/resources/browse-schema.vm
+++ b/hollow-explorer-ui/src/main/resources/browse-schema.vm
@@ -14,9 +14,10 @@
  *     limitations under the License.
 *#
 
-<b>TYPE:</b> &nbsp;&nbsp; <span style="font-family: monospace;">$esc.html($schemaDisplay.getSchema().getName())</span>
-
-#showSchema($schemaDisplay "")
+#foreach($schemaDisplay in $schemaDisplays)
+	<b>TYPE:</b> &nbsp;&nbsp; <span style="font-family: monospace;">$esc.html($schemaDisplay.getSchema().getName())</span>
+	#showSchema($schemaDisplay)
+#end
 
 #macro(showSchema $schemaDisplay)
 	
@@ -28,9 +29,11 @@
 				<span style="font-family: monospace;">
 					#if($field.getReferencedType())
 						#if($field.getReferencedType().isExpanded())
-							<a href="$basePath/schema?type=$esc.url($type)&collapse=$esc.url($field.getFieldPath())">$esc.html($field.getFieldName())</a>
+							<a href="$basePath/schema?#foreach($t in $type)type=$esc.url($t)#if($foreach.hasNext)&amp;
+#end#end&collapse=$esc.url($field.getFieldPath())">$esc.html($field.getFieldName())</a>
 						#else
-							<a href="$basePath/schema?type=$esc.url($type)&expand=$esc.url($field.getFieldPath())">$esc.html($field.getFieldName())</a>
+							<a href="$basePath/schema?#foreach($t in $type)type=$esc.url($t)#if($foreach.hasNext)&amp;
+#end#end&expand=$esc.url($field.getFieldPath())">$esc.html($field.getFieldName())</a>
 						#end
 						
 						($esc.html($field.getReferencedType().getTypeName()) - $esc.html($field.getReferencedType().getSchema().getSchemaType()))

--- a/hollow-explorer-ui/src/main/resources/explorer-header.vm
+++ b/hollow-explorer-ui/src/main/resources/explorer-header.vm
@@ -34,10 +34,15 @@
 			#end
 			#if($stateVersion)
 				<td class="nav">[ State Version: $stateVersion ]</td>
-			#end			
-			#if($type)
+			#end
+			## When $type is defined and is not a list, display links to browse
+			## data and schema for that type.
+			#if($type && !($type.size() > 0))
 				<td class="nav">[ Type: <span style="font-family: monospace;">$esc.html($type)</span> ]</td>
 				<td class="nav">[ <a href="$basePath/type?type=$esc.url($type)">Browse Data</a> | <a href="$basePath/schema?type=$esc.url($type)">Browse Schema</a> ]</td>
+			#end
+			#if(!$type && $topLevelTypes && $topLevelTypes.size() > 0)
+				<td class="nav">[ <a href="$basePath/schema?#foreach($t in $topLevelTypes)type=$esc.url($t)#if($foreach.hasNext)&amp;#end#end">Browse Top Level Schemas</a> ]</td>
 			#end
 			<td class="nav">[ <a href="$basePath/query">SEARCH</a> ]</td>
 		</tr>

--- a/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HttpHandlerWithServletSupport.java
+++ b/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HttpHandlerWithServletSupport.java
@@ -164,6 +164,11 @@ public class HttpHandlerWithServletSupport implements HttpHandler {
         }
 
         @Override
+        public String[] getParameterValues(String name) {
+            return postData.get(name);
+        }
+
+        @Override
         public Map<String, String[]> getParameterMap() {
             return postData;
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaUtil.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaUtil.java
@@ -1,0 +1,48 @@
+package com.netflix.hollow.core.schema;
+
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.engine.HollowTypeReadState;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class HollowSchemaUtil {
+
+    /* *
+     * Finds the top-level types in the Hollow dataset. A top-level type is one that is not a
+     * reference from another type, i.e., it is not an element of a list, set, or map, nor is it
+     * a field in an object schema.
+     *
+     * @return a set of top-level type names
+     */
+    public static Set<String> getTopLevelTypes(HollowReadStateEngine readState) {
+        List<HollowSchema> schemas = readState.getSchemas();
+        Set<String> topLevelTypes = new HashSet<>(readState.getAllTypes());
+        for (HollowSchema schema : schemas) {
+            switch (schema.getSchemaType()) {
+                case LIST:
+                    HollowListSchema listSchema = (HollowListSchema) schema;
+                    topLevelTypes.remove(listSchema.getElementType());
+                    break;
+                case SET:
+                    HollowSetSchema setSchema = (HollowSetSchema) schema;
+                    topLevelTypes.remove(setSchema.getElementType());
+                    break;
+                case MAP:
+                    HollowMapSchema mapSchema = (HollowMapSchema) schema;
+                    topLevelTypes.remove(mapSchema.getKeyType());
+                    topLevelTypes.remove(mapSchema.getValueType());
+                    break;
+                case OBJECT:
+                    HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
+                    for (int fieldIdx=0; fieldIdx < objectSchema.numFields(); fieldIdx++) {
+                        if (objectSchema.getFieldType(fieldIdx) == HollowObjectSchema.FieldType.REFERENCE) {
+                            topLevelTypes.remove(objectSchema.getReferencedType(fieldIdx));
+                        }
+                    }
+            }
+        }
+        return topLevelTypes;
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/schema/HollowTopLevelTypesTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/schema/HollowTopLevelTypesTest.java
@@ -1,0 +1,87 @@
+package com.netflix.hollow.core.schema;
+
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.test.InMemoryBlobStore;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+public class HollowTopLevelTypesTest {
+
+    @Test
+    public void testHollowTopLevelTypes() throws IOException {
+        HollowProducer p = HollowProducer.withPublisher(new InMemoryBlobStore())
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        TypeWithPrimitive primitive = new TypeWithPrimitive();
+        TypeWithReference reference = new TypeWithReference();
+        TypeWithSetOfReference setOfReference = new TypeWithSetOfReference();
+
+        p.runCycle(cycle -> {
+            cycle.add(reference);
+        });
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(p.getWriteEngine(), readStateEngine);
+        Assert.assertEquals(
+                new HashSet<String>() {{
+                    add("TypeWithPrimitive");
+                    add("TypeWithReference");
+                }},
+                readStateEngine.getAllTypes());
+        Assert.assertEquals(
+                new HashSet<String>() {{
+                    add("TypeWithReference");
+                }},
+                HollowSchemaUtil.getTopLevelTypes(readStateEngine));
+
+        // Add a new type with a set of TypeWithReference, now only
+        // TypeWithSetOfReference should be a top-level type.
+        p.runCycle(cycle -> {
+            cycle.add(setOfReference);
+        });
+        StateEngineRoundTripper.roundTripSnapshot(p.getWriteEngine(), readStateEngine);
+        Assert.assertEquals(
+                new HashSet<String>() {{
+                    add("TypeWithPrimitive");
+                    add("TypeWithReference");
+                    add("TypeWithSetOfReference");
+                    add("SetOfTypeWithReference");
+                }},
+                readStateEngine.getAllTypes());
+        Assert.assertEquals(
+                new HashSet<String>() {{
+                    add("TypeWithSetOfReference");
+                }},
+                HollowSchemaUtil.getTopLevelTypes(readStateEngine));
+    }
+
+    private static class TypeWithSetOfReference {
+        private final HashSet<TypeWithReference> set;
+
+        public TypeWithSetOfReference() {
+            this.set = new HashSet<>();
+        }
+    }
+
+    private static class TypeWithPrimitive {
+        private final int value;
+
+        public TypeWithPrimitive() {
+            this.value = 0;
+        }
+    }
+
+    private static class TypeWithReference {
+        private final TypeWithPrimitive primitive ;
+
+        public TypeWithReference() {
+            this.primitive = new TypeWithPrimitive();
+        }
+    }
+}


### PR DESCRIPTION
Clicking on `Browse Top Level Schemas` will return a schema page with all of the top level schemas. A top level schema is not referenced by any other schema.

As part of this change, the `BrowseSchemaPage` was updated to support displaying multiple types.