### PR TITLE
[Improve]: Hollow API Generation Handling Missing Types;

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
@@ -19,6 +19,7 @@ package com.netflix.hollow.api.codegen;
 import static com.netflix.hollow.api.codegen.HollowAPIGenerator.SCHEMA_DOC_SUFFIX;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.hollowFactoryClassname;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.hollowObjectProviderName;
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.lowercase;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.typeAPIClassname;
 
@@ -123,12 +124,16 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
         builder.append("    private final HollowObjectCreationSampler objectCreationSampler;\n\n");
 
         for (HollowSchema schema : schemaList) {
+            if (!includeType(schema, dataset))
+                continue;
             builder.append("    private final " + typeAPIClassname(schema.getName())).append(" ").append(lowercase(typeAPIClassname(schema.getName()))).append(";\n");
         }
 
         builder.append("\n");
 
         for(HollowSchema schema : schemaList) {
+            if (!includeType(schema, dataset))
+                continue;
             builder.append("    private final HollowObjectProvider ").append(hollowObjectProviderName(schema.getName())).append(";\n");
         }
 
@@ -153,13 +158,22 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
         builder.append("        HollowFactory factory;\n\n");
         builder.append("        objectCreationSampler = new HollowObjectCreationSampler(");
         for(int i=0;i<schemaList.size();i++) {
+            if (!includeType(schemaList.get(i), dataset))
+                continue;
+
             builder.append("\"").append(schemaList.get(i).getName()).append("\"");
-            if(i < schemaList.size() - 1)
-                builder.append(",");
+            builder.append(",");
         }
+
+        if (builder.charAt(builder.length()-1) == ',') {
+            builder.deleteCharAt(builder.length()-1);
+        }
+
         builder.append(");\n\n");
 
         for (HollowSchema schema : schemaList) {
+            if (!includeType(schema, dataset))
+                continue;
             builder.append("        typeDataAccess = dataAccess.getTypeDataAccess(\"").append(schema.getName()).append("\");\n");
             builder.append("        if(typeDataAccess != null) {\n");
             builder.append("            ").append(lowercase(typeAPIClassname(schema.getName()))).append(" = new ").append(typeAPIClassname(schema.getName())).append("(this, (Hollow").append(schemaType(schema)).append("TypeDataAccess)typeDataAccess);\n");
@@ -186,6 +200,8 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
 
         builder.append("    public void detachCaches() {\n");
         for(HollowSchema schema : schemaList) {
+            if (!includeType(schema, dataset))
+                continue;
             builder.append("        if(").append(hollowObjectProviderName(schema.getName())).append(" instanceof HollowObjectCacheProvider)\n");
             builder.append("            ((HollowObjectCacheProvider)").append(hollowObjectProviderName(schema.getName())).append(").detach();\n");
         }
@@ -193,6 +209,8 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
 
 
         for (HollowSchema schema : schemaList) {
+            if (!includeType(schema, dataset))
+                continue;
             builder.append("    public ").append(typeAPIClassname(schema.getName())).append(" get" + typeAPIClassname(schema.getName())).append("() {\n");
             builder.append("        return ").append(lowercase(typeAPIClassname(schema.getName()))).append(";\n");
             builder.append("    }\n");
@@ -200,6 +218,8 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
 
         for(int i=0;i<schemaList.size();i++) {
             HollowSchema schema = schemaList.get(i);
+            if (!includeType(schema, dataset))
+                continue;
             if(parameterizeClassNames) {
                 builder.append("    public <T> Collection<T> getAll").append(hollowImplClassname(schema.getName())).append("() {\n");
                 builder.append("        HollowTypeDataAccess tda = Objects.requireNonNull(getDataAccess().getTypeDataAccess(\"").append(schema.getName()).append("\"), \"type not loaded or does not exist in dataset; type=").append(schema.getName()).append("\");\n");

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowConsumerJavaFileGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowConsumerJavaFileGenerator.java
@@ -27,6 +27,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
+
 /**
  * Not intended for external consumption.
  *
@@ -95,6 +97,9 @@ public abstract class HollowConsumerJavaFileGenerator implements HollowJavaFileG
                 }
                 Set<String> schemaNameSet = new HashSet<>();
                 for (HollowSchema schema : schemasToImport) {
+                    if (!includeType(schema, this.dataset))
+                        continue;
+
                     switch (schema.getSchemaType()) {
                         case OBJECT:
                             addToSetIfNotPrimitiveOrCollection(schemaNameSet, schema.getName());

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/api/TypeAPIObjectJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/api/TypeAPIObjectJavaGenerator.java
@@ -17,6 +17,7 @@
 package com.netflix.hollow.api.codegen.api;
 
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.delegateLookupClassname;
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.substituteInvalidChars;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.typeAPIClassname;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.uppercase;
@@ -95,7 +96,9 @@ public class TypeAPIObjectJavaGenerator extends HollowTypeAPIGenerator {
                     classBodyBuilder.append(generateLongFieldAccessor(i));
                     break;
                 case REFERENCE:
-                    classBodyBuilder.append(generateReferenceFieldAccessors(i));
+                    if (includeType(objectSchema.getReferencedType(i), this.dataset)) {
+                        classBodyBuilder.append(generateReferenceFieldAccessors(i));
+                    }
                     break;
                 case STRING:
                     classBodyBuilder.append(generateStringFieldAccessors(i));

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateInterfaceGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateInterfaceGenerator.java
@@ -17,6 +17,7 @@
 package com.netflix.hollow.api.codegen.delegate;
 
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.delegateInterfaceName;
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.substituteInvalidChars;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.typeAPIClassname;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.uppercase;
@@ -81,30 +82,32 @@ public class HollowObjectDelegateInterfaceGenerator extends HollowObjectDelegate
                 classBuilder.append("    public Long get").append(methodFieldName).append("Boxed(int ordinal);\n\n");
                 break;
             case REFERENCE:
-                Shortcut shortcut = ergonomicShortcuts.getShortcut(schema.getName() + "." + schema.getFieldName(i));
-                if(shortcut != null) {
-                    switch(shortcut.getType()) {
-                    case BOOLEAN:
-                    case DOUBLE:
-                    case FLOAT:
-                    case INT:
-                    case LONG:
-                        classBuilder.append("    public " + HollowCodeGenerationUtils.getJavaScalarType(shortcut.getType()) + " get").append(methodFieldName).append("(int ordinal);\n\n");
-                        classBuilder.append("    public " + HollowCodeGenerationUtils.getJavaBoxedType(shortcut.getType()) + " get").append(methodFieldName).append("Boxed(int ordinal);\n\n");
-                        break;
-                    case BYTES:
-                        classBuilder.append("    public byte[] get").append(methodFieldName).append("(int ordinal);\n\n");
-                        break;
-                    case STRING:
-                        classBuilder.append("    public String get").append(methodFieldName).append("(int ordinal);\n\n");
-                        classBuilder.append("    public boolean is").append(methodFieldName).append("Equal(int ordinal, String testValue);\n\n");
-                        break;
-                    case REFERENCE:
-                    default:
+                if (includeType(schema.getReferencedType(i), this.dataset)) {
+                    Shortcut shortcut = ergonomicShortcuts.getShortcut(schema.getName() + "." + schema.getFieldName(i));
+                    if (shortcut != null) {
+                        switch (shortcut.getType()) {
+                            case BOOLEAN:
+                            case DOUBLE:
+                            case FLOAT:
+                            case INT:
+                            case LONG:
+                                classBuilder.append("    public " + HollowCodeGenerationUtils.getJavaScalarType(shortcut.getType()) + " get").append(methodFieldName).append("(int ordinal);\n\n");
+                                classBuilder.append("    public " + HollowCodeGenerationUtils.getJavaBoxedType(shortcut.getType()) + " get").append(methodFieldName).append("Boxed(int ordinal);\n\n");
+                                break;
+                            case BYTES:
+                                classBuilder.append("    public byte[] get").append(methodFieldName).append("(int ordinal);\n\n");
+                                break;
+                            case STRING:
+                                classBuilder.append("    public String get").append(methodFieldName).append("(int ordinal);\n\n");
+                                classBuilder.append("    public boolean is").append(methodFieldName).append("Equal(int ordinal, String testValue);\n\n");
+                                break;
+                            case REFERENCE:
+                            default:
+                        }
                     }
-                }
 
-                classBuilder.append("    public int get").append(methodFieldName).append("Ordinal(int ordinal);\n\n");
+                    classBuilder.append("    public int get").append(methodFieldName).append("Ordinal(int ordinal);\n\n");
+                }
                 break;
             case STRING:
                 classBuilder.append("    public String get").append(methodFieldName).append("(int ordinal);\n\n");

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateLookupImplGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/delegate/HollowObjectDelegateLookupImplGenerator.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.api.codegen.delegate;
 
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.delegateInterfaceName;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.delegateLookupImplName;
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.substituteInvalidChars;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.typeAPIClassname;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.uppercase;
@@ -122,14 +123,16 @@ public class HollowObjectDelegateLookupImplGenerator extends HollowObjectDelegat
                 builder.append("    }\n\n");
                 break;
             case REFERENCE:
-                Shortcut shortcut = ergonomicShortcuts.getShortcut(schema.getName() + "." + schema.getFieldName(i));
-                if(shortcut != null) {
-                    addShortcutAccessMethod(builder, methodFieldName, shortcut);
-                }
+                if (includeType(schema.getReferencedType(i), dataset)) {
+                    Shortcut shortcut = ergonomicShortcuts.getShortcut(schema.getName() + "." + schema.getFieldName(i));
+                    if(shortcut != null) {
+                        addShortcutAccessMethod(builder, methodFieldName, shortcut);
+                    }
 
-                builder.append("    public int get").append(methodFieldName).append("Ordinal(int ordinal) {\n");
-                builder.append("        return typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
-                builder.append("    }\n\n");
+                    builder.append("    public int get").append(methodFieldName).append("Ordinal(int ordinal) {\n");
+                    builder.append("        return typeAPI.get").append(methodFieldName).append("Ordinal(ordinal);\n");
+                    builder.append("    }\n\n");
+                }
                 break;
             }
         }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowHashIndexGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowHashIndexGenerator.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.hollow.api.codegen.indexes;
 
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.substituteInvalidChars;
 
 import com.netflix.hollow.api.codegen.CodeGeneratorConfig;
@@ -82,6 +83,9 @@ public class HollowHashIndexGenerator extends HollowIndexGenerator {
         builder.append("    }\n\n");
 
         for(HollowSchema schema : schemaList) {
+            if (!includeType(schema, dataset))
+                continue;
+
             builder.append("    public Iterable<" + hollowImplClassname(schema.getName()) + "> find" + substituteInvalidChars(schema.getName()) + "Matches(Object... keys) {\n");
             builder.append("        HollowHashIndexResult matches = idx.findMatches(keys);\n");
             builder.append("        if(matches == null) return Collections.emptySet();\n\n");

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowPrimaryKeyIndexGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/indexes/HollowPrimaryKeyIndexGenerator.java
@@ -27,6 +27,8 @@ import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
+
 /**
  * This class contains template logic for generating a {@link HollowAPI} implementation.  Not intended for external consumption.
  *
@@ -61,6 +63,10 @@ public class HollowPrimaryKeyIndexGenerator extends HollowUniqueKeyIndexGenerato
             FieldType ft = pk.getFieldType(dataset, i);
             if (FieldType.REFERENCE.equals(ft)) {
                 HollowObjectSchema refSchema = pk.getFieldSchema(dataset, i);
+                if (!includeType(schema, dataset)) {
+                    // Primary key references a type that does not exist in the dataset.
+                    throw new IllegalStateException("Primary key references a type that does not exist in the dataset: " + schema.getName());
+                }
                 params.add(refSchema.getName() + " " + fn);
             } else {
                 params.add(HollowCodeGenerationUtils.getJavaScalarType(ft) + " " + fn);

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/objects/HollowObjectJavaGenerator.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.api.codegen.objects;
 
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.delegateInterfaceName;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.generateBooleanAccessorMethodName;
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.isPrimitiveType;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.substituteInvalidChars;
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.typeAPIClassname;
@@ -165,7 +166,10 @@ public class HollowObjectJavaGenerator extends HollowConsumerJavaFileGenerator {
                     classBuilder.append(generateLongFieldAccessor(i));
                     break;
                 case REFERENCE:
-                    classBuilder.append(generateReferenceFieldAccessor(i));
+                    if (includeType(schema.getReferencedType(i), this.dataset)) {
+                        classBuilder.append(generateReferenceFieldAccessor(i));
+                    }
+
                     break;
                 case STRING:
                     classBuilder.append(generateStringFieldAccessors(i));

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIClassGenerator.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
+
 class HollowPerformanceAPIClassGenerator {
 
     private final HollowDataset dataset;
@@ -59,6 +61,10 @@ class HollowPerformanceAPIClassGenerator {
         schemas.sort(Comparator.comparing(HollowSchema::getName));
 
         for(HollowSchema schema : schemas) {
+            if (!includeType(schema, dataset)) {
+                continue;
+            }
+
             String schemaName = schema.getName();
 
             switch(schema.getSchemaType()) {
@@ -83,6 +89,10 @@ class HollowPerformanceAPIClassGenerator {
         builder.append("        super(dataAccess);\n\n");
 
         for(HollowSchema schema : schemas) {
+            if (!includeType(schema, dataset)) {
+                continue;
+            }
+            
             String schemaName = schema.getName();
 
             switch (schema.getSchemaType()) {

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowPerformanceAPIGenerator.java
@@ -109,7 +109,7 @@ public class HollowPerformanceAPIGenerator {
         for (HollowSchema schema : dataset.getSchemas()) {
             if (schema.getSchemaType() == SchemaType.OBJECT) {
                 Path objClassDestination = destination.resolve(schema.getName() + "PerfAPI.java");
-                String objClassContent = new HollowObjectTypePerfAPIClassGenerator((HollowObjectSchema) schema, packageName, checkFieldExistsMethods).generate();
+                String objClassContent = new HollowObjectTypePerfAPIClassGenerator((HollowObjectSchema) schema, packageName, checkFieldExistsMethods, dataset).generate();
                 try (FileWriter writer = new FileWriter(objClassDestination.toFile())) {
                     writer.write(objClassContent);
                 }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowObjectTypeTestDataAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowObjectTypeTestDataAPIClassGenerator.java
@@ -27,6 +27,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
+
 class HollowObjectTypeTestDataAPIClassGenerator {
     
     private final HollowDataset dataset;
@@ -109,6 +111,10 @@ class HollowObjectTypeTestDataAPIClassGenerator {
                 break;
             case REFERENCE:
                 String refType = schema.getReferencedType(i);
+                if (!includeType(refType, dataset)) {
+                    break;
+                }
+
                 String returnType = className(refType) + "<" + className + "<T>>";
                 builder.append("    public " + returnType + " " + fieldName + "() {\n");
                 builder.append("        " + returnType + " __x = new " + returnType + "(this);\n");

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowTestDataAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowTestDataAPIClassGenerator.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
+
 class HollowTestDataAPIClassGenerator {
     
     private final HollowDataset dataset;
@@ -47,6 +49,9 @@ class HollowTestDataAPIClassGenerator {
         schemas.sort(Comparator.comparing(HollowSchema::getName));
 
         for(HollowSchema schema : schemas) {
+            if (!includeType(schema, dataset)) {
+                continue;
+            }
             builder.append("    public " + schema.getName() + "TestData<Void> " + schema.getName() + "() {\n");
             builder.append("        " + schema.getName() + "TestData<Void> rec = new " + schema.getName() + "TestData<>(null);\n");
             builder.append("        add(rec);\n");

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowTestDataAPIGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/testdata/HollowTestDataAPIGenerator.java
@@ -29,6 +29,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
+
 public class HollowTestDataAPIGenerator {
     
     private HollowDataset dataset;
@@ -90,6 +92,10 @@ public class HollowTestDataAPIGenerator {
         }
 
         for(HollowSchema schema : dataset.getSchemas()) {
+            if (!includeType(schema, dataset)) {
+                continue;
+            }
+
             File classDestination = destination.resolve(schema.getName() + "TestData.java").toFile();
             String classContent = null;
             switch(schema.getSchemaType()) {

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/AbstractHollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/AbstractHollowAPIGeneratorTest.java
@@ -21,14 +21,24 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.netflix.hollow.HollowGenerated;
+import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchemaParser;
+import com.netflix.hollow.core.schema.SimpleHollowDataset;
 import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.annotation.Annotation;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 import org.junit.After;
 
 public class AbstractHollowAPIGeneratorTest {
@@ -39,12 +49,7 @@ public class AbstractHollowAPIGeneratorTest {
 
     protected void runGenerator(String apiClassName, String packageName, Class<?> clazz,
             UnaryOperator<HollowAPIGenerator.Builder> generatorCustomizer) throws Exception {
-        System.out.println(String.format("Folders (%s) : \n\tsource=%s \n\tclasses=%s",
-                    getClass().getSimpleName(), sourceFolder, clazzFolder));
-
-        // Setup Folders
-        HollowCodeGenerationCompileUtil.cleanupFolder(new File(sourceFolder), null);
-        HollowCodeGenerationCompileUtil.cleanupFolder(new File(clazzFolder), null);
+        setupFolders();
 
         // Run Generator
         HollowAPIGenerator generator = generatorCustomizer.apply(new HollowAPIGenerator.Builder())
@@ -55,15 +60,15 @@ public class AbstractHollowAPIGeneratorTest {
         if(generator.config.isUseMetaInfo()) {
             metaInfoPath = generator.config.getMetaInfoPath();
         }
-        // Compile to validate generated files
-        HollowCodeGenerationCompileUtil.compileSrcFiles(sourceFolder, clazzFolder);
+        
+        compileGeneratedFiles();
     }
 
     protected void assertNonEmptyFileExists(Path absolutePath) {
         assertTrue("File at " + absolutePath + " should exist", absolutePath.toFile().exists() && absolutePath.toFile().length() > 0L);
     }
 
-    void assertClassHasHollowTypeName(String clazz, String typeName) throws IOException, ClassNotFoundException {
+    protected void assertClassHasHollowTypeName(String clazz, String typeName) throws IOException, ClassNotFoundException {
         ClassLoader cl = new URLClassLoader(new URL[]{new File(clazzFolder).toURI().toURL()});
         Class cls = cl.loadClass(clazz);
         Annotation annotation = cls.getAnnotation(HollowTypeName.class);
@@ -78,12 +83,118 @@ public class AbstractHollowAPIGeneratorTest {
         assertNotNull(annotation);
     }
 
-    void assertFileDoesNotExist(String relativePath) {
+    protected void assertFileDoesNotExist(String relativePath) {
         if (relativePath.startsWith("/")) {
             throw new IllegalArgumentException("Relative paths should not start with /");
         }
         assertFalse("File should not exist at " + relativePath,
                 new File(sourceFolder + "/" + relativePath).exists());
+    }
+
+    protected void runPerformanceGenerator(String apiClassName, String packageName, Class<?> clazz) throws Exception {
+        setupFolders();
+
+        // Run generator
+        com.netflix.hollow.api.codegen.perfapi.HollowPerformanceAPIGenerator generator =
+                com.netflix.hollow.api.codegen.perfapi.HollowPerformanceAPIGenerator.newBuilder()
+                .withDestination(sourceFolder)
+                .withPackageName(packageName)
+                .withAPIClassname(apiClassName)
+                .withDataset(SimpleHollowDataset.fromClassDefinitions(clazz))
+                .build();
+        generator.generateSourceFiles();
+
+        compileGeneratedFiles();
+    }
+
+    protected void runGeneratorFromSchemaString(String apiClassName, String packageName, String schemaContentAsStr,
+                                                UnaryOperator<HollowAPIGenerator.Builder> generatorCustomizer) throws Exception {
+        setupFolders();
+        SimpleHollowDataset dataset = new SimpleHollowDataset(HollowSchemaParser.parseCollectionOfSchemas(schemaContentAsStr));
+        // Run Generator
+        HollowAPIGenerator generator = generatorCustomizer.apply(new HollowAPIGenerator.Builder())
+                .withDataModel(dataset)
+                .withAPIClassname(apiClassName)
+                .withPackageName(packageName)
+                .withDestination(sourceFolder)
+                .build();
+        generator.generateSourceFiles();
+
+        if(generator.config.isUseMetaInfo()) {
+            metaInfoPath = generator.config.getMetaInfoPath();
+        }
+
+        compileGeneratedFiles();
+    }
+
+    protected void runGeneratorFromSchemaFile(String apiClassName, String packageName, String schemaFilePathOrResource,
+            UnaryOperator<HollowAPIGenerator.Builder> generatorCustomizer) throws Exception {
+        setupFolders();
+
+        SimpleHollowDataset dataset = readSchemaFile(schemaFilePathOrResource);
+
+        // Run Generator
+        HollowAPIGenerator generator = generatorCustomizer.apply(new HollowAPIGenerator.Builder())
+                .withDataModel(dataset)
+                .withAPIClassname(apiClassName)
+                .withPackageName(packageName)
+                .withDestination(sourceFolder)
+                .build();
+        generator.generateSourceFiles();
+
+        if(generator.config.isUseMetaInfo()) {
+            metaInfoPath = generator.config.getMetaInfoPath();
+        }
+
+        compileGeneratedFiles();
+    }
+
+    protected void runPerformanceGeneratorFromSchemaFile(String apiClassName, String packageName, String schemaFilePathOrResource) throws Exception {
+        setupFolders();
+
+        SimpleHollowDataset dataset = readSchemaFile(schemaFilePathOrResource);
+
+        // Run Generator
+        com.netflix.hollow.api.codegen.perfapi.HollowPerformanceAPIGenerator generator = 
+                com.netflix.hollow.api.codegen.perfapi.HollowPerformanceAPIGenerator.newBuilder()
+                .withDataset(dataset)
+                .withAPIClassname(apiClassName)
+                .withPackageName(packageName)
+                .withDestination(sourceFolder)
+                .build();
+        generator.generateSourceFiles();
+
+        compileGeneratedFiles();
+    }
+
+    private void setupFolders() {
+        System.out.println(String.format("Folders (%s) : \n\tsource=%s \n\tclasses=%s",
+                getClass().getSimpleName(), sourceFolder, clazzFolder));
+        HollowCodeGenerationCompileUtil.cleanupFolder(new File(sourceFolder), null);
+        HollowCodeGenerationCompileUtil.cleanupFolder(new File(clazzFolder), null);
+    }
+
+    private SimpleHollowDataset readSchemaFile(String schemaFilePathOrResource) throws Exception {
+        String schemaContent;
+        InputStream inputStream = getClass().getResourceAsStream(schemaFilePathOrResource);
+        if (inputStream == null) {
+            // Try as file path
+            File schemaFile = new File(schemaFilePathOrResource);
+            if (!schemaFile.exists()) {
+                throw new FileNotFoundException("Schema file not found as resource or file: " + schemaFilePathOrResource);
+            }
+            inputStream = new FileInputStream(schemaFile);
+        }
+        try (InputStream is = inputStream;
+             BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+            schemaContent = reader.lines().collect(Collectors.joining("\n"));
+        }
+        List<HollowSchema> schemaList = HollowSchemaParser.parseCollectionOfSchemas(schemaContent);
+        return new SimpleHollowDataset(schemaList);
+    }
+
+    private void compileGeneratedFiles() throws Exception {
+        HollowCodeGenerationCompileUtil.compileSrcFiles(sourceFolder, clazzFolder);
     }
 
     @After

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPIGeneratorTest.java
@@ -88,6 +88,28 @@ public class HollowAPIGeneratorTest extends AbstractHollowAPIGeneratorTest {
         assertClassHasGeneratedAnnotation("codegen.api.MyClassTestAPI");
     }
 
+    @Test
+    public void testGenerateFromSchemaFileWithMissingTypes() throws Exception {
+        String schemaResourcePath = "/hollow_code_gen_test.schema";
+
+        // Generate code from schema file
+        runGeneratorFromSchemaFile("TestSchemaAPI", "codegen.api", schemaResourcePath, b->b);
+
+        // Verify valid types exist (types that have complete definitions)
+        assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen/api/TopLevelObject.java"));
+        assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen/api/Object1.java"));
+        assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen/api/ListOfObject1.java"));
+        assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen/api/SetOfObject1.java"));
+        assertNonEmptyFileExists(Paths.get(sourceFolder, "codegen/api/MapOfStringToObject1.java"));
+
+        // Verify invalid types do NOT exist (Object2 is undefined, so these should not be generated)
+        assertFileDoesNotExist("codegen/api/Object2.java");
+        assertFileDoesNotExist("codegen/api/ListOfObject2.java");
+        assertFileDoesNotExist("codegen/api/SetOfObject2.java");
+        assertFileDoesNotExist("codegen/api/MapOfStringToObject2.java");
+        assertFileDoesNotExist("codegen/api/MapOfObject2ToString.java");
+    }
+
 
     @SuppressWarnings("unused")
     @HollowPrimaryKey(fields = "id")

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowCodeGenerationCompileUtil.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowCodeGenerationCompileUtil.java
@@ -32,6 +32,12 @@ public class HollowCodeGenerationCompileUtil {
     private static final String FILENAME_FINDBUGS = "findbugs.xml";
     private static final String PROPERTY_CLASSPATH = "java.class.path";
 
+    public static void compileSrcFilesAndCheckForBugs(String sourceDirPath, String classDirPath) throws Exception {
+        compileSrcFiles(sourceDirPath, classDirPath);
+        File classDir = new File(classDirPath);
+        runFindbugs(classDir);
+    }
+
     /**
      * Compiles java source files in the provided source directory, to the provided class directory.
      * This also runs findbugs on the compiled classes, throwing an exception if findbugs fails.
@@ -60,7 +66,6 @@ public class HollowCodeGenerationCompileUtil {
         int err = compiler.run(null, System.out, System.out, args);
         if (err != 0)
             throw new RuntimeException("compiler errors, see system.out");
-        runFindbugs(classDir);
     }
 
     /**

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/testdata/HollowTestDataAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/testdata/HollowTestDataAPIGeneratorTest.java
@@ -1,0 +1,28 @@
+package com.netflix.hollow.api.codegen.testdata;
+
+import com.netflix.hollow.api.codegen.AbstractHollowAPIGeneratorTest;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+public class HollowTestDataAPIGeneratorTest extends AbstractHollowAPIGeneratorTest  {
+  @Test
+  public void testGenerateTestDataApi() throws Exception {
+      String schemaResourcePath = "/hollow_code_gen_test.schema";
+      runTestDataAPIGeneratorFromSchemaFile("TestSchemaAPI", "codegen.perfapi", schemaResourcePath);
+
+      // Verify valid types exist (types that have complete definitions)
+      assertNonEmptyFileExists(Paths.get(sourceFolder, "TopLevelObjectTestData.java"));
+      assertNonEmptyFileExists(Paths.get(sourceFolder, "Object1TestData.java"));
+      assertNonEmptyFileExists(Paths.get(sourceFolder, "ListOfObject1TestData.java"));
+      assertNonEmptyFileExists(Paths.get(sourceFolder, "SetOfObject1TestData.java"));
+      assertNonEmptyFileExists(Paths.get(sourceFolder, "MapOfStringToObject1TestData.java"));
+
+      // Verify invalid types do NOT exist (Object2 is undefined, so these should not be generated)
+      assertFileDoesNotExist("Object2TestData.java");
+      assertFileDoesNotExist("ListOfObject2TestData.java");
+      assertFileDoesNotExist("SetOfObject2TestData.java");
+      assertFileDoesNotExist("MapOfStringToObject2TestData.java");
+      assertFileDoesNotExist("MapOfObject2ToStringTestData.java");
+  }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/schema/HollowSchemaParserTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/schema/HollowSchemaParserTest.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.hollow.core.schema;
 
+import com.netflix.hollow.api.codegen.HollowAPIGenerator;
 import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.io.BufferedReader;
@@ -27,7 +28,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class HollowSchemaParserTest {
-
     @Test
     public void parsesObjectSchema() throws IOException {
         String objectSchema =

--- a/hollow/src/test/resources/hollow_code_gen_test.schema
+++ b/hollow/src/test/resources/hollow_code_gen_test.schema
@@ -1,0 +1,34 @@
+/*
+ * This schema contains an undefined type, Object2.
+ * When generate API from this schema, Object2 as well List/Map/Set that has Object2 as its type argument, should be
+ * skipped and not have their type files generated. They should not be referenced by other types as well.
+ */
+TopLevelObject {
+	ListOfObject1 validListField;
+	SetOfObject1 validSetField;
+	MapOfStringToObject1 validMapField;
+	Object1 validMemberField;
+	ListOfObject2 invalidListField;
+	SetOfObject2 invalidSetField;
+	MapOfStringToObject2 invalidMapField1;
+	MapOfObject2ToString invalidMapField2;
+	Object2 invalidMemberField;
+}
+
+ListOfObject1 List<Object1>;
+SetOfObject1 Set<Object1>;
+MapOfStringToObject1 Map<String,Object1>;
+
+Object1 {
+	String val;
+}
+
+String {
+    string value;
+}
+
+/* invalid types that should not be generated */
+ListOfObject2 List<Object2>;
+SetOfObject2 Set<Object2>;
+MapOfStringToObject2 Map<String,Object2>;
+MapOfObject2ToString Map<Object2,String>;


### PR DESCRIPTION
In some use cases, HollowProducer would be producing header blob for a dataset, which does not contain data for one or more types yet. Currently, 1. the code can run into `NullPointerException` when generating the API. 2. the user can later encounter `Cannot Find Symbol` compilation errors when using the generated API. 

Noted these undefined types as `undefinedType`, when API generators, like `HollowAPIGenerator`, generate files using a list of `HollowSchema` derived from the header blob, it generates classes containing methods (i.e. getters) referring to the `undefinedType`.

To work around this, by referring to the existing work in RAWHollow, we simply ignore the `undefinedType` during code generation. Also ignore any types taking the `undefinedType` as its type arguments.