### PR TITLE
[To Be Deprecated]: modify data explorer and history page headers to carry more values;

### DIFF
--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/HollowHistoryUI.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/HollowHistoryUI.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -63,6 +64,15 @@ public class HollowHistoryUI extends HollowUIRouter implements HollowRecordDiffU
     private final TimeZone timeZone;
 
     private String[] overviewDisplayHeaders;
+    /** General purpose map to store header string and corresponding values used in HollowExplorer. It also stores headerDisplayString
+     *  for backwards compatibility.
+     *  use thread-safe map as value writer and renders may perform concurrent reads/writes.
+     **/
+    private final ConcurrentHashMap<String, String> commonHeadersDisplayMap = new ConcurrentHashMap<>();
+    private final static String HEADER_DISPLAY_NAMESPACE = "headerDisplayNamespace";
+    private final static String HEADER_DISPLAY_ENV="headerDisplayEnv";
+    private final static String HEADER_DISPLAY_ENV_COLOR="headerDisplayEnvColor";
+    private final static String HEADER_DISPLAY_PINNED_VERSION="headerDisplayPinnedVersion";
 
     /**
      * HollowHistoryUI constructor that builds history for a consumer that transitions forwards i.e. in increasing
@@ -260,4 +270,37 @@ public class HollowHistoryUI extends HollowUIRouter implements HollowRecordDiffU
     public TimeZone getTimeZone() {
         return timeZone;
     }
+
+    public String getHeaderDisplayNamespace() {
+        return commonHeadersDisplayMap.get(HEADER_DISPLAY_NAMESPACE);
+    }
+
+    public void setHeaderDisplayNamespace(String str) {
+        this.commonHeadersDisplayMap.put(HEADER_DISPLAY_NAMESPACE, str);
+    }
+
+    public String getHeaderDisplayEnv() {
+        return commonHeadersDisplayMap.get(HEADER_DISPLAY_ENV);
+    }
+
+    public void setHeaderDisplayEnv(String str) {
+        this.commonHeadersDisplayMap.put(HEADER_DISPLAY_ENV, str);
+    }
+
+    public String getHeaderDisplayEnvColor() {
+        return this.commonHeadersDisplayMap.get(HEADER_DISPLAY_ENV_COLOR);
+    }
+
+    public String setHeaderDisplayEnvColor(String str) {
+        return this.commonHeadersDisplayMap.put(HEADER_DISPLAY_ENV_COLOR, str);
+    }
+
+    public String getHeaderDisplayPinnedVersion() {
+        return commonHeadersDisplayMap.get(HEADER_DISPLAY_PINNED_VERSION);
+    }
+
+    public void setHeaderDisplayPinnedVersion(long version) {
+        this.commonHeadersDisplayMap.put(HEADER_DISPLAY_PINNED_VERSION, Long.toString(version));
+    }
+
 }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/HollowHistoryUI.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/HollowHistoryUI.java
@@ -299,6 +299,10 @@ public class HollowHistoryUI extends HollowUIRouter implements HollowRecordDiffU
         return commonHeadersDisplayMap.get(HEADER_DISPLAY_PINNED_VERSION);
     }
 
+    public void removeHeaderDisplayPinnedVersion() {
+        this.commonHeadersDisplayMap.remove(HEADER_DISPLAY_PINNED_VERSION);
+    }
+
     public void setHeaderDisplayPinnedVersion(long version) {
         this.commonHeadersDisplayMap.put(HEADER_DISPLAY_PINNED_VERSION, Long.toString(version));
     }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/pages/HistoryPage.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/history/ui/pages/HistoryPage.java
@@ -57,6 +57,25 @@ public abstract class HistoryPage {
             throw e;
         }
 
+        String headerDisplayNamespace = ui.getHeaderDisplayNamespace();
+        if (headerDisplayNamespace != null) {
+            ctx.put("headerDisplayNamespace", headerDisplayNamespace);
+        }
+
+        String headerDisplayEnv = ui.getHeaderDisplayEnv();
+        if (headerDisplayEnv != null) {
+            ctx.put("headerDisplayEnv", headerDisplayEnv);
+            String headerDisplayEnvColor = ui.getHeaderDisplayEnvColor();
+            if (headerDisplayEnvColor != null) {
+                ctx.put("headerDisplayEnvColor", headerDisplayEnvColor);
+            }
+        }
+
+        String headerDisplayPinnedVersion = ui.getHeaderDisplayPinnedVersion();
+        if (headerDisplayPinnedVersion != null) {
+            ctx.put("headerDisplayPinnedVersion", headerDisplayPinnedVersion);
+        }
+
         if(includeHeaderAndFooter())
             headerTemplate.merge(ctx, writer);
         template.merge(ctx, writer);

--- a/hollow-diff-ui/src/main/resources/history-header.vm
+++ b/hollow-diff-ui/src/main/resources/history-header.vm
@@ -18,13 +18,28 @@
 
 <head>
     <title>Hollow Data History</title>
+    <style>
+        .nav { text-align: left; padding-left: 5px; padding-right: 80px; border-left:1px solid #DCDCDC; }
+    </style>
 </head>
 
 <body>
-
-#if($showHomeLink)
-    <a href="$basePath/overview">Home</a>
-#end
+<table>
+    <tr>
+        #if($showHomeLink)
+        <td class="nav"><a href="$basePath/overview">Home</a> </td>
+        #end
+        #if($headerDisplayEnv)
+            <td class="nav">[ <span#if($headerDisplayEnvColor != "") style="color: $headerDisplayEnvColor;"#end>$headerDisplayEnv</span> ]</td>
+        #end
+        #if($headerDisplayNamespace)
+        <td class="nav">[ $headerDisplayNamespace ]</td>
+        #end
+        #if($headerDisplayPinnedVersion)
+        <td class="nav">[ Explorer is Pinned To: $headerDisplayPinnedVersion ]</td>
+        #end
+    </tr>
+</table>
 
 <form action="$basePath/query">
 Lookup Key: 

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
@@ -142,8 +142,12 @@ public class HollowExplorerUI extends HollowUIRouter {
         return headerDisplayMap.get(HEADER_DISPLAY_PINNED_VERSION);
     }
 
-    public void setHeaderDisplayPinnedVersion(long version) {
+    public void setHeaderDisplayPinnedVersion(Long version) {
         this.headerDisplayMap.put(HEADER_DISPLAY_PINNED_VERSION, Long.toString(version));
+    }
+
+    public void removeHeaderDisplayPinnedVersion() {
+        this.headerDisplayMap.remove(HEADER_DISPLAY_PINNED_VERSION);
     }
 
     public void addToHeaderDisplayMap(String key, String value) {

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
@@ -26,7 +26,7 @@ import com.netflix.hollow.explorer.ui.pages.ShowAllTypesPage;
 import com.netflix.hollow.ui.HollowUIRouter;
 import com.netflix.hollow.ui.HollowUISession;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -38,9 +38,13 @@ public class HollowExplorerUI extends HollowUIRouter {
     private final HollowReadStateEngine stateEngine;
     /** General purpose map to store header string and corresponding values used in HollowExplorer. It also stores headerDisplayString
      *  for backwards compatibility.
+     *  use thread-safe map as value writer and renders may perform concurrent reads/writes.
      **/
-    private final HashMap<String, String> headerDisplayMap = new HashMap<>();
+    private final ConcurrentHashMap<String, String> headerDisplayMap = new ConcurrentHashMap<>();
     private final static String HEADER_DISPLAY_STRING = "headerDisplayString";
+    private final static String HEADER_DISPLAY_ENV="headerDisplayEnv";
+    private final static String HEADER_DISPLAY_ENV_COLOR="headerDisplayEnvColor";
+    private final static String HEADER_DISPLAY_PINNED_VERSION="headerDisplayPinnedVersion";
 
     private final ShowAllTypesPage showAllTypesPage;
     private final BrowseSelectedTypePage browseTypePage;
@@ -116,6 +120,30 @@ public class HollowExplorerUI extends HollowUIRouter {
 
     public void setHeaderDisplayString(String str) {
         this.headerDisplayMap.put(HEADER_DISPLAY_STRING, str);
+    }
+
+    public String getHeaderDisplayEnv() {
+        return headerDisplayMap.get(HEADER_DISPLAY_ENV);
+    }
+
+    public void setHeaderDisplayEnv(String str) {
+        this.headerDisplayMap.put(HEADER_DISPLAY_ENV, str);
+    }
+
+    public String getHeaderDisplayEnvColor() {
+        return this.headerDisplayMap.get(HEADER_DISPLAY_ENV_COLOR);
+    }
+
+    public String setHeaderDisplayEnvColor(String str) {
+        return this.headerDisplayMap.put(HEADER_DISPLAY_ENV_COLOR, str);
+    }
+
+    public String getHeaderDisplayPinnedVersion() {
+        return headerDisplayMap.get(HEADER_DISPLAY_PINNED_VERSION);
+    }
+
+    public void setHeaderDisplayPinnedVersion(long version) {
+        this.headerDisplayMap.put(HEADER_DISPLAY_PINNED_VERSION, Long.toString(version));
     }
 
     public void addToHeaderDisplayMap(String key, String value) {

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/HollowExplorerPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/HollowExplorerPage.java
@@ -54,6 +54,20 @@ public abstract class HollowExplorerPage {
             ctx.put("headerStringURL", headerDisplayURL);
         }
 
+        String headerDisplayEnv = ui.getHeaderDisplayEnv();
+        if (headerDisplayEnv != null) {
+            ctx.put("headerDisplayEnv", headerDisplayEnv);
+            String headerDisplayEnvColor = ui.getHeaderDisplayEnvColor();
+            if (headerDisplayEnvColor != null) {
+                ctx.put("headerDisplayEnvColor", headerDisplayEnvColor);
+            }
+        }
+
+        String headerDisplayPinnedVersion = ui.getHeaderDisplayPinnedVersion();
+        if (headerDisplayPinnedVersion != null) {
+            ctx.put("headerDisplayPinnedVersion", headerDisplayPinnedVersion);
+        }
+
         ctx.put("basePath", ui.getBaseURLPath());
 
         ctx.put("esc", new EscapingTool());
@@ -76,5 +90,4 @@ public abstract class HollowExplorerPage {
      * Populates the provided VelocityContext.
      */
     protected abstract void setUpContext(HttpServletRequest req, HollowUISession session, VelocityContext ctx);
-
 }

--- a/hollow-explorer-ui/src/main/resources/explorer-header.vm
+++ b/hollow-explorer-ui/src/main/resources/explorer-header.vm
@@ -29,11 +29,17 @@
 	<table>
 		<tr>
 			<td class="nav"><a href="$basePath/home">[ Hollow Data Explorer ]</a></td>
+			#if($headerDisplayEnv)
+				<td class="nav">[ <span#if($headerDisplayEnvColor != "") style="color: $headerDisplayEnvColor;"#end>$headerDisplayEnv</span> ]</td>
+			#end
 			#if($headerDisplayString)
 				<td class="nav">[ <a target="_blank" href="$headerStringURL">$esc.html($headerDisplayString)</a> ]</td>
 			#end
 			#if($stateVersion)
 				<td class="nav">[ State Version: $stateVersion ]</td>
+			#end
+			#if($headerDisplayPinnedVersion)
+				<td class="nav">[ Explorer is Pinned To: $headerDisplayPinnedVersion ]</td>
 			#end
 			## When $type is defined and is not a list, display links to browse
 			## data and schema for that type.


### PR DESCRIPTION
Asks from the users:
1. Should show if the namespace is pinned for history/data explorer
2. For history explorer, be able to exhibit the namespace, environment.