### PR TITLE
add null primary key validator

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/NullPrimaryKeyFieldValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/NullPrimaryKeyFieldValidator.java
@@ -1,0 +1,180 @@
+package com.netflix.hollow.api.producer.validation;
+
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.core.index.key.PrimaryKey;
+import com.netflix.hollow.core.read.HollowReadFieldUtils;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+import com.netflix.hollow.core.write.objectmapper.HollowTypeMapper;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
+
+/**
+ * A validator that fails if any records of a given type have null primary key fields.
+ * <p>
+ * The primary key may be declared on a data model class using the {@link HollowPrimaryKey} annotation, may be
+ * declared more directly using {@link PrimaryKey} with {@link HollowObjectSchema}, or declared explicitly when
+ * instantiating this validator.
+ */
+public class NullPrimaryKeyFieldValidator implements ValidatorListener {
+    private static final String NAME = NullPrimaryKeyFieldValidator.class.getName();
+    private static final String NULL_PRIMARY_KEYS_FOUND_ERROR_MSG_FORMAT =
+            "Null primary key fields found for type %s. Primary Key in schema is %s. "
+                    + "Null records: [%s]";
+    private static final String NO_PRIMARY_KEY_ERROR_MSG_FORMAT =
+            "NullPrimaryKeyFieldValidator defined but unable to find primary key for data type %s. "
+                    + "Please check schema definition.";
+
+    private static final String NO_SCHEMA_FOUND_MSG_FORMAT =
+            "NullPrimaryKeyFieldValidator defined for data type %s but schema not found. "
+                    + "Please check that the HollowProducer is initialized with "
+                    + "the data type's schema (see initializeDataModel)";
+    private static final String NOT_AN_OBJECT_ERROR_MSG_FORMAT =
+            "NullPrimaryKeyFieldValidator is defined but schema type of %s is not Object. "
+                    + "This validation cannot be done.";
+
+    private static final String FIELD_PATH_NAME = "FieldPaths";
+    private static final String DATA_TYPE_NAME = "Typename";
+
+    private final String dataTypeName;
+
+    /**
+     * Creates a validator to detect records with null primary key fields for the type
+     * that corresponds to the given data type class annotated with {@link HollowPrimaryKey}.
+     *
+     * @param dataType the data type class
+     * @throws IllegalArgumentException if the data type class is not annotated with {@link HollowPrimaryKey}
+     */
+    public NullPrimaryKeyFieldValidator(Class<?> dataType) {
+        Objects.requireNonNull(dataType);
+
+        if (!dataType.isAnnotationPresent(HollowPrimaryKey.class)) {
+            throw new IllegalArgumentException("The data class " +
+                    dataType.getName() +
+                    " must be annotated with @HollowPrimaryKey");
+        }
+
+        this.dataTypeName = HollowTypeMapper.getDefaultTypeName(dataType);
+    }
+
+    /**
+     * Creates a validator to detect records with null primary keys of the type
+     * that corresponds to the given data type class annotated with {@link HollowPrimaryKey}.
+     * <p>
+     * The validator will fail, when {@link #onValidate validating}, if a schema with a
+     * primary key definition does not exist for the given data type name.
+     *
+     * @param dataTypeName the data type name
+     */
+    public NullPrimaryKeyFieldValidator(String dataTypeName) {
+        this.dataTypeName = Objects.requireNonNull(dataTypeName);
+    }
+
+    @Override
+    public String getName() {
+        return NAME + "_" + dataTypeName;
+    }
+
+    @Override
+    public ValidationResult onValidate(HollowProducer.ReadState readState) {
+        ValidationResult.ValidationResultBuilder vrb = ValidationResult.from(this);
+        vrb.detail(DATA_TYPE_NAME, dataTypeName);
+
+        PrimaryKey primaryKey;
+        HollowSchema schema = readState.getStateEngine().getSchema(dataTypeName);
+        if (schema == null) {
+            return vrb.failed(String.format(NO_SCHEMA_FOUND_MSG_FORMAT, dataTypeName));
+        }
+        if (schema.getSchemaType() != HollowSchema.SchemaType.OBJECT) {
+            return vrb.failed(String.format(NOT_AN_OBJECT_ERROR_MSG_FORMAT, dataTypeName));
+        }
+
+        HollowObjectSchema oSchema = (HollowObjectSchema) schema;
+        primaryKey = oSchema.getPrimaryKey();
+        if (primaryKey == null) {
+            return vrb.failed(String.format(NO_PRIMARY_KEY_ERROR_MSG_FORMAT, dataTypeName));
+        }
+
+        String fieldPaths = Arrays.toString(primaryKey.getFieldPaths());
+        vrb.detail(FIELD_PATH_NAME, fieldPaths);
+
+        Map<Integer, Object[]> ordinalToNullPkey = getNullPrimaryKeyValues(readState, primaryKey);
+        if (!ordinalToNullPkey.isEmpty()) {
+            return vrb.failed(String.format(NULL_PRIMARY_KEYS_FOUND_ERROR_MSG_FORMAT,
+                    dataTypeName, fieldPaths,
+                    nullKeysToString(ordinalToNullPkey)));
+        }
+
+        return vrb.passed(getName() + "no records with null primary key fields");
+    }
+
+    private Map<Integer, Object[]> getNullPrimaryKeyValues(HollowProducer.ReadState readState, PrimaryKey primaryKey) {
+        HollowReadStateEngine stateEngine = readState.getStateEngine();
+        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) stateEngine.getTypeState(dataTypeName);
+
+        int[][] fieldPathIndexes = new int[primaryKey.getFieldPaths().length][];
+        for (int i = 0; i < fieldPathIndexes.length; i++) {
+            fieldPathIndexes[i] = primaryKey.getFieldPathIndex(stateEngine, i);
+        }
+
+        BitSet ordinals = typeState.getPopulatedOrdinals();
+        int ordinal = ordinals.nextSetBit(0);
+        Map<Integer, Object[]> ordinalToNullPkey = new HashMap<>();
+        while (ordinal != ORDINAL_NONE) {
+            Object[] primaryKeyValues = getPrimaryKeyValue(typeState, fieldPathIndexes, ordinal);
+            if (Arrays.stream(primaryKeyValues).anyMatch(Objects::isNull)) {
+                ordinalToNullPkey.put(ordinal, primaryKeyValues);
+            }
+            ordinal = ordinals.nextSetBit(ordinal + 1);
+        }
+        return ordinalToNullPkey;
+    }
+
+    private Object[] getPrimaryKeyValue(HollowObjectTypeReadState typeState, int[][] fieldPathIndexes, int ordinal) {
+        Object[] results = new Object[fieldPathIndexes.length];
+        for (int i = 0; i < fieldPathIndexes.length; i++) {
+            results[i] = getPrimaryKeyFieldValue(typeState, fieldPathIndexes[i], ordinal);
+        }
+
+        return results;
+    }
+
+    private Object getPrimaryKeyFieldValue(HollowObjectTypeReadState typeState, int[] fieldPathIndexes, int ordinal) {
+        HollowObjectSchema schema = typeState.getSchema();
+        int lastFieldPath = fieldPathIndexes.length - 1;
+        for (int i = 0; i < lastFieldPath; i++) {
+            if (ordinal == ORDINAL_NONE) {
+                // The ordinal must have referenced a null record.
+                return null;
+            }
+            ordinal = typeState.readOrdinal(ordinal, fieldPathIndexes[i]);
+            typeState = (HollowObjectTypeReadState) schema.getReferencedTypeState(fieldPathIndexes[i]);
+            schema = typeState.getSchema();
+        }
+
+        if (ordinal == ORDINAL_NONE) {
+            // The ordinal must have referenced a record with a null value for this field.
+            return null;
+        }
+
+        return HollowReadFieldUtils.fieldValueObject(typeState, ordinal, fieldPathIndexes[lastFieldPath]);
+    }
+
+    private String nullKeysToString(Map<Integer, Object[]> nullPrimaryKeyValues) {
+        return nullPrimaryKeyValues.entrySet().stream()
+                .map(entry -> {
+                    return "(ordinal=" + entry.getKey() + ", key=" + Arrays.toString(entry.getValue()) + ")";
+                })
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/NullPrimaryKeyFieldValidatorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/NullPrimaryKeyFieldValidatorTest.java
@@ -1,0 +1,194 @@
+package com.netflix.hollow.api.producer.validation;
+
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+import com.netflix.hollow.test.InMemoryBlobStore;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NullPrimaryKeyFieldValidatorTest {
+    private InMemoryBlobStore blobStore;
+
+    @Before
+    public void setUp() {
+        blobStore = new InMemoryBlobStore();
+    }
+
+    @Test
+    public void testValidPrimaryKey() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new NullPrimaryKeyFieldValidator(TypeWithSinglePrimaryKey.class)).build();
+        try {
+            producer.runCycle(state -> {
+                TypeWithSinglePrimaryKey nullSinglePrimaryKey = new TypeWithSinglePrimaryKey(1);
+                state.add(nullSinglePrimaryKey);
+            });
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testInvalidNoSchema() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new NullPrimaryKeyFieldValidator(TypeWithSinglePrimaryKey.class)).build();
+        try {
+            producer.runCycle(state -> {
+                state.add("hello");
+            });
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof ValidationStatusException);
+            ValidationStatusException expected = (ValidationStatusException) e;
+            assertEquals(1, expected.getValidationStatus().getResults().size());
+            assertEquals("NullPrimaryKeyFieldValidator defined for data type TypeWithSinglePrimaryKey "+
+                            "but schema not found. Please check that the HollowProducer is initialized "+
+                            "with the data type's schema (see initializeDataModel)",
+                    expected.getValidationStatus().getResults().get(0).getMessage());
+        }
+    }
+
+    @Test
+    public void testInvalidNoPrimaryKey() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new NullPrimaryKeyFieldValidator("TypeWithoutPrimaryKey")).build();
+        try {
+            producer.runCycle(state -> {
+                state.add(new TypeWithoutPrimaryKey(1));
+            });
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof ValidationStatusException);
+            ValidationStatusException expected = (ValidationStatusException) e;
+            assertEquals(1, expected.getValidationStatus().getResults().size());
+            assertEquals("NullPrimaryKeyFieldValidator defined but unable to find primary key "+
+                            "for data type TypeWithoutPrimaryKey. Please check schema definition.",
+                    expected.getValidationStatus().getResults().get(0).getMessage());
+        }
+    }
+
+    @Test
+    public void testInvalidNullSinglePrimaryKey() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new NullPrimaryKeyFieldValidator(TypeWithSinglePrimaryKey.class)).build();
+        try {
+            producer.runCycle(state -> {
+                TypeWithSinglePrimaryKey nullSinglePrimaryKey = new TypeWithSinglePrimaryKey(null);
+                state.add(nullSinglePrimaryKey);
+            });
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof ValidationStatusException);
+            ValidationStatusException expected = (ValidationStatusException) e;
+            assertEquals(1, expected.getValidationStatus().getResults().size());
+            assertEquals("Null primary key fields found for type TypeWithSinglePrimaryKey. "+
+                    "Primary Key in schema is [id]. Null records: [(ordinal=0, key=[null])]",
+                    expected.getValidationStatus().getResults().get(0).getMessage());
+        }
+    }
+
+    @Test
+    public void testInvalidNullMultiPrimaryKeys() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new NullPrimaryKeyFieldValidator(TypeWithMultiplePrimaryKeys.class)).build();
+        try {
+            producer.runCycle(state -> {
+                TypeWithMultiplePrimaryKeys nullMultiPrimaryKey = new TypeWithMultiplePrimaryKeys(1, null);
+                state.add(nullMultiPrimaryKey);
+            });
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof ValidationStatusException);
+            ValidationStatusException expected = (ValidationStatusException) e;
+            assertEquals(1, expected.getValidationStatus().getResults().size());
+            assertEquals("Null primary key fields found for type TypeWithMultiplePrimaryKeys. "+
+                            "Primary Key in schema is [id, name]. Null records: [(ordinal=0, key=[1, null])]",
+                    expected.getValidationStatus().getResults().get(0).getMessage());
+        }
+    }
+
+    @Test
+    public void testInvalidNullNestedPrimaryKey() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new NullPrimaryKeyFieldValidator(TypeWithNestedPrimaryKey.class)).build();
+
+        // Case where the referenced object itself is null.
+        try {
+            producer.runCycle(state -> {
+                TypeWithNestedPrimaryKey nestedPrimaryKey = new TypeWithNestedPrimaryKey(null);
+                state.add(nestedPrimaryKey);
+            });
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof ValidationStatusException);
+            ValidationStatusException expected = (ValidationStatusException) e;
+            assertEquals(1, expected.getValidationStatus().getResults().size());
+            assertEquals("Null primary key fields found for type TypeWithNestedPrimaryKey. "+
+                            "Primary Key in schema is [nested.id]. Null records: [(ordinal=0, key=[null])]",
+                    expected.getValidationStatus().getResults().get(0).getMessage());
+        }
+
+        // Case where the nested object key field is null.
+        try {
+            producer.runCycle(state -> {
+                TypeWithNestedPrimaryKey nestedPrimaryKey = new TypeWithNestedPrimaryKey(new TypeWithoutPrimaryKey(null));
+                state.add(nestedPrimaryKey);
+            });
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof ValidationStatusException);
+            ValidationStatusException expected = (ValidationStatusException) e;
+            assertEquals(1, expected.getValidationStatus().getResults().size());
+            assertEquals("Null primary key fields found for type TypeWithNestedPrimaryKey. "+
+                            "Primary Key in schema is [nested.id]. Null records: [(ordinal=0, key=[null])]",
+                    expected.getValidationStatus().getResults().get(0).getMessage());
+        }
+    }
+
+
+    @HollowPrimaryKey(fields = "id")
+    static class TypeWithSinglePrimaryKey {
+        private final Integer id;
+
+        public TypeWithSinglePrimaryKey(Integer id) {
+            this.id = id;
+        }
+    }
+
+    @HollowPrimaryKey(fields = {"id", "name"})
+    static class TypeWithMultiplePrimaryKeys {
+        private final Integer id;
+        private final String name;
+
+        public TypeWithMultiplePrimaryKeys(Integer id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    @HollowPrimaryKey(fields = {"nested.id"})
+    static class TypeWithNestedPrimaryKey {
+        private final TypeWithoutPrimaryKey nested;
+
+        public TypeWithNestedPrimaryKey(TypeWithoutPrimaryKey nested) {
+            this.nested = nested;
+        }
+    }
+
+    static class TypeWithoutPrimaryKey {
+        private final Integer id;
+
+        public TypeWithoutPrimaryKey(Integer id) {
+            this.id = id;
+        }
+    }
+}


### PR DESCRIPTION
Null primary keys are not supported. Add a validator which can be used to detect when a record with a null primary key field is produced.