### PR TITLE
Fix repeated google.protobuf.*Value fields in HollowProtoAdapter

### DIFF
--- a/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowMessageMapper.java
+++ b/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowMessageMapper.java
@@ -220,7 +220,8 @@ public class HollowMessageMapper {
 
                 // Ensure the element type schema exists
                 if (field.getType() == Descriptors.FieldDescriptor.Type.MESSAGE) {
-                    // Already created above
+                    // *Value types are unwrapped by getElementTypeName() which also creates
+                    // the wrapper schema. Regular messages are created in the recursion above.
                 } else {
                     // For primitive repeated fields, create wrapper if needed
                     ensurePrimitiveWrapperSchema(elementType);
@@ -568,7 +569,16 @@ public class HollowMessageMapper {
      */
     private String getElementTypeName(Descriptors.FieldDescriptor field) {
         if (field.getType() == Descriptors.FieldDescriptor.Type.MESSAGE) {
-            return field.getMessageType().getName();
+            Descriptors.Descriptor messageType = field.getMessageType();
+            // Unwrap google.protobuf.*Value types to their wrapper names (e.g., StringValue -> String)
+            if (isProtoValueType(messageType)) {
+                String wrapperType = getValueTypeWrapper(messageType);
+                if (wrapperType != null) {
+                    ensurePrimitiveWrapperSchema(wrapperType);
+                    return wrapperType;
+                }
+            }
+            return messageType.getName();
         } else if (field.getType() == Descriptors.FieldDescriptor.Type.ENUM) {
             return "String"; // Enums stored as strings
         } else {

--- a/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowProtoAdapter.java
+++ b/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowProtoAdapter.java
@@ -454,7 +454,14 @@ import java.util.concurrent.ConcurrentHashMap;
 
             for (Object value : values) {
                 int elementOrdinal;
-                if (value instanceof Message) {
+                if (value instanceof Message && isProtoValueType(((Message) value).getDescriptorForType())) {
+                    // Unwrap google.protobuf.*Value wrapper types (e.g., StringValue, Int32Value)
+                    // These are stored as primitive wrapper schemas (String, Integer, etc.)
+                    Message msgValue = (Message) value;
+                    Object unwrappedValue = unwrapValueType(msgValue);
+                    FieldDescriptor.JavaType unwrappedType = getUnwrappedJavaType(msgValue.getDescriptorForType().getName());
+                    elementOrdinal = wrapPrimitiveValue(unwrappedType, unwrappedValue, elementType, flatRecordWriter);
+                } else if (value instanceof Message) {
                     elementOrdinal = parseMessage((Message) value, flatRecordWriter, elementType);
                 } else {
                     // Handle primitive types in collections

--- a/hollow-protoadapter/src/test/java/com/netflix/hollow/protoadapter/HollowProtoAdapterTest.java
+++ b/hollow-protoadapter/src/test/java/com/netflix/hollow/protoadapter/HollowProtoAdapterTest.java
@@ -910,5 +910,134 @@ public class HollowProtoAdapterTest {
         assertEquals("total_revenue should be LONG",
             HollowObjectSchema.FieldType.LONG, personSchema.getFieldType(totalRevenuePos));
     }
+
+    /**
+     * Test that repeated google.protobuf.*Value fields (e.g., repeated StringValue, repeated Int32Value)
+     * are correctly unwrapped in collections. These wrapper types should be stored as their primitive
+     * wrapper schemas (String, Integer) in Hollow lists, not as StringValue/Int32Value schemas.
+     */
+    @Test
+    public void testRepeatedValueTypeFields() throws Exception {
+        Class<?> inventoryClass = protoClassLoader.loadClass("com.netflix.hollow.test.proto.PersonProtos$Inventory");
+        Class<?> stringValueClass = protoClassLoader.loadClass("com.google.protobuf.StringValue");
+        Class<?> int32ValueClass = protoClassLoader.loadClass("com.google.protobuf.Int32Value");
+
+        Method newBuilder = inventoryClass.getMethod("newBuilder");
+        Method stringValueOf = stringValueClass.getMethod("of", String.class);
+        Method int32ValueOf = int32ValueClass.getMethod("of", int.class);
+
+        // Build an Inventory with repeated StringValue tags and repeated Int32Value quantities
+        Message.Builder builder = (Message.Builder) newBuilder.invoke(null);
+        builder.setField(builder.getDescriptorForType().findFieldByName("id"), "INV-001");
+        builder.addRepeatedField(builder.getDescriptorForType().findFieldByName("tags"),
+            stringValueOf.invoke(null, "electronics"));
+        builder.addRepeatedField(builder.getDescriptorForType().findFieldByName("tags"),
+            stringValueOf.invoke(null, "sale"));
+        builder.addRepeatedField(builder.getDescriptorForType().findFieldByName("quantities"),
+            int32ValueOf.invoke(null, 10));
+        builder.addRepeatedField(builder.getDescriptorForType().findFieldByName("quantities"),
+            int32ValueOf.invoke(null, 25));
+        Message inventory = builder.build();
+
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowMessageMapper mapper = new HollowMessageMapper(writeStateEngine);
+        mapper.add(inventory);
+
+        // Verify schemas: StringValue and Int32Value should NOT exist as separate types
+        assertNull("StringValue schema should not exist (unwrapped)", writeStateEngine.getSchema("StringValue"));
+        assertNull("Int32Value schema should not exist (unwrapped)", writeStateEngine.getSchema("Int32Value"));
+
+        // String and Integer wrapper schemas should exist
+        assertNotNull("String schema should exist", writeStateEngine.getSchema("String"));
+        assertNotNull("Integer schema should exist", writeStateEngine.getSchema("Integer"));
+
+        // List schemas should reference the wrapper types
+        HollowListSchema tagsListSchema = (HollowListSchema) writeStateEngine.getSchema("ListOfString");
+        assertNotNull("ListOfString schema should exist", tagsListSchema);
+        assertEquals("ListOfString element type should be String", "String", tagsListSchema.getElementType());
+
+        HollowListSchema quantitiesListSchema = (HollowListSchema) writeStateEngine.getSchema("ListOfInteger");
+        assertNotNull("ListOfInteger schema should exist", quantitiesListSchema);
+        assertEquals("ListOfInteger element type should be Integer", "Integer", quantitiesListSchema.getElementType());
+
+        // Round-trip and verify data
+        writeStateEngine.prepareForWrite();
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // Verify Inventory record exists
+        HollowObjectTypeReadState inventoryState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("Inventory");
+        assertNotNull("Inventory state should exist", inventoryState);
+        assertEquals("Should have 1 inventory", 1, inventoryState.maxOrdinal() + 1);
+
+        // Verify String values are readable
+        HollowObjectTypeReadState stringState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("String");
+        assertNotNull("String state should exist", stringState);
+        // Should have "electronics", "sale", and "INV-001" (from the id field's primary key)
+        assertTrue("Should have String values", stringState.maxOrdinal() >= 1);
+
+        // Verify Integer values are readable
+        HollowObjectTypeReadState integerState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("Integer");
+        assertNotNull("Integer state should exist", integerState);
+        assertTrue("Should have Integer values", integerState.maxOrdinal() >= 1);
+    }
+
+    /**
+     * Test that map fields with google.protobuf.*Value values (e.g., map<string, StringValue>)
+     * correctly unwrap the value type. Proto maps are internally represented as repeated entry
+     * messages, so the *Value is a singular field on the entry — handled by the existing singular
+     * unwrap path in addObjectField.
+     */
+    @Test
+    public void testMapWithValueTypeValues() throws Exception {
+        Class<?> inventoryClass = protoClassLoader.loadClass("com.netflix.hollow.test.proto.PersonProtos$Inventory");
+        Class<?> stringValueClass = protoClassLoader.loadClass("com.google.protobuf.StringValue");
+
+        Method newBuilder = inventoryClass.getMethod("newBuilder");
+        Method stringValueOf = stringValueClass.getMethod("of", String.class);
+
+        // Build an Inventory with map<string, StringValue> attributes
+        Message.Builder builder = (Message.Builder) newBuilder.invoke(null);
+        builder.setField(builder.getDescriptorForType().findFieldByName("id"), "INV-002");
+
+        // Proto maps use putAllXxx or the builder's mutable map
+        // Use reflection to call putAttributes(String, StringValue)
+        Descriptors.FieldDescriptor attributesField = builder.getDescriptorForType().findFieldByName("attributes");
+
+        // Proto3 map entries are added as repeated message fields
+        Descriptors.Descriptor entryDescriptor = attributesField.getMessageType();
+        Message.Builder entryBuilder1 = builder.newBuilderForField(attributesField);
+        entryBuilder1.setField(entryDescriptor.findFieldByName("key"), "color");
+        entryBuilder1.setField(entryDescriptor.findFieldByName("value"), stringValueOf.invoke(null, "red"));
+        builder.addRepeatedField(attributesField, entryBuilder1.build());
+
+        Message.Builder entryBuilder2 = builder.newBuilderForField(attributesField);
+        entryBuilder2.setField(entryDescriptor.findFieldByName("key"), "size");
+        entryBuilder2.setField(entryDescriptor.findFieldByName("value"), stringValueOf.invoke(null, "large"));
+        builder.addRepeatedField(attributesField, entryBuilder2.build());
+
+        Message inventory = builder.build();
+
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowMessageMapper mapper = new HollowMessageMapper(writeStateEngine);
+        mapper.add(inventory);
+
+        // StringValue should not exist as a schema
+        assertNull("StringValue schema should not exist (unwrapped)", writeStateEngine.getSchema("StringValue"));
+        assertNotNull("String schema should exist", writeStateEngine.getSchema("String"));
+
+        // Round-trip and verify data
+        writeStateEngine.prepareForWrite();
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        HollowObjectTypeReadState inventoryState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("Inventory");
+        assertNotNull("Inventory state should exist", inventoryState);
+        assertEquals("Should have 1 inventory", 1, inventoryState.maxOrdinal() + 1);
+    }
 }
 

--- a/hollow-protoadapter/src/test/resources/test_person.proto
+++ b/hollow-protoadapter/src/test/resources/test_person.proto
@@ -76,6 +76,16 @@ message Product {
   string name = 2 [(com.netflix.hollow.hollow_type_name) = "ProductTitle"];
 }
 
+// Test message for repeated google.protobuf.*Value fields
+message Inventory {
+  option (com.netflix.hollow.hollow_primary_key) = {fields: ["id"]};
+
+  string id = 1;
+  repeated google.protobuf.StringValue tags = 2;
+  repeated google.protobuf.Int32Value quantities = 3;
+  map<string, google.protobuf.StringValue> attributes = 4;
+}
+
 // Test message for hollow_inline option and composite primary key
 message Account {
   option (com.netflix.hollow.hollow_primary_key) = {fields: ["account_id", "region"]};


### PR DESCRIPTION
## Summary

Fixes a bug where repeated fields of `google.protobuf.*Value` wrapper types (e.g., `repeated StringValue`, `repeated Int32Value`) failed at runtime with `Schema not found for type: StringValue`.

Two code paths needed to unwrap `*Value` types consistently with how singular `*Value` fields are already handled:

- **`HollowMessageMapper.getElementTypeName()`** — returned the raw message name (`StringValue`) instead of the unwrapped wrapper (`String`) for collection element types, causing list schemas to reference a non-existent type.
- **`HollowProtoAdapter.parseCollection()`** — called `parseMessage()` on `*Value` wrapper instances instead of unwrapping them to primitive values first.

## Reproduction

Any proto message with `repeated google.protobuf.StringValue` (or other `*Value` types) would fail when data was present:

```protobuf
message PhysicalStorage {
  repeated google.protobuf.StringValue regions = 6;  // fails at runtime
}
```

Found while building a Cinder producer that publishes DGW namespace proto messages containing `PhysicalStorage` with populated `regions` fields.

## Test plan

- [x] New test `testRepeatedValueTypeFields` — `repeated StringValue` and `repeated Int32Value` in collections
- [x] New test `testMapWithValueTypeValues` — `map<string, StringValue>` (proto maps with `*Value` values)
- [x] All existing protoadapter tests pass