### PR TITLE
Skip no-op delta rebuilds for root-local hash indexes

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -29,6 +29,7 @@ import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeStateListener;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,6 +52,9 @@ public class HollowHashIndex implements HollowTypeStateListener {
     private final String type;
     private final String selectField;
     private final String[] matchFields;
+    private final boolean supportsNoOpDeltaUpdateSkip;
+
+    private boolean deltaHadTypeChanges;
 
     /**
      * This constructor is for binary-compatibility for code compiled against
@@ -85,6 +89,7 @@ public class HollowHashIndex implements HollowTypeStateListener {
         this.typeState = (HollowObjectTypeDataAccess) hollowDataAccess.getTypeDataAccess(type);
         this.selectField = selectField;
         this.matchFields = matchFields;
+        this.supportsNoOpDeltaUpdateSkip = canSkipNoOpDeltaUpdate();
 
         if (typeState == null) {
             LOG.log(Level.WARNING, "Index initialization for " + this + " failed because type "
@@ -115,6 +120,39 @@ public class HollowHashIndex implements HollowTypeStateListener {
 
         builder.buildIndex();
         this.hashStateVolatile = new HollowHashIndexState(builder);
+    }
+
+    private boolean canSkipNoOpDeltaUpdate() {
+        if (typeState == null || !"".equals(selectField)) {
+            return false;
+        }
+
+        for (String matchField : matchFields) {
+            if (!isRootLocalField(matchField)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isRootLocalField(String fieldPath) {
+        try {
+            FieldPaths.FieldPath<FieldPaths.FieldSegment> path =
+                    FieldPaths.createFieldPathForHashIndex(hollowDataAccess, type, fieldPath);
+            if (path.getSegments().size() != 1) {
+                return false;
+            }
+
+            FieldPaths.FieldSegment segment = path.getSegments().get(0);
+            if (!(segment instanceof FieldPaths.ObjectFieldSegment)) {
+                return false;
+            }
+
+            return ((FieldPaths.ObjectFieldSegment) segment).getType() != FieldType.REFERENCE;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
 
@@ -255,19 +293,30 @@ public class HollowHashIndex implements HollowTypeStateListener {
     }
 
     @Override
-    public void beginUpdate() { }
+    public void beginUpdate() {
+        deltaHadTypeChanges = false;
+    }
 
     @Override
-    public void addedOrdinal(int ordinal) { }
+    public void addedOrdinal(int ordinal) {
+        deltaHadTypeChanges = true;
+    }
 
     @Override
-    public void removedOrdinal(int ordinal) { }
+    public void removedOrdinal(int ordinal) {
+        deltaHadTypeChanges = true;
+    }
 
     @Override
     public void endUpdate() {
         if (hashStateVolatile == null) {
             return;
         }
+
+        if (supportsNoOpDeltaUpdateSkip && !deltaHadTypeChanges) {
+            return;
+        }
+
         reindexHashIndex();
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
@@ -32,6 +32,7 @@ import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowInline;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -335,6 +336,77 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
         Assert.assertNull("Original index subscribed using listenForDeltaUpdates not expected to refresh on " +
                 "deltas after incurring a double snapshot", index.findMatches(6));
     }
+
+    @Test
+    public void testRootLocalIndexSkipsNoOpDeltaRebuild() throws Exception {
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+        mapper.add(new TypeC(new TypeD("before")));
+
+        roundTripSnapshot();
+
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "", "a1");
+        index.listenForDeltaUpdates();
+
+        Object initialState = getHashState(index);
+
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+        mapper.add(new TypeC(new TypeD("after")));
+
+        roundTripDelta();
+
+        Assert.assertSame(initialState, getHashState(index));
+        assertIteratorContainsAll(index.findMatches(1).iterator(), 0);
+        assertIteratorContainsAll(index.findMatches(2).iterator(), 1);
+    }
+
+    @Test
+    public void testRootLocalIndexRebuildsWhenRootTypeChanges() throws Exception {
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+
+        roundTripSnapshot();
+
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "", "a1");
+        index.listenForDeltaUpdates();
+
+        Object initialState = getHashState(index);
+
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(3, 3.3d, new TypeB("three")));
+
+        roundTripDelta();
+
+        Assert.assertNotSame(initialState, getHashState(index));
+        assertIteratorContainsAll(index.findMatches(1).iterator(), 0);
+        Assert.assertNull(index.findMatches(2));
+        Assert.assertNotNull(index.findMatches(3));
+    }
+
+    @Test
+    public void testNonRootLocalIndexStillRebuildsOnUnrelatedDelta() throws Exception {
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+        mapper.add(new TypeC(new TypeD("before")));
+
+        roundTripSnapshot();
+
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "", "ab.element.b1.value");
+        index.listenForDeltaUpdates();
+
+        Object initialState = getHashState(index);
+
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+        mapper.add(new TypeC(new TypeD("after")));
+
+        roundTripDelta();
+
+        Assert.assertNotSame(initialState, getHashState(index));
+        assertIteratorContainsAll(index.findMatches("one").iterator(), 0);
+        assertIteratorContainsAll(index.findMatches("two").iterator(), 1);
+    }
     
     @Test
     public void testGettingPropertiesValues() throws Exception {
@@ -398,6 +470,12 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
 
         Set<Integer> expectedSet = IntStream.of(expectedOrdinals).boxed().collect(toSet());
         Assert.assertEquals(expectedSet, ordinalSet);
+    }
+
+    private Object getHashState(HollowHashIndex index) throws Exception {
+        Field hashStateField = HollowHashIndex.class.getDeclaredField("hashStateVolatile");
+        hashStateField.setAccessible(true);
+        return hashStateField.get(index);
     }
 
     @SuppressWarnings({"unused", "FieldCanBeLocal"})


### PR DESCRIPTION
## Summary
- skip `HollowHashIndex` delta reindexing when the index is root-select and all match fields are direct non-reference fields on the root type
- keep the existing rebuild-on-every-delta behavior for traversing or reference-based hash indexes
- add regression tests covering skipped rebuilds, rebuilds on root changes, and unchanged behavior for non-root-local indexes

## Testing
- `./gradlew :hollow:test --tests com.netflix.hollow.core.index.HollowHashIndexTest --rerun-tasks -Pcom.netflix.gradle-predictive-test-selection.enabled=false`