### PR TITLE
[fix] holes cost estimation;

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew :hollow-protoadapter:test:*)",
+      "Bash(./gradlew:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(./gradlew :hollow-protoadapter:test:*)",
-      "Bash(./gradlew:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ secrets/signing-key
 
 # IDE related files
 **/.DS_Store
-**/.claude/
-**/.cursor/
+**/.claude
+**/.cursor

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,7 @@ venv
 # publishing secrets
 secrets/signing-key
 
+# IDE related files
 **/.DS_Store
+**/.claude/
+**/.cursor/

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateShard.java
@@ -93,7 +93,7 @@ class HollowListTypeReadStateShard implements HollowTypeReadStateShard {
         long holeBits = 0;
         
         int holeOrdinal = populatedOrdinals.nextClearBit(0);
-        while(holeOrdinal <= dataElements.maxOrdinal) {
+        while((holeOrdinal >>> shardOrdinalShift) <= dataElements.maxOrdinal) {
             if((holeOrdinal & (numShards - 1)) == shardNumber)
                 holeBits += dataElements.bitsPerListPointer;
             

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadStateShard.java
@@ -112,7 +112,7 @@ class HollowMapTypeReadStateShard implements HollowTypeReadStateShard {
         long holeBits = 0;
         
         int holeOrdinal = populatedOrdinals.nextClearBit(0);
-        while(holeOrdinal <= dataElements.maxOrdinal) {
+        while((holeOrdinal >>> shardOrdinalShift) <= dataElements.maxOrdinal) {
             if((holeOrdinal & (numShards - 1)) == shardNumber)
                 holeBits += dataElements.bitsPerFixedLengthMapPortion;
             

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
@@ -267,7 +267,7 @@ class HollowObjectTypeReadStateShard implements HollowTypeReadStateShard {
         long holeBits = 0;
         
         int holeOrdinal = populatedOrdinals.nextClearBit(0);
-        while(holeOrdinal <= dataElements.maxOrdinal) {
+        while((holeOrdinal >>> shardOrdinalShift) <= dataElements.maxOrdinal) {
             if((holeOrdinal & (numShards - 1)) == shardNumber)
                 holeBits += dataElements.bitsPerRecord;
             

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateShard.java
@@ -102,7 +102,7 @@ class HollowSetTypeReadStateShard implements HollowTypeReadStateShard {
         long holeBits = 0;
         
         int holeOrdinal = populatedOrdinals.nextClearBit(0);
-        while(holeOrdinal <= dataElements.maxOrdinal) {
+        while((holeOrdinal >>> shardOrdinalShift) <= dataElements.maxOrdinal) {
             if((holeOrdinal & (numShards - 1)) == shardNumber)
                 holeBits += dataElements.bitsPerFixedLengthSetPortion;
             

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/AbstractHollowTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/AbstractHollowTypeDataElementsSplitJoinTest.java
@@ -4,6 +4,7 @@ import com.netflix.hollow.core.AbstractStateEngineTest;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
 import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import org.junit.Before;
 
 public class AbstractHollowTypeDataElementsSplitJoinTest extends AbstractStateEngineTest {
@@ -27,6 +28,11 @@ public class AbstractHollowTypeDataElementsSplitJoinTest extends AbstractStateEn
 
     protected void populateWriteStateEngine(int numRecords) {
         initWriteStateEngine();
+        populateWriteStateEngine(writeStateEngine, schema, numRecords);
+    }
+
+    protected void populateWriteStateEngine(HollowWriteStateEngine writeStateEngine, HollowObjectSchema schema,
+                                            int numRecords) {
         HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
         for(int i=0;i<numRecords;i++) {
             rec.reset();
@@ -41,6 +47,11 @@ public class AbstractHollowTypeDataElementsSplitJoinTest extends AbstractStateEn
 
     protected void populateWriteStateEngine(int[] recordIds) {
         initWriteStateEngine();
+        populateWriteStateEngine(writeStateEngine, schema, recordIds);
+    }
+
+    protected void populateWriteStateEngine(HollowWriteStateEngine writeStateEngine, HollowObjectSchema schema,
+                                            int[] recordIds) {
         HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
         for(int recordId : recordIds) {
             rec.reset();

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/AbstractHollowListTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/AbstractHollowListTypeDataElementsSplitJoinTest.java
@@ -43,7 +43,7 @@ public class AbstractHollowListTypeDataElementsSplitJoinTest extends AbstractHol
         writeStateEngine.setTargetMaxTypeShardSize(4 * 100 * 1000 * 1024);
     }
 
-    private void populateWriteStateEngine(int[][] listContents) {
+    protected void populateWriteStateEngineWithListRecords(int[][] listContents) {
         for(int[] list : listContents) {
             addRecord(Arrays.stream(list).toArray());
         }
@@ -63,7 +63,7 @@ public class AbstractHollowListTypeDataElementsSplitJoinTest extends AbstractHol
         for (int[] list : listContents) {
             populateWriteStateEngine(list);
         }
-        populateWriteStateEngine(listContents);
+        populateWriteStateEngineWithListRecords(listContents);
         roundTripSnapshot();
         return (HollowListTypeReadState) readStateEngine.getTypeState("TestList");
     }

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateTest.java
@@ -3,10 +3,49 @@ package com.netflix.hollow.core.read.engine.list;
 import static junit.framework.TestCase.assertEquals;
 
 import com.netflix.hollow.core.read.engine.HollowTypeReshardingStrategy;
+import com.netflix.hollow.core.write.HollowListTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.util.Random;
 import org.junit.Test;
 
 public class HollowListTypeReadStateTest extends AbstractHollowListTypeDataElementsSplitJoinTest {
+
+    @Test
+    public void testApproximateHoleCountWithShards() throws Exception {
+        // Setup with 2 shards
+        writeStateEngine = new HollowWriteStateEngine();
+        writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema, 2));
+        writeStateEngine.addTypeState(new HollowListTypeWriteState(listSchema, 2));
+
+        // Cycle 1
+        // populate TestObject with ordinal values 0 - 6
+        populateWriteStateEngine(writeStateEngine, schema, 6);
+        // populate TestList with ordinal values 0 - 6
+        populateWriteStateEngineWithListRecords(new int[][]{
+                {0}, {1}, {2}, {3}, {4}, {5}
+        });
+        roundTripSnapshot();
+
+        // Cycle 2
+        // readded all the TestObject records.
+        // for TestList:
+        // Shard 0 (even: 0=hole, 2=pop, 4=pop) -> 1 hole
+        // Shard 1 (odd: 1=hole, 3=hole, 5=hole) -> 3 holes
+        populateWriteStateEngine(writeStateEngine, schema, 6);
+        populateWriteStateEngineWithListRecords(new int[][]{
+                {2}, {4}
+        });
+        roundTripDelta();
+
+        HollowListTypeReadState typeState = (HollowListTypeReadState) readStateEngine.getTypeState("TestList");
+        assertEquals(2, typeState.numShards());
+        assertEquals(2, typeState.getPopulatedOrdinals().cardinality());
+        HollowListTypeReadStateShard[] shards = (HollowListTypeReadStateShard[])typeState.getShardsVolatile().getShards();
+        long holeCost = shards[0].dataElements.bitsPerListPointer/8L +
+                shards[1].dataElements.bitsPerListPointer*3L/8;
+        assertEquals(holeCost, typeState.getApproximateHoleCostInBytes());
+    }
 
     @Test
     public void testResharding() throws Exception {

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 public class HollowListTypeReadStateTest extends AbstractHollowListTypeDataElementsSplitJoinTest {
 
     @Test
-    public void testApproximateHoleCountWithShards() throws Exception {
+    public void testApproximateHoleCostWithShards() throws Exception {
         // Setup with 2 shards
         writeStateEngine = new HollowWriteStateEngine();
         writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema, 2));
@@ -32,7 +32,7 @@ public class HollowListTypeReadStateTest extends AbstractHollowListTypeDataEleme
         // for TestList:
         // Shard 0 (even: 0=hole, 2=pop, 4=pop, 6=hole) -> 2 hole
         // Shard 1 (odd: 1=hole, 3=hole, 5=hole, 7=hole) -> 4 holes
-        populateWriteStateEngine(writeStateEngine, schema, 6);
+        populateWriteStateEngine(writeStateEngine, schema, 8);
         populateWriteStateEngineWithListRecords(new int[][]{
                 {2}, {4}
         });

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateTest.java
@@ -19,19 +19,19 @@ public class HollowListTypeReadStateTest extends AbstractHollowListTypeDataEleme
         writeStateEngine.addTypeState(new HollowListTypeWriteState(listSchema, 2));
 
         // Cycle 1
-        // populate TestObject with ordinal values 0 - 6
-        populateWriteStateEngine(writeStateEngine, schema, 6);
-        // populate TestList with ordinal values 0 - 6
+        // populate TestObject with ordinal values 0 - 7
+        populateWriteStateEngine(writeStateEngine, schema, 8);
+        // populate TestList with ordinal values 0 - 7
         populateWriteStateEngineWithListRecords(new int[][]{
-                {0}, {1}, {2}, {3}, {4}, {5}
+                {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}
         });
         roundTripSnapshot();
 
         // Cycle 2
         // readded all the TestObject records.
         // for TestList:
-        // Shard 0 (even: 0=hole, 2=pop, 4=pop) -> 1 hole
-        // Shard 1 (odd: 1=hole, 3=hole, 5=hole) -> 3 holes
+        // Shard 0 (even: 0=hole, 2=pop, 4=pop, 6=hole) -> 2 hole
+        // Shard 1 (odd: 1=hole, 3=hole, 5=hole, 7=hole) -> 4 holes
         populateWriteStateEngine(writeStateEngine, schema, 6);
         populateWriteStateEngineWithListRecords(new int[][]{
                 {2}, {4}
@@ -42,8 +42,8 @@ public class HollowListTypeReadStateTest extends AbstractHollowListTypeDataEleme
         assertEquals(2, typeState.numShards());
         assertEquals(2, typeState.getPopulatedOrdinals().cardinality());
         HollowListTypeReadStateShard[] shards = (HollowListTypeReadStateShard[])typeState.getShardsVolatile().getShards();
-        long holeCost = shards[0].dataElements.bitsPerListPointer/8L +
-                shards[1].dataElements.bitsPerListPointer*3L/8;
+        long holeCost = shards[0].dataElements.bitsPerListPointer*2L/8 +
+                shards[1].dataElements.bitsPerListPointer*4L/8;
         assertEquals(holeCost, typeState.getApproximateHoleCostInBytes());
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/map/AbstractHollowMapTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/map/AbstractHollowMapTypeDataElementsSplitJoinTest.java
@@ -65,6 +65,10 @@ public class AbstractHollowMapTypeDataElementsSplitJoinTest extends AbstractHoll
                 writeStateEngine.add("TestObject", rec);
             }
         }
+        populateWriteStateEngineWithMap(writeStateEngine, maps);
+    }
+
+    protected void populateWriteStateEngineWithMap(HollowWriteStateEngine writeStateEngine, int[][][] maps) {
         for(int[][] map : maps) {
             HollowMapWriteRecord rec = new HollowMapWriteRecord();
             for (int[] entry : map) {

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadStateTest.java
@@ -3,10 +3,46 @@ package com.netflix.hollow.core.read.engine.map;
 import static junit.framework.TestCase.assertEquals;
 
 import com.netflix.hollow.core.read.engine.HollowTypeReshardingStrategy;
+import com.netflix.hollow.core.write.HollowMapTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.util.Random;
 import org.junit.Test;
 
 public class HollowMapTypeReadStateTest extends AbstractHollowMapTypeDataElementsSplitJoinTest {
+
+    @Test
+    public void testApproximateHoleCostWithShards() throws Exception {
+        // Setup with 2 shards
+        writeStateEngine = new HollowWriteStateEngine();
+        writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema, 2));
+        writeStateEngine.addTypeState(new HollowMapTypeWriteState(mapSchema, 2));
+
+        // Cycle 1: add TestObject records and 6 map records with varying sizes
+        // Cycle 1
+        // populate TestObject with ordinal values 0 - 5
+        populateWriteStateEngine(writeStateEngine, schema, 6);
+        // populate TestMap with map entries, each containing ordinal value {x : x}, where x is from 0-5
+        populateWriteStateEngineWithMap(writeStateEngine, new int[][][] {{{0,0}}, {{1,1}}, {{2,2}}, {{3,3}}, {{4,4}}, {{5,5}}});
+        roundTripSnapshot();
+
+        // Cycle 2: re-add all TestObjects
+        // for TestMap:
+        // Shard 0 (even: 0=hole, 2=pop, 4=pop) -> 1 hole
+        // Shard 1 (odd: 1=hole, 3=hole, 5=hole) -> 3 holes
+        populateWriteStateEngine(writeStateEngine, schema, 6);
+        // populate TestMap with ordinal values 2 and 4
+        populateWriteStateEngineWithMap(writeStateEngine, new int[][][] {{{2,2}}, {{4,4}}});
+        roundTripDelta();
+
+        HollowMapTypeReadState typeState = (HollowMapTypeReadState) readStateEngine.getTypeState("TestMap");
+        assertEquals(2, typeState.numShards());
+        assertEquals(2, typeState.getPopulatedOrdinals().cardinality());
+        HollowMapTypeReadStateShard[] shards = (HollowMapTypeReadStateShard[])typeState.getShardsVolatile().getShards();
+        long holeCost = shards[0].dataElements.bitsPerFixedLengthMapPortion/8L +
+                shards[1].dataElements.bitsPerFixedLengthMapPortion*3L/8;
+        assertEquals(holeCost, typeState.getApproximateHoleCostInBytes());
+    }
 
     @Test
     public void testResharding() throws Exception {

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateTest.java
@@ -3,6 +3,9 @@ package com.netflix.hollow.core.read.engine.object;
 import static junit.framework.TestCase.assertEquals;
 
 import com.netflix.hollow.core.read.engine.HollowTypeReshardingStrategy;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.util.Random;
 import org.junit.Test;
 
@@ -40,6 +43,32 @@ public class HollowObjectTypeReadStateTest extends AbstractHollowObjectTypeDataE
                 assertDataUnchanged(objectTypeReadState, numRecords);
             }
         }
+    }
+
+    @Test
+    public void testApproximateHoleCountWithShards() throws Exception {
+        // Setup with 2 shards
+        writeStateEngine = new HollowWriteStateEngine();
+        writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema, 2));
+
+        // Cycle 1: snapshot with 6 records (ordinals 0-5)
+        // note that the ordinal assigned would be also be 0-4.
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
+        populateWriteStateEngine(writeStateEngine, schema, 6);
+        roundTripSnapshot();
+        // Cycle 2: keep only records 2 and 4, creating holes at 0, 1, 3, 5
+        populateWriteStateEngine(writeStateEngine, schema, new int[]{2, 4});
+        roundTripDelta();
+
+        HollowObjectTypeReadState typeState = (HollowObjectTypeReadState) readStateEngine.getTypeState("TestObject");
+        assertEquals(2, typeState.numShards());
+        assertEquals(2, typeState.getPopulatedOrdinals().cardinality());
+
+        // Shard 0 (even: 0=hole, 2=pop, 4=pop) -> 1 hole
+        // Shard 1 (odd: 1=hole, 3=hole, 5=hole) -> 3 holes
+        HollowObjectTypeReadStateShard[] shards = (HollowObjectTypeReadStateShard[])typeState.getShardsVolatile().getShards();
+        long holeCost = shards[0].dataElements.bitsPerRecord/8L + shards[1].dataElements.bitsPerRecord*3L/8;
+        assertEquals(holeCost, typeState.getApproximateHoleCostInBytes());
     }
 
     @Test

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateTest.java
@@ -4,7 +4,6 @@ import static junit.framework.TestCase.assertEquals;
 
 import com.netflix.hollow.core.read.engine.HollowTypeReshardingStrategy;
 import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
-import com.netflix.hollow.core.write.HollowObjectWriteRecord;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.util.Random;
 import org.junit.Test;
@@ -46,14 +45,13 @@ public class HollowObjectTypeReadStateTest extends AbstractHollowObjectTypeDataE
     }
 
     @Test
-    public void testApproximateHoleCountWithShards() throws Exception {
+    public void testApproximateHoleCostWithShards() throws Exception {
         // Setup with 2 shards
         writeStateEngine = new HollowWriteStateEngine();
         writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema, 2));
 
         // Cycle 1: snapshot with 6 records (ordinals 0-5)
         // note that the ordinal assigned would be also be 0-4.
-        HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
         populateWriteStateEngine(writeStateEngine, schema, 6);
         roundTripSnapshot();
         // Cycle 2: keep only records 2 and 4, creating holes at 0, 1, 3, 5

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/set/AbstractHollowSetTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/set/AbstractHollowSetTypeDataElementsSplitJoinTest.java
@@ -10,13 +10,12 @@ import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
 import com.netflix.hollow.core.schema.HollowSetSchema;
 import com.netflix.hollow.core.write.HollowSetTypeWriteState;
 import com.netflix.hollow.core.write.HollowSetWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/set/AbstractHollowSetTypeDataElementsSplitJoinTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/set/AbstractHollowSetTypeDataElementsSplitJoinTest.java
@@ -15,6 +15,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -43,7 +45,7 @@ public class AbstractHollowSetTypeDataElementsSplitJoinTest extends AbstractHoll
         writeStateEngine.setTargetMaxTypeShardSize(4 * 100 * 1000 * 1024);
     }
 
-    int[][] generateSetContents(int numRecords) {
+    protected int[][] generateSetContents(int numRecords) {
         int[][] setContents = new int[numRecords][];
         for (int i=0;i<numRecords;i++) {
             setContents[i] = new int[i+1];
@@ -61,6 +63,12 @@ public class AbstractHollowSetTypeDataElementsSplitJoinTest extends AbstractHoll
                 .orElse(0);
         // populate write state with that many ordinals
         super.populateWriteStateEngine(numOrdinals);
+        populateTypeStateWith(writeStateEngine, setContents);
+        roundTripSnapshot();
+        return (HollowSetTypeReadState) readStateEngine.getTypeState("TestSet");
+    }
+
+    protected void populateTypeStateWith(HollowWriteStateEngine writeStateEngine, int[][] setContents) {
         for(int[] set : setContents) {
             HollowSetWriteRecord rec = new HollowSetWriteRecord();
             for(int ordinal : set) {
@@ -68,8 +76,6 @@ public class AbstractHollowSetTypeDataElementsSplitJoinTest extends AbstractHoll
             }
             writeStateEngine.add("TestSet", rec);
         }
-        roundTripSnapshot();
-        return (HollowSetTypeReadState) readStateEngine.getTypeState("TestSet");
     }
 
     protected void assertDataUnchanged(HollowSetTypeReadState typeState, int[][] setContents) {

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateTest.java
@@ -3,10 +3,46 @@ package com.netflix.hollow.core.read.engine.set;
 import static junit.framework.TestCase.assertEquals;
 
 import com.netflix.hollow.core.read.engine.HollowTypeReshardingStrategy;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowSetTypeWriteState;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import java.util.Random;
 import org.junit.Test;
 
 public class HollowSetTypeReadStateTest extends AbstractHollowSetTypeDataElementsSplitJoinTest {
+
+    @Test
+    public void testApproximateHoleCostWithShards() throws Exception {
+        // Setup with 2 shards
+        writeStateEngine = new HollowWriteStateEngine();
+        writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema, 2));
+        writeStateEngine.addTypeState(new HollowSetTypeWriteState(setSchema, 2));
+
+        // Cycle 1: add TestObject records and 5 set records with varying sizes
+        // Cycle 1
+        // populate TestObject with ordinal values 0 - 4
+        populateWriteStateEngine(writeStateEngine, schema, 6);
+        // populate TestSet with ordinal values 0 - 4
+        populateTypeStateWith(writeStateEngine, new int[][] {{0}, {1}, {2}, {3}, {4}, {5}});
+        roundTripSnapshot();
+
+        // Cycle 2: re-add all TestObjects
+        // for TestSet:
+        // Shard 0 (even: 0=hole, 2=pop, 4=pop) -> 1 hole
+        // Shard 1 (odd: 1=hole, 3=hole, 5=hole) -> 3 holes
+        populateWriteStateEngine(writeStateEngine, schema, 6);
+        // populate TestSet with ordinal values 0 - 4
+        populateTypeStateWith(writeStateEngine, new int[][] {{2}, {4}});
+        roundTripDelta();
+
+        HollowSetTypeReadState typeState = (HollowSetTypeReadState) readStateEngine.getTypeState("TestSet");
+        assertEquals(2, typeState.numShards());
+        assertEquals(2, typeState.getPopulatedOrdinals().cardinality());
+        HollowSetTypeReadStateShard[] shards = (HollowSetTypeReadStateShard[])typeState.getShardsVolatile().getShards();
+        long holeCost = shards[0].dataElements.bitsPerFixedLengthSetPortion/8L +
+                shards[1].dataElements.bitsPerFixedLengthSetPortion*3L/8;
+        assertEquals(holeCost, typeState.getApproximateHoleCostInBytes());
+    }
 
     @Test
     public void testResharding() throws Exception {

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateTest.java
@@ -18,11 +18,10 @@ public class HollowSetTypeReadStateTest extends AbstractHollowSetTypeDataElement
         writeStateEngine.addTypeState(new HollowObjectTypeWriteState(schema, 2));
         writeStateEngine.addTypeState(new HollowSetTypeWriteState(setSchema, 2));
 
-        // Cycle 1: add TestObject records and 5 set records with varying sizes
-        // Cycle 1
-        // populate TestObject with ordinal values 0 - 4
+        // Cycle 1:
+        // populate TestObject with ordinal values 0 - 5
         populateWriteStateEngine(writeStateEngine, schema, 6);
-        // populate TestSet with ordinal values 0 - 4
+        // populate TestSet with ordinal values 0 - 5
         populateTypeStateWith(writeStateEngine, new int[][] {{0}, {1}, {2}, {3}, {4}, {5}});
         roundTripSnapshot();
 


### PR DESCRIPTION
## Summary
 - Fix incorrect hole cost estimation in `getApproximateHoleCostInBytes` for all type shards (list, map, set, object)

 ## Details
 When `numShards > 1`, ordinals are distributed across shards via `ordinal % numShards`, and each shard stores records at shard-local ordinal `ordinal / numShards` (equivalently `ordinal >>> shardOrdinalShift`). The `maxOrdinal` field in `dataElements` is this shard-local max.

For one internal namespace, the difference between the actual value and the estimated one is 8X.

 The bug: the while-loop condition `holeOrdinal <= dataElements.maxOrdinal` compared a global ordinal against a shard-local max, causing the loop to terminate too early and undercount holes. For example, with 8 shards and maxOrdinal=2 (shard-local), the loop would stop at global ordinal 2 instead of scanning up to global ordinal ~23.

 The fix: `(holeOrdinal >>> shardOrdinalShift) <= dataElements.maxOrdinal` correctly converts to shard-local space.
