### PR TITLE
hollowwritestatecreator: improve populatestateenginewithtypewritestates

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
@@ -24,6 +24,7 @@ import com.netflix.hollow.core.schema.HollowMapSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSchemaParser;
+import com.netflix.hollow.core.schema.HollowSchemaSorter;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 import com.netflix.hollow.core.write.HollowListTypeWriteState;
 import com.netflix.hollow.core.write.HollowMapTypeWriteState;
@@ -40,6 +41,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Use to pre-populate, or create a {@link HollowWriteStateEngine} which is pre-populated, with a particular data model.  
@@ -87,8 +93,8 @@ public class HollowWriteStateCreator {
      * @param schemas The schemas from the data model.
      */
     public static void populateStateEngineWithTypeWriteStates(HollowWriteStateEngine stateEngine, Collection<HollowSchema> schemas) {
-
-        for(HollowSchema schema : schemas) {
+        List<HollowSchema> dependencyOrderedSchemas = getDependencyOrderedSchemas(schemas);
+        for(HollowSchema schema : dependencyOrderedSchemas) {
             if(stateEngine.getTypeState(schema.getName()) == null) {
                 switch(schema.getSchemaType()) {
                 case OBJECT:
@@ -106,6 +112,32 @@ public class HollowWriteStateCreator {
                 }
             }
         }
+    }
+
+    private static List<HollowSchema> getDependencyOrderedSchemas(Collection<HollowSchema> schemas) {
+        Set<String> duplicateSchemaNames = schemas.stream()
+            .map(HollowSchema::getName)
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
+            .entrySet()
+            .stream()
+            .filter(entry -> entry.getValue() > 1)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+        if (!duplicateSchemaNames.isEmpty()) {
+            throw new IllegalStateException("Duplicate schema name(s): " + duplicateSchemaNames);
+        }
+        List<HollowSchema> dependencyOrderedSchemas = HollowSchemaSorter.dependencyOrderedSchemaList(schemas);
+        if (schemas.size() != dependencyOrderedSchemas.size()) {
+            Set<String> missingSchemaNames = schemas.stream()
+                .map(HollowSchema::getName)
+                .collect(Collectors.toSet());
+            dependencyOrderedSchemas.forEach(schema -> missingSchemaNames.remove(schema.getName()));
+            throw new IllegalStateException(String.format(
+                "Missing schema(s) for %s in dependency ordered list (likely due to circular dependencies). This is unexpected and warrants investigation.",
+                missingSchemaNames
+            ));
+        }
+        return dependencyOrderedSchemas;
     }
     
     /**


### PR DESCRIPTION
Populate schemas in dependency order, ensuring data can be read safely via populated ordinals during delta updates.