### PR TITLE
fix: correct field index in PerfAPI codegen when fields are filtered

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowObjectTypePerfAPIClassGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/perfapi/HollowObjectTypePerfAPIClassGenerator.java
@@ -20,6 +20,9 @@ import com.netflix.hollow.api.codegen.HollowCodeGenerationUtils;
 import com.netflix.hollow.core.HollowDataset;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import static com.netflix.hollow.api.codegen.HollowCodeGenerationUtils.includeType;
@@ -60,17 +63,18 @@ class HollowObjectTypePerfAPIClassGenerator {
         builder.append("\n@SuppressWarnings(\"all\")\n");
         builder.append("public class " + schema.getName() + "PerfAPI extends HollowObjectTypePerfAPI {\n\n");
 
+        List<Integer> fieldPositions = new ArrayList<>(schema.numFields());
+
         builder.append("    public static final String fieldNames[] = { ");
         int addedFields = 0;
         for(int i=0;i<schema.numFields();i++) {
-            if (dataset != null && schema.getFieldType(i) == HollowObjectSchema.FieldType.REFERENCE &&
-                !includeType(schema.getReferencedType(i), dataset)) {
+            if (dataset != null && schema.getFieldType(i) == HollowObjectSchema.FieldType.REFERENCE && !includeType(schema.getReferencedType(i), dataset)) {
                 continue;
             }
-
             if(addedFields > 0) {
                 builder.append(", ");
             }
+            fieldPositions.add(i);
             builder.append("\"").append(schema.getFieldName(i)).append("\"");
             addedFields++;
         }
@@ -81,14 +85,11 @@ class HollowObjectTypePerfAPIClassGenerator {
         builder.append("        super(dataAccess, typeName, api, fieldNames);\n");
         builder.append("    }\n\n");
 
-        for(int i=0;i<schema.numFields();i++) {
-            if (dataset != null && schema.getFieldType(i) == HollowObjectSchema.FieldType.REFERENCE && !includeType(schema.getReferencedType(i), dataset)) {
-                continue;
-            }
-
-            FieldType fieldType = schema.getFieldType(i);
-            String fieldName = schema.getFieldName(i);
-            String referencedType = schema.getReferencedType(i);
+        for(int i=0;i<fieldPositions.size();i++) {
+            int position = fieldPositions.get(i);
+            String fieldName = schema.getFieldName(position);
+            FieldType fieldType = schema.getFieldType(position);
+            String referencedType = schema.getReferencedType(position);
             appendFieldMethod(builder, fieldType, fieldName, i, referencedType);
         }
 

--- a/hollow/src/test/resources/hollow_code_gen_test.schema
+++ b/hollow/src/test/resources/hollow_code_gen_test.schema
@@ -13,6 +13,7 @@ TopLevelObject {
 	MapOfStringToObject2 invalidMapField1;
 	MapOfObject2ToString invalidMapField2;
 	Object2 invalidMemberField;
+	String validStringField;
 }
 
 ListOfObject1 List<Object1>;


### PR DESCRIPTION
When generating PerfAPI accessor methods, field indices were incorrect if some fields were skipped (e.g., filtered reference types). The loop index was used instead of tracking actual field positions in the schema.