### PR TITLE
add type & %change to RecordCountPercentChangeValidator failure message

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/RecordCountPercentChangeValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/RecordCountPercentChangeValidator.java
@@ -84,7 +84,25 @@ public class RecordCountPercentChangeValidator implements ValidatorListener {
                     getName(), addedPercent * 100, addedPercentageThreshold * 100,  removedPercent * 100,
                     removedPercentageThreshold * 100, updatedPercent * 100, updatedPercentageThreshold * 100));
         }
-        return builder.failed("record count change is more than threshold");
+
+        StringBuilder details = new StringBuilder();
+        if (addedPercentageThreshold >= 0 && addedPercent >= addedPercentageThreshold) {
+            details.append(String.format("added %.2f%% > %.2f%%",
+                    addedPercent * 100, addedPercentageThreshold * 100));
+        }
+        if (removedPercentageThreshold >= 0 && removedPercent >= removedPercentageThreshold) {
+            if (details.length() > 0) details.append(", ");
+            details.append(String.format("removed %.2f%% > %.2f%%",
+                    removedPercent * 100, removedPercentageThreshold * 100));
+        }
+        if (updatedPercentageThreshold >= 0 && updatedPercent >= updatedPercentageThreshold) {
+            if (details.length() > 0) details.append(", ");
+            details.append(String.format("updated %.2f%% > %.2f%%",
+                    updatedPercent * 100, updatedPercentageThreshold * 100));
+        }
+
+        return builder.failed(String.format("'%s' record count change exceeds threshold: %s",
+                typeName, details));
     }
 
     /**

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/RecordCountPercentChangeValidatorTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/RecordCountPercentChangeValidatorTests.java
@@ -54,6 +54,9 @@ public class RecordCountPercentChangeValidatorTests {
             assertTrue(e instanceof ValidationStatusException);
             ValidationStatusException expected = (ValidationStatusException) e;
             assertEquals(1, expected.getValidationStatus().getResults().size());
+            String message = expected.getValidationStatus().getResults().get(0).getMessage();
+            assertTrue(message.startsWith("'TypeWithPrimaryKey' record count change exceeds threshold: "));
+            assertTrue(message.contains("added 80.00% > 50.00%"));
         }
     }
 
@@ -68,6 +71,9 @@ public class RecordCountPercentChangeValidatorTests {
             assertTrue(e instanceof ValidationStatusException);
             ValidationStatusException expected = (ValidationStatusException) e;
             assertEquals(1, expected.getValidationStatus().getResults().size());
+            String message = expected.getValidationStatus().getResults().get(0).getMessage();
+            assertTrue(message.startsWith("'TypeWithPrimaryKey' record count change exceeds threshold: "));
+            assertTrue(message.contains("removed 80.00% > 50.00%"));
         }
     }
 
@@ -76,14 +82,35 @@ public class RecordCountPercentChangeValidatorTests {
         try {
             testHelper(RecordCountPercentChangeValidator.Threshold.builder()
                     .withUpdatedPercentageThreshold(() ->0.5f)
-                    .withAddedPercentageThreshold(() -> 0.5f)
-                    .withAddedPercentageThreshold(() -> 0.5f)
-                    .build(), 4, 1, 1);
+                    .build(), 4, 0, 0);
             fail();
         } catch (Exception e) {
             assertTrue(e instanceof ValidationStatusException);
             ValidationStatusException expected = (ValidationStatusException) e;
             assertEquals(1, expected.getValidationStatus().getResults().size());
+            String message = expected.getValidationStatus().getResults().get(0).getMessage();
+            assertTrue(message.startsWith("'TypeWithPrimaryKey' record count change exceeds threshold: "));
+            assertTrue(message.contains("updated 80.00% > 50.00%"));
+        }
+    }
+
+    @Test
+    public void testMultipleThresholdsExceeded() {
+        try {
+            testHelper(RecordCountPercentChangeValidator.Threshold.builder()
+                    .withAddedPercentageThreshold(() -> 0.5f)
+                    .withRemovedPercentageThreshold(() -> 0.3f)
+                    .build(), 0, 4, 3);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof ValidationStatusException);
+            ValidationStatusException expected = (ValidationStatusException) e;
+            assertEquals(1, expected.getValidationStatus().getResults().size());
+            String message = expected.getValidationStatus().getResults().get(0).getMessage();
+            assertTrue(message.startsWith("'TypeWithPrimaryKey' record count change exceeds threshold: "));
+            assertTrue(message.contains("added 80.00% > 50.00%"));
+            assertTrue(message.contains("removed 60.00% > 30.00%"));
+            assertTrue(message.contains(", "));
         }
     }
 


### PR DESCRIPTION
Add type name, change type, and percentages to validation failure messages.

**Before:**
`record count change is more than threshold`

**After:**
`'TypeWithPrimaryKey' record count change exceeds threshold: added 80.00% > 50.00%`

**Multiple failures:**
`'TypeWithPrimaryKey' record count change exceeds threshold: added 80.00% > 50.00%, removed 60.00% > 40.00%`