### PR TITLE
Fixes OOM during error message construction

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
  * record's type will never fail.
  */
 public class DuplicateDataDetectionValidator implements ValidatorListener {
+    private static final int MAX_DISPLAYED_DUPLICATE_KEYS = 100;
     private static final String DUPLICATE_KEYS_FOUND_ERRRO_MSG_FORMAT =
             "Duplicate keys found for type %s. Primarykey in schema is %s. "
                     + "Duplicate IDs are: %s";
@@ -189,7 +190,17 @@ public class DuplicateDataDetectionValidator implements ValidatorListener {
     }
 
     private String duplicateKeysToString(Collection<Object[]> duplicateKeys) {
-        return duplicateKeys.stream().map(Arrays::toString).collect(Collectors.joining(","));
+        long totalCount = duplicateKeys.size();
+        String duplicateKeysString = duplicateKeys.stream()
+                .limit(MAX_DISPLAYED_DUPLICATE_KEYS)
+                .map(Arrays::toString)
+                .collect(Collectors.joining(", "));
+
+        if (totalCount > MAX_DISPLAYED_DUPLICATE_KEYS) {
+            return String.format("%s ... (showing %d of %d duplicates)",
+                    duplicateKeysString, MAX_DISPLAYED_DUPLICATE_KEYS, totalCount);
+        }
+        return duplicateKeysString;
     }
 
     /**

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/NullPrimaryKeyFieldValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/NullPrimaryKeyFieldValidator.java
@@ -27,6 +27,7 @@ import static com.netflix.hollow.core.HollowConstants.ORDINAL_NONE;
  * instantiating this validator.
  */
 public class NullPrimaryKeyFieldValidator implements ValidatorListener {
+    private static final int MAX_DISPLAYED_NULL_KEYS = 100;
     private static final String NAME = NullPrimaryKeyFieldValidator.class.getName();
     private static final String NULL_PRIMARY_KEYS_FOUND_ERROR_MSG_FORMAT =
             "Null primary key fields found for type %s. Primary Key in schema is %s. "
@@ -171,10 +172,18 @@ public class NullPrimaryKeyFieldValidator implements ValidatorListener {
     }
 
     private String nullKeysToString(Map<Integer, Object[]> nullPrimaryKeyValues) {
-        return nullPrimaryKeyValues.entrySet().stream()
+        long totalCount = nullPrimaryKeyValues.size();
+        String nullPrimaryKeysString = nullPrimaryKeyValues.entrySet().stream()
+                .limit(MAX_DISPLAYED_NULL_KEYS)
                 .map(entry -> {
                     return "(ordinal=" + entry.getKey() + ", key=" + Arrays.toString(entry.getValue()) + ")";
                 })
                 .collect(Collectors.joining(", "));
+
+        if (totalCount > MAX_DISPLAYED_NULL_KEYS) {
+            return String.format("%s ... (showing %d of %d null keys)",
+                    nullPrimaryKeysString, MAX_DISPLAYED_NULL_KEYS, totalCount);
+        }
+        return nullPrimaryKeysString;
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.api.producer.validation;
 
 import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 import com.netflix.hollow.test.InMemoryBlobStore;
 import org.junit.Assert;
 import org.junit.Before;
@@ -42,6 +43,38 @@ public class DuplicateDataDetectionValidatorTests {
             Assert.assertEquals(1, expected.getValidationStatus().getResults().size());
             Assert.assertTrue(expected.getValidationStatus().getResults().get(0).getMessage()
                     .endsWith("(see initializeDataModel)"));
+        }
+    }
+
+    @Test
+    public void test_errorMessageIsTruncatedWhenThereAreManyDuplicates() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new DuplicateDataDetectionValidator(TypeWithPrimaryKey.class))
+                .build();
+
+        try {
+            producer.runCycle(writeState -> {
+                // Add 1000 records with the same primary key
+                for (int i = 0; i < 1000; i++) {
+                    writeState.add(new TypeWithPrimaryKey(1, "Duplicate" + i));
+                }
+            });
+            Assert.fail("Expected ValidationStatusException");
+        } catch (ValidationStatusException expected) {
+            String message = expected.getValidationStatus().getResults().get(0).getMessage();
+            Assert.assertTrue(message.contains("showing 100 of 499500 duplicates")); // 499500 is the number of duplicate pairs for 1000 identical keys (n * (n-1)/2)
+        }
+    }
+
+    @HollowPrimaryKey(fields = {"id"})
+    static class TypeWithPrimaryKey {
+        int id;
+        String name;
+
+        TypeWithPrimaryKey(int id, String name) {
+            this.id = id;
+            this.name = name;
         }
     }
 }


### PR DESCRIPTION
The duplicate detection finds pair-wise duplicates, which means if there are `1000` duplicate keys, it will find `499,500` duplicate key pairs (`(n * n-1) / 2`). The validator then tries to construct a message with all the duplicate pairs as single error message. This results in the below OOM error message.
```
java.lang.OutOfMemoryError: Requested array size exceeds VM limit
  at java.util.StringJoiner.checkAddLength(StringJoiner.java:203)
  at java.util.StringJoiner.add(StringJoiner.java:194)
  at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
  at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
  at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
  at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
  at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
  at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
  at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
  at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
  at com.netflix.hollow.api.producer.validation.DuplicateDataDetectionValidator.duplicateKeysToString(DuplicateDataDetectionValidator.java:192)
  at com.netflix.hollow.api.producer.validation.DuplicateDataDetectionValidator.onValidate(DuplicateDataDetectionValidator.java:155)
  at com.netflix.cinder.producer.migration.AbstractPrimaryKeyBackgroundValidator.validateType(AbstractPrimaryKeyBackgroundValidator.java:126)
  at com.netflix.cinder.producer.migration.AbstractPrimaryKeyBackgroundValidator.onValidate(AbstractPrimaryKeyBackgroundValidator.java:85)
```

This PR fixes this by limiting the number of duplicate keys included in the error message to a max of 100. It also adds a similar limit on the error message for the `NullPrimaryKeyValidator` as well.

One potential improvement in the future could be to only compute the MAX number of duplicates (100 for instance), instead of computing everything and then displaying only the 100.