### PR TITLE
Download protoc via Maven instead of requiring system install

### DIFF
--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
-      - name: Install protoc
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
       - uses: actions/cache@v5
         id: gradle-cache
         with:

--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -20,11 +20,6 @@ jobs:
         with:
           java-version: 8
           distribution: 'zulu'
-      - name: Install protoc
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
       - uses: actions/cache@v5
         id: gradle-cache
         with:

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -34,11 +34,6 @@ jobs:
           path: |
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/*') }}
-      - name: Install protoc
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
       - name: Build
         run: ./gradlew build snapshot
         env:

--- a/hollow-protoadapter/build.gradle
+++ b/hollow-protoadapter/build.gradle
@@ -1,23 +1,71 @@
 apply plugin: 'java-library'
 
+// Download the protoc binary and well-known proto includes for the current platform
+configurations {
+    protocBinary
+    protobufIncludes
+}
+
+static String getProtocArtifactClassifier() {
+    String os = System.getProperty('os.name').toLowerCase()
+    String arch = System.getProperty('os.arch').toLowerCase()
+
+    String osName
+    if (os.contains('linux')) {
+        osName = 'linux'
+    } else if (os.contains('mac') || os.contains('darwin')) {
+        osName = 'osx'
+    } else if (os.contains('windows')) {
+        osName = 'windows'
+    } else {
+        throw new IllegalStateException("Unsupported OS for protoc: ${os}")
+    }
+
+    String archName
+    if (arch == 'aarch64' || arch == 'arm64') {
+        archName = 'aarch_64'
+    } else if (arch == 'amd64' || arch == 'x86_64') {
+        archName = 'x86_64'
+    } else {
+        throw new IllegalStateException("Unsupported architecture for protoc: ${arch}")
+    }
+
+    return "${osName}-${archName}"
+}
+
+// Extract well-known .proto files (e.g. google/protobuf/descriptor.proto) from protobuf-java
+tasks.register('extractProtobufIncludes', Sync) {
+    description = 'Extract well-known .proto files from protobuf-java for use with protoc'
+
+    from({ configurations.protobufIncludes.collect { zipTree(it) } }) {
+        include 'google/**/*.proto'
+    }
+    into "${buildDir}/protobuf-includes"
+}
+
 // Compile hollow_options.proto for the main library
 tasks.register('compileMainProtos', Exec) {
+    dependsOn extractProtobufIncludes
     description = 'Compile hollow_options.proto for library distribution'
 
     def protoSrcDir = file('src/main/proto')
     def protoOutputDir = file("${buildDir}/generated/source/proto/main/java")
+    def protoIncludeDir = file("${buildDir}/protobuf-includes")
 
     inputs.dir(protoSrcDir)
+    inputs.files(configurations.protocBinary)
     outputs.dir(protoOutputDir)
 
     doFirst {
         protoOutputDir.mkdirs()
+        def protoc = configurations.protocBinary.singleFile
+        protoc.setExecutable(true)
+        commandLine protoc.absolutePath,
+                "--proto_path=${protoIncludeDir}",
+                "--proto_path=${protoSrcDir}",
+                "--java_out=${protoOutputDir}",
+                "${protoSrcDir}/hollow_options.proto"
     }
-
-    commandLine 'protoc',
-            "--proto_path=${protoSrcDir}",
-            "--java_out=${protoOutputDir}",
-            "${protoSrcDir}/hollow_options.proto"
 }
 
 // Add generated proto sources to main source set
@@ -58,20 +106,24 @@ tasks.register('compileTestProtos', Exec) {
     def protoSrcDir = file('src/test/resources')
     def mainProtoDir = file('src/main/proto')
     def protoOutputDir = file("${buildDir}/test-proto-classes")
+    def protoIncludeDir = file("${buildDir}/protobuf-includes")
 
     inputs.dir(protoSrcDir)
     inputs.dir(mainProtoDir)
+    inputs.files(configurations.protocBinary)
     outputs.dir(protoOutputDir)
 
     doFirst {
         protoOutputDir.mkdirs()
+        def protoc = configurations.protocBinary.singleFile
+        protoc.setExecutable(true)
+        commandLine protoc.absolutePath,
+                "--proto_path=${protoIncludeDir}",
+                "--proto_path=${mainProtoDir}",
+                "--proto_path=${protoSrcDir}",
+                "--java_out=${protoOutputDir}",
+                "${protoSrcDir}/test_person.proto"
     }
-
-    commandLine 'protoc',
-            "--proto_path=${mainProtoDir}",
-            "--proto_path=${protoSrcDir}",
-            "--java_out=${protoOutputDir}",
-            "${protoSrcDir}/test_person.proto"
 }
 
 // Custom task to compile the generated Java proto classes
@@ -105,4 +157,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.11'
     testImplementation 'com.google.protobuf:protobuf-java-util:3.+'
+
+    protocBinary "com.google.protobuf:protoc:3.+:${getProtocArtifactClassifier()}@exe"
+    protobufIncludes 'com.google.protobuf:protobuf-java:3.+'
 }

--- a/hollow-protoadapter/dependencies.lock
+++ b/hollow-protoadapter/dependencies.lock
@@ -1,73 +1,53 @@
 {
     "compileClasspath": {
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.4.3"
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.4.3"
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.8"
         },
         "com.netflix.hollow:hollow": {
             "project": true
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6"
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6"
+        }
+    },
+    "protobufIncludes": {
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.8"
+        }
+    },
+    "protocBinary": {
+        "com.google.protobuf:protoc": {
+            "locked": "3.25.8"
         }
     },
     "runtimeClasspath": {
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.4.3"
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.4.3"
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.8"
         },
         "com.netflix.hollow:hollow": {
             "project": true
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6"
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6"
         }
     },
     "testCompileClasspath": {
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.4.3"
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.8"
         },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.4.3"
+        "com.google.protobuf:protobuf-java-util": {
+            "locked": "3.25.8"
         },
         "com.netflix.hollow:hollow": {
             "project": true
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6"
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6"
         },
         "junit:junit": {
             "locked": "4.11"
         }
     },
     "testRuntimeClasspath": {
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.4.3"
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.8"
         },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.4.3"
+        "com.google.protobuf:protobuf-java-util": {
+            "locked": "3.25.8"
         },
         "com.netflix.hollow:hollow": {
             "project": true
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6"
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6"
         },
         "junit:junit": {
             "locked": "4.11"


### PR DESCRIPTION
The protobuf adaptor tests relied on a system-installed protoc compiler, causing build failures for contributors without it. This resolves the protoc binary and well-known proto includes as Maven artifacts (com.google.protobuf:protoc) with automatic OS/arch detection, removing the need for system protoc in both local builds and CI workflows.