### PR TITLE
add max blob age to local filesystem blob retriever

### DIFF
--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/LocalBlobStoreTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/LocalBlobStoreTest.java
@@ -6,6 +6,7 @@ import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.Collections;
 
 import com.netflix.hollow.test.InMemoryBlobStore;
@@ -81,7 +82,79 @@ public class LocalBlobStoreTest {
         assertNDeltas(1, localDir);
         assertNDeltas(1, "LONG", localDir);
     }
-    
+
+    @Test
+    public void testBlobStoreOverrideLowMaxBlobAge() throws Exception {
+        File localDir = createLocalDir();
+        InMemoryBlobStore bs = new InMemoryBlobStore();
+
+        HollowProducer producer = HollowProducer.withPublisher(bs)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = producer.runCycle(ws -> {
+            ws.add(1);
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(bs)
+                .withLocalBlobStore(localDir, true, Duration.ofNanos(0)).build();
+        consumer.triggerRefreshTo(v1);
+        Assert.assertEquals(v1, consumer.getCurrentVersionId());
+        assertNSnapshots(1, localDir);
+        Assert.assertEquals(v1, getLastSnapshotVersion(localDir));
+
+        long v2 = producer.runCycle(ws -> {
+            ws.add(2);
+        });
+
+        consumer = HollowConsumer.withBlobRetriever(bs)
+                .withLocalBlobStore(localDir, true, Duration.ofNanos(0)).build();
+        consumer.triggerRefreshTo(v2);
+
+        Assert.assertEquals(v2, consumer.getCurrentVersionId());
+        assertNSnapshots(1, localDir);
+        // Since the max blob age is 0, we don't expect the stale snapshot to be used,
+        // so there should be a new snapshot pulled with the latest version.
+        assertNDeltas(0, localDir);
+        Assert.assertEquals(v2, getLastSnapshotVersion(localDir));
+    }
+
+    @Test
+    public void testBlobStoreOverrideHighMaxBlobAge() throws Exception {
+        File localDir = createLocalDir();
+        InMemoryBlobStore bs = new InMemoryBlobStore();
+
+        HollowProducer producer = HollowProducer.withPublisher(bs)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v1 = producer.runCycle(ws -> {
+            ws.add(1);
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(bs)
+                .withLocalBlobStore(localDir, true, Duration.ofDays(10)).build();
+        consumer.triggerRefreshTo(v1);
+        Assert.assertEquals(v1, consumer.getCurrentVersionId());
+        assertNSnapshots(1, localDir);
+        Assert.assertEquals(v1, getLastSnapshotVersion(localDir));
+
+        long v2 = producer.runCycle(ws -> {
+            ws.add(2);
+        });
+
+        consumer = HollowConsumer.withBlobRetriever(bs)
+                .withLocalBlobStore(localDir, true, Duration.ofDays(10)).build();
+        consumer.triggerRefreshTo(v2);
+
+        Assert.assertEquals(v2, consumer.getCurrentVersionId());
+        assertNSnapshots(1, localDir);
+        assertNDeltas(1, localDir);
+        // Since the max blob age is high, we expect the stale snapshot
+        // to be used along with a delta.
+        Assert.assertEquals(v1, getLastSnapshotVersion(localDir));
+    }
+
     @Test
     public void testBlobStoreOverrideOptionalPartNotLoaded() throws Exception {
         File localDir = createLocalDir();
@@ -134,6 +207,14 @@ public class LocalBlobStoreTest {
         long nSnapshots = Files.list(localDir.toPath()).filter(p -> p.getFileName().toString().startsWith("snapshot-"))
                 .count();
         Assert.assertEquals(n, nSnapshots);
+    }
+
+    static long getLastSnapshotVersion(File localDir) throws IOException {
+        return Files.list(localDir.toPath())
+                .filter(p -> p.getFileName().toString().startsWith("snapshot-"))
+                .mapToLong(p -> Long.parseLong(p.getFileName().toString().split("-")[1]))
+                .max()
+                .orElseThrow(() -> new IOException("No snapshots found in directory: " + localDir));
     }
 
     static void assertNDeltas(int n, File localDir) throws IOException {


### PR DESCRIPTION
Add `existingBlobMaxAge` to the local filesystem blob retriever, used in local development. When `existingBlobMaxAge` is configured, local blobs older than the conigured duration will be deleted and not used when retrieivng snapshot/header/delta blobs.