### PR TITLE
Sort blob information header entries alphabetically in diff UI

### DIFF
--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/pages/DiffPage.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/pages/DiffPage.java
@@ -25,10 +25,10 @@ import com.netflix.hollow.tools.diff.HollowTypeDiff;
 import com.netflix.hollow.ui.HollowUISession;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.velocity.Template;
@@ -141,7 +141,7 @@ public abstract class DiffPage {
         Map<String, String> fromTags = diffUI.getDiff().getFromStateEngine().getHeaderTags();
         Map<String, String> toTags = diffUI.getDiff().getToStateEngine().getHeaderTags();
 
-        Set<String> allKeys = new HashSet<String>();
+        Set<String> allKeys = new TreeSet<String>();
         allKeys.addAll(fromTags.keySet());
         allKeys.addAll(toTags.keySet());
 

--- a/hollow-diff-ui/src/test/java/com/netflix/hollow/diffview/HollowDiffUITest.java
+++ b/hollow-diff-ui/src/test/java/com/netflix/hollow/diffview/HollowDiffUITest.java
@@ -1,0 +1,67 @@
+package com.netflix.hollow.diffview;
+
+import static org.junit.Assert.assertTrue;
+
+import com.netflix.hollow.diff.ui.HollowDiffUIServer;
+import com.netflix.hollow.tools.diff.HollowDiff;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HollowDiffUITest {
+
+    private static final int PORT = 17777;
+    private static final String DIFF_PATH = "diff";
+
+    private HollowDiffUIServer server;
+
+    @Before
+    public void init() throws Exception {
+        HollowDiff testDiff = new FakeHollowDiffGenerator().createFakeDiff();
+        server = new HollowDiffUIServer(PORT);
+        server.addDiff(DIFF_PATH, testDiff);
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void blobInformationTableIsSortedAlphabetically() throws Exception {
+        // FakeHollowDiffGenerator seeds header tags:
+        //   from: tag1, tag2, fromTag
+        //   to:   tag1, tag2, toTag
+        // Alphabetical union: fromTag < tag1 < tag2 < toTag
+        String html = fetch("/" + DIFF_PATH + "/");
+
+        int iFromTag = html.indexOf("fromTag");
+        int iTag1    = html.indexOf(">tag1<");
+        int iTag2    = html.indexOf(">tag2<");
+        int iToTag   = html.indexOf("toTag");
+
+        assertTrue("fromTag not found in Blob Information table", iFromTag >= 0);
+        assertTrue("tag1 not found in Blob Information table",    iTag1    >= 0);
+        assertTrue("tag2 not found in Blob Information table",    iTag2    >= 0);
+        assertTrue("toTag not found in Blob Information table",   iToTag   >= 0);
+
+        assertTrue("Expected fromTag before tag1 (alphabetical order)", iFromTag < iTag1);
+        assertTrue("Expected tag1 before tag2 (alphabetical order)",    iTag1    < iTag2);
+        assertTrue("Expected tag2 before toTag (alphabetical order)",   iTag2    < iToTag);
+    }
+
+    private String fetch(String path) throws Exception {
+        URL url = new URL("http://localhost:" + PORT + path);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        try (Scanner scanner = new Scanner(conn.getInputStream(), "UTF-8").useDelimiter("\\A")) {
+            return scanner.hasNext() ? scanner.next() : "";
+        }
+    }
+}


### PR DESCRIPTION
### Summary
The **Blob Information** table on the Hollow Diff UI renders header tags in a non-deterministic order. `DiffPage.getHeaderEntries()` merges the FROM- and TO-side header tag keys into a `HashSet<String>` before building the display list, so the row order depends on string hash distribution and varies between runs and JDK versions.

### Fix
Replace the `HashSet<String>` in `DiffPage.getHeaderEntries()` with a `TreeSet<String>`, which iterates keys in natural alphabetical order. The Velocity template `diff-footer.vm` already renders rows in the list order it receives, so the fix is localized to the Java side. The numeric `#` column is assigned during iteration and is renumbered to match the new sorted order. No changes to the data model (`HollowHeaderEntry`) or any public API — this is purely a rendering order change.

### Test plan
- Added `HollowDiffUITest.blobInformationTableIsSortedAlphabetically` (mirrors the style of `HollowHistoryUITest`): boots a `HollowDiffUIServer` backed by `FakeHollowDiffGenerator` and asserts the four seeded header keys (`fromTag`, `tag1`, `tag2`, `toTag`) appear in alphabetical order in the rendered HTML.
- Verified locally against real Cinder-managed namespace (`WorkdayProject.v4`, ` ad_creatives`, `WorkdaySupplier.v7`) via `CinderDevUtils.diff(...)` — the Blob Information table now renders in alphabetical order, with `hollow.*` entries preceding `hollowservice.*` entries.
- Existing `hollow-diff-ui` test suite passes.