### PR TITLE
[Improv]: Enable using 4 ByteArrayOrdinalMap per HollowTypeWriteState;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 **.iws
 .idea
 venv
+.cursor
 
 # publishing secrets
 secrets/signing-key

--- a/docs/advanced-topics.md
+++ b/docs/advanced-topics.md
@@ -251,6 +251,38 @@ Within a continuous delta chain, the type sharding configuration cannot be chang
 
 
 
+### Partitioned Ordinal Map
+
+Each type in Hollow is backed by a `ByteArrayOrdinalMap` that assigns ordinals to records. By default, a single map is used per type, limiting ordinals to the range `[0, 2^29 - 1]` — approximately 500 million unique records per type.
+
+When the partitioned ordinal map feature is enabled, each type's ordinal map is split into 4 internal partitions. Records are hash-routed to one of the 4 maps, and the 32-bit ordinal encodes both the partition index and the within-partition ordinal:
+
+```
+|  1 unused bit  |  29 bits (ordinal within partition)  |  2 bits (partition index)  |
+```
+
+This raises the effective per-type record limit to approximately 2 billion.
+
+#### Enabling
+
+Enable the partitioned ordinal map on the `HollowProducer` builder:
+
+```java
+HollowProducer producer = HollowProducer
+    .withPublisher(publisher)
+    .withPartitionedOrdinalMap(true)
+    .build();
+```
+
+The feature is disabled by default.
+
+#### Compatibility
+
+The partitioned ordinal map is a **write-path-only** change. No blob format changes are introduced, so:
+
+* Consumers at older version can read blobs produced with the feature enabled.
+* Producers at the new version can read blobs produced without the feature.
+
 ### Object Longevity
 
 A Hollow object returned from a generated API contains a reference to the Hollow data store, and an ordinal.  For this reason, if a reference to a Hollow object is retained by the consumer for an extended period of time, and the underlying record changes unexpected results may begin to be returned from these references.  We call Hollow objects which were obtained from a no longer current state stale references.

--- a/docs/producer-consumer-apis.md
+++ b/docs/producer-consumer-apis.md
@@ -26,6 +26,7 @@ HollowProducer
    .withNumStatesBetweenSnapshots(n) /// optional: an int
    .withTargetMaxTypeShardSize(size) /// optional: a long
    .withBlobStorageCleaner(blobStorageCleaner) //optional: a BlobStorageCleaner
+   .withPartitionedOrdinalMap(enabled) /// optional: a boolean
    .withMetricsCollector(hollowMetricsCollector) //optional: a HollowMetricsCollector<HollowProducerMetrics>
 ```
 
@@ -58,9 +59,12 @@ only every `(n+1)th` cycle.
 * `VersionMinter`: Allows for a custom version identifier minting strategy.
 * __Target max type shard size__: Specify a [target max type shard size](advanced-topics.md#type-sharding).  Defaults to 
 16MB.
-* `BlobStorageCleaner`: Using the [blob storage cleaning](tooling.md#blob-storage-manipulation) capability, it's 
+* `BlobStorageCleaner`: Using the [blob storage cleaning](tooling.md#blob-storage-manipulation) capability, it's
 possible to free up the blob storage and prevent running out of space because of old snapshots/deltas.
-* `HollowMetricsCollector`: Implementing a [`HollowMetricsCollector`](tooling.md#metrics) allows to either store or 
+* __Partitioned ordinal map__: Enables partitioning each type's internal ordinal map into 4 partitions, raising the
+per-type record limit from ~500M to ~2B. See [Partitioned Ordinal Map](advanced-topics.md#partitioned-ordinal-map).
+Defaults to `false`.
+* `HollowMetricsCollector`: Implementing a [`HollowMetricsCollector`](tooling.md#metrics) allows to either store or
 publish those metrics to your preferred provider, such as Prometheus.
 
 Each time a new _data state_ should be produced, users should call `.runCycle(Populator)`.  See 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -326,7 +326,6 @@ abstract class AbstractHollowProducer {
                 client.triggerRefreshTo(versionInfoDesired);
                 readState = ReadStateHelper.newReadState(client.getCurrentVersionId(), client.getStateEngine());
                 readStates = ReadStateHelper.restored(readState);
-                verifyPartitionOrdinalMapCompatability();
 
                 // Need to restore data to new ObjectMapper since can't restore to non empty Write State Engine
                 Collection<HollowSchema> schemas = objectMapper.getStateEngine().getSchemas();
@@ -981,27 +980,6 @@ abstract class AbstractHollowProducer {
             } finally {
                 listeners.fireAnnouncementComplete(status);
             }
-        }
-    }
-
-    private void verifyPartitionOrdinalMapCompatability() throws  IllegalStateException {
-        String datasetTag = readStates.current().getStateEngine()
-                .getHeaderTag(HollowStateEngine.HEADER_TAG_PARTITIONED_ORDINAL_MAP);
-        boolean datasetPartitionedOrdinalMap = Boolean.parseBoolean(datasetTag);
-        String message;
-        if (partitionedOrdinalMap && !datasetPartitionedOrdinalMap) {
-            message = String.format("trying to restore a HollowProducer with partitionedOrdinalMap enabled to version %d " +
-                    "that is produced with this feature disabled. In order to enable partitionedOrdinalMap " +
-                    "feature, please start a new delta chain.", readStates.current().getVersion());
-            log.log(Level.SEVERE, message);
-            throw new IllegalStateException(message);
-        }
-        if (!partitionedOrdinalMap && datasetPartitionedOrdinalMap) {
-            message = String.format("trying to restore a HollowProducer with partitionedOrdinalMap disabled to version %d " +
-                    "that is produced with this feature enabled. In order to disable partitionedOrdinalMap " +
-                    "feature, please start a new delta chain.", readStates.current().getVersion());
-            log.log(Level.SEVERE, message);
-            throw new IllegalStateException(message);
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -751,6 +751,7 @@ public class HollowProducer extends AbstractHollowProducer {
         SingleProducerEnforcer singleProducerEnforcer = new BasicSingleProducerEnforcer();
         HollowObjectHashCodeFinder hashCodeFinder = null;
         boolean doIntegrityCheck = true;
+        boolean partitionedOrdinalMap = false;
         ProducerOptionalBlobPartConfig optionalPartConfig = null;
         HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier = HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE;
         Supplier<Boolean> ignoreSoftLimits = null;
@@ -967,6 +968,17 @@ public class HollowProducer extends AbstractHollowProducer {
         
         public B noIntegrityCheck() {
             this.doIntegrityCheck = false;
+            return (B) this;
+        }
+
+        /*
+         * By partitioning a {@link HollowTypeWriteState} into 4 {@link com.netflix.hollow.core.memory.ByteArrayOrdinalMap} instead of 1,
+         * we can increase the ordinal limit (record cardinality limit) of the {@link HollowTypeWriteState} by 4 times.
+         * @param partitionedOrdinalMap true to enable the partition.
+         * @return this builder
+         */
+        public B withPartitionedOrdinalMap(boolean partitionedOrdinalMap) {
+            this.partitionedOrdinalMap = partitionedOrdinalMap;
             return (B) this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowStateEngine.java
@@ -80,6 +80,11 @@ public interface HollowStateEngine extends HollowDataset {
      */
     String HEADER_TAG_DELTA_CHAIN_VERSION_COUNTER = "hollow.delta.chain.version.counter";
 
+    /**
+     * A header tag indicating whether the producer used partitioned ordinal maps.
+     */
+    String HEADER_TAG_PARTITIONED_ORDINAL_MAP = "hollow.partitioned.ordinal.map";
+
     @Override
     List<HollowSchema> getSchemas();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
@@ -183,7 +183,7 @@ public class ByteArrayOrdinalMap {
     }
 
     /// acquire the lock before writing.
-    private synchronized int assignOrdinal(ByteDataArray serializedRepresentation, int hash, int preferredOrdinal) {
+    public synchronized int assignOrdinal(ByteDataArray serializedRepresentation, int hash, int preferredOrdinal) {
         if (preferredOrdinal < -1 || preferredOrdinal > ORDINAL_MASK) {
             throw new IllegalArgumentException(String.format(
                     "The given preferred ordinal %s is out of bounds and not within the closed interval [-1, %s]",
@@ -379,7 +379,7 @@ public class ByteArrayOrdinalMap {
     }
 
     /**
-     * Public method to get an ordinal using a pre-computed hash.
+     * Public method to find the ordinal for the serializedRepresentation with its pre-computed hash.
      *
      * @param serializedRepresentation the serialized representation
      * @param hash the pre-computed hash of the serialized representation
@@ -511,7 +511,6 @@ public class ByteArrayOrdinalMap {
         // Reset the array then fill with compacted values
         // Volatile store not required, could use plain store
         // See VarHandles for JDK >= 9
-        // TODO: why not just swap pao with populatedReverseKeys?
         for (int i = 0; i < pao.length(); i++) {
             pao.lazySet(i, EMPTY_BUCKET_VALUE);
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
@@ -168,6 +168,20 @@ public class ByteArrayOrdinalMap {
         return ordinal != -1 ? ordinal : assignOrdinal(serializedRepresentation, hash, preferredOrdinal);
     }
 
+    /**
+     * Adds a sequence of bytes to this map using a pre-computed hash.
+     * This avoids re-computing the hash when it's already been calculated for routing purposes.
+     *
+     * @param serializedRepresentation the sequence of bytes
+     * @param hash the pre-computed hash of the serialized representation
+     * @param preferredOrdinal the preferred ordinal to assign
+     * @return the assigned ordinal
+     */
+    public int getOrAssignOrdinal(ByteDataArray serializedRepresentation, int hash, int preferredOrdinal) {
+        int ordinal = get(serializedRepresentation, hash);
+        return ordinal != -1 ? ordinal : assignOrdinal(serializedRepresentation, hash, preferredOrdinal);
+    }
+
     /// acquire the lock before writing.
     private synchronized int assignOrdinal(ByteDataArray serializedRepresentation, int hash, int preferredOrdinal) {
         if (preferredOrdinal < -1 || preferredOrdinal > ORDINAL_MASK) {
@@ -364,7 +378,14 @@ public class ByteArrayOrdinalMap {
         return get(serializedRepresentation, HashCodes.hashCode(serializedRepresentation));
     }
 
-    private int get(ByteDataArray serializedRepresentation, int hash) {
+    /**
+     * Public method to get an ordinal using a pre-computed hash.
+     *
+     * @param serializedRepresentation the serialized representation
+     * @param hash the pre-computed hash of the serialized representation
+     * @return the ordinal for this serialized representation, or -1 if not found
+     */
+    public int get(ByteDataArray serializedRepresentation, int hash) {
         AtomicLongArray pao = pointersAndOrdinals;
 
         int modBitmask = pao.length() - 1;
@@ -436,9 +457,9 @@ public class ByteArrayOrdinalMap {
      * the key array to reflect the new pointers and exclude the removed entries.  This is also where ordinals
      * which are unused are returned to the pool.<p>
      *
-     * @param usedOrdinals a bit set representing the ordinals which are currently referenced by any image.
+     * @param usedGlobalOrdinals a bit set representing the ordinals which are currently referenced.
      */
-    public void compact(ThreadSafeBitSet usedOrdinals, int numShards, boolean focusHoleFillInFewestShards) {
+    public void compact(ThreadSafeBitSet usedGlobalOrdinals, int numShards, boolean focusHoleFillInFewestShards, int mapIdx, int mapIndexBits) {
         long[] populatedReverseKeys = new long[size];
 
         int counter = 0;
@@ -456,10 +477,12 @@ public class ByteArrayOrdinalMap {
         SegmentedByteArray arr = byteData.getUnderlyingArray();
         long currentCopyPointer = 0;
 
+        int currMapUsedOrdinalCnt = 0;
         for (int i = 0; i < populatedReverseKeys.length; i++) {
             int ordinal = (int) (populatedReverseKeys[i] & ORDINAL_MASK);
+            int globalOrdinal = (ordinal << mapIndexBits) | mapIdx;
 
-            if (usedOrdinals.get(ordinal)) {
+            if (usedGlobalOrdinals.get(globalOrdinal)) {
                 long pointer = populatedReverseKeys[i] >>> BITS_PER_ORDINAL;
                 int length = VarInt.readVInt(arr, pointer);
                 length += VarInt.sizeOfVInt(length);
@@ -471,6 +494,7 @@ public class ByteArrayOrdinalMap {
                 populatedReverseKeys[i] = populatedReverseKeys[i] << BITS_PER_POINTER | currentCopyPointer;
 
                 currentCopyPointer += length;
+                currMapUsedOrdinalCnt++;
             } else {
                 freeOrdinalTracker.returnOrdinalToPool(ordinal);
                 populatedReverseKeys[i] = EMPTY_BUCKET_VALUE;
@@ -480,18 +504,19 @@ public class ByteArrayOrdinalMap {
         byteData.setPosition(currentCopyPointer);
 
         if(focusHoleFillInFewestShards && numShards > 1)
-            freeOrdinalTracker.sort(numShards);
+            freeOrdinalTracker.sort(numShards, mapIndexBits, mapIdx);
         else
             freeOrdinalTracker.sort();
 
         // Reset the array then fill with compacted values
         // Volatile store not required, could use plain store
         // See VarHandles for JDK >= 9
+        // TODO: why not just swap pao with populatedReverseKeys?
         for (int i = 0; i < pao.length(); i++) {
             pao.lazySet(i, EMPTY_BUCKET_VALUE);
         }
         populateNewHashArray(pao, populatedReverseKeys);
-        size = usedOrdinals.cardinality();
+        size = currMapUsedOrdinalCnt;
 
         pointersByOrdinal = null;
         unusedPreviousOrdinals = null;

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/FreeOrdinalTracker.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/FreeOrdinalTracker.java
@@ -90,14 +90,16 @@ public class FreeOrdinalTracker {
      * Focus returned ordinal holes in as few shards as possible.
      * Within each shard, return ordinals in ascending order.
      */
-    public void sort(int numShards) {
+    public void sort(int numShards, int mapIndexBits, int mapIdx) {
         int shardNumberMask = numShards - 1;
         Shard shards[] = new Shard[numShards];
         for(int i=0;i<shards.length;i++)
             shards[i] = new Shard();
 
-        for(int i=0;i<size;i++)
-            shards[freeOrdinals[i] & shardNumberMask].freeOrdinalCount++;
+        for(int i=0;i<size;i++) {
+            int freeGlobalOrdinal = (freeOrdinals[i] << mapIndexBits) | mapIdx;
+            shards[freeGlobalOrdinal & shardNumberMask].freeOrdinalCount++;
+        }
 
         Shard orderedShards[] = Arrays.copyOf(shards, shards.length);
         Arrays.sort(orderedShards, (s1, s2) -> s2.freeOrdinalCount - s1.freeOrdinalCount);
@@ -110,7 +112,8 @@ public class FreeOrdinalTracker {
 
         int newFreeOrdinals[] = new int[freeOrdinals.length];
         for(int i=0;i<size;i++) {
-            Shard shard = shards[freeOrdinals[i] & shardNumberMask];
+            int freeGlobalOrdinal = (freeOrdinals[i] << mapIndexBits) | mapIdx;
+            Shard shard = shards[freeGlobalOrdinal & shardNumberMask];
             newFreeOrdinals[shard.currentPos] = freeOrdinals[i];
             shard.currentPos++;
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/util/HollowWriteStateCreator.java
@@ -96,20 +96,22 @@ public class HollowWriteStateCreator {
      */
     public static void populateStateEngineWithTypeWriteStates(HollowWriteStateEngine stateEngine, Collection<HollowSchema> schemas) {
         List<HollowSchema> dependencyOrderedSchemas = getDependencyOrderedSchemas(schemas);
+        boolean partitioned = stateEngine.isPartitionedOrdinalMap();
+
         for(HollowSchema schema : dependencyOrderedSchemas) {
             if(stateEngine.getTypeState(schema.getName()) == null) {
                 switch(schema.getSchemaType()) {
                 case OBJECT:
-                    stateEngine.addTypeState(new HollowObjectTypeWriteState((HollowObjectSchema)schema, -1, stateEngine.getIgnoreOrdinalLimitsSupplier()));
+                    stateEngine.addTypeState(new HollowObjectTypeWriteState((HollowObjectSchema)schema, -1, partitioned, stateEngine.getIgnoreOrdinalLimitsSupplier()));
                     break;
                 case LIST:
-                    stateEngine.addTypeState(new HollowListTypeWriteState((HollowListSchema)schema, -1, stateEngine.getIgnoreOrdinalLimitsSupplier()));
+                    stateEngine.addTypeState(new HollowListTypeWriteState((HollowListSchema)schema, -1, partitioned, stateEngine.getIgnoreOrdinalLimitsSupplier()));
                     break;
                 case SET:
-                    stateEngine.addTypeState(new HollowSetTypeWriteState((HollowSetSchema)schema, -1, stateEngine.getIgnoreOrdinalLimitsSupplier()));
+                    stateEngine.addTypeState(new HollowSetTypeWriteState((HollowSetSchema)schema, -1, partitioned, stateEngine.getIgnoreOrdinalLimitsSupplier()));
                     break;
                 case MAP:
-                    stateEngine.addTypeState(new HollowMapTypeWriteState((HollowMapSchema)schema, -1, stateEngine.getIgnoreOrdinalLimitsSupplier()));
+                    stateEngine.addTypeState(new HollowMapTypeWriteState((HollowMapSchema)schema, -1, partitioned, stateEngine.getIgnoreOrdinalLimitsSupplier()));
                     break;
                 }
             }
@@ -204,7 +206,7 @@ public class HollowWriteStateCreator {
                         
                         BitSet populatedOrdinals = readState.getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
 
-                        writeState.resizeOrdinalMap(populatedOrdinals.cardinality());
+                        writeState.resizeOrdinalMaps(populatedOrdinals.cardinality() >>> writeState.getOrdinalMapIndexBits());
                         int ordinal = populatedOrdinals.nextSetBit(0);
                         while(ordinal != -1) {
                             HollowWriteRecord rec = copier.copy(ordinal);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -143,12 +143,18 @@ public abstract class HollowTypeWriteState {
      * @return the global ordinal if found, or -1 if not found
      */
     private int searchAllMaps(ByteArrayOrdinalMap[] maps, ByteDataArray scratch, int hash) {
-        for (int i = 0; i < maps.length; i++) {
-            int found = maps[i].get(scratch, hash);
+        // small optimization -- assignOrdinal would use record hash to determine which ByteArrayOrdinalMap to route to.
+        // If the record was assigned the ordinal with assignOrdinal, the first look-up at
+        // maps[hash & ordinalMapIndexMask] would find it.
+        int startMapIdx = hash & ordinalMapIndexMask;
+        for (int i = startMapIdx; i < startMapIdx + ordinalMapNum; i++) {
+            int mapIdx = i % ordinalMapNum;
+            int found = maps[mapIdx].get(scratch, hash);
             if (found != -1) {
-                return (found << ordinalMapIndexBits) | i;
+                return (found << ordinalMapIndexBits) | mapIdx;
             }
         }
+
         return -1;
     }
 
@@ -173,9 +179,9 @@ public abstract class HollowTypeWriteState {
 
         // Not found — assign in hash-routed map
         int mapIndex = hash & ordinalMapIndexMask;
-        // TODO: getOrAssignOrdinal performs a redundant check to see if rec exists in the specified
-        // ByteArrayOrdinalMap, which has been done via searchAllMaps.
-        int localOrdinal = ordinalMaps[mapIndex].getOrAssignOrdinal(scratch, hash, -1);
+        // NOTE: assignOrdinal is a synchronized method. Directly invoke it instead of using getOrAssignOrdinal, as the
+        // record is not found across all ordinalMaps, no need to perform another search.
+        int localOrdinal = ordinalMaps[mapIndex].assignOrdinal(scratch, hash, -1);
         int globalOrdinal = (localOrdinal << ordinalMapIndexBits) | mapIndex;
 
         scratch.reset();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -23,7 +23,9 @@ import com.netflix.hollow.core.HollowStateEngine;
 import com.netflix.hollow.core.memory.ByteArrayOrdinalMap;
 import com.netflix.hollow.core.memory.ByteArrayOrdinalMapStats;
 import com.netflix.hollow.core.memory.ByteDataArray;
+import com.netflix.hollow.core.memory.SegmentedByteArray;
 import com.netflix.hollow.core.memory.ThreadSafeBitSet;
+import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.memory.pool.WastefulRecycler;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
@@ -45,10 +47,14 @@ import java.util.logging.Logger;
  */
 public abstract class HollowTypeWriteState {
     private static final Logger LOG = Logger.getLogger(HollowTypeWriteState.class.getName());
-
     protected final HollowSchema schema;
 
-    protected final ByteArrayOrdinalMap ordinalMap;
+    // Instance fields for configurable ordinal map count
+    protected final int ordinalMapNum;
+    protected final int ordinalMapIndexBits;
+    protected final int ordinalMapIndexMask;
+    protected final ByteArrayOrdinalMap[] ordinalMaps;
+
     protected int maxOrdinal;
     private final Supplier<Boolean> ignoreSoftLimits;
 
@@ -57,7 +63,7 @@ public abstract class HollowTypeWriteState {
     private int resetToLastNumShards;
 
     protected HollowSchema restoredSchema;
-    protected ByteArrayOrdinalMap restoredMap;
+    protected ByteArrayOrdinalMap[] restoredMaps;
     protected HollowTypeReadState restoredReadState;
 
     protected ThreadSafeBitSet currentCyclePopulated;
@@ -70,19 +76,34 @@ public abstract class HollowTypeWriteState {
     private boolean wroteData = false;
 
     private final boolean isNumShardsPinned;  // if numShards is pinned in data model
-    protected int maxShardOrdinal[];
-    protected int revMaxShardOrdinal[];
+    protected int[] maxShardOrdinal;
+    protected int[] revMaxShardOrdinal;
 
 
     public HollowTypeWriteState(HollowSchema schema, int numShards) {
-        this(schema, numShards, null);
+        this(schema, numShards, false, null);
     }
 
-    public HollowTypeWriteState(HollowSchema schema, int numShards, Supplier<Boolean> ignoreSoftLimits) {
+    public HollowTypeWriteState(HollowSchema schema, int numShards, boolean usePartitionedOrdinalMap, Supplier<Boolean> ignoreSoftLimits) {
         this.schema = schema;
         this.ignoreSoftLimits = ignoreSoftLimits;
-        this.ordinalMap = new ByteArrayOrdinalMap(
-                ignoreSoftLimits == null || ignoreSoftLimits.get());
+
+        // Configure ordinal map count based on partitioning flag
+        if (usePartitionedOrdinalMap) {
+            this.ordinalMapNum = 4;
+            this.ordinalMapIndexBits = 2;
+        } else {
+            this.ordinalMapNum = 1;
+            this.ordinalMapIndexBits = 0;
+        }
+        this.ordinalMapIndexMask = (1 << this.ordinalMapIndexBits) - 1;
+
+        this.ordinalMaps = new ByteArrayOrdinalMap[ordinalMapNum];
+        for (int i = 0; i < ordinalMapNum; i++) {
+            this.ordinalMaps[i] = new ByteArrayOrdinalMap(
+                    ignoreSoftLimits == null || ignoreSoftLimits.get());
+        }
+
         this.serializedScratchSpace = new ThreadLocal<ByteDataArray>();
         this.currentCyclePopulated = new ThreadSafeBitSet();
         this.previousCyclePopulated = new ThreadSafeBitSet();
@@ -101,12 +122,12 @@ public abstract class HollowTypeWriteState {
      * @return the ordinal of the added record
      */
     public int add(HollowWriteRecord rec) {
-        if(!ordinalMap.isReadyForAddingObjects())
+        if(!ordinalMaps[0].isReadyForAddingObjects())
             throw new RuntimeException("The HollowWriteStateEngine is not ready to add more Objects.  Did you remember to call stateEngine.prepareForNextCycle()?");
 
         int ordinal;
 
-        if(restoredMap == null) {
+        if(restoredMaps == null) {
             ordinal = assignOrdinal(rec);
         } else {
             ordinal = reuseOrdinalFromRestoredState(rec);
@@ -117,43 +138,92 @@ public abstract class HollowTypeWriteState {
         return ordinal;
     }
 
+    /**
+     * Search all maps in the given array for a record matching the scratch bytes.
+     * @return the global ordinal if found, or -1 if not found
+     */
+    private int searchAllMaps(ByteArrayOrdinalMap[] maps, ByteDataArray scratch, int hash) {
+        for (int i = 0; i < maps.length; i++) {
+            int found = maps[i].get(scratch, hash);
+            if (found != -1) {
+                return (found << ordinalMapIndexBits) | i;
+            }
+        }
+        return -1;
+    }
+
+    /*
+     * Assign an ordinal to a record. Use the record hash to determine the which ordinal map it belongs to and
+     * its ordinal within that map (localOrdinal). Then convert the local ordinal to a global ordinal and return.
+     *
+     * @param rec the record to assign an ordinal to
+     * @return the ordinal of the record
+     */
     private int assignOrdinal(HollowWriteRecord rec) {
         ByteDataArray scratch = scratch();
         rec.writeDataTo(scratch);
-        int ordinal = ordinalMap.getOrAssignOrdinal(scratch);
+        int hash = HashCodes.hashCode(scratch);
+
+        // Search ALL maps for existing record (dedup across maps)
+        int existingGlobal = searchAllMaps(ordinalMaps, scratch, hash);
+        if (existingGlobal != -1) {
+            scratch.reset();
+            return existingGlobal;
+        }
+
+        // Not found — assign in hash-routed map
+        int mapIndex = hash & ordinalMapIndexMask;
+        // TODO: getOrAssignOrdinal performs a redundant check to see if rec exists in the specified
+        // ByteArrayOrdinalMap, which has been done via searchAllMaps.
+        int localOrdinal = ordinalMaps[mapIndex].getOrAssignOrdinal(scratch, hash, -1);
+        int globalOrdinal = (localOrdinal << ordinalMapIndexBits) | mapIndex;
+
         scratch.reset();
-        return ordinal;
+        return globalOrdinal;
     }
 
 
     private int reuseOrdinalFromRestoredState(HollowWriteRecord rec) {
         ByteDataArray scratch = scratch();
 
-        int ordinal;
-
+        // Serialize with restored-compatible format and find preferred ordinal
+        int preferredGlobal;
+        // Special handling for potential schema change -- use the restored schema so that the same records can be
+        // properly found from the restoreMaps, even if some new fields get added.
         if(restoredSchema instanceof HollowObjectSchema) {
             ((HollowObjectWriteRecord)rec).writeDataTo(scratch, (HollowObjectSchema)restoredSchema);
-            int preferredOrdinal = restoredMap.get(scratch);
+        } else if(rec instanceof HollowHashableWriteRecord) {
+            ((HollowHashableWriteRecord) rec).writeDataTo(scratch, IGNORED_HASHES);
+        } else {
+            rec.writeDataTo(scratch);
+        }
+        preferredGlobal = searchAllMaps(restoredMaps, scratch, HashCodes.hashCode(scratch));
+
+        // Re-serialize with current schema if it could differ from the restored format
+        if(restoredSchema instanceof HollowObjectSchema || rec instanceof HollowHashableWriteRecord) {
             scratch.reset();
             rec.writeDataTo(scratch);
-            ordinal = ordinalMap.getOrAssignOrdinal(scratch, preferredOrdinal);
-        } else {
-            if(rec instanceof HollowHashableWriteRecord) {
-                ((HollowHashableWriteRecord) rec).writeDataTo(scratch, IGNORED_HASHES);
-                int preferredOrdinal = restoredMap.get(scratch);
-                scratch.reset();
-                rec.writeDataTo(scratch);
-                ordinal = ordinalMap.getOrAssignOrdinal(scratch, preferredOrdinal);
-            } else {
-                rec.writeDataTo(scratch);
-                int preferredOrdinal = restoredMap.get(scratch);
-                ordinal = ordinalMap.getOrAssignOrdinal(scratch, preferredOrdinal);
-            }
         }
 
+        int ordinal = assignToPreferredMap(scratch, preferredGlobal);
         scratch.reset();
-
         return ordinal;
+    }
+
+    /**
+     * Assign a record (already serialized in scratch) into the ordinal map corresponding to
+     * the preferred global ordinal, or hash-route if no preferred ordinal exists.
+     */
+    private int assignToPreferredMap(ByteDataArray scratch, int preferredGlobal) {
+        int hash = HashCodes.hashCode(scratch);
+        int mapIndex = preferredGlobal != -1
+            ? (preferredGlobal & ordinalMapIndexMask)
+            : (hash & ordinalMapIndexMask);
+        int preferredLocal = preferredGlobal != -1
+            ? (preferredGlobal >>> ordinalMapIndexBits)
+            : -1;
+        int newLocal = ordinalMaps[mapIndex].getOrAssignOrdinal(scratch, hash, preferredLocal);
+        return (newLocal << ordinalMapIndexBits) | mapIndex;
     }
 
     /**
@@ -163,49 +233,53 @@ public abstract class HollowTypeWriteState {
         numShards = resetToLastNumShards;
         if(restoredReadState == null) {
             currentCyclePopulated.clearAll();
-            ordinalMap.compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards());
-            ordinalMap.setIgnoreSoftLimits(
-                    ignoreSoftLimits == null || ignoreSoftLimits.get());
-            ordinalMap.resetLogSoftLimitsBreach();
+            for (int i = 0; i < ordinalMapNum; i++) {
+                ordinalMaps[i].compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards(), i, ordinalMapIndexBits);
+                ordinalMaps[i].setIgnoreSoftLimits(
+                        ignoreSoftLimits == null || ignoreSoftLimits.get());
+                ordinalMaps[i].resetLogSoftLimitsBreach();
+            }
         } else {
             /// this state engine began the cycle as a restored state engine
             currentCyclePopulated.clearAll();
             previousCyclePopulated.clearAll();
-            ordinalMap.compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards());
-            ordinalMap.setIgnoreSoftLimits(
-                    ignoreSoftLimits == null || ignoreSoftLimits.get());
-            ordinalMap.resetLogSoftLimitsBreach();
+            for (int i = 0; i < ordinalMapNum; i++) {
+                ordinalMaps[i].compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards(), i, ordinalMapIndexBits);
+                ordinalMaps[i].setIgnoreSoftLimits(
+                        ignoreSoftLimits == null || ignoreSoftLimits.get());
+                ordinalMaps[i].resetLogSoftLimitsBreach();
+            }
             restoreFrom(restoredReadState);
             wroteData = false;
         }
     }
 
     public void addAllObjectsFromPreviousCycle() {
-        if(!ordinalMap.isReadyForAddingObjects())
+        if(!ordinalMaps[0].isReadyForAddingObjects())
             throw new RuntimeException("The HollowWriteStateEngine is not ready to add more Objects.  Did you remember to call stateEngine.prepareForNextCycle()?");
 
         currentCyclePopulated = ThreadSafeBitSet.orAll(previousCyclePopulated, currentCyclePopulated);
     }
-    
+
     public void addOrdinalFromPreviousCycle(int ordinal) {
-        if(!ordinalMap.isReadyForAddingObjects())
+        if(!ordinalMaps[0].isReadyForAddingObjects())
             throw new RuntimeException("The HollowWriteStateEngine is not ready to add more Objects.  Did you remember to call stateEngine.prepareForNextCycle()?");
 
         if(!previousCyclePopulated.get(ordinal))
             throw new IllegalArgumentException("Ordinal " + ordinal + " was not present in the previous cycle");
-        
+
         currentCyclePopulated.set(ordinal);
     }
 
     public void removeOrdinalFromThisCycle(int ordinalToRemove) {
-        if(!ordinalMap.isReadyForAddingObjects())
+        if(!ordinalMaps[0].isReadyForAddingObjects())
             throw new RuntimeException("The HollowWriteStateEngine is not ready to add more Objects.  Did you remember to call stateEngine.prepareForNextCycle()?");
 
         currentCyclePopulated.clear(ordinalToRemove);
     }
-    
+
     public void removeAllOrdinalsFromThisCycle() {
-        if(!ordinalMap.isReadyForAddingObjects())
+        if(!ordinalMaps[0].isReadyForAddingObjects())
             throw new RuntimeException("The HollowWriteStateEngine is not ready to add more Objects.  Did you remember to call stateEngine.prepareForNextCycle()?");
 
         currentCyclePopulated.clearAll();
@@ -227,12 +301,17 @@ public abstract class HollowTypeWriteState {
      * @param markCurrentCycle true if the current populated cycle should be updated
      */
     public void mapOrdinal(HollowWriteRecord rec, int newOrdinal, boolean markPreviousCycle, boolean markCurrentCycle) {
-        if(!ordinalMap.isReadyForAddingObjects())
+        if(!ordinalMaps[0].isReadyForAddingObjects())
             throw new RuntimeException("The HollowWriteStateEngine is not ready to add more Objects.  Did you remember to call stateEngine.prepareForNextCycle()?");
 
         ByteDataArray scratch = scratch();
         rec.writeDataTo(scratch);
-        ordinalMap.put(scratch, newOrdinal);
+
+        // Decode the newOrdinal to determine which map and local ordinal
+        int mapIndex = newOrdinal & ordinalMapIndexMask;
+        int localOrdinal = newOrdinal >>> ordinalMapIndexBits;
+
+        ordinalMaps[mapIndex].put(scratch, localOrdinal);
         if(markPreviousCycle)
             previousCyclePopulated.set(newOrdinal);
         if(markCurrentCycle)
@@ -244,7 +323,9 @@ public abstract class HollowTypeWriteState {
      * Correct the free ordinal list after using mapOrdinal()
      */
     public void recalculateFreeOrdinals() {
-        ordinalMap.recalculateFreeOrdinals();
+        for (int i = 0; i < ordinalMapNum; i++) {
+            ordinalMaps[i].recalculateFreeOrdinals();
+        }
     }
 
     public ThreadSafeBitSet getPopulatedBitSet() {
@@ -259,6 +340,10 @@ public abstract class HollowTypeWriteState {
         return schema;
     }
     
+    public int getOrdinalMapIndexBits() {
+        return ordinalMapIndexBits;
+    }
+
     public int getNumShards() {
         return numShards;
     }
@@ -280,8 +365,11 @@ public abstract class HollowTypeWriteState {
         }
     }
 
-    public void resizeOrdinalMap(int size) {
-        ordinalMap.resize(size);
+    public void resizeOrdinalMaps(int size) {
+        // Resize all maps
+        for (int i = 0; i < ordinalMapNum; i++) {
+            ordinalMaps[i].resize(size);
+        }
     }
 
     /**
@@ -291,10 +379,16 @@ public abstract class HollowTypeWriteState {
      * Postcondition: We are ready to add objects to this state engine for the next server cycle.
      */
     public void prepareForNextCycle() {
-        ordinalMap.compact(currentCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards());
-        ordinalMap.setIgnoreSoftLimits(
-                ignoreSoftLimits == null || ignoreSoftLimits.get());
-        ordinalMap.resetLogSoftLimitsBreach();
+        // Compact each ordinal map independently
+        for (int i = 0; i < ordinalMapNum; i++) {
+            ordinalMaps[i].compact(currentCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards(), i, ordinalMapIndexBits);
+            ordinalMaps[i].setIgnoreSoftLimits(
+                    ignoreSoftLimits == null || ignoreSoftLimits.get());
+            ordinalMaps[i].resetLogSoftLimitsBreach();
+        }
+
+        // Null out restored maps — the cycle 2+ uses assignOrdinal() with search-all dedup
+        restoredMaps = null;
 
         ThreadSafeBitSet temp = previousCyclePopulated;
         previousCyclePopulated = currentCyclePopulated;
@@ -302,7 +396,6 @@ public abstract class HollowTypeWriteState {
 
         currentCyclePopulated.clearAll();
 
-        restoredMap = null;
         restoredSchema = null;
         restoredReadState = null;
 
@@ -315,16 +408,27 @@ public abstract class HollowTypeWriteState {
         if(isRestored() && !wroteData) {
             HollowRecordCopier copier = HollowRecordCopier.createCopier(restoredReadState, schema);
 
-            BitSet unusedPreviousOrdinals = ordinalMap.getUnusedPreviousOrdinals();
-            int ordinal = unusedPreviousOrdinals.nextSetBit(0);
+            // Process unused ordinals for each map
+            for (int mapIdx = 0; mapIdx < ordinalMapNum; mapIdx++) {
+                BitSet unusedPreviousOrdinals = ordinalMaps[mapIdx].getUnusedPreviousOrdinals();
+                if (unusedPreviousOrdinals != null) {
+                    int localOrdinal = unusedPreviousOrdinals.nextSetBit(0);
 
-            while(ordinal != -1) {
-                restoreOrdinal(ordinal, copier, ordinalMap, UNMIXED_HASHES);
-                ordinal = unusedPreviousOrdinals.nextSetBit(ordinal + 1);
+                    while(localOrdinal != -1) {
+                        // Convert local ordinal to global interleaved ordinal
+                        int globalOrdinal = (localOrdinal << ordinalMapIndexBits) | mapIdx;
+                        restoreOrdinal(globalOrdinal, copier, ordinalMaps[mapIdx], UNMIXED_HASHES);
+                        localOrdinal = unusedPreviousOrdinals.nextSetBit(localOrdinal + 1);
+                    }
+                }
             }
         }
 
-        this.maxOrdinal = ordinalMap.prepareForWrite();
+        // Prepare all maps for writing
+        maxOrdinal = -1;
+        for (int i = 0; i < ordinalMapNum; i++) {
+            maxOrdinal = Math.max(maxOrdinal, (ordinalMaps[i].prepareForWrite() << ordinalMapIndexBits) | i);
+        }
         wroteData = true;
     }
 
@@ -341,7 +445,13 @@ public abstract class HollowTypeWriteState {
     }
     
     public boolean isRestored() {
-        return ordinalMap.getUnusedPreviousOrdinals() != null;
+        // Check if any map has unused previous ordinals
+        for (int i = 0; i < ordinalMapNum; i++) {
+            if (ordinalMaps[i].getUnusedPreviousOrdinals() != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public abstract void calculateSnapshot();
@@ -373,7 +483,7 @@ public abstract class HollowTypeWriteState {
     protected void restoreFrom(HollowTypeReadState readState) {
         if(previousCyclePopulated.cardinality() != 0 || currentCyclePopulated.cardinality() != 0)
             throw new IllegalStateException("Attempting to restore into a non-empty state (type " + schema.getName() + ")");
-        
+
         PopulatedOrdinalListener listener = readState.getListener(PopulatedOrdinalListener.class);
         BitSet populatedOrdinals = listener.getPopulatedOrdinals();
 
@@ -384,24 +494,51 @@ public abstract class HollowTypeWriteState {
             restoredSchema = readState.getSchema();
         HollowRecordCopier copier = HollowRecordCopier.createCopier(restoredReadState, restoredSchema);
 
-        // Size the restore ordinal map to avoid resizing when adding ordinals
+        // Size the restore ordinal maps to avoid resizing when adding ordinals
         int size = populatedOrdinals.cardinality();
-        restoredMap = new ByteArrayOrdinalMap(size,
-            ignoreSoftLimits == null || ignoreSoftLimits.get());
-        int ordinal = populatedOrdinals.nextSetBit(0);
-        while(ordinal != -1) {
-            previousCyclePopulated.set(ordinal);
-            restoreOrdinal(ordinal, copier, restoredMap, IGNORED_HASHES);
-            ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
+        restoredMaps = new ByteArrayOrdinalMap[ordinalMapNum];
+        for (int i = 0; i < ordinalMapNum; i++) {
+            restoredMaps[i] = new ByteArrayOrdinalMap(size >>> ordinalMapIndexBits,
+                    ignoreSoftLimits == null || ignoreSoftLimits.get());
         }
 
-        // Resize the ordinal map to avoid resizing when populating
-        ordinalMap.resize(size);
-        ordinalMap.reservePreviouslyPopulatedOrdinals(populatedOrdinals);
+        // Restore ordinals to appropriate maps
+        int globalOrdinal = populatedOrdinals.nextSetBit(0);
+        while(globalOrdinal != -1) {
+            previousCyclePopulated.set(globalOrdinal);
+
+            // Decode which map this ordinal belongs to
+            int mapIndex = globalOrdinal & ordinalMapIndexMask;
+
+            restoreOrdinal(globalOrdinal, copier, restoredMaps[mapIndex], IGNORED_HASHES);
+            globalOrdinal = populatedOrdinals.nextSetBit(globalOrdinal + 1);
+        }
+
+        // Resize the ordinal maps to avoid resizing when populating
+        for (int i = 0; i < ordinalMapNum; i++) {
+            ordinalMaps[i].resize(size  >>> ordinalMapIndexBits);
+
+            // Create a bitset with only the ordinals for this map
+            BitSet mapSpecificOrdinals = new BitSet();
+            for (int ord = populatedOrdinals.nextSetBit(0); ord >= 0; ord = populatedOrdinals.nextSetBit(ord + 1)) {
+                if ((ord & ordinalMapIndexMask) == i) {
+                    mapSpecificOrdinals.set(ord >>> ordinalMapIndexBits);  // Set local ordinal
+                }
+            }
+            ordinalMaps[i].reservePreviouslyPopulatedOrdinals(mapSpecificOrdinals);
+        }
     }
 
-    protected void restoreOrdinal(int ordinal, HollowRecordCopier copier, ByteArrayOrdinalMap destinationMap, HashBehavior hashBehavior) {
-        HollowWriteRecord rec = copier.copy(ordinal);
+    /**
+     * Restore an ordinal from the read state into a destination map.
+     *
+     * @param globalOrdinal the global ordinal to restore
+     * @param copier the record copier
+     * @param destinationMap the destination ByteArrayOrdinalMap
+     * @param hashBehavior the hash behavior for hashable records
+     */
+    protected void restoreOrdinal(int globalOrdinal, HollowRecordCopier copier, ByteArrayOrdinalMap destinationMap, HashBehavior hashBehavior) {
+        HollowWriteRecord rec = copier.copy(globalOrdinal);
 
         ByteDataArray scratch = scratch();
         if(rec instanceof HollowHashableWriteRecord)
@@ -409,8 +546,31 @@ public abstract class HollowTypeWriteState {
         else
             rec.writeDataTo(scratch);
 
-        destinationMap.put(scratch, ordinal);
+        // Convert global ordinal to local ordinal for the destination map
+        int localOrdinal = globalOrdinal >>> ordinalMapIndexBits;
+        destinationMap.put(scratch, localOrdinal);
         scratch.reset();
+    }
+
+    /**
+     * Get the pointer to the data for a given ordinal by routing to the correct ordinal map.
+     * @param ordinal the global ordinal
+     * @return the pointer to the data
+     */
+    protected long getPointerForData(int ordinal) {
+        int mapIndex = ordinal & ordinalMapIndexMask;
+        int localOrdinal = ordinal >>> ordinalMapIndexBits;
+        return ordinalMaps[mapIndex].getPointerForData(localOrdinal);
+    }
+
+    /**
+     * Get the SegmentedByteArray for a given ordinal by routing to the correct ordinal map.
+     * @param ordinal the global ordinal across ordinalMaps
+     * @return the SegmentedByteArray containing the serialized data
+     */
+    protected SegmentedByteArray getByteDataForOrdinal(int ordinal) {
+        int mapIndex = ordinal & ordinalMapIndexMask;
+        return ordinalMaps[mapIndex].getByteData().getUnderlyingArray();
     }
 
     /**
@@ -480,13 +640,21 @@ public abstract class HollowTypeWriteState {
     }
 
     /**
-     * Returns statistics for this instance {@code ordinalMap}.
+     * Returns statistics across {@code ordinalMaps}.
      * Should be invoked after {@code prepareForWrite}
      *
      * @return a {@link ByteArrayOrdinalMapStats} containing map statistics
      */
     public ByteArrayOrdinalMapStats getOrdinalMapStats() {
-        return new ByteArrayOrdinalMapStats(maxOrdinal, ordinalMap.getByteDataLength(), ordinalMap.getLoadFactor());
+        long maxByteDataLength = 0;
+        float maxLoadFactor = 0;
+        for (int i = 0; i < ordinalMapNum; i++) {
+            ByteArrayOrdinalMap currBaom = ordinalMaps[i];
+            maxByteDataLength = Math.max(maxByteDataLength, currBaom.getDataSize());
+            maxLoadFactor = Math.max(maxLoadFactor, currBaom.getLoadFactor());
+        }
+
+        return new ByteArrayOrdinalMapStats(maxOrdinal, maxByteDataLength, maxLoadFactor);
     }
 
     protected abstract int typeStateNumShards(int maxOrdinal);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
@@ -78,6 +78,8 @@ public class HollowWriteStateEngine implements HollowStateEngine {
     private boolean allowTypeResharding = false;
     //// supplier to determine whether to ignore ordinal threshold breaches (log instead of throwing exception)
     private Supplier<Boolean> ignoreSoftLimits;
+    //// whether to partition each type into 4 {@link com.netflix.hollow.core.memory.ByteArrayOrdinalMap} instead of 1
+    private boolean partitionedOrdinalMap = false;
 
     private List<String> restoredStates;
     private boolean preparedForNextCycle = true;
@@ -455,6 +457,13 @@ public class HollowWriteStateEngine implements HollowStateEngine {
         return this.allowTypeResharding;
     }
 
+    public void setPartitionedOrdinalMap(boolean partitionedOrdinalMap) {
+        this.partitionedOrdinalMap = partitionedOrdinalMap;
+    }
+
+    public boolean isPartitionedOrdinalMap() {
+        return this.partitionedOrdinalMap;
+    }
 
     /**
      * Experimental: Setting this will focus the holes returned by the FreeOrdinalTracker for each state into as few shards as possible.

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEnginePrimaryKeyHasher.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEnginePrimaryKeyHasher.java
@@ -17,7 +17,6 @@
 package com.netflix.hollow.core.write;
 
 import com.netflix.hollow.core.index.key.PrimaryKey;
-import com.netflix.hollow.core.memory.ByteArrayOrdinalMap;
 import com.netflix.hollow.core.memory.SegmentedByteArray;
 import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.memory.encoding.VarInt;
@@ -64,18 +63,16 @@ class HollowWriteStateEnginePrimaryKeyHasher {
         int lastFieldPath = fieldPathIndexes[fieldIdx].length - 1;
         for (int i = 0; i < lastFieldPath; i++) {
             int fieldPosition = fieldPathIndexes[fieldIdx][i];
-            ByteArrayOrdinalMap ordinalMap = typeStates[fieldIdx][i].ordinalMap;
-            long offset = ordinalMap.getPointerForData(ordinal);
-            SegmentedByteArray recordDataArray = ordinalMap.getByteData().getUnderlyingArray();
-            
+            long offset = typeStates[fieldIdx][i].getPointerForData(ordinal);
+            SegmentedByteArray recordDataArray = typeStates[fieldIdx][i].getByteDataForOrdinal(ordinal);
+
             offset = navigateToField(typeStates[fieldIdx][i].getSchema(), fieldPosition, recordDataArray, offset);
             ordinal = VarInt.readVInt(recordDataArray, offset);
         }
 
         int fieldPosition = fieldPathIndexes[fieldIdx][lastFieldPath];
-        ByteArrayOrdinalMap ordinalMap = typeStates[fieldIdx][lastFieldPath].ordinalMap;
-        long offset = ordinalMap.getPointerForData(ordinal);
-        SegmentedByteArray recordDataArray = ordinalMap.getByteData().getUnderlyingArray();
+        long offset = typeStates[fieldIdx][lastFieldPath].getPointerForData(ordinal);
+        SegmentedByteArray recordDataArray = typeStates[fieldIdx][lastFieldPath].getByteDataForOrdinal(ordinal);
         HollowObjectSchema schema = typeStates[fieldIdx][lastFieldPath].getSchema();
 
         offset = navigateToField(schema, fieldPosition, recordDataArray, offset);

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowListTypeMapper.java
@@ -55,8 +55,7 @@ public class HollowListTypeMapper extends HollowTypeMapper {
         this.ignoreListOrdering = ignoreListOrdering;
 
         HollowListTypeWriteState existingTypeState = (HollowListTypeWriteState)parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = existingTypeState != null ? existingTypeState : new HollowListTypeWriteState(schema, numShards,
-                parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
+        this.writeState = existingTypeState != null ? existingTypeState : new HollowListTypeWriteState(schema, numShards, parentMapper.getStateEngine().isPartitionedOrdinalMap(), parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowMapTypeMapper.java
@@ -64,8 +64,7 @@ public class HollowMapTypeMapper extends HollowTypeMapper {
         this.hashCodeFinder = stateEngine.getHashCodeFinder();
 
         HollowMapTypeWriteState typeState = (HollowMapTypeWriteState) parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = typeState != null ? typeState : new HollowMapTypeWriteState(schema, numShards,
-                parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
+        this.writeState = typeState != null ? typeState : new HollowMapTypeWriteState(schema, numShards, parentMapper.getStateEngine().isPartitionedOrdinalMap(), parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowObjectTypeMapper.java
@@ -136,8 +136,7 @@ public class HollowObjectTypeMapper extends HollowTypeMapper {
             this.writeState = existingWriteState;
         } else {
             int numShardsByAnnotation = getNumShardsByAnnotation(clazz);
-            this.writeState = new HollowObjectTypeWriteState(schema, numShardsByAnnotation,
-                    parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
+            this.writeState = new HollowObjectTypeWriteState(schema, numShardsByAnnotation, parentMapper.getStateEngine().isPartitionedOrdinalMap(), parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
         }
 
         this.assignedOrdinalFieldOffset = assignedOrdinalFieldOffset;

--- a/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/objectmapper/HollowSetTypeMapper.java
@@ -58,8 +58,7 @@ public class HollowSetTypeMapper extends HollowTypeMapper {
         this.hashCodeFinder = stateEngine.getHashCodeFinder();
 
         HollowSetTypeWriteState existingTypeState = (HollowSetTypeWriteState) parentMapper.getStateEngine().getTypeState(typeName);
-        this.writeState = existingTypeState != null ? existingTypeState : new HollowSetTypeWriteState(schema, numShards,
-                parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
+        this.writeState = existingTypeState != null ? existingTypeState : new HollowSetTypeWriteState(schema, numShards, parentMapper.getStateEngine().isPartitionedOrdinalMap(), parentMapper.getStateEngine().getIgnoreOrdinalLimitsSupplier());
     }
 
     @Override

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
@@ -677,7 +677,77 @@ public class HollowProducerTest {
     }
 
     @Test
-    public void testOrdinalStabilityAfterSchemaChange() {
+    public void testOrdinalStabilityWithPartitionedOrdinalMapToggledOnAndOff() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+        // --- ProducerA: publish 100 records with withPartitionedOrdinalMap feature off ---
+        HollowProducer producerA = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(false)
+                .build();
+        producerA.initializeDataModel(PartitionedTestType.class);
+
+        Map<String, Integer> primaryKeyToOrdinalCycle1 = new HashMap<>();
+        long versionA = producerA.runCycle(ws -> {
+            for (int i = 0; i < 100; i++) {
+                int ordinal = ws.add(buildPartitionedTestType(i));
+                String key = i + ":" + "name_" + i;
+                primaryKeyToOrdinalCycle1.put(key, ordinal);
+            }
+        });
+
+        // --- ProducerB: restore from versionA, publish 200 records with withPartitionedOrdinalMap feature on ---
+        HollowProducer producerB = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(true)
+                .build();
+        producerB.initializeDataModel(PartitionedTestType.class);
+        HollowProducer.ReadState readStateB = producerB.restore(versionA, blobStore);
+        assertEquals(versionA, readStateB.getVersion());
+        Map<String, Integer> primaryKeyToOrdinalCycle2 = new HashMap<>();
+        long versionB = producerB.runCycle(ws -> {
+            for (int i = 0; i < 200; i++) {
+                int ordinal = ws.add(buildPartitionedTestType(i));
+                String key = i + ":" + "name_" + i;
+                primaryKeyToOrdinalCycle2.put(key, ordinal);
+            }
+        });
+
+        // --- verify that the same 100 records have the same ordinal in both versionA and versionB ---
+        for (Map.Entry<String, Integer> entry : primaryKeyToOrdinalCycle1.entrySet()) {
+            Integer ordCycle2 = primaryKeyToOrdinalCycle2.get(entry.getKey());
+            assertEquals("Ordinal mismatch for key " + entry.getKey(),
+                    entry.getValue(), ordCycle2);
+        }
+
+        // --- ProducerC: restore from versionB, publish 300 records with withPartitionedOrdinalMap feature off ---
+        HollowProducer producerC = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(false)
+                .build();
+        producerC.initializeDataModel(PartitionedTestType.class);
+        HollowProducer.ReadState readStateC = producerC.restore(versionB, blobStore);
+        assertEquals(versionB, readStateC.getVersion());
+
+        Map<String, Integer> primaryKeyToOrdinalCycle3 = new HashMap<>();
+        long versionC = producerC.runCycle(ws -> {
+            for (int i = 0; i < 300; i++) {
+                int ordinal = ws.add(buildPartitionedTestType(i));
+                String key = i + ":" + "name_" + i;
+                primaryKeyToOrdinalCycle3.put(key, ordinal);
+            }
+        });
+
+        // --- verify that the same 200 records have the same ordinal in both versionA and versionB ---
+        for (Map.Entry<String, Integer> entry : primaryKeyToOrdinalCycle2.entrySet()) {
+            Integer ordCycle3 = primaryKeyToOrdinalCycle3.get(entry.getKey());
+            assertEquals("Ordinal mismatch for key " + entry.getKey(),
+                    entry.getValue(), ordCycle3);
+        }
+    }
+
+    @Test
+    public void testOrdinalStabilityAfterSchemaChangeWithPartitionedOrdinalMap() {
         InMemoryBlobStore blobStore = new InMemoryBlobStore();
         HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
 
@@ -1434,6 +1504,7 @@ public class HollowProducerTest {
         Set<String> setOfStrings;
         List<Integer> listOfInts;
         Map<Integer, String> mapOfIntToString;
+        // extra fields added to PartitionedTestType
         String extraStringField;
         long extraLongField;
         List<Integer> extraListOfInts;

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
@@ -17,6 +17,7 @@
 package com.netflix.hollow.api.producer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,8 +27,12 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.objects.HollowRecord;
 import com.netflix.hollow.api.objects.delegate.HollowObjectGenericDelegate;
+import com.netflix.hollow.api.objects.generic.GenericHollowList;
+import com.netflix.hollow.api.objects.generic.GenericHollowMap;
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.api.objects.generic.GenericHollowSet;
 import com.netflix.hollow.api.producer.HollowProducer.Blob;
 import com.netflix.hollow.api.producer.HollowProducer.Blob.Type;
 import com.netflix.hollow.api.producer.HollowProducer.HeaderBlob;
@@ -37,7 +42,10 @@ import com.netflix.hollow.api.producer.HollowProducerListener.RestoreStatus;
 import com.netflix.hollow.api.producer.HollowProducerListener.Status;
 import com.netflix.hollow.api.producer.enforcer.BasicSingleProducerEnforcer;
 import com.netflix.hollow.api.producer.enforcer.SingleProducerEnforcer;
+import com.netflix.hollow.api.consumer.fs.HollowFilesystemBlobRetriever;
 import com.netflix.hollow.api.producer.fs.HollowFilesystemAnnouncer;
+import com.netflix.hollow.api.producer.fs.HollowFilesystemBlobStager;
+import com.netflix.hollow.api.producer.fs.HollowFilesystemPublisher;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
 import com.netflix.hollow.api.producer.listener.VetoableListener;
 import com.netflix.hollow.api.producer.model.CustomReferenceType;
@@ -52,7 +60,9 @@ import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import com.netflix.hollow.core.write.HollowMapWriteRecord;
 import com.netflix.hollow.core.write.HollowObjectWriteRecord;
 import com.netflix.hollow.core.write.HollowTypeWriteState;
+import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
 import com.netflix.hollow.core.write.objectmapper.HollowInline;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
 import com.netflix.hollow.test.InMemoryBlobStore;
 import java.io.File;
@@ -60,6 +70,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -70,6 +81,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -77,6 +92,7 @@ import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class HollowProducerTest {
@@ -137,13 +153,14 @@ public class HollowProducerTest {
     private void checkBaomIgnoreOrdinalSoftLimit(boolean expected, HollowProducer producer) {
         for (HollowTypeWriteState hollowTypeWriteState : producer.getWriteEngine().getOrderedTypeStates()) {
             try {
-                java.lang.reflect.Field ordinalMapField = HollowTypeWriteState.class.getDeclaredField("ordinalMap");
-                ordinalMapField.setAccessible(true);
-                com.netflix.hollow.core.memory.ByteArrayOrdinalMap ordinalMap =
-                        (com.netflix.hollow.core.memory.ByteArrayOrdinalMap) ordinalMapField.get(hollowTypeWriteState);
-
-                assertEquals("ByteArrayOrdinalMap.ignoreSoftLimits should be " + expected,
-                        expected, ordinalMap.getIgnoreSoftLimits());
+                java.lang.reflect.Field ordinalMapsField = HollowTypeWriteState.class.getDeclaredField("ordinalMaps");
+                ordinalMapsField.setAccessible(true);
+                com.netflix.hollow.core.memory.ByteArrayOrdinalMap[] ordinalMaps =
+                        (com.netflix.hollow.core.memory.ByteArrayOrdinalMap[]) ordinalMapsField.get(hollowTypeWriteState);
+                for (com.netflix.hollow.core.memory.ByteArrayOrdinalMap baom : ordinalMaps) {
+                    assertEquals("ByteArrayOrdinalMap.ignoreSoftLimits should be " + expected,
+                            expected, baom.getIgnoreSoftLimits());
+                }
             } catch (NoSuchFieldException | IllegalAccessException ex) {
                 Assert.fail(ex.getMessage());
             }
@@ -508,6 +525,271 @@ public class HollowProducerTest {
             ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
         }
         System.out.println("Asserted Correctness of version:" + version + "\n\n");
+    }
+
+    @Test
+    public void testRestorePartitionedOrdinalMapMatch() {
+        // restore is expected to fail if datasetEnabled != producerEnabled
+        verifyRestorePartitionedOrdinalMap(true, false);
+        verifyRestorePartitionedOrdinalMap(false, true);
+        verifyRestorePartitionedOrdinalMap(false, false);
+        verifyRestorePartitionedOrdinalMap(true, true);
+    }
+
+    private void verifyRestorePartitionedOrdinalMap( boolean datasetEnabled, boolean producerEnabled) {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+
+        HollowProducer producer1 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(datasetEnabled)
+                .build();
+        producer1.initializeDataModel(TestPojoV1.class);
+        long version = producer1.runCycle(ws -> ws.add(new TestPojoV1(1, 1)));
+
+        HollowProducer producer2 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(producerEnabled)
+                .build();
+        producer2.initializeDataModel(TestPojoV1.class);
+
+        try {
+            HollowProducer.ReadState readState = producer2.restore(version, blobStore);
+            Assert.assertNotNull(readState);
+            assertEquals(version, readState.getVersion());
+        } catch (IllegalStateException e) {
+            Assert.assertNotEquals(datasetEnabled, producerEnabled);
+        }
+    }
+
+    @Test
+    public void testPartitionedOrdinalMapProducerOps() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+
+        // --- Producer 1: run 2 cycles with partitionedOrdinalMap enabled ---
+        HollowProducer producer1 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(true)
+                .build();
+        producer1.initializeDataModel(PartitionedTestType.class);
+
+        // Cycle 1
+        producer1.runCycle(ws -> {
+            for (int i = 0; i < 2048; i++) {
+                ws.add(buildPartitionedTestType(i));
+            }
+        });
+
+        // Cycle 2: track ordinals via primaryKeyToOrdinal map
+        Map<String, Integer> primaryKeyToOrdinal = new HashMap<>();
+        Map<Integer, PartitionedTestType> ordinalToObject = new HashMap<>();
+        long version2 = producer1.runCycle(ws -> {
+            for (int i = 0; i < 4096; i++) {
+                PartitionedTestType obj = buildPartitionedTestType(i);
+                int ordinal = ws.add(obj);
+                String key = i + ":" + "name_" + i;
+                primaryKeyToOrdinal.put(key, ordinal);
+                ordinalToObject.put(ordinal, obj);
+            }
+        });
+
+        // --- Producer 2: restore from producer1's blob ---
+        HollowProducer producer2 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(true)
+                .build();
+        producer2.initializeDataModel(PartitionedTestType.class);
+        HollowProducer.ReadState readState = producer2.restore(version2, blobStore);
+        assertEquals(version2, readState.getVersion());
+
+        // --- Verify ordinals via iteration ---
+        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState)
+                readState.getStateEngine().getTypeState("PartitionedTestType");
+        BitSet populatedOrdinals = typeState.getPopulatedOrdinals();
+        assertEquals(4096, populatedOrdinals.cardinality());
+
+        // --- Cycle 3 on producer2: remove 10 records (ids 100-109) and verify ---
+        Set<String> removedKeys = new HashSet<>();
+        for (int i = 100; i < 110; i++) {
+            removedKeys.add(i + ":" + "name_" + i);
+        }
+
+        long version3 = producer2.runCycle(ws -> {
+            for (int i = 0; i < 4096; i++) {
+                String key = i + ":" + "name_" + i;
+                if (!removedKeys.contains(key)) {
+                    ws.add(buildPartitionedTestType(i));
+                }
+            }
+        });
+
+        // Restore to a new producer to get the read state after removals
+        HollowProducer producer3 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(true)
+                .build();
+        producer3.initializeDataModel(PartitionedTestType.class);
+        HollowProducer.ReadState readState3 = producer3.restore(version3, blobStore);
+        assertEquals(version3, readState3.getVersion());
+
+        // Verify removals via populated ordinals
+        HollowObjectTypeReadState typeState2 = (HollowObjectTypeReadState)
+                readState3.getStateEngine().getTypeState("PartitionedTestType");
+        BitSet populatedOrdinals2 = typeState2.getPopulatedOrdinals();
+        assertEquals(4086, populatedOrdinals2.cardinality());
+
+        // Verify none of the removed keys appear in populated ordinals
+        int ord2 = populatedOrdinals2.nextSetBit(0);
+        while (ord2 != -1) {
+            GenericHollowObject obj2 = new GenericHollowObject(
+                    new HollowObjectGenericDelegate(typeState2), ord2);
+            int id2 = obj2.getInt("id");
+            String name2 = obj2.getObject("name").getString("value");
+            String key2 = id2 + ":" + name2;
+            assertFalse("Removed key " + key2 + " should not be present",
+                    removedKeys.contains(key2));
+            ord2 = populatedOrdinals2.nextSetBit(ord2 + 1);
+        }
+
+        // Verify via HollowPrimaryKeyIndex that removed records return -1
+        HollowPrimaryKeyIndex primaryKeyIndex2 = new HollowPrimaryKeyIndex(
+                readState3.getStateEngine(), "PartitionedTestType", "id", "name.value");
+        for (String removedKey : removedKeys) {
+            String[] parts = removedKey.split(":", 2);
+            int id = Integer.parseInt(parts[0]);
+            String name = parts[1];
+            int matchingOrdinal = primaryKeyIndex2.getMatchingOrdinal(id, name);
+            assertEquals("Removed record id=" + id + " name=" + name + " should not be found",
+                    -1, matchingOrdinal);
+        }
+
+        // Verify remaining records still resolve correctly
+        for (Map.Entry<String, Integer> entry : primaryKeyToOrdinal.entrySet()) {
+            if (removedKeys.contains(entry.getKey())) continue;
+            String[] parts = entry.getKey().split(":", 2);
+            int id = Integer.parseInt(parts[0]);
+            String name = parts[1];
+            int actualOrdinal = primaryKeyIndex2.getMatchingOrdinal(id, name);
+            assertTrue("Remaining record id=" + id + " name=" + name + " should still be found",
+                    actualOrdinal != -1);
+        }
+    }
+
+    @Test
+    public void testOrdinalStabilityAfterSchemaChange() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowInMemoryBlobStager blobStager = new HollowInMemoryBlobStager();
+
+        // --- ProducerA: publish 100 records with PartitionedTestType schema ---
+        HollowProducer producerA = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(true)
+                .build();
+        producerA.initializeDataModel(PartitionedTestType.class);
+
+        Map<String, Integer> primaryKeyToOrdinalCycle1 = new HashMap<>();
+        long versionA = producerA.runCycle(ws -> {
+            for (int i = 0; i < 100; i++) {
+                int ordinal = ws.add(buildPartitionedTestType(i));
+                String key = i + ":" + "name_" + i;
+                primaryKeyToOrdinalCycle1.put(key, ordinal);
+            }
+        });
+
+        // --- ProducerB: restore from producerA, publish with PartitionedTestTypeModified schema ---
+        HollowProducer producerB = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(true)
+                .build();
+        producerB.initializeDataModel(PartitionedTestTypeModified.class);
+        HollowProducer.ReadState readStateB = producerB.restore(versionA, blobStore);
+        assertEquals(versionA, readStateB.getVersion());
+
+        // Cycle 2: same 100 records with modified schema, verify ordinals match cycle 1
+        Map<String, Integer> primaryKeyToOrdinalCycle2 = new HashMap<>();
+        long versionB = producerB.runCycle(ws -> {
+            for (int i = 0; i < 100; i++) {
+                int ordinal = ws.add(buildPartitionedTestTypeModified(i));
+                String key = i + ":" + "name_" + i;
+                primaryKeyToOrdinalCycle2.put(key, ordinal);
+            }
+        });
+
+        for (Map.Entry<String, Integer> entry : primaryKeyToOrdinalCycle1.entrySet()) {
+            Integer ordCycle2 = primaryKeyToOrdinalCycle2.get(entry.getKey());
+            assertEquals("Ordinal mismatch after schema change for key " + entry.getKey(),
+                    entry.getValue(), ordCycle2);
+        }
+
+        // Cycle 3: same 100 + 20 new records, verify original ordinals still stable
+        Map<String, Integer> primaryKeyToOrdinalCycle3 = new HashMap<>();
+        long versionC = producerB.runCycle(ws -> {
+            for (int i = 0; i < 120; i++) {
+                int ordinal = ws.add(buildPartitionedTestTypeModified(i));
+                String key = i + ":" + "name_" + i;
+                primaryKeyToOrdinalCycle3.put(key, ordinal);
+            }
+        });
+
+        // Verify original 100 ordinals are stable
+        for (Map.Entry<String, Integer> entry : primaryKeyToOrdinalCycle1.entrySet()) {
+            Integer ordCycle3 = primaryKeyToOrdinalCycle3.get(entry.getKey());
+            assertEquals("Ordinal mismatch in cycle 3 for key " + entry.getKey(),
+                    entry.getValue(), ordCycle3);
+        }
+
+        // Verify all 120 records exist via HollowPrimaryKeyIndex
+        HollowProducer producer3 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(blobStager)
+                .withPartitionedOrdinalMap(true)
+                .build();
+        producer3.initializeDataModel(PartitionedTestTypeModified.class);
+        HollowProducer.ReadState readState3 = producer3.restore(versionC, blobStore);
+        assertEquals(versionC, readState3.getVersion());
+
+        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState)
+                readState3.getStateEngine().getTypeState("PartitionedTestType");
+        BitSet populatedOrdinals = typeState.getPopulatedOrdinals();
+        assertEquals(120, populatedOrdinals.cardinality());
+
+        HollowPrimaryKeyIndex primaryKeyIndex = new HollowPrimaryKeyIndex(
+                readState3.getStateEngine(), "PartitionedTestType", "id", "name.value");
+        for (int i = 0; i < 120; i++) {
+            int matchingOrdinal = primaryKeyIndex.getMatchingOrdinal(i, "name_" + i);
+            assertTrue("Record i=" + i + " should be found", matchingOrdinal != -1);
+        }
+    }
+
+    private static PartitionedTestType buildPartitionedTestType(int i) {
+        return new PartitionedTestType(
+                i,
+                "name_" + i,
+                (long) i * 100,
+                (float) i * 1.1f,
+                (double) i * 2.2,
+                i % 2 == 0,
+                new HashSet<>(Arrays.asList("s_" + i, "s2_" + i, "s3_" + i)),
+                Arrays.asList(i, i + 1),
+                new HashMap<Integer, String>() {{ put(i, "v_0_" + i); put(i+1, "v_1_" + i); put(i+2, "v_2_" + i);}}
+        );
+    }
+
+    private static PartitionedTestTypeModified buildPartitionedTestTypeModified(int i) {
+        return new PartitionedTestTypeModified(
+                i,
+                "name_" + i,
+                (long) i * 100,
+                (float) i * 1.1f,
+                (double) i * 2.2,
+                i % 2 == 0,
+                new HashSet<>(Arrays.asList("s_" + i, "s2_" + i, "s3_" + i)),
+                Arrays.asList(i, i + 1),
+                new HashMap<Integer, String>() {{ put(i, "v_0_" + i); put(i+1, "v_1_" + i); put(i+2, "v_2_" + i);}},
+                "extra_" + i,
+                i * 1000L,
+                Arrays.asList(i * 10, i * 20)
+        );
     }
 
     @Test
@@ -1110,6 +1392,78 @@ public class HollowProducerTest {
 
         Assert.assertEquals(iVal, typeState.readInt(ordinal, typeState.getSchema().getPosition("intVal")));
         Assert.assertEquals(sVal, typeState.readString(ordinal, typeState.getSchema().getPosition("strVal")));
+    }
+
+    @HollowPrimaryKey(fields = {"id", "name"})
+    private static class PartitionedTestType {
+        int id;
+        String name;
+        long longField;
+        float floatField;
+        double doubleField;
+        boolean boolField;
+        Set<String> setOfStrings;
+        List<Integer> listOfInts;
+        Map<Integer, String> mapOfIntToString;
+
+        PartitionedTestType(int id, String name, long longField, float floatField,
+                            double doubleField, boolean boolField,
+                            Set<String> setOfStrings, List<Integer> listOfInts,
+                            Map<Integer, String> mapOfIntToString) {
+            this.id = id;
+            this.name = name;
+            this.longField = longField;
+            this.floatField = floatField;
+            this.doubleField = doubleField;
+            this.boolField = boolField;
+            this.setOfStrings = setOfStrings;
+            this.listOfInts = listOfInts;
+            this.mapOfIntToString = mapOfIntToString;
+        }
+    }
+
+    @HollowTypeName(name = "PartitionedTestType")
+    @HollowPrimaryKey(fields = {"id", "name"})
+    private static class PartitionedTestTypeModified {
+        int id;
+        String name;
+        long longField;
+        float floatField;
+        double doubleField;
+        boolean boolField;
+        Set<String> setOfStrings;
+        List<Integer> listOfInts;
+        Map<Integer, String> mapOfIntToString;
+        String extraStringField;
+        long extraLongField;
+        List<Integer> extraListOfInts;
+
+        PartitionedTestTypeModified(int id, String name, long longField, float floatField,
+                                    double doubleField, boolean boolField,
+                                    Set<String> setOfStrings, List<Integer> listOfInts,
+                                    Map<Integer, String> mapOfIntToString,
+                                    String extraStringField, long extraLongField,
+                                    List<Integer> extraListOfInts) {
+            this.id = id;
+            this.name = name;
+            this.longField = longField;
+            this.floatField = floatField;
+            this.doubleField = doubleField;
+            this.boolField = boolField;
+            this.setOfStrings = setOfStrings;
+            this.listOfInts = listOfInts;
+            this.mapOfIntToString = mapOfIntToString;
+            this.extraStringField = extraStringField;
+            this.extraLongField = extraLongField;
+            this.extraListOfInts = extraListOfInts;
+        }
+    }
+
+    private static class SimpleRecord {
+        int id;
+        SimpleRecord(int id) {
+            this.id = id;
+        }
     }
 
     @SuppressWarnings("unused")

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/FreeOrdinalTrackerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/FreeOrdinalTrackerTest.java
@@ -44,7 +44,7 @@ public class FreeOrdinalTrackerTest {
         tracker.returnOrdinalToPool(14);
 
         /// sort for 4 shards
-        tracker.sort(4);
+        tracker.sort(4, 0, 0);
 
         Assert.assertEquals(1, tracker.getFreeOrdinal());
         Assert.assertEquals(5, tracker.getFreeOrdinal());

--- a/hollow/src/test/java/com/netflix/hollow/core/write/restore/RestoreWriteStateEngineListTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/restore/RestoreWriteStateEngineListTest.java
@@ -76,7 +76,7 @@ public class RestoreWriteStateEngineListTest extends AbstractStateEngineTest {
         roundTripSnapshot();
         
         HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
-        HollowListTypeWriteState misconfiguredTypeState = new HollowListTypeWriteState(new HollowListSchema("TestList", "TestObject"), 16);
+        HollowListTypeWriteState misconfiguredTypeState = new HollowListTypeWriteState(new HollowListSchema("TestList", "TestObject"), 16, false, null);
         writeStateEngine.addTypeState(misconfiguredTypeState);
 
         try {

--- a/hollow/src/test/java/com/netflix/hollow/core/write/restore/RestoreWriteStateEngineMapTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/restore/RestoreWriteStateEngineMapTest.java
@@ -81,7 +81,7 @@ public class RestoreWriteStateEngineMapTest extends AbstractStateEngineTest {
         roundTripSnapshot();
         
         HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
-        HollowMapTypeWriteState misconfiguredTypeState = new HollowMapTypeWriteState(new HollowMapSchema("TestMap", "TestKey", "TestValue"), 16);
+        HollowMapTypeWriteState misconfiguredTypeState = new HollowMapTypeWriteState(new HollowMapSchema("TestMap", "TestKey", "TestValue"), 16, false, null);
         writeStateEngine.addTypeState(misconfiguredTypeState);
 
         try {

--- a/hollow/src/test/java/com/netflix/hollow/core/write/restore/RestoreWriteStateEngineObjectTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/restore/RestoreWriteStateEngineObjectTest.java
@@ -93,7 +93,7 @@ public class RestoreWriteStateEngineObjectTest extends AbstractStateEngineTest {
         roundTripSnapshot();
         
         HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
-        HollowObjectTypeWriteState misconfiguredTypeState = new HollowObjectTypeWriteState(schema, 4);
+        HollowObjectTypeWriteState misconfiguredTypeState = new HollowObjectTypeWriteState(schema, 4, false, null);
         writeStateEngine.addTypeState(misconfiguredTypeState);
 
         try {

--- a/hollow/src/test/java/com/netflix/hollow/core/write/restore/RestoreWriteStateEngineSetTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/write/restore/RestoreWriteStateEngineSetTest.java
@@ -75,7 +75,7 @@ public class RestoreWriteStateEngineSetTest extends AbstractStateEngineTest {
         roundTripSnapshot();
         
         HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
-        HollowSetTypeWriteState misconfiguredTypeState = new HollowSetTypeWriteState(new HollowSetSchema("TestSet", "TestObject"), 16);
+        HollowSetTypeWriteState misconfiguredTypeState = new HollowSetTypeWriteState(new HollowSetSchema("TestSet", "TestObject"), 16, false, null);
         writeStateEngine.addTypeState(misconfiguredTypeState);
 
         try {


### PR DESCRIPTION
  Summary: Partitioned Ordinal Map Feature (4x Ordinal Limit)

  This change introduces the ability to partition a HollowTypeWriteState's ByteArrayOrdinalMap into 4 separate maps instead of 1, effectively quadrupling the ordinal limit (record cardinality limit) per type.

  Key changes:

  1. New builder option (HollowProducer / AbstractHollowProducer):
  - Added withPartitionedOrdinalMap(boolean) to the producer builder
  - Propagated through AbstractHollowProducer constructor → HollowWriteStateEngine → each HollowTypeWriteState

  2. Core: HollowTypeWriteState (biggest change):
  - Instead of a single ordinalMap (ByteArrayOrdinalMap), now supports an array of maps (ordinalMaps[])
  - Ordinals are routed to a specific map partition based on hash bits (2 bits → 4 partitions)
  - New helper methods getPointerForData(ordinal) and getByteDataForOrdinal(ordinal) abstract over single vs. multi-map access
  - All four type write states (Object, List, Set, Map) updated to use these helpers instead of directly accessing ordinalMap
  - Deduplication across all maps -- When adding a record, all maps are searched before assigning to prevent duplicates across partitions
