### PR TITLE
[Fix] the previous button can be missing when viewing diffs;

### DIFF
--- a/hollow-diff-ui/src/main/resources/diff-field.vm
+++ b/hollow-diff-ui/src/main/resources/diff-field.vm
@@ -22,7 +22,7 @@
     </a><br/>
 #end
 
-#if($previousDiffPairPageBeginIdx)
+#if($previousDiffPairPageBeginIdx >= 0)
     <a href="$path/fielddiff?type=$typeDiff.getTypeName()&fieldIdx=$fieldIdx&diffPairBeginIdx=$previousDiffPairPageBeginIdx#objectDiffs">&lt;&lt; Previous</a>
 #end
 #if($nextDiffPairPageBeginIdx)

--- a/hollow-diff-ui/src/main/resources/diff-type.vm
+++ b/hollow-diff-ui/src/main/resources/diff-type.vm
@@ -53,7 +53,7 @@ Number of Fields With Diffs: $typeDiff.getFieldDiffs().size() <br/>
     </a><br/>
 #end
 
-#if($previousDiffPairPageBeginIdx)
+#if($previousDiffPairPageBeginIdx >= 0)
     <a href="$path/typediff?type=$typeDiff.getTypeName()&diffPairBeginIdx=$previousDiffPairPageBeginIdx#objectDiffs">&lt;&lt; Previous</a>
 #end
 #if($nextDiffPairPageBeginIdx)
@@ -76,7 +76,7 @@ Number of Fields With Diffs: $typeDiff.getFieldDiffs().size() <br/>
                     $object.getDisplayKey()
                 </a><br/>           
             #end
-            #if($previousUnmatchedFromPageBeginIdx)
+            #if($previousUnmatchedFromPageBeginIdx >= 0)
                 <a href="$path/typediff?type=$typeDiff.getTypeName()&unmatchedFromBeginIdx=$previousUnmatchedFromPageBeginIdx#unmatchedObjects">&lt;&lt; Previous</a>
             #end
             #if($nextUnmatchedFromPageBeginIdx)
@@ -90,7 +90,7 @@ Number of Fields With Diffs: $typeDiff.getFieldDiffs().size() <br/>
                     $object.getDisplayKey()
                 </a><br/>        
             #end
-            #if($previousUnmatchedToPageBeginIdx)
+            #if($previousUnmatchedToPageBeginIdx >= 0)
                 <a href="$path/typediff?type=$typeDiff.getTypeName()&unmatchedToBeginIdx=$previousUnmatchedToPageBeginIdx#unmatchedObjects">&lt;&lt; Previous</a>
             #end
             #if($nextUnmatchedToPageBeginIdx)


### PR DESCRIPTION
Fix a trivial bug, when create diff UI views using `HollowDiffUIServer`, the "previous" button can be missing when viewing diffs.
