### PR TITLE
Revert null check in `HollowPrimaryKeyIndex` to original state

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -33,7 +33,6 @@ import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
-import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -33,7 +33,6 @@ import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -33,6 +33,8 @@ import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -630,14 +632,15 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         for(int i=0;i<lastFieldPath;i++) {
             int fieldPosition = fieldPathIndexes[fieldIdx][i];
             ordinal = typeState.readOrdinal(ordinal, fieldPosition);
-            if (ordinal == ORDINAL_NONE) {
-                HollowObjectSchema parentSchema =  this.typeState.getSchema();
-                throw new NullPointerException("Cannot hash null field " +
-                        parentSchema.getFieldName(fieldIdx) + " in type " +
-                        parentSchema.getName() + " at ordinal " + parentOrdinal);
-            }
             typeState = (HollowObjectTypeReadState) schema.getReferencedTypeState(fieldPosition); //This causes an incompatibility with object longevity.
             schema = typeState.getSchema();
+        }
+
+        if (ordinal == ORDINAL_NONE) {
+            HollowObjectSchema parentSchema =  this.typeState.getSchema();
+            throw new NullPointerException("Cannot hash null field " +
+                    parentSchema.getFieldName(fieldIdx) + " in type " +
+                    parentSchema.getName() + " at ordinal " + parentOrdinal);
         }
 
         int hashCode = HollowReadFieldUtils.fieldHashCode(typeState, ordinal, fieldPathIndexes[fieldIdx][lastFieldPath]);

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndexTest.java
@@ -345,7 +345,6 @@ public class HollowPrimaryKeyIndexTest extends AbstractStateEngineTest {
         Assert.assertEquals(0, validPki.getMatchingOrdinal(1L));
     }
 
-
     @Test
     public void testNullPKeyIdx() throws IOException {
         HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
@@ -354,19 +353,6 @@ public class HollowPrimaryKeyIndexTest extends AbstractStateEngineTest {
 
         try {
             HollowPrimaryKeyIndex invalidPkIdx = new HollowPrimaryKeyIndex(this.readStateEngine, "TypeNullPKey", "id");
-            fail("Index on type with null fields is expected to fail construction");
-        } catch (NullPointerException e) {}
-    }
-
-    @Test
-    public void testNullPKeyIdxNested() throws IOException {
-        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
-        mapper.add(new TypeA(1, 1.1d, new TypeB("test", true)));
-        mapper.add(new TypeA(1, 1.1d, null));
-        roundTripSnapshot();
-
-        try {
-            HollowPrimaryKeyIndex invalidPkIdx = new HollowPrimaryKeyIndex(this.readStateEngine, "TypeA", "a1", "a2", "ab.b1");
             fail("Index on type with null fields is expected to fail construction");
         } catch (NullPointerException e) {}
     }


### PR DESCRIPTION
The null check added in `HollowPrimaryKeyIndex` does not provide the correct field name in the error message. This PR reverts the null check made in #768 to its original state. This means, `HollowPrimaryKeyIndex` does not handle null values in nested types. This will be fixed in a separate PR.