### PR TITLE
Resolve missing type dependencies from snapshot during producer restore

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -41,10 +41,8 @@ import com.netflix.hollow.core.read.HollowBlobInput;
 import com.netflix.hollow.core.read.engine.HollowBlobHeaderReader;
 import com.netflix.hollow.core.read.engine.HollowBlobReader;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
-import com.netflix.hollow.core.schema.HollowCollectionSchema;
-import com.netflix.hollow.core.schema.HollowMapSchema;
-import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
+import com.netflix.hollow.core.schema.HollowSchemaUtil;
 import com.netflix.hollow.core.schema.HollowSchemaHash;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
 import com.netflix.hollow.core.util.HollowWriteStateCreator;
@@ -389,7 +387,7 @@ abstract class AbstractHollowProducer {
         while (changed) {
             changed = false;
             for (HollowSchema schema : new ArrayList<>(result.values())) {
-                for (String refType : getReferencedTypeNames(schema)) {
+                for (String refType : HollowSchemaUtil.getReferencedTypeNames(schema)) {
                     if (!result.containsKey(refType) && snapshotByName.containsKey(refType)) {
                         result.put(refType, snapshotByName.get(refType));
                         changed = true;
@@ -400,25 +398,6 @@ abstract class AbstractHollowProducer {
         return result.values();
     }
 
-    private static List<String> getReferencedTypeNames(HollowSchema schema) {
-        List<String> refs = new ArrayList<>();
-        if (schema instanceof HollowObjectSchema) {
-            HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
-            for (int i = 0; i < objectSchema.numFields(); i++) {
-                if (objectSchema.getFieldType(i) == HollowObjectSchema.FieldType.REFERENCE) {
-                    refs.add(objectSchema.getReferencedType(i));
-                }
-            }
-        } else if (schema instanceof com.netflix.hollow.core.schema.HollowCollectionSchema) {
-            refs.add(((com.netflix.hollow.core.schema.HollowCollectionSchema) schema).getElementType());
-        } else if (schema instanceof com.netflix.hollow.core.schema.HollowMapSchema) {
-            com.netflix.hollow.core.schema.HollowMapSchema mapSchema =
-                    (com.netflix.hollow.core.schema.HollowMapSchema) schema;
-            refs.add(mapSchema.getKeyType());
-            refs.add(mapSchema.getValueType());
-        }
-        return refs;
-    }
 
     public HollowWriteStateEngine getWriteEngine() {
         return objectMapper.getStateEngine();

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -41,6 +41,9 @@ import com.netflix.hollow.core.read.HollowBlobInput;
 import com.netflix.hollow.core.read.engine.HollowBlobHeaderReader;
 import com.netflix.hollow.core.read.engine.HollowBlobReader;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.schema.HollowCollectionSchema;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSchemaHash;
 import com.netflix.hollow.core.util.HollowObjectHashCodeFinder;
@@ -54,7 +57,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -324,7 +329,15 @@ abstract class AbstractHollowProducer {
                 readStates = ReadStateHelper.restored(readState);
 
                 // Need to restore data to new ObjectMapper since can't restore to non empty Write State Engine
-                Collection<HollowSchema> schemas = objectMapper.getStateEngine().getSchemas();
+                // Start with the producer's registered schemas, then resolve any missing type
+                // dependencies from the restored snapshot. This handles types created dynamically
+                // (e.g., by HollowMessageMapper's lazy schema creation for Struct/Value/ListValue)
+                // that exist in the snapshot but weren't registered at init time via initializeDataModel().
+                // Only types transitively referenced by the producer's schemas are adopted — types
+                // intentionally removed by the producer are not re-added.
+                Collection<HollowSchema> schemas = resolveMissingDependencies(
+                        objectMapper.getStateEngine().getSchemas(),
+                        readState.getStateEngine().getSchemas());
                 HollowWriteStateEngine writeEngine = hashCodeFinder == null
                         ? new HollowWriteStateEngine()
                         : new HollowWriteStateEngine(hashCodeFinder);
@@ -351,6 +364,60 @@ abstract class AbstractHollowProducer {
             localListeners.fireProducerRestoreComplete(status);
         }
         return readState;
+    }
+
+    /**
+     * Resolve missing type dependencies by checking the producer's schemas for references
+     * to types not in the producer's model, and adopting those types from the snapshot.
+     * This handles dynamically-created types (e.g., HollowMessageMapper's lazy Struct/Value)
+     * without re-adding types the producer intentionally removed.
+     */
+    static Collection<HollowSchema> resolveMissingDependencies(
+            Collection<HollowSchema> producerSchemas,
+            Collection<HollowSchema> snapshotSchemas) {
+        Map<String, HollowSchema> result = new LinkedHashMap<>();
+        for (HollowSchema s : producerSchemas) {
+            result.put(s.getName(), s);
+        }
+        Map<String, HollowSchema> snapshotByName = new HashMap<>();
+        for (HollowSchema s : snapshotSchemas) {
+            snapshotByName.put(s.getName(), s);
+        }
+
+        // Iteratively resolve: find referenced types missing from result, adopt from snapshot
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            for (HollowSchema schema : new ArrayList<>(result.values())) {
+                for (String refType : getReferencedTypeNames(schema)) {
+                    if (!result.containsKey(refType) && snapshotByName.containsKey(refType)) {
+                        result.put(refType, snapshotByName.get(refType));
+                        changed = true;
+                    }
+                }
+            }
+        }
+        return result.values();
+    }
+
+    private static List<String> getReferencedTypeNames(HollowSchema schema) {
+        List<String> refs = new ArrayList<>();
+        if (schema instanceof HollowObjectSchema) {
+            HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
+            for (int i = 0; i < objectSchema.numFields(); i++) {
+                if (objectSchema.getFieldType(i) == HollowObjectSchema.FieldType.REFERENCE) {
+                    refs.add(objectSchema.getReferencedType(i));
+                }
+            }
+        } else if (schema instanceof com.netflix.hollow.core.schema.HollowCollectionSchema) {
+            refs.add(((com.netflix.hollow.core.schema.HollowCollectionSchema) schema).getElementType());
+        } else if (schema instanceof com.netflix.hollow.core.schema.HollowMapSchema) {
+            com.netflix.hollow.core.schema.HollowMapSchema mapSchema =
+                    (com.netflix.hollow.core.schema.HollowMapSchema) schema;
+            refs.add(mapSchema.getKeyType());
+            refs.add(mapSchema.getValueType());
+        }
+        return refs;
     }
 
     public HollowWriteStateEngine getWriteEngine() {

--- a/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaUtil.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/schema/HollowSchemaUtil.java
@@ -3,6 +3,7 @@ package com.netflix.hollow.core.schema;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -44,5 +45,31 @@ public class HollowSchemaUtil {
             }
         }
         return topLevelTypes;
+    }
+
+    /**
+     * Get the names of all types referenced by a schema (via REFERENCE fields,
+     * collection element types, or map key/value types).
+     *
+     * @param schema the schema to inspect
+     * @return list of referenced type names
+     */
+    public static List<String> getReferencedTypeNames(HollowSchema schema) {
+        List<String> refs = new ArrayList<>();
+        if (schema instanceof HollowObjectSchema) {
+            HollowObjectSchema objectSchema = (HollowObjectSchema) schema;
+            for (int i = 0; i < objectSchema.numFields(); i++) {
+                if (objectSchema.getFieldType(i) == HollowObjectSchema.FieldType.REFERENCE) {
+                    refs.add(objectSchema.getReferencedType(i));
+                }
+            }
+        } else if (schema instanceof HollowCollectionSchema) {
+            refs.add(((HollowCollectionSchema) schema).getElementType());
+        } else if (schema instanceof HollowMapSchema) {
+            HollowMapSchema mapSchema = (HollowMapSchema) schema;
+            refs.add(mapSchema.getKeyType());
+            refs.add(mapSchema.getValueType());
+        }
+        return refs;
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/DynamicSchemaRestoreTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/DynamicSchemaRestoreTest.java
@@ -1,0 +1,324 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
+import com.netflix.hollow.core.schema.HollowListSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.write.HollowListTypeWriteState;
+import com.netflix.hollow.core.write.HollowListWriteRecord;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.test.InMemoryBlobStore;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for producer restore when the snapshot contains schemas that weren't
+ * registered at init time. This simulates dynamic schema creation (e.g.,
+ * HollowMessageMapper's lazy schema creation for Struct/Value/ListValue).
+ */
+public class DynamicSchemaRestoreTest {
+
+    private InMemoryBlobStore blobStore;
+
+    @Before
+    public void setUp() {
+        blobStore = new InMemoryBlobStore();
+    }
+
+    /**
+     * Test that restore succeeds when the snapshot contains additional types
+     * not registered via initializeDataModel(). This simulates the case where
+     * a producer dynamically creates schemas (e.g., for google.protobuf.Struct)
+     * during runCycle, and a new producer instance tries to restore from that
+     * snapshot with only the base types registered.
+     */
+    @Test
+    public void testRestoreWithAdditionalTypesInSnapshot() {
+        // --- Producer 1: publish with base types + dynamic types ---
+        HollowProducer producer1 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        // Register base schema: Person with name and metadata reference
+        HollowObjectSchema personSchema = new HollowObjectSchema("Person", 2);
+        personSchema.addField("name", FieldType.REFERENCE, "String");
+        personSchema.addField("metadata", FieldType.REFERENCE, "Metadata");
+
+        HollowObjectSchema stringSchema = new HollowObjectSchema("String", 1);
+        stringSchema.addField("value", FieldType.STRING);
+
+        // Metadata is a "dynamically created" type (like Struct)
+        HollowObjectSchema metadataSchema = new HollowObjectSchema("Metadata", 1);
+        metadataSchema.addField("data", FieldType.STRING);
+
+        producer1.initializeDataModel(personSchema, stringSchema, metadataSchema);
+
+        long v1 = producer1.runCycle(state -> {
+            HollowWriteStateEngine engine = state.getStateEngine();
+
+            HollowObjectWriteRecord stringRec = new HollowObjectWriteRecord(stringSchema);
+            stringRec.setString("value", "Alice");
+            int nameOrd = engine.add("String", stringRec);
+
+            HollowObjectWriteRecord metaRec = new HollowObjectWriteRecord(metadataSchema);
+            metaRec.setString("data", "some-metadata");
+            int metaOrd = engine.add("Metadata", metaRec);
+
+            HollowObjectWriteRecord personRec = new HollowObjectWriteRecord(personSchema);
+            personRec.setReference("name", nameOrd);
+            personRec.setReference("metadata", metaOrd);
+            engine.add("Person", personRec);
+        });
+
+        // --- Producer 2: restore with only base types (no Metadata) ---
+        // This simulates a new producer instance that only knows about Person and
+        // String but not the dynamically-created Metadata type.
+        HollowProducer producer2 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        // Only register Person and String — not Metadata
+        producer2.initializeDataModel(personSchema, stringSchema);
+
+        // Restore should succeed, adopting Metadata from the snapshot
+        HollowProducer.ReadState readState = producer2.restore(v1, blobStore);
+        assertNotNull("Restore should succeed", readState);
+        assertEquals(v1, readState.getVersion());
+
+        // Verify the restored data includes Metadata
+        HollowReadStateEngine readEngine = readState.getStateEngine();
+        assertNotNull("Metadata type should exist after restore",
+                readEngine.getTypeState("Metadata"));
+
+        // Verify we can continue the delta chain
+        long v2 = producer2.runCycle(state -> {
+            HollowWriteStateEngine engine = state.getStateEngine();
+
+            HollowObjectWriteRecord stringRec = new HollowObjectWriteRecord(stringSchema);
+            stringRec.setString("value", "Bob");
+            int nameOrd = engine.add("String", stringRec);
+
+            HollowObjectWriteRecord metaRec = new HollowObjectWriteRecord(metadataSchema);
+            metaRec.setString("data", "bob-metadata");
+            int metaOrd = engine.add("Metadata", metaRec);
+
+            HollowObjectWriteRecord personRec = new HollowObjectWriteRecord(personSchema);
+            personRec.setReference("name", nameOrd);
+            personRec.setReference("metadata", metaOrd);
+            engine.add("Person", personRec);
+        });
+
+        assertTrue("Should produce a new version", v2 > v1);
+
+        // Verify delta was produced (not just a snapshot)
+        assertNotNull("Delta blob should exist", blobStore.retrieveDeltaBlob(v1));
+    }
+
+    /**
+     * Test that restore works when the snapshot has a type with additional fields
+     * not in the producer's schema (non-breaking: field added in snapshot).
+     * The producer's schema should take precedence — extra fields from the
+     * snapshot are ignored during restore.
+     */
+    @Test
+    public void testRestoreWithExtraFieldsInSnapshotSchema() {
+        // --- Producer 1: publish with extended Person (has age field) ---
+        HollowProducer producer1 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        HollowObjectSchema personSchemaV2 = new HollowObjectSchema("Person", 2);
+        personSchemaV2.addField("name", FieldType.STRING);
+        personSchemaV2.addField("age", FieldType.INT);
+
+        producer1.initializeDataModel(personSchemaV2);
+
+        long v1 = producer1.runCycle(state -> {
+            HollowObjectWriteRecord rec = new HollowObjectWriteRecord(personSchemaV2);
+            rec.setString("name", "Alice");
+            rec.setInt("age", 30);
+            state.getStateEngine().add("Person", rec);
+        });
+
+        // --- Producer 2: restore with Person that only has name (no age) ---
+        HollowProducer producer2 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        HollowObjectSchema personSchemaV1 = new HollowObjectSchema("Person", 1);
+        personSchemaV1.addField("name", FieldType.STRING);
+
+        producer2.initializeDataModel(personSchemaV1);
+
+        // Restore should succeed — producer's schema wins, extra fields ignored
+        HollowProducer.ReadState readState = producer2.restore(v1, blobStore);
+        assertNotNull("Restore should succeed with schema evolution", readState);
+
+        // The restored data should be readable with the producer's schema
+        long v2 = producer2.runCycle(state -> {
+            HollowObjectWriteRecord rec = new HollowObjectWriteRecord(personSchemaV1);
+            rec.setString("name", "Bob");
+            state.getStateEngine().add("Person", rec);
+        });
+
+        assertTrue("Should produce a new version", v2 > v1);
+    }
+
+    /**
+     * Test that restore works when the producer adds a new field not in the
+     * snapshot (non-breaking: field added by producer).
+     */
+    @Test
+    public void testRestoreWithNewFieldInProducerSchema() {
+        // --- Producer 1: publish with basic Person ---
+        HollowProducer producer1 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        HollowObjectSchema personSchemaV1 = new HollowObjectSchema("Person", 1);
+        personSchemaV1.addField("name", FieldType.STRING);
+
+        producer1.initializeDataModel(personSchemaV1);
+
+        long v1 = producer1.runCycle(state -> {
+            HollowObjectWriteRecord rec = new HollowObjectWriteRecord(personSchemaV1);
+            rec.setString("name", "Alice");
+            state.getStateEngine().add("Person", rec);
+        });
+
+        // --- Producer 2: restore with extended Person (has age) ---
+        HollowProducer producer2 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        HollowObjectSchema personSchemaV2 = new HollowObjectSchema("Person", 2);
+        personSchemaV2.addField("name", FieldType.STRING);
+        personSchemaV2.addField("age", FieldType.INT);
+
+        producer2.initializeDataModel(personSchemaV2);
+
+        // Restore should succeed — producer's schema wins, missing fields are empty
+        HollowProducer.ReadState readState = producer2.restore(v1, blobStore);
+        assertNotNull("Restore should succeed with new field", readState);
+
+        long v2 = producer2.runCycle(state -> {
+            HollowObjectWriteRecord rec = new HollowObjectWriteRecord(personSchemaV2);
+            rec.setString("name", "Bob");
+            rec.setInt("age", 25);
+            state.getStateEngine().add("Person", rec);
+        });
+
+        assertTrue("Should produce a new version", v2 > v1);
+    }
+
+    /**
+     * Test restore when snapshot has a complex type hierarchy not registered
+     * by the producer. Simulates HollowMessageMapper's lazy creation of
+     * List types and nested reference chains.
+     */
+    @Test
+    public void testRestoreWithDynamicListAndNestedTypes() {
+        // --- Producer 1: publish with Person + Tags list (dynamic types) ---
+        HollowProducer producer1 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        HollowObjectSchema personSchema = new HollowObjectSchema("Person", 2);
+        personSchema.addField("name", FieldType.STRING);
+        personSchema.addField("tags", FieldType.REFERENCE, "ListOfTag");
+
+        HollowObjectSchema tagSchema = new HollowObjectSchema("Tag", 1);
+        tagSchema.addField("value", FieldType.STRING);
+
+        HollowListSchema listOfTagSchema = new HollowListSchema("ListOfTag", "Tag");
+
+        producer1.initializeDataModel(personSchema, tagSchema, listOfTagSchema);
+
+        long v1 = producer1.runCycle(state -> {
+            HollowWriteStateEngine engine = state.getStateEngine();
+
+            HollowObjectWriteRecord tag1Rec = new HollowObjectWriteRecord(tagSchema);
+            tag1Rec.setString("value", "important");
+            int tag1Ord = engine.add("Tag", tag1Rec);
+
+            HollowObjectWriteRecord tag2Rec = new HollowObjectWriteRecord(tagSchema);
+            tag2Rec.setString("value", "urgent");
+            int tag2Ord = engine.add("Tag", tag2Rec);
+
+            HollowListWriteRecord listRec = new HollowListWriteRecord();
+            listRec.addElement(tag1Ord);
+            listRec.addElement(tag2Ord);
+            int listOrd = engine.add("ListOfTag", listRec);
+
+            HollowObjectWriteRecord personRec = new HollowObjectWriteRecord(personSchema);
+            personRec.setString("name", "Alice");
+            personRec.setReference("tags", listOrd);
+            engine.add("Person", personRec);
+        });
+
+        // --- Producer 2: only registers Person (no Tag, no ListOfTag) ---
+        HollowProducer producer2 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        // Only register Person schema — Tag and ListOfTag are "dynamic"
+        producer2.initializeDataModel(personSchema);
+
+        // Restore should succeed, adopting Tag and ListOfTag from snapshot
+        HollowProducer.ReadState readState = producer2.restore(v1, blobStore);
+        assertNotNull("Restore should succeed", readState);
+
+        HollowReadStateEngine readEngine = readState.getStateEngine();
+        assertNotNull("Tag type should exist after restore",
+                readEngine.getTypeState("Tag"));
+        assertNotNull("ListOfTag type should exist after restore",
+                readEngine.getTypeState("ListOfTag"));
+
+        // Verify we can continue producing with all types
+        long v2 = producer2.runCycle(state -> {
+            HollowWriteStateEngine engine = state.getStateEngine();
+
+            HollowObjectWriteRecord tagRec = new HollowObjectWriteRecord(tagSchema);
+            tagRec.setString("value", "new-tag");
+            int tagOrd = engine.add("Tag", tagRec);
+
+            HollowListWriteRecord listRec = new HollowListWriteRecord();
+            listRec.addElement(tagOrd);
+            int listOrd = engine.add("ListOfTag", listRec);
+
+            HollowObjectWriteRecord personRec = new HollowObjectWriteRecord(personSchema);
+            personRec.setString("name", "Bob");
+            personRec.setReference("tags", listOrd);
+            engine.add("Person", personRec);
+        });
+
+        assertTrue("Should produce a new version", v2 > v1);
+        assertNotNull("Delta blob should exist", blobStore.retrieveDeltaBlob(v1));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a failure during `HollowProducer.restore()` when the snapshot contains types not registered via `initializeDataModel()`. The restore would throw `IllegalStateException: Missing schema(s) in dependency ordered list`.

This happens when using `HollowMessageMapper` (proto adapter) which lazily creates schemas for types like `Struct`, `Value`, and `ListValue` during `runCycle`. On restart, the producer only has the base types registered, but the snapshot contains the lazy types too.

### Fix

During restore, resolve missing type dependencies by adopting types from the snapshot that are **transitively referenced** by the producer's registered schemas but not in the producer's model. Types intentionally removed by the producer are not re-added — only dependency-resolved types are adopted.

### Why not adopt all snapshot types?

Existing behavior allows producers to intentionally remove types between versions (e.g., `initializeDataModel(TypeA, TypeE)` dropping `TypeB`). Blindly merging all snapshot types would break this. The transitive-dependency approach preserves intentional removals while resolving missing dependencies.

## Test plan

- [x] `testRestoreWithAdditionalTypesInSnapshot` — dynamic types adopted from snapshot
- [x] `testRestoreWithExtraFieldsInSnapshotSchema` — producer schema wins on field differences
- [x] `testRestoreWithNewFieldInProducerSchema` — new fields work on restore
- [x] `testRestoreWithDynamicListAndNestedTypes` — transitive adoption of list + nested types
- [x] Existing `canRemoveAndModifyNewTypesFromRestoredState` — intentional type removal still works
- [x] Full hollow test suite passes