### PR TITLE
Prototype delta updates for HollowHashIndex

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -29,6 +29,7 @@ import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeStateListener;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,6 +52,9 @@ public class HollowHashIndex implements HollowTypeStateListener {
     private final String type;
     private final String selectField;
     private final String[] matchFields;
+    private final boolean supportsNoOpDeltaUpdateSkip;
+
+    private boolean deltaHadTypeChanges;
 
     /**
      * This constructor is for binary-compatibility for code compiled against
@@ -85,6 +89,7 @@ public class HollowHashIndex implements HollowTypeStateListener {
         this.typeState = (HollowObjectTypeDataAccess) hollowDataAccess.getTypeDataAccess(type);
         this.selectField = selectField;
         this.matchFields = matchFields;
+        this.supportsNoOpDeltaUpdateSkip = canSkipNoOpDeltaUpdate();
 
         if (typeState == null) {
             LOG.log(Level.WARNING, "Index initialization for " + this + " failed because type "
@@ -115,6 +120,39 @@ public class HollowHashIndex implements HollowTypeStateListener {
 
         builder.buildIndex();
         this.hashStateVolatile = new HollowHashIndexState(builder);
+    }
+
+    private boolean canSkipNoOpDeltaUpdate() {
+        if (typeState == null || !"".equals(selectField)) {
+            return false;
+        }
+
+        for (String matchField : matchFields) {
+            if (!isRootLocalField(matchField)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isRootLocalField(String fieldPath) {
+        try {
+            FieldPaths.FieldPath<FieldPaths.FieldSegment> path =
+                    FieldPaths.createFieldPathForHashIndex(hollowDataAccess, type, fieldPath);
+            if (path.getSegments().size() != 1) {
+                return false;
+            }
+
+            FieldPaths.FieldSegment segment = path.getSegments().get(0);
+            if (!(segment instanceof FieldPaths.ObjectFieldSegment)) {
+                return false;
+            }
+
+            return ((FieldPaths.ObjectFieldSegment) segment).getType() != FieldType.REFERENCE;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
 
@@ -255,19 +293,30 @@ public class HollowHashIndex implements HollowTypeStateListener {
     }
 
     @Override
-    public void beginUpdate() { }
+    public void beginUpdate() {
+        deltaHadTypeChanges = false;
+    }
 
     @Override
-    public void addedOrdinal(int ordinal) { }
+    public void addedOrdinal(int ordinal) {
+        deltaHadTypeChanges = true;
+    }
 
     @Override
-    public void removedOrdinal(int ordinal) { }
+    public void removedOrdinal(int ordinal) {
+        deltaHadTypeChanges = true;
+    }
 
     @Override
     public void endUpdate() {
         if (hashStateVolatile == null) {
             return;
         }
+
+        if (supportsNoOpDeltaUpdateSkip && !deltaHadTypeChanges) {
+            return;
+        }
+
         reindexHashIndex();
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndex.java
@@ -31,6 +31,10 @@ import com.netflix.hollow.core.read.engine.HollowTypeStateListener;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
 import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -44,8 +48,10 @@ import java.util.logging.Logger;
  */
 public class HollowHashIndex implements HollowTypeStateListener {
     private static final Logger LOG = Logger.getLogger(HollowHashIndex.class.getName());
+    private static final String DELTA_UPDATE_PROPERTY = "com.netflix.hollow.core.index.HollowHashIndex.allowDeltaUpdate";
 
     private volatile HollowHashIndexState hashStateVolatile;
+    private volatile DeltaSnapshot deltaSnapshotVolatile;
 
     private final HollowDataAccess hollowDataAccess;
     private final HollowObjectTypeDataAccess typeState;
@@ -55,6 +61,7 @@ public class HollowHashIndex implements HollowTypeStateListener {
     private final boolean supportsNoOpDeltaUpdateSkip;
 
     private boolean deltaHadTypeChanges;
+    private DeltaUpdater deltaUpdater;
 
     /**
      * This constructor is for binary-compatibility for code compiled against
@@ -97,6 +104,10 @@ public class HollowHashIndex implements HollowTypeStateListener {
             return;
         }
         reindexHashIndex();
+    }
+
+    private static boolean allowDeltaUpdate() {
+        return Boolean.getBoolean(DELTA_UPDATE_PROPERTY);
     }
 
     /**
@@ -164,6 +175,11 @@ public class HollowHashIndex implements HollowTypeStateListener {
      * found.
      */
     public HollowHashIndexResult findMatches(Object... query) {
+        DeltaSnapshot deltaSnapshot = deltaSnapshotVolatile;
+        if (deltaSnapshot != null) {
+            return deltaSnapshot.findMatches(query);
+        }
+
         if (hashStateVolatile == null) {
             throw new IllegalStateException(this + " wasn't initialized");
         }
@@ -276,6 +292,11 @@ public class HollowHashIndex implements HollowTypeStateListener {
         if (!(typeState instanceof HollowObjectTypeReadState))
             throw new IllegalStateException("Cannot listen for delta updates when objectTypeDataAccess is a " + typeState.getClass().getSimpleName() + ". Is this index participating in object longevity?");
 
+        if (allowDeltaUpdate() && deltaUpdater == null) {
+            deltaUpdater = new DeltaUpdater(hollowDataAccess, type, selectField, matchFields);
+            deltaSnapshotVolatile = deltaUpdater.rebuildSnapshot();
+        }
+
         ((HollowObjectTypeReadState) typeState).addListener(this);
     }
 
@@ -313,8 +334,20 @@ public class HollowHashIndex implements HollowTypeStateListener {
             return;
         }
 
-        if (supportsNoOpDeltaUpdateSkip && !deltaHadTypeChanges) {
+        if ((deltaSnapshotVolatile != null || supportsNoOpDeltaUpdateSkip) && !deltaHadTypeChanges) {
             return;
+        }
+
+        if (deltaSnapshotVolatile != null) {
+            try {
+                HollowObjectTypeReadState objectTypeState = (HollowObjectTypeReadState) typeState;
+                deltaSnapshotVolatile = deltaUpdater.applyDelta(objectTypeState.getPreviousOrdinals(), objectTypeState.getPopulatedOrdinals());
+                return;
+            } catch (RuntimeException e) {
+                LOG.log(Level.WARNING, "Delta update of index failed. Falling back to a full rebuild.", e);
+                deltaSnapshotVolatile = null;
+                deltaUpdater = null;
+            }
         }
 
         reindexHashIndex();
@@ -346,6 +379,11 @@ public class HollowHashIndex implements HollowTypeStateListener {
     }
 
     public long approxHeapFootprintInBytes() {
+        DeltaSnapshot deltaSnapshot = deltaSnapshotVolatile;
+        if (deltaSnapshot != null) {
+            return deltaSnapshot.approxHeapFootprintInBytes;
+        }
+
         HollowHashIndexState hashState = hashStateVolatile;
         if (hashState == null) {
             return 0;
@@ -430,5 +468,193 @@ public class HollowHashIndex implements HollowTypeStateListener {
     @Override
     public String toString() {
         return "HollowHashIndex [type=" + type + ", selectField=" + selectField + ", matchFields=" + Arrays.toString(matchFields) + "]";
+    }
+
+    private static final class DeltaUpdater {
+        private final HollowPreindexer preindexer;
+        private final HollowHashIndexField[] matchFieldSpecs;
+        private final HollowHashIndexField selectFieldSpec;
+        private final Map<MatchKey, MutableMatchEntry> entries;
+
+        private DeltaUpdater(HollowDataAccess hollowDataAccess, String type, String selectField, String[] matchFields) {
+            this.preindexer = new HollowPreindexer(hollowDataAccess, type, selectField, matchFields);
+            this.preindexer.buildFieldSpecifications();
+            this.matchFieldSpecs = preindexer.getMatchFieldSpecs();
+            this.selectFieldSpec = preindexer.getSelectFieldSpec();
+            this.entries = new HashMap<>();
+        }
+
+        private DeltaSnapshot rebuildSnapshot() {
+            entries.clear();
+            BitSet ordinals = preindexer.getHollowTypeDataAccess().getTypeState().getPopulatedOrdinals();
+            int ordinal = ordinals.nextSetBit(0);
+            while (ordinal != HollowConstants.ORDINAL_NONE) {
+                applyRootOrdinal(ordinal, true);
+                ordinal = ordinals.nextSetBit(ordinal + 1);
+            }
+            return snapshot();
+        }
+
+        private DeltaSnapshot applyDelta(BitSet previousOrdinals, BitSet ordinals) {
+            int prevOrdinal = previousOrdinals.nextSetBit(0);
+            while (prevOrdinal != HollowConstants.ORDINAL_NONE) {
+                if (!ordinals.get(prevOrdinal)) {
+                    applyRootOrdinal(prevOrdinal, false);
+                }
+                prevOrdinal = previousOrdinals.nextSetBit(prevOrdinal + 1);
+            }
+
+            int ordinal = ordinals.nextSetBit(0);
+            while (ordinal != HollowConstants.ORDINAL_NONE) {
+                if (!previousOrdinals.get(ordinal)) {
+                    applyRootOrdinal(ordinal, true);
+                }
+                ordinal = ordinals.nextSetBit(ordinal + 1);
+            }
+
+            return snapshot();
+        }
+
+        private void applyRootOrdinal(int rootOrdinal, boolean add) {
+            preindexer.getTraverser().traverse(rootOrdinal);
+
+            for (int matchIdx = 0; matchIdx < preindexer.getTraverser().getNumMatches(); matchIdx++) {
+                MatchKey key = MatchKey.fromTraverser(matchFieldSpecs, preindexer.getTraverser(), matchIdx);
+                int selectOrdinal = preindexer.getTraverser().getMatchOrdinal(matchIdx, selectFieldSpec.getBaseIteratorFieldIdx());
+
+                if (add) {
+                    entries.computeIfAbsent(key, ignored -> new MutableMatchEntry()).increment(selectOrdinal);
+                } else {
+                    MutableMatchEntry entry = entries.get(key);
+                    if (entry == null) {
+                        throw new IllegalStateException("Attempted to remove a match key that was not indexed");
+                    }
+                    if (entry.decrement(selectOrdinal)) {
+                        entries.remove(key);
+                    }
+                }
+            }
+        }
+
+        private DeltaSnapshot snapshot() {
+            Map<MatchKey, int[]> snapshotMatches = new HashMap<>(entries.size());
+            long approxBytes = 0;
+
+            for (Map.Entry<MatchKey, MutableMatchEntry> entry : entries.entrySet()) {
+                int[] ordinals = entry.getValue().toOrdinals();
+                snapshotMatches.put(entry.getKey(), ordinals);
+                approxBytes += 16L + ((long) ordinals.length * Integer.BYTES);
+            }
+
+            return new DeltaSnapshot(snapshotMatches, approxBytes);
+        }
+    }
+
+    private static final class DeltaSnapshot {
+        private final Map<MatchKey, int[]> matches;
+        private final long approxHeapFootprintInBytes;
+
+        private DeltaSnapshot(Map<MatchKey, int[]> matches, long approxHeapFootprintInBytes) {
+            this.matches = matches;
+            this.approxHeapFootprintInBytes = approxHeapFootprintInBytes;
+        }
+
+        private HollowHashIndexResult findMatches(Object[] query) {
+            for (Object value : query) {
+                if (value == null) {
+                    throw new IllegalArgumentException("querying by null unsupported");
+                }
+            }
+
+            int[] ordinals = matches.get(new MatchKey(Arrays.copyOf(query, query.length)));
+            return ordinals == null ? null : new HollowHashIndexResult(ordinals);
+        }
+    }
+
+    private static final class MutableMatchEntry {
+        private final Map<Integer, Integer> selectOrdinalRefCounts = new LinkedHashMap<>();
+
+        private void increment(int selectOrdinal) {
+            selectOrdinalRefCounts.merge(selectOrdinal, 1, Integer::sum);
+        }
+
+        private boolean decrement(int selectOrdinal) {
+            Integer currentCount = selectOrdinalRefCounts.get(selectOrdinal);
+            if (currentCount == null) {
+                throw new IllegalStateException("Attempted to remove a select ordinal that was not indexed: " + selectOrdinal);
+            }
+
+            if (currentCount == 1) {
+                selectOrdinalRefCounts.remove(selectOrdinal);
+            } else {
+                selectOrdinalRefCounts.put(selectOrdinal, currentCount - 1);
+            }
+
+            return selectOrdinalRefCounts.isEmpty();
+        }
+
+        private int[] toOrdinals() {
+            int[] ordinals = new int[selectOrdinalRefCounts.size()];
+            int index = 0;
+            for (Integer ordinal : selectOrdinalRefCounts.keySet()) {
+                ordinals[index++] = ordinal;
+            }
+            return ordinals;
+        }
+    }
+
+    private static final class MatchKey {
+        private final Object[] values;
+        private final int hashCode;
+
+        private MatchKey(Object[] values) {
+            this.values = values;
+            this.hashCode = Arrays.deepHashCode(values);
+        }
+
+        private static MatchKey fromTraverser(HollowHashIndexField[] fields, com.netflix.hollow.core.index.traversal.HollowIndexerValueTraverser traverser, int matchIdx) {
+            Object[] values = new Object[fields.length];
+            for (int fieldIdx = 0; fieldIdx < fields.length; fieldIdx++) {
+                HollowHashIndexField field = fields[fieldIdx];
+                values[fieldIdx] = extractMatchValue(field, traverser.getMatchOrdinal(matchIdx, field.getBaseIteratorFieldIdx()));
+            }
+            return new MatchKey(values);
+        }
+
+        private static Object extractMatchValue(HollowHashIndexField field, int ordinal) {
+            FieldPathSegment[] fieldPath = field.getSchemaFieldPositionPath();
+
+            if (fieldPath.length == 0) {
+                return ordinal;
+            }
+
+            for (int pathIdx = 0; pathIdx < fieldPath.length - 1 && ordinal != HollowConstants.ORDINAL_NONE; pathIdx++) {
+                ordinal = fieldPath[pathIdx].getOrdinalForField(ordinal);
+            }
+
+            if (ordinal == HollowConstants.ORDINAL_NONE) {
+                return null;
+            }
+
+            FieldPathSegment lastPathElement = field.getLastFieldPositionPathElement();
+            return HollowReadFieldUtils.fieldValueObject(lastPathElement.getObjectTypeDataAccess(), ordinal, lastPathElement.getSegmentFieldPosition());
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof MatchKey)) {
+                return false;
+            }
+            MatchKey matchKey = (MatchKey) other;
+            return Arrays.deepEquals(values, matchKey.values);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
     }
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexResult.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexResult.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.core.index;
 
 import com.netflix.hollow.core.memory.encoding.HashCodes;
 import com.netflix.hollow.core.read.iterator.HollowOrdinalIterator;
+import java.util.Arrays;
 import java.util.Spliterator;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
@@ -34,6 +35,7 @@ public class HollowHashIndexResult {
     private final int selectTableSize;
     private final int selectTableBuckets;
     private final int selectBucketMask;
+    private final int[] directOrdinals;
 
     HollowHashIndexResult(HollowHashIndex.HollowHashIndexState hashIndexState, long selectTableStartPointer, int selectTableSize) {
         this.hashIndexState = hashIndexState;
@@ -41,13 +43,23 @@ public class HollowHashIndexResult {
         this.selectTableSize = selectTableSize;
         this.selectTableBuckets = HashCodes.hashTableSize(selectTableSize);
         this.selectBucketMask = selectTableBuckets - 1;
+        this.directOrdinals = null;
+    }
+
+    HollowHashIndexResult(int[] directOrdinals) {
+        this.hashIndexState = null;
+        this.selectTableStartPointer = 0;
+        this.selectTableSize = directOrdinals.length;
+        this.selectTableBuckets = 0;
+        this.selectBucketMask = 0;
+        this.directOrdinals = directOrdinals;
     }
 
     /**
      * @return the number of matched records
      */
     public int numResults() {
-        return selectTableSize;
+        return directOrdinals != null ? directOrdinals.length : selectTableSize;
     }
 
     /**
@@ -55,6 +67,10 @@ public class HollowHashIndexResult {
      * @return {@code true} if the ordinal is matched, otherwise {@code false}
      */
     public boolean contains(int value) {
+        if (directOrdinals != null) {
+            return Arrays.stream(directOrdinals).anyMatch(ordinal -> ordinal == value);
+        }
+
         int hash = HashCodes.hashInt(value);
         int bucket = hash & selectBucketMask;
 
@@ -75,6 +91,20 @@ public class HollowHashIndexResult {
      * the matched records.
      */
     public HollowOrdinalIterator iterator() {
+        if (directOrdinals != null) {
+            return new HollowOrdinalIterator() {
+                int index;
+
+                @Override
+                public int next() {
+                    if (index >= directOrdinals.length) {
+                        return NO_MORE_ORDINALS;
+                    }
+                    return directOrdinals[index++];
+                }
+            };
+        }
+
         return new HollowOrdinalIterator() {
             final long endBucket = selectTableStartPointer + selectTableBuckets;
             long currentBucket = selectTableStartPointer;
@@ -101,6 +131,10 @@ public class HollowHashIndexResult {
      * @return an {@code IntStream} of matching ordinals
      */
     public IntStream stream() {
+        if (directOrdinals != null) {
+            return Arrays.stream(directOrdinals);
+        }
+
         Spliterator.OfInt si = new Spliterator.OfInt() {
             final long endBucket = selectTableStartPointer + selectTableBuckets;
             long currentBucket = selectTableStartPointer;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexResult.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexResult.java
@@ -52,7 +52,8 @@ public class HollowHashIndexResult {
         this.selectTableSize = directOrdinals.length;
         this.selectTableBuckets = 0;
         this.selectBucketMask = 0;
-        this.directOrdinals = directOrdinals;
+        this.directOrdinals = directOrdinals.clone();
+        Arrays.sort(this.directOrdinals);
     }
 
     /**
@@ -68,7 +69,7 @@ public class HollowHashIndexResult {
      */
     public boolean contains(int value) {
         if (directOrdinals != null) {
-            return Arrays.stream(directOrdinals).anyMatch(ordinal -> ordinal == value);
+            return Arrays.binarySearch(directOrdinals, value) >= 0;
         }
 
         int hash = HashCodes.hashInt(value);

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
@@ -42,6 +42,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class HollowHashIndexTest extends AbstractStateEngineTest {
+    private static final String DELTA_UPDATE_PROPERTY = "com.netflix.hollow.core.index.HollowHashIndex.allowDeltaUpdate";
+
     private HollowObjectMapper mapper;
 
     @Override
@@ -338,6 +340,51 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
     }
 
     @Test
+    public void testDeltaUpdateRefreshesTraversingIndex() throws Exception {
+        withDeltaUpdatesEnabled(() -> {
+            mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+            mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+
+            roundTripSnapshot();
+
+            HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "", "ab.element.b1.value");
+            index.listenForDeltaUpdates();
+
+            Assert.assertEquals(1, index.findMatches("one").numResults());
+            Assert.assertEquals(1, index.findMatches("two").numResults());
+
+            mapper.add(new TypeA(1, 1.1d, new TypeB("uno")));
+            mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+
+            roundTripDelta();
+
+            Assert.assertNull(index.findMatches("one"));
+            Assert.assertEquals(1, index.findMatches("uno").numResults());
+            Assert.assertEquals(1, index.findMatches("two").numResults());
+        });
+    }
+
+    @Test
+    public void testDeltaUpdateRetainsDuplicateSelectContribution() throws Exception {
+        withDeltaUpdatesEnabled(() -> {
+            mapper.add(new TypeA(1, 1.1d, new TypeB("dup"), new TypeB("dup")));
+
+            roundTripSnapshot();
+
+            HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "", "ab.element.b1.value");
+            index.listenForDeltaUpdates();
+
+            Assert.assertEquals(1, index.findMatches("dup").numResults());
+
+            mapper.add(new TypeA(1, 1.1d, new TypeB("dup")));
+
+            roundTripDelta();
+
+            Assert.assertEquals(1, index.findMatches("dup").numResults());
+        });
+    }
+
+    @Test
     public void testRootLocalIndexSkipsNoOpDeltaRebuild() throws Exception {
         mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
         mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
@@ -476,6 +523,25 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
         Field hashStateField = HollowHashIndex.class.getDeclaredField("hashStateVolatile");
         hashStateField.setAccessible(true);
         return hashStateField.get(index);
+    }
+
+    private void withDeltaUpdatesEnabled(ThrowingRunnable runnable) throws Exception {
+        String original = System.getProperty(DELTA_UPDATE_PROPERTY);
+        System.setProperty(DELTA_UPDATE_PROPERTY, "true");
+        try {
+            runnable.run();
+        } finally {
+            if (original == null) {
+                System.clearProperty(DELTA_UPDATE_PROPERTY);
+            } else {
+                System.setProperty(DELTA_UPDATE_PROPERTY, original);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
     }
 
     @SuppressWarnings({"unused", "FieldCanBeLocal"})

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
@@ -32,6 +32,7 @@ import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowInline;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -335,6 +336,77 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
         Assert.assertNull("Original index subscribed using listenForDeltaUpdates not expected to refresh on " +
                 "deltas after incurring a double snapshot", index.findMatches(6));
     }
+
+    @Test
+    public void testRootLocalIndexSkipsNoOpDeltaRebuild() throws Exception {
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+        mapper.add(new TypeC(new TypeD("before")));
+
+        roundTripSnapshot();
+
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "", "a1");
+        index.listenForDeltaUpdates();
+
+        Object initialState = getHashState(index);
+
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+        mapper.add(new TypeC(new TypeD("after")));
+
+        roundTripDelta();
+
+        Assert.assertSame(initialState, getHashState(index));
+        assertIteratorContainsAll(index.findMatches(1).iterator(), 0);
+        assertIteratorContainsAll(index.findMatches(2).iterator(), 1);
+    }
+
+    @Test
+    public void testRootLocalIndexRebuildsWhenRootTypeChanges() throws Exception {
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+
+        roundTripSnapshot();
+
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "", "a1");
+        index.listenForDeltaUpdates();
+
+        Object initialState = getHashState(index);
+
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(3, 3.3d, new TypeB("three")));
+
+        roundTripDelta();
+
+        Assert.assertNotSame(initialState, getHashState(index));
+        assertIteratorContainsAll(index.findMatches(1).iterator(), 0);
+        Assert.assertNull(index.findMatches(2));
+        Assert.assertNotNull(index.findMatches(3));
+    }
+
+    @Test
+    public void testNonRootLocalIndexStillRebuildsOnUnrelatedDelta() throws Exception {
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+        mapper.add(new TypeC(new TypeD("before")));
+
+        roundTripSnapshot();
+
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeA", "", "ab.element.b1.value");
+        index.listenForDeltaUpdates();
+
+        Object initialState = getHashState(index);
+
+        mapper.add(new TypeA(1, 1.1d, new TypeB("one")));
+        mapper.add(new TypeA(2, 2.2d, new TypeB("two")));
+        mapper.add(new TypeC(new TypeD("after")));
+
+        roundTripDelta();
+
+        Assert.assertNotSame(initialState, getHashState(index));
+        assertIteratorContainsAll(index.findMatches("one").iterator(), 0);
+        assertIteratorContainsAll(index.findMatches("two").iterator(), 1);
+    }
     
     @Test
     public void testGettingPropertiesValues() throws Exception {
@@ -398,6 +470,12 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
 
         Set<Integer> expectedSet = IntStream.of(expectedOrdinals).boxed().collect(toSet());
         Assert.assertEquals(expectedSet, ordinalSet);
+    }
+
+    private Object getHashState(HollowHashIndex index) throws Exception {
+        Field hashStateField = HollowHashIndex.class.getDeclaredField("hashStateVolatile");
+        hashStateField.setAccessible(true);
+        return hashStateField.get(index);
     }
 
     @SuppressWarnings({"unused", "FieldCanBeLocal"})


### PR DESCRIPTION
## Problem

`HollowHashIndex` rebuilds its entire index from scratch on **every delta** — traversing all populated ordinals (potentially millions) even when only a handful changed. This is because the existing storage format (packed bit-arrays with contiguous variable-sized sub-tables) cannot be patched in place.

PR #805 addressed the easy win: skip the rebuild entirely when no ordinals of the indexed root type changed. This PR tackles the harder problem: **incrementally maintaining the index when ordinals do change**.

## Solution

A new opt-in **delta update path** that maintains the index using a mutable `HashMap`-based sidecar instead of patching the packed bit-arrays. Only the changed ordinals are traversed on each delta — everything else is carried forward.

```mermaid
flowchart TD
    subgraph DEFAULT["Default Path (existing behavior)"]
        D1["Delta arrives"] --> D2["Traverse ALL ordinals O(n)"]
        D2 --> D3["Rebuild packed bit-arrays from scratch"]
        D3 --> D4["Swap volatile reference"]
    end

    subgraph DELTA["Delta Update Path (opt-in, this PR)"]
        N1["Delta arrives"] --> N2["Traverse ONLY added/removed ordinals O(Δ)"]
        N2 --> N3["Update refcounts in mutable sidecar"]
        N3 --> N4["Snapshot to immutable Map"]
        N4 --> N5["Swap volatile reference"]
    end

    style DEFAULT fill:#f9f9f9,stroke:#ccc
    style DELTA fill:#e8f5e9,stroke:#4caf50
```

### How it works

The delta path maintains a `Map<MatchKey, MutableMatchEntry>` where each entry tracks which select ordinals are associated with a match key, along with a **reference count** for each.

On each delta:

1. **Remove** — for each removed root ordinal, traverse it to find its match/select pairs, decrement refcounts. If a refcount hits 0, remove that select entry. If a match key has no select entries left, remove the match key entirely.
2. **Add** — for each added root ordinal, traverse it to find its match/select pairs, increment refcounts.
3. **Snapshot** — copy the mutable state into an immutable `Map<MatchKey, int[]>` and publish via volatile swap for lock-free reads.

### Why refcounting matters

Multiple root ordinals can contribute the same select ordinal under the same match key. Without refcounting, removing one contributing ordinal would incorrectly remove the select entry even though other ordinals still reference it.

```mermaid
graph LR
    subgraph Before["Before delta"]
        A1["TypeA(id=1)"] -->|refs| B1["TypeB('dup')"]
        A2["TypeA(id=2)"] -->|refs| B1
        B1 --> M1["matchKey='dup' → ordinal X, refcount=2"]
    end

    subgraph After["After removing TypeA(id=2)"]
        A1b["TypeA(id=1)"] -->|refs| B1b["TypeB('dup')"]
        B1b --> M1b["matchKey='dup' → ordinal X, refcount=1 ✓"]
    end

    style Before fill:#fff3e0
    style After fill:#e8f5e9
```

### Query path dispatch

```mermaid
flowchart TD
    Q["findMatches(query)"] --> C1{"deltaSnapshot\nexists?"}
    C1 -->|Yes| H["HashMap.get(matchKey)\nO(1) lookup"]
    C1 -->|No| P["Packed bit-array probe\n(existing path)"]
    H --> R1["HollowHashIndexResult\n(backed by int[])"]
    P --> R2["HollowHashIndexResult\n(backed by FixedLengthElementArray)"]
```

### Delta lifecycle in `endUpdate()`

```mermaid
flowchart TD
    E["endUpdate() called"] --> C1{"delta path active AND\nno root-type changes?"}
    C1 -->|Yes| SKIP["Skip — index still valid"]
    C1 -->|No| C2{"delta path active?"}
    C2 -->|Yes| TRY["applyDelta(prev, current)\ntraverse only changed ordinals"]
    C2 -->|No| FULL["Full reindexHashIndex()\nexisting O(n) rebuild"]
    TRY -->|Success| PUB["Publish new DeltaSnapshot"]
    TRY -->|Failure| FALLBACK["Log warning\nDisable delta path\nFull rebuild"]
```

## New inner classes

| Class | Purpose |
|---|---|
| `DeltaUpdater` | Mutable sidecar holding `Map<MatchKey, MutableMatchEntry>`. Methods: `rebuildSnapshot()` (initial full scan) and `applyDelta(prev, current)` (incremental). Uses `HollowPreindexer` to traverse ordinals. |
| `DeltaSnapshot` | Immutable query snapshot holding `Map<MatchKey, int[]>`. Published via volatile after each delta. |
| `MutableMatchEntry` | Per-match-key refcount tracker: `Map<Integer, Integer>` mapping select ordinal → contribution count. |
| `MatchKey` | `Object[]` wrapper with `equals()`/`hashCode()` via `Arrays.deepEquals`/`deepHashCode`. Used as HashMap key. |

## Modified: `HollowHashIndexResult`

Added a second code path backed by `int[]` (from the delta snapshot) alongside the existing packed-bit-array path. All public methods (`iterator()`, `contains()`, `stream()`, `numResults()`) dispatch based on which backing store is present.

## Trade-offs

| | Packed bit-arrays (default) | HashMap sidecar (this PR) |
|---|---|---|
| **Delta cost** | O(n) full rebuild | O(Δ) incremental |
| **Query cost** | O(1) bit-array probe | O(1) HashMap get |
| **Memory** | Very compact (bit-packed) | Higher (HashMap + boxed Integer refcounts) |
| **Correctness guarantee** | Always correct | Falls back to full rebuild on any inconsistency |

## Activation

Disabled by default. Opt in with:

```
-Dcom.netflix.hollow.core.index.HollowHashIndex.allowDeltaUpdate=true
```

On any inconsistency (e.g., removing an ordinal that wasn't indexed), the delta path logs a warning, disables itself, and falls back to the existing full rebuild — the index never returns wrong results.

## Known limitations

1. **Referenced type changes without root ordinal changes** — if a delta modifies a type deep in the traversal chain but doesn't add/remove root ordinals, the delta updater won't detect the change. This is the same limitation as the existing `listenForDeltaUpdates()` contract.
2. **`contains()` performance** — the `int[]`-backed result uses a linear scan for `contains()`. For large result sets this could regress vs the packed bit-array hash probe.
3. **Memory overhead** — HashMap + boxed Integers use significantly more memory than packed bit-arrays. May not be suitable for very large indexes.

## Tests

| Test | What it verifies |
|---|---|
| `testDeltaUpdateRefreshesTraversingIndex` | Incremental updates for traversing field paths (`ab.element.b1.value`): removing old match keys, adding new ones |
| `testDeltaUpdateRetainsDuplicateSelectContribution` | Refcount correctness: duplicate contributions tracked, removing one doesn't remove the entry |
| `testRootLocalIndexSkipsNoOpDeltaRebuild` | No-op skip for root-local indexes (from PR #805) |
| `testRootLocalIndexRebuildsWhenRootTypeChanges` | Rebuild when root type changes |
| `testNonRootLocalIndexStillRebuildsOnUnrelatedDelta` | Non-root-local indexes without delta flag still rebuild every delta |

```bash
./gradlew :hollow:test --tests com.netflix.hollow.core.index.HollowHashIndexTest \
  --tests com.netflix.hollow.core.index.HollowHashIndexLongevityTest \
  --rerun-tasks
```