### PR TITLE
Validations on number of blob headers and empty snapshot in integrity check

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -870,6 +870,18 @@ abstract class AbstractHollowProducer {
             HollowReadStateEngine pending = readStates.pending().getStateEngine();
             readSnapshot(artifacts.snapshot, pending);
 
+            long writtenOrdinals = getWriteEngine().getOrderedTypeStates().stream()
+                    .mapToLong(ts -> ts.getPopulatedBitSet().cardinality())
+                    .sum();
+            long pendingOrdinals = pending.getTypeStates().stream()
+                    .mapToLong(ts -> ts.getPopulatedOrdinals().cardinality())
+                    .sum();
+            if (writtenOrdinals > 0 && pendingOrdinals == 0) {
+                throw new IllegalStateException(
+                        "Integrity check failed: snapshot produced zero records (wrote " + writtenOrdinals + " records)."
+                                + " This indicates possible blob corruption.");
+            }
+
             if (readStates.hasCurrent()) {
                 HollowReadStateEngine current = readStates.current().getStateEngine();
 

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobHeaderWriter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowBlobHeaderWriter.java
@@ -56,7 +56,13 @@ public class HollowBlobHeaderWriter {
         VarInt.writeVInt(dos, 0);
 
         /// write the header tags -- intended to include input source data versions
-        dos.writeShort(header.getHeaderTags().size());
+        int numHeaderTags = header.getHeaderTags().size();
+        if (numHeaderTags > Short.MAX_VALUE) {
+            throw new IOException("Cannot write blob header: number of header tags (" + numHeaderTags
+                    + ") exceeds the maximum supported (" + Short.MAX_VALUE + "). "
+                    + "Exceeding this limit causes data corruption.");
+        }
+        dos.writeShort(numHeaderTags);
 
         for (Map.Entry<String, String> headerTag : header.getHeaderTags().entrySet()) {
             dos.writeUTF(headerTag.getKey());

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerTest.java
@@ -39,6 +39,10 @@ import com.netflix.hollow.api.producer.enforcer.BasicSingleProducerEnforcer;
 import com.netflix.hollow.api.producer.enforcer.SingleProducerEnforcer;
 import com.netflix.hollow.api.producer.fs.HollowFilesystemAnnouncer;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.HollowConstants;
+import com.netflix.hollow.core.write.HollowBlobWriter;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.api.producer.listener.VetoableListener;
 import com.netflix.hollow.api.producer.model.CustomReferenceType;
 import com.netflix.hollow.api.producer.model.HasAllTypeStates;
@@ -55,6 +59,8 @@ import com.netflix.hollow.core.write.HollowTypeWriteState;
 import com.netflix.hollow.core.write.objectmapper.HollowInline;
 import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
 import com.netflix.hollow.test.InMemoryBlobStore;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -1089,6 +1095,27 @@ public class HollowProducerTest {
         assertEquals(version1, readState.getVersion());
     }
 
+    @Test
+    public void integrityCheckFailsWhenSnapshotReadsBackZeroRecords() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowObjectSchema testSchema = new HollowObjectSchema("TestObject", 1);
+        testSchema.addField("id", FieldType.INT);
+
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new CorruptedSnapshotBlobStager(testSchema))
+                .build();
+        producer.initializeDataModel(testSchema);
+
+        try {
+            producer.runCycle(ws -> {
+                HollowObjectWriteRecord rec = new HollowObjectWriteRecord(testSchema);
+                rec.setInt("id", 1);
+                ws.getStateEngine().add("TestObject", rec);
+            });
+            fail("Expected integrity check to fail when snapshot reads back zero records");
+        } catch (RuntimeException e) {}
+    }
+
     private void add(HollowProducer.WriteState state, String sVal, int iVal) {
         TestRec rec = new TestRec(sVal, iVal);
         state.add(rec);
@@ -1181,6 +1208,39 @@ public class HollowProducerTest {
         @Override
         public void onValidationStart(long version) {
             singleProducerEnforcer.disable();
+        }
+    }
+
+    private static class CorruptedSnapshotBlobStager extends HollowInMemoryBlobStager {
+        private final HollowObjectSchema schema;
+
+        CorruptedSnapshotBlobStager(HollowObjectSchema schema) {
+            this.schema = schema;
+        }
+
+        @Override
+        public HollowProducer.Blob openSnapshot(long version) {
+            return new HollowProducer.Blob(HollowConstants.VERSION_NONE, version, HollowProducer.Blob.Type.SNAPSHOT) {
+                private byte[] data;
+
+                @Override
+                public void write(HollowBlobWriter writer) throws IOException {
+                    // Produce empty snapshot to simulate corruption
+                    HollowWriteStateEngine emptyEngine = new HollowWriteStateEngine();
+                    emptyEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    new HollowBlobWriter(emptyEngine).writeSnapshot(baos);
+                    data = baos.toByteArray();
+                }
+
+                @Override
+                public InputStream newInputStream() throws IOException {
+                    return new ByteArrayInputStream(data);
+                }
+
+                @Override
+                public void cleanup() {}
+            };
         }
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/core/read/HollowBlobHeaderTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/HollowBlobHeaderTest.java
@@ -81,6 +81,15 @@ public class HollowBlobHeaderTest {
         Assert.assertEquals(HEADER_VAL2, readStateEngine.getHeaderTag(HEADER_NAME2));
     }
 
+    @Test(expected = IOException.class)
+    public void writeSnapshotFailsWhenHeaderTagCountExceedsShortMax() throws IOException {
+        HollowWriteStateEngine engine = new HollowWriteStateEngine();
+        for (int i = 0; i <= Short.MAX_VALUE; i++) {
+            engine.addHeaderTag("key_" + i, "val_" + i);
+        }
+        new HollowBlobWriter(engine).writeSnapshot(baos);
+    }
+
     private void roundTripSnapshot() throws IOException {
         blobWriter.writeSnapshot(baos);
         writeStateEngine.prepareForNextCycle();


### PR DESCRIPTION
Added couple of validations
- Throw if the number of headers exceed 32,767. More headers than this limit results in data corruption.
- Integrity check throws if the read snapshot is empty. This is to fail-fast and avoid publishing empty snapshots when there is data corruption.