### PR TITLE
[Improv]: enable max ordinal check after write state engine prepare write;

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 /**
  * A HollowProducer is the top-level class used by producers of Hollow data to populate, publish, and announce data states.
@@ -752,6 +753,7 @@ public class HollowProducer extends AbstractHollowProducer {
         boolean doIntegrityCheck = true;
         ProducerOptionalBlobPartConfig optionalPartConfig = null;
         HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier = HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE;
+        Supplier<Boolean> ignoreSoftLimits = null;
 
         protected HollowProducerEventListener customProducerMetricsListener = null;
 
@@ -970,6 +972,18 @@ public class HollowProducer extends AbstractHollowProducer {
 
         public B withUpdatePlanVerifier(HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier) {
             this.updatePlanBlobVerifier = updatePlanBlobVerifier;
+            return (B) this;
+        }
+
+        /**
+         * set the ignoreSoftLimits. When set to true, ignore soft limits like
+         * {@link com.netflix.hollow.core.memory.ByteArrayOrdinalMap} ordinal limit, instead of failing.
+         * @param ignoreSoftLimits the supplier for whether to ignore
+         * {@link com.netflix.hollow.core.memory.ByteArrayOrdinalMap} ordinal soft limit breaches
+         * @return this builder
+         */
+        public B withIgnoreSoftLimits(Supplier<Boolean> ignoreSoftLimits) {
+            this.ignoreSoftLimits = ignoreSoftLimits;
             return (B) this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ProducerListenerSupport.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ProducerListenerSupport.java
@@ -35,6 +35,7 @@ import com.netflix.hollow.api.producer.listener.RestoreListener;
 import com.netflix.hollow.api.producer.validation.ValidationStatus;
 import com.netflix.hollow.api.producer.validation.ValidationStatusListener;
 import com.netflix.hollow.api.producer.validation.ValidatorListener;
+
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -213,7 +214,6 @@ final class ProducerListenerSupport extends ListenerSupport {
                     l -> l.onBlobStage(s, blob, elapsed));
         }
 
-
         void fireBlobPublishAsync(CompletableFuture<HollowProducer.Blob> f) {
             fire(PublishListener.class,
                     l -> l.onBlobPublishAsync(f));
@@ -228,13 +228,13 @@ final class ProducerListenerSupport extends ListenerSupport {
                     l -> l.onBlobPublish(s, blob, elapsed));
         }
 
-        void firePublishComplete(Status.StageBuilder b) {
+        void firePublishComplete(Status.StageBuilder b, PublishStageStats stats) {
             Status s = b.build();
             long version = b.version;
             Duration elapsed = b.elapsed();
 
             fire(PublishListener.class,
-                    l -> l.onPublishComplete(s, version, elapsed));
+                    l -> l.onPublishComplete(s, version, elapsed, stats));
         }
 
         Status.StageWithStateBuilder fireIntegrityCheckStart(HollowProducer.ReadState readState) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/PublishStageStats.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/PublishStageStats.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2016-2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+import com.netflix.hollow.core.memory.ByteArrayOrdinalMapStats;
+
+import java.util.Map;
+
+public class PublishStageStats implements StageStats {
+    private final Map<String, ByteArrayOrdinalMapStats> getOrdinalMapStats;
+    private PublishStageStats(Map<String, ByteArrayOrdinalMapStats> getOrdinalMapStats) {
+        this.getOrdinalMapStats = getOrdinalMapStats;
+    }
+
+    public Map<String, ByteArrayOrdinalMapStats> getOrdinalMapStats() {
+        return this.getOrdinalMapStats;
+    }
+
+    public static class Builder {
+        private Map<String, ByteArrayOrdinalMapStats> byteArrayOrdinalMapStatsByType;
+        public Builder withStats(Map<String, ByteArrayOrdinalMapStats> byteArrayOrdinalMapStatsByType) {
+            this.byteArrayOrdinalMapStatsByType = byteArrayOrdinalMapStatsByType;
+            return this;
+        }
+
+        public PublishStageStats build() {
+            return new PublishStageStats(byteArrayOrdinalMapStatsByType);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/StageStats.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/StageStats.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2016-2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+/**
+ * The top-level type for all stage stats.
+ */
+public interface StageStats {
+}

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMapStats.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMapStats.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2016-2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.memory;
+
+/**
+ * Statistics for a {@link ByteArrayOrdinalMap}.
+ */
+public class ByteArrayOrdinalMapStats {
+    private final int maxOrdinal;
+    private final long byteDataLength;
+    private final float loadFactor;
+
+    public ByteArrayOrdinalMapStats(int maxOrdinal, long byteDataLength, float loadFactor) {
+        this.maxOrdinal = maxOrdinal;
+        this.byteDataLength = byteDataLength;
+        this.loadFactor = loadFactor;
+    }
+
+    /**
+     * @return the maximum ordinal value in the map
+     */
+    public int getMaxOrdinal() {
+        return maxOrdinal;
+    }
+
+    /**
+     * @return the length of the byte data array
+     */
+    public long getByteDataLength() {
+        return byteDataLength;
+    }
+
+    /**
+     * @return the current load factor of the map
+     */
+    public float getLoadFactor() {
+        return loadFactor;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{\"maxOrdinal\":%d,\"byteDataLength\":%d,\"loadFactor\":%f}",
+            maxOrdinal, byteDataLength, loadFactor);
+    }
+
+}
+

--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
@@ -100,16 +100,16 @@ public class HollowWriteStateCreator {
             if(stateEngine.getTypeState(schema.getName()) == null) {
                 switch(schema.getSchemaType()) {
                 case OBJECT:
-                    stateEngine.addTypeState(new HollowObjectTypeWriteState((HollowObjectSchema)schema));
+                    stateEngine.addTypeState(new HollowObjectTypeWriteState((HollowObjectSchema)schema, -1, stateEngine.getIgnoreOrdinalLimitsSupplier()));
                     break;
                 case LIST:
-                    stateEngine.addTypeState(new HollowListTypeWriteState((HollowListSchema)schema));
+                    stateEngine.addTypeState(new HollowListTypeWriteState((HollowListSchema)schema, -1, stateEngine.getIgnoreOrdinalLimitsSupplier()));
                     break;
                 case SET:
-                    stateEngine.addTypeState(new HollowSetTypeWriteState((HollowSetSchema)schema));
+                    stateEngine.addTypeState(new HollowSetTypeWriteState((HollowSetSchema)schema, -1, stateEngine.getIgnoreOrdinalLimitsSupplier()));
                     break;
                 case MAP:
-                    stateEngine.addTypeState(new HollowMapTypeWriteState((HollowMapSchema)schema));
+                    stateEngine.addTypeState(new HollowMapTypeWriteState((HollowMapSchema)schema, -1, stateEngine.getIgnoreOrdinalLimitsSupplier()));
                     break;
                 }
             }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowListTypeWriteState.java
@@ -25,6 +25,7 @@ import com.netflix.hollow.core.memory.pool.WastefulRecycler;
 import com.netflix.hollow.core.schema.HollowListSchema;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.function.Supplier;
 
 public class HollowListTypeWriteState extends HollowTypeWriteState {
 
@@ -50,7 +51,11 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
     }
     
     public HollowListTypeWriteState(HollowListSchema schema, int numShards) {
-        super(schema, numShards);
+        this(schema, numShards, null);
+    }
+
+    public HollowListTypeWriteState(HollowListSchema schema, int numShards, Supplier<Boolean> ignoreSoftLimits) {
+        super(schema, numShards, ignoreSoftLimits);
     }
 
     @Override
@@ -62,7 +67,6 @@ public class HollowListTypeWriteState extends HollowTypeWriteState {
     public void prepareForWrite(boolean canReshard) {
         super.prepareForWrite(canReshard);
 
-        maxOrdinal = ordinalMap.maxOrdinal();
         gatherShardingStats(maxOrdinal, canReshard);
         gatherStatistics(numShards != revNumShards);
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowMapTypeWriteState.java
@@ -29,6 +29,7 @@ import com.netflix.hollow.core.memory.pool.WastefulRecycler;
 import com.netflix.hollow.core.schema.HollowMapSchema;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -59,7 +60,11 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
     }
 
     public HollowMapTypeWriteState(HollowMapSchema schema, int numShards) {
-        super(schema, numShards);
+        this(schema, numShards, null);
+    }
+
+    public HollowMapTypeWriteState(HollowMapSchema schema, int numShards, Supplier<Boolean> ignoreSoftLimits) {
+        super(schema, numShards, ignoreSoftLimits);
     }
 
     @Override
@@ -71,7 +76,6 @@ public class HollowMapTypeWriteState extends HollowTypeWriteState {
     public void prepareForWrite(boolean canReshard) {
         super.prepareForWrite(canReshard);
 
-        maxOrdinal = ordinalMap.maxOrdinal();
         gatherShardingStats(maxOrdinal, canReshard);
         gatherStatistics(numShards != revNumShards);
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowObjectTypeWriteState.java
@@ -27,6 +27,7 @@ import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -49,8 +50,13 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
         this(schema, -1);
     }
 
+    // visible for test purpose
     public HollowObjectTypeWriteState(HollowObjectSchema schema, int numShards) {
-        super(schema, numShards);
+        this(schema, numShards, null);
+    }
+
+    public HollowObjectTypeWriteState(HollowObjectSchema schema, int numShards, Supplier<Boolean> ignoreSoftLimits) {
+        super(schema, numShards, ignoreSoftLimits);
     }
 
     @Override
@@ -69,7 +75,6 @@ public class HollowObjectTypeWriteState extends HollowTypeWriteState {
     public void prepareForWrite(boolean canReshard) {
         super.prepareForWrite(canReshard);
 
-        maxOrdinal = ordinalMap.maxOrdinal();
         gatherFieldStats();
         gatherShardingStats(maxOrdinal, canReshard);
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowSetTypeWriteState.java
@@ -29,6 +29,7 @@ import com.netflix.hollow.core.memory.pool.WastefulRecycler;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -58,7 +59,11 @@ public class HollowSetTypeWriteState extends HollowTypeWriteState {
     }
 
     public HollowSetTypeWriteState(HollowSetSchema schema, int numShards) {
-        super(schema, numShards);
+        this(schema, numShards, null);
+    }
+
+    public HollowSetTypeWriteState(HollowSetSchema schema, int numShards, Supplier<Boolean> ignoreSoftLimits) {
+        super(schema, numShards, ignoreSoftLimits);
     }
 
     @Override
@@ -70,7 +75,6 @@ public class HollowSetTypeWriteState extends HollowTypeWriteState {
     public void prepareForWrite(boolean canReshard) {
         super.prepareForWrite(canReshard);
 
-        maxOrdinal = ordinalMap.maxOrdinal();
         gatherShardingStats(maxOrdinal, canReshard);
         gatherStatistics(numShards != revNumShards);
     }

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
@@ -55,7 +55,8 @@ public class HollowListTypeMapper extends HollowTypeMapper {
         this.ignoreListOrdering = ignoreListOrdering;
 
         HollowListTypeWriteState existingTypeState = (HollowListTypeWriteState)parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = existingTypeState != null ? existingTypeState : new HollowListTypeWriteState(schema, numShards);
+        this.writeState = existingTypeState != null ? existingTypeState : new HollowListTypeWriteState(schema, numShards,
+                parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -64,7 +64,8 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
         this.hashCodeFinder = stateEngine.getHashCodeFinder();
 
         HollowMapTypeWriteState typeState = (HollowMapTypeWriteState) parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = typeState != null ? typeState : new HollowMapTypeWriteState(schema, numShards);
+        this.writeState = typeState != null ? typeState : new HollowMapTypeWriteState(schema, numShards,
+                parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -136,7 +136,8 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             this.writeState = existingWriteState;
         } else {
             int numShardsByAnnotation = getNumShardsByAnnotation(clazz);
-            this.writeState = new HollowObjectTypeWriteState(schema, numShardsByAnnotation);
+            this.writeState = new HollowObjectTypeWriteState(schema, numShardsByAnnotation,
+                    parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
         }
 
         this.assignedOrdinalFieldOffset = assignedOrdinalFieldOffset;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -58,7 +58,8 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
         this.hashCodeFinder = stateEngine.getHashCodeFinder();
 
         HollowSetTypeWriteState existingTypeState = (HollowSetTypeWriteState) parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = existingTypeState != null ? existingTypeState : new HollowSetTypeWriteState(schema, numShards);
+        this.writeState = existingTypeState != null ? existingTypeState : new HollowSetTypeWriteState(schema, numShards,
+                parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
     }
 
     @Override
@@ -70,7 +71,7 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
     protected int write(Object obj) {
         if(obj instanceof MemoizedSet) {
             long assignedOrdinal = ((MemoizedSet<?>)obj).__assigned_ordinal;
-            
+
             if((assignedOrdinal & ASSIGNED_ORDINAL_CYCLE_MASK) == cycleSpecificAssignedOrdinalBits())
                 return (int)assignedOrdinal & Integer.MAX_VALUE;
         }

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/ByteArrayOrdinalTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/ByteArrayOrdinalTest.java
@@ -16,10 +16,43 @@
  */
 package com.netflix.hollow.core.memory;
 
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import java.lang.reflect.Field;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class ByteArrayOrdinalTest {
+
+    private static final int TEST_SOFT_ORDINAL_LIMIT = 1 << 3; // 8
+
+    /**
+     * Sets SOFT_ORDINAL_LIMIT to a small value for testing and returns the original value.
+     */
+    private int setSoftOrdinalLimitForTesting() throws Exception {
+        Field softLimitField = ByteArrayOrdinalMap.class.getDeclaredField("SOFT_ORDINAL_LIMIT");
+        softLimitField.setAccessible(true);
+        int originalValue = softLimitField.getInt(null);
+        softLimitField.set(null, TEST_SOFT_ORDINAL_LIMIT);
+
+        return originalValue;
+    }
+
+    /**
+     * Restores the original SOFT_ORDINAL_LIMIT value to avoid impacting other tests.
+     */
+    private void restoreSoftOrdinalLimit(int originalValue) throws Exception {
+        Field softLimitField = ByteArrayOrdinalMap.class.getDeclaredField("SOFT_ORDINAL_LIMIT");
+        softLimitField.setAccessible(true);
+        softLimitField.set(null, originalValue);
+    }
 
     @Test
     public void testResize() {
@@ -58,6 +91,66 @@ public class ByteArrayOrdinalTest {
         }
 
         Assert.assertArrayEquals(ordinals, newOrdinals);
+    }
+
+    @Test
+    public void testIgnoreSoftLimits() throws Exception {
+        int originalLimit = setSoftOrdinalLimitForTesting();
+        try {
+            ByteArrayOrdinalMap m = new ByteArrayOrdinalMap(256, false);
+
+            for (int i = 0; i < TEST_SOFT_ORDINAL_LIMIT; i++) {
+                m.getOrAssignOrdinal(createBuffer("TEST" + i));
+            }
+
+            // add 1 extra record to breach the SOFT_ORDINAL_LIMIT to cause exception
+            try {
+                m.getOrAssignOrdinal(createBuffer("TEST_BREACH_LIMIT"));
+                fail("Expected IllegalStateException to be thrown when soft ordinal limit is breached with ignoreSoftLimits=false");
+            } catch (IllegalStateException e) {
+                Assert.assertTrue(e.getMessage().contains("exceeds the soft ordinal limit"));
+            }
+
+            // when ignoreSoftLimits set to true, limit breach should be ignored.
+            m.setIgnoreSoftLimits(true);
+            m.getOrAssignOrdinal(createBuffer("TEST_OVER_LIMIT"));
+        } finally {
+            restoreSoftOrdinalLimit(originalLimit);
+        }
+    }
+
+    @Test
+    public void testLogSoftLimitsBreach() throws Exception {
+        int originalLimit = setSoftOrdinalLimitForTesting();
+        Logger logger = Logger.getLogger(ByteArrayOrdinalMap.class.getName());
+        Handler mockHandler = mock(Handler.class);
+        logger.addHandler(mockHandler);
+        logger.setLevel(Level.ALL);
+        boolean originalUseParentHandlers = logger.getUseParentHandlers();
+        logger.setUseParentHandlers(false);
+        try {
+            ByteArrayOrdinalMap m = new ByteArrayOrdinalMap(256, true);
+
+            // breach SOFT_ORDINAL_LIMIT 5 times should only result in 1 related log being published.
+            for (int i = 0; i < TEST_SOFT_ORDINAL_LIMIT + 5; i++) {
+                m.getOrAssignOrdinal(createBuffer("TEST" + i));
+            }
+
+            ArgumentCaptor<LogRecord> logCaptor = ArgumentCaptor.forClass(LogRecord.class);
+            verify(mockHandler, times(1)).publish(logCaptor.capture());
+
+            // after reset, add new records to breach SOFT_ORDINAL_LIMIT for another 5 times, should result in 1 more
+            // related log being published.
+            m.resetLogSoftLimitsBreach();
+            for (int i = TEST_SOFT_ORDINAL_LIMIT + 5; i < TEST_SOFT_ORDINAL_LIMIT + 10; i++) {
+                m.getOrAssignOrdinal(createBuffer("TEST" + i));
+            }
+            verify(mockHandler, times(2)).publish(logCaptor.capture());
+        } finally {
+            restoreSoftOrdinalLimit(originalLimit);
+            logger.removeHandler(mockHandler);
+            logger.setUseParentHandlers(originalUseParentHandlers);
+        }
     }
 
     static ByteDataArray createBuffer(String s) {


### PR DESCRIPTION
  Summary:
  This change adds configurable soft limit validation to ByteArrayOrdinalMap and exposes ordinal map
  statistics to PublishListeners for monitoring.

  Changes:

  1. Soft Limit Enforcement
    - Adds soft limit threshold at 268,435,456 (2^28) - half of the hard limit
    - Throws exception when soft limit exceeded (configurable behavior)
    - Override mechanism via HollowProducer.withIgnoreSoftLimits(Supplier<Boolean>)
    - One-time logging per cycle to prevent log spam
  2. Stats Exposure
    - New ByteArrayOrdinalMapStats class captures maxOrdinal, byteDataLength, and loadFactor
    - New PublishStageStats wraps stats for all type write states
    - Extended PublishListener.onPublishComplete() to receive stats (backward compatible)
    - Stats collected after successful publish and passed through listener chain
    3. Perf Improvement
    - Remove redundant scan of `pointersAndOrdinals` to find the max ordinal in `HollowWriteTypeState`. Instead, find and return the max ordinal when doing `prepareForWrite`

  Backward Compatibility:
  - Default constructor maintains existing behavior (soft limits disabled by default)
  - Deprecated onPublishComplete method preserved with default implementation
  - No breaking changes to existing API