### PR TITLE
Set the secure flag on UI cookies when the request is secure

### DIFF
--- a/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HollowUISession.java
+++ b/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HollowUISession.java
@@ -70,6 +70,7 @@ public class HollowUISession {
         if(sessionId == null) {
             sessionId = new Random().nextLong() & Long.MAX_VALUE;
             Cookie cookie = new Cookie("hollowUISessionId", sessionId.toString());
+            cookie.setSecure(req.isSecure());
             cookie.setComment(HTTP_ONLY_COMMENT);
             resp.addCookie(cookie);
         }

--- a/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HttpHandlerWithServletSupport.java
+++ b/hollow-ui-tools/src/main/java/com/netflix/hollow/ui/HttpHandlerWithServletSupport.java
@@ -88,6 +88,7 @@ public class HttpHandlerWithServletSupport implements HttpHandler {
         @Override
         public Cookie[] getCookies() {
             Headers headers = ex.getRequestHeaders();
+            boolean isSecure = "https".equals(ex.getProtocol());
             if (headers != null) {
                 List<String> strCookies = headers.get("Cookie");
                 if (strCookies != null) {
@@ -97,7 +98,9 @@ public class HttpHandlerWithServletSupport implements HttpHandler {
                         for (String token : tokens) {
                             String[] keyVal = token.split("\\s*=\\s*");
                             if(keyVal.length == 2){
-                                cookies.add(new Cookie(keyVal[0], keyVal[1]));
+                                Cookie cookie = new Cookie(keyVal[0], keyVal[1]);
+                                cookie.setSecure(isSecure);
+                                cookies.add(cookie);
                             }
                         }
                    }


### PR DESCRIPTION
Hello esteemed hollow maintainers!

Amazon's internal infosec policies dictate that all cookies need to set the secure flag for sites served by `https`, and hollow library code was flagged as being in violation of this policy.

I've raised this PR to ensure that secure cookies are used when the diff and explorer UIs are served from `https` endpoints. This should make the hollow web UIs more secure in production environments while still enabling standing up quick localhost instances of the UIs.