### PR TITLE
Throw NPE when a field is null during unique index construction

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -630,15 +630,14 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         for(int i=0;i<lastFieldPath;i++) {
             int fieldPosition = fieldPathIndexes[fieldIdx][i];
             ordinal = typeState.readOrdinal(ordinal, fieldPosition);
+            if (ordinal == ORDINAL_NONE) {
+                HollowObjectSchema parentSchema =  this.typeState.getSchema();
+                throw new NullPointerException("Cannot hash null field " +
+                        parentSchema.getFieldName(fieldIdx) + " in type " +
+                        parentSchema.getName() + " at ordinal " + parentOrdinal);
+            }
             typeState = (HollowObjectTypeReadState) schema.getReferencedTypeState(fieldPosition); //This causes an incompatibility with object longevity.
             schema = typeState.getSchema();
-        }
-
-        if (ordinal == ORDINAL_NONE) {
-            HollowObjectSchema parentSchema =  this.typeState.getSchema();
-            throw new NullPointerException("Cannot hash null field " +
-                    parentSchema.getFieldName(fieldIdx) + " in type " +
-                    parentSchema.getName() + " at ordinal " + parentOrdinal);
         }
 
         int hashCode = HollowReadFieldUtils.fieldHashCode(typeState, ordinal, fieldPathIndexes[fieldIdx][lastFieldPath]);

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndexTest.java
@@ -358,6 +358,19 @@ public class HollowPrimaryKeyIndexTest extends AbstractStateEngineTest {
         } catch (NullPointerException e) {}
     }
 
+    @Test
+    public void testNullPKeyIdxNested() throws IOException {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+        mapper.add(new TypeA(1, 1.1d, new TypeB("test", true)));
+        mapper.add(new TypeA(1, 1.1d, null));
+        roundTripSnapshot();
+
+        try {
+            HollowPrimaryKeyIndex invalidPkIdx = new HollowPrimaryKeyIndex(this.readStateEngine, "TypeA", "a1", "a2", "ab.b1");
+            fail("Index on type with null fields is expected to fail construction");
+        } catch (NullPointerException e) {}
+    }
+
     private static void addDataForDupTesting(HollowWriteStateEngine writeStateEngine, int a1Start, double a2, int size) {
         TypeB typeB = new TypeB("commonTypeB");
         HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowUniqueKeyIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowUniqueKeyIndexTest.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.fail;
+
 
 @SuppressWarnings("unused")
 public class HollowUniqueKeyIndexTest extends HollowPrimaryKeyIndexTest {
@@ -346,6 +348,35 @@ public class HollowUniqueKeyIndexTest extends HollowPrimaryKeyIndexTest {
             this.b1 = b1;
             this.isDuplicate = isDuplicate;
         }
+    }
+
+    @Test
+    public void testNullFieldValue() throws IOException {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+        mapper.add(new TypeB("test", false));
+        mapper.add(new TypeB(null, true));
+
+        roundTripSnapshot();
+
+        try {
+            createIndex("TypeB", "b1", "isDuplicate");
+            fail("Unique key index on type with null fields is expected to fail construction");
+        } catch (NullPointerException e) {}
+    }
+
+    @Test
+    public void testNullFieldValueNested() throws IOException {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 3.3d, new TypeB("three")));
+        mapper.add(new TypeA(3, 2.2d, null));
+
+        roundTripSnapshot();
+
+        try {
+            createIndex("TypeA", "a1", "a2", "ab.b1");
+            fail("UniqueKeyIndex on type with null fields is expected to fail construction");
+        } catch (NullPointerException e) {}
     }
 
     @Override

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowUniqueKeyIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowUniqueKeyIndexTest.java
@@ -379,6 +379,36 @@ public class HollowUniqueKeyIndexTest extends HollowPrimaryKeyIndexTest {
         } catch (NullPointerException e) {}
     }
 
+    @Test
+    public void testNullFieldValueDeepNested() throws IOException {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB(null, true)));
+
+        roundTripSnapshot();
+
+        try {
+            createIndex("TypeA", "a1", "a2", "ab.b1");
+            fail("UniqueKeyIndex on type with null fields is expected to fail construction");
+        } catch (NullPointerException e) {}
+    }
+
+
+    @Test
+    public void testNullFieldValueNotInFieldPath() throws IOException {
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, null));
+
+        roundTripSnapshot();
+
+        try {
+            createIndex("TypeA", "a1", "a2");
+        } catch (NullPointerException e) {
+            fail("UniqueKeyIndex on type with null fields not in the field path is not expected to fail construction");
+        }
+    }
+
     @Override
     protected void initializeTypeStates() { }
 


### PR DESCRIPTION
This PR handles null field values during UniqueKey index creation, by throwing `NullPointerException`. It also handles the null fields in the nested field paths in both PrimaryKey and UniqueKey indexes.