### PR TITLE
Improve initialization speed for HollowPrimiaryKeyIndex by allowing parallel hash computation

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -59,6 +59,7 @@ import java.util.logging.Logger;
 public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableUniqueKeyIndex {
     private static final Logger LOG = Logger.getLogger(HollowPrimaryKeyIndex.class.getName());
 
+
     private final HollowObjectTypeReadState typeState;
     private final int[][] fieldPathIndexes;
     private final FieldType[] fieldTypes;
@@ -460,6 +461,9 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
     private static final boolean ALLOW_DELTA_UPDATE =
             Boolean.getBoolean("com.netflix.hollow.core.index.HollowPrimaryKeyIndex.allowDeltaUpdate");
 
+    private static final int PARALLEL_HASH_THRESHOLD =
+            Integer.getInteger("com.netflix.hollow.core.index.HollowPrimaryKeyIndex.parallelHashThreshold", 4096);
+
     @Override
     public synchronized void endUpdate() {
         if (hashTableVolatile == null) {
@@ -488,7 +492,6 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
                 well fix that.  Attempts to reproduce this locally has so far failed.
                 Given the importance of indexing a full reindex is performed on such a failure.  This, however,
                 will make it more difficult to detect such issues.
-
                 This approach does not protect against the case where the index is corrupt and not yet
                 detected, until a further update.  In such cases it may be possible for clients, in the interim
                 of a forced reindex, to operate on a corrupt index: queries may incorrectly return no match.  As such
@@ -528,24 +531,45 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
             ordinals = listener.getPopulatedOrdinals();
         }
 
-        int hashTableSize = HashCodes.hashTableSize(ordinals.cardinality());
+        int cardinality = ordinals.cardinality();
+        int hashTableSize = HashCodes.hashTableSize(cardinality);
         int bitsPerElement = (32 - Integer.numberOfLeadingZeros(typeState.maxOrdinal() + 1));
 
         FixedLengthElementArray hashedArray = new FixedLengthElementArray(memoryRecycler, (long)hashTableSize * (long)bitsPerElement);
 
         int hashMask = hashTableSize - 1;
 
-        int ordinal = ordinals.nextSetBit(0);
-        while(ordinal != ORDINAL_NONE) {
-            int hashCode = recordHash(ordinal);
-            int bucket = hashCode & hashMask;
+        if (shouldComputeHashesInParallel(cardinality)) {
+            int[] ordinalArray = new int[cardinality];
+            int pos = 0;
+            for (int o = ordinals.nextSetBit(0); o >= 0; o = ordinals.nextSetBit(o + 1)) {
+                ordinalArray[pos++] = o;
+            }
+            int[] hashCodes = new int[cardinality];
+            Arrays.parallelSetAll(hashCodes, i -> recordHash(ordinalArray[i]));
+            for (int i = 0; i < cardinality; i++) {
+                int hashCode = hashCodes[i];
+                int ordinal = ordinalArray[i];
+                int bucket = hashCode & hashMask;
+                while (hashedArray.getElementValue((long)bucket * (long)bitsPerElement, bitsPerElement) != 0) {
+                    bucket = (bucket + 1) & hashMask;
+                }
+                hashedArray.setElementValue((long)bucket * (long)bitsPerElement, bitsPerElement, ordinal + 1);
+            }
+        } else {
+            int ordinal = ordinals.nextSetBit(0);
+            while (ordinal != ORDINAL_NONE) {
+                int hashCode = recordHash(ordinal);
+                int bucket = hashCode & hashMask;
 
-            while(hashedArray.getElementValue((long)bucket * (long)bitsPerElement, bitsPerElement) != 0)
-                bucket = (bucket + 1) & hashMask;
+                while (hashedArray.getElementValue((long)bucket * (long)bitsPerElement, bitsPerElement) != 0) {
+                    bucket = (bucket + 1) & hashMask;
+                }
 
-            hashedArray.setElementValue((long)bucket * (long)bitsPerElement, bitsPerElement, ordinal + 1);
+                hashedArray.setElementValue((long)bucket * (long)bitsPerElement, bitsPerElement, ordinal + 1);
 
-            ordinal = ordinals.nextSetBit(ordinal + 1);
+                ordinal = ordinals.nextSetBit(ordinal + 1);
+            }
         }
 
         setHashTable(new PrimaryKeyIndexHashTable(hashedArray, hashTableSize, hashMask, bitsPerElement));
@@ -649,6 +673,10 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         } else {
             return testBucket > fromBucket || testBucket <= toBucket;
         }
+    }
+
+    private boolean shouldComputeHashesInParallel(int cardinality) {
+        return cardinality >= PARALLEL_HASH_THRESHOLD;
     }
 
     private int recordHash(int ordinal) {

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -59,6 +59,7 @@ import java.util.logging.Logger;
 public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableUniqueKeyIndex {
     private static final Logger LOG = Logger.getLogger(HollowPrimaryKeyIndex.class.getName());
 
+    public static final int DEFAULT_PARALLEL_HASH_THRESHOLD = 4096;
 
     private final HollowObjectTypeReadState typeState;
     private final int[][] fieldPathIndexes;
@@ -69,6 +70,8 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
     private final ArraySegmentRecycler memoryRecycler;
 
     private final BitSet specificOrdinalsToIndex;
+
+    private final int parallelHashThreshold;
 
     private volatile PrimaryKeyIndexHashTable hashTableVolatile;
 
@@ -97,6 +100,21 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
      * @param specificOrdinalsToIndex the bit set
      */
     public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, ArraySegmentRecycler memoryRecycler, BitSet specificOrdinalsToIndex) {
+        this(stateEngine, primaryKey, memoryRecycler, specificOrdinalsToIndex, DEFAULT_PARALLEL_HASH_THRESHOLD);
+    }
+
+    /**
+     * This initializer can be used to create a HollowPrimaryKeyIndex which will only index a subset of the records in the specified type,
+     * and to override the cardinality threshold at which hash codes are computed in parallel during (re)indexing.
+     *
+     * @param stateEngine the read state engine
+     * @param primaryKey the primary key
+     * @param memoryRecycler the memory recycler
+     * @param specificOrdinalsToIndex the bit set, or null to index all populated ordinals
+     * @param parallelHashThreshold the minimum cardinality at which hash code computation runs in parallel; pass
+     *                              {@link Integer#MAX_VALUE} to disable parallel hashing entirely
+     */
+    public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, ArraySegmentRecycler memoryRecycler, BitSet specificOrdinalsToIndex, int parallelHashThreshold) {
         requireNonNull(primaryKey, "Hollow Primary Key Index creation failed because primaryKey was null");
         requireNonNull(stateEngine, "Hollow Primary Key Index creation for type [" + primaryKey.getType()
                 + "] failed because read state wasn't initialized");
@@ -107,6 +125,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
         this.memoryRecycler = memoryRecycler;
         this.specificOrdinalsToIndex = specificOrdinalsToIndex;
+        this.parallelHashThreshold = parallelHashThreshold;
         this.typeState = (HollowObjectTypeReadState) stateEngine.getTypeState(primaryKey.getType());
 
         if (typeState == null) {
@@ -461,9 +480,6 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
     private static final boolean ALLOW_DELTA_UPDATE =
             Boolean.getBoolean("com.netflix.hollow.core.index.HollowPrimaryKeyIndex.allowDeltaUpdate");
 
-    private static final int PARALLEL_HASH_THRESHOLD =
-            Integer.getInteger("com.netflix.hollow.core.index.HollowPrimaryKeyIndex.parallelHashThreshold", 4096);
-
     @Override
     public synchronized void endUpdate() {
         if (hashTableVolatile == null) {
@@ -676,7 +692,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
     }
 
     private boolean shouldComputeHashesInParallel(int cardinality) {
-        return cardinality >= PARALLEL_HASH_THRESHOLD;
+        return cardinality >= parallelHashThreshold;
     }
 
     private int recordHash(int ordinal) {

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndexTest.java
@@ -429,6 +429,94 @@ public class HollowPrimaryKeyIndexTest extends AbstractStateEngineTest {
         } catch (NullPointerException e) {}
     }
 
+    // Default PARALLEL_HASH_THRESHOLD is 4096
+    private static final int PARALLEL_HASH_THRESHOLD = 4096;
+
+    @Test
+    public void testParallelHashMatchesSerialHashForSameLookups() throws IOException {
+        // Parallel path: cardinality >= PARALLEL_HASH_THRESHOLD
+        int parallelCount = PARALLEL_HASH_THRESHOLD + 1000;
+        HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);
+        for (int i = 0; i < parallelCount; i++) {
+            mapper.add(new TypeA(i, i * 0.1d, new TypeB("val" + i)));
+        }
+        roundTripSnapshot();
+
+        TestableUniqueKeyIndex parallelIdx = createIndex("TypeA");
+        for (int i = 0; i < parallelCount; i += 100) {
+            int ordinal = parallelIdx.getMatchingOrdinal(i, i * 0.1d, "val" + i);
+            Assert.assertTrue("Expected valid ordinal for parallel-hashed key " + i, ordinal >= 0);
+            Object[] key = parallelIdx.getRecordKey(ordinal);
+            Assert.assertEquals(i, key[0]);
+            Assert.assertEquals(i * 0.1d, (Double) key[1], 0.0);
+            Assert.assertEquals("val" + i, key[2]);
+        }
+        Assert.assertEquals(-1, parallelIdx.getMatchingOrdinal(parallelCount, parallelCount * 0.1d, "val" + parallelCount));
+
+        // Serial path: cardinality < PARALLEL_HASH_THRESHOLD
+        int serialCount = 100;
+        HollowWriteStateEngine serialWriteEngine = new HollowWriteStateEngine();
+        HollowObjectMapper serialMapper = new HollowObjectMapper(serialWriteEngine);
+        for (int i = 0; i < serialCount; i++) {
+            serialMapper.add(new TypeA(i, i * 0.1d, new TypeB("val" + i)));
+        }
+        HollowReadStateEngine serialReadEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(serialWriteEngine, serialReadEngine);
+
+        HollowPrimaryKeyIndex serialIdx = new HollowPrimaryKeyIndex(serialReadEngine, "TypeA");
+        for (int i = 0; i < serialCount; i++) {
+            int ordinal = serialIdx.getMatchingOrdinal(i, i * 0.1d, "val" + i);
+            Assert.assertTrue("Expected valid ordinal for serial-hashed key " + i, ordinal >= 0);
+            Object[] key = serialIdx.getRecordKey(ordinal);
+            Assert.assertEquals(i, key[0]);
+            Assert.assertEquals(i * 0.1d, (Double) key[1], 0.0);
+            Assert.assertEquals("val" + i, key[2]);
+        }
+        Assert.assertEquals(-1, serialIdx.getMatchingOrdinal(serialCount, serialCount * 0.1d, "val" + serialCount));
+    }
+
+    @Test
+    public void testParallelHashThresholdBoundary() throws IOException {
+        // Just below threshold — serial path
+        int belowThreshold = PARALLEL_HASH_THRESHOLD - 1;
+        HollowWriteStateEngine writeBelow = new HollowWriteStateEngine();
+        HollowObjectMapper mapperBelow = new HollowObjectMapper(writeBelow);
+        for (int i = 0; i < belowThreshold; i++) {
+            mapperBelow.add(new TypeA(i, i * 0.1d, new TypeB("val" + i)));
+        }
+        HollowReadStateEngine readBelow = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeBelow, readBelow);
+        HollowPrimaryKeyIndex idxBelow = new HollowPrimaryKeyIndex(readBelow, "TypeA");
+        for (int i = 0; i < belowThreshold; i += 500) {
+            int ordinal = idxBelow.getMatchingOrdinal(i, i * 0.1d, "val" + i);
+            Assert.assertTrue("Expected valid ordinal below threshold for key " + i, ordinal >= 0);
+            Object[] key = idxBelow.getRecordKey(ordinal);
+            Assert.assertEquals(i, key[0]);
+            Assert.assertEquals(i * 0.1d, (Double) key[1], 0.0);
+            Assert.assertEquals("val" + i, key[2]);
+        }
+        Assert.assertEquals(-1, idxBelow.getMatchingOrdinal(belowThreshold, belowThreshold * 0.1d, "val" + belowThreshold));
+
+        // At threshold — parallel path
+        HollowWriteStateEngine writeAt = new HollowWriteStateEngine();
+        HollowObjectMapper mapperAt = new HollowObjectMapper(writeAt);
+        for (int i = 0; i < PARALLEL_HASH_THRESHOLD; i++) {
+            mapperAt.add(new TypeA(i, i * 0.1d, new TypeB("val" + i)));
+        }
+        HollowReadStateEngine readAt = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeAt, readAt);
+        HollowPrimaryKeyIndex idxAt = new HollowPrimaryKeyIndex(readAt, "TypeA");
+        for (int i = 0; i < PARALLEL_HASH_THRESHOLD; i += 500) {
+            int ordinal = idxAt.getMatchingOrdinal(i, i * 0.1d, "val" + i);
+            Assert.assertTrue("Expected valid ordinal at threshold for key " + i, ordinal >= 0);
+            Object[] key = idxAt.getRecordKey(ordinal);
+            Assert.assertEquals(i, key[0]);
+            Assert.assertEquals(i * 0.1d, (Double) key[1], 0.0);
+            Assert.assertEquals("val" + i, key[2]);
+        }
+        Assert.assertEquals(-1, idxAt.getMatchingOrdinal(PARALLEL_HASH_THRESHOLD, PARALLEL_HASH_THRESHOLD * 0.1d, "val" + PARALLEL_HASH_THRESHOLD));
+    }
+
     private static void addDataForDupTesting(HollowWriteStateEngine writeStateEngine, int a1Start, double a2, int size) {
         TypeB typeB = new TypeB("commonTypeB");
         HollowObjectMapper mapper = new HollowObjectMapper(writeStateEngine);


### PR DESCRIPTION
###   **Summary**                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
###   Parallel hash computation during reindex                                                                                                                                                                                                                                                                                                                                                                             
   
Parallel hash computation: During reindex(), record hashes can be computed in parallel using Arrays.parallelSetAll for large datasets (configurable via system properties). Hash insertion into the table remains serial to avoid race conditions.                                                                        
                                                            
###   Configurable parallel hash threshold                                                                                                                                                                                                                                                                                                                                                                                 
                                                            
  The threshold that gates parallel hashing defaults to 4096 and is tunable at JVM startup:                                                                                                                                                                                                                                                                                                                            
  -Dcom.netflix.hollow.core.index.HollowPrimaryKeyIndex.parallelHashThreshold=<N>
  This follows the same pattern as the existing allowDeltaUpdate flag in the same class.                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                       
###   Test coverage                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                       
  - testParallelHashMatchesSerialHashForSameLookups — verifies the parallel path (>4096 records) and serial path (<4096 records) both return correct ordinals and that missing keys return -1                                                                                                                                                                                                                          
  - testParallelHashThresholdBoundary — exercises exactly 4095 records (serial) and 4096 records (parallel) to validate correct behaviour at the boundary                                                                                                                                                                                                                                                              
                                                                                                                                                           