### PR TITLE
[Improv] cache mem heap stats in HollowExplorerUI;

### DIFF
--- a/hollow-explorer-ui/build.gradle
+++ b/hollow-explorer-ui/build.gradle
@@ -14,4 +14,5 @@ dependencies {
     implementation "javax.servlet:javax.servlet-api:4.0.1"
 
     testImplementation 'junit:junit:4.11'
+    testImplementation 'org.mockito:mockito-core:2.15.0'
 }

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -119,6 +120,14 @@ public class HollowExplorerUI extends HollowUIRouter {
         if(client != null)
             return client.getStateEngine();
         return stateEngine;
+    }
+
+    /**
+     * Precomputes each type's heap footprint and hole cost and caches them to serve future requests.
+     * If executor is non-null, the computation is parallelized across it; otherwise it runs synchronously.
+     */
+    public void prefillHeapStatsCache(Executor executor) {
+        showAllTypesPage.prefillHeapStatsCache(executor);
     }
 
     public String getHeaderDisplayString() {

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -124,13 +123,18 @@ public class HollowExplorerUI extends HollowUIRouter {
 
     /**
      * Precomputes each type's heap footprint and hole cost and caches them to serve future requests.
-     * If executor is non-null, the computation is parallelized across it; otherwise it runs synchronously.
      */
-    public void prefillHeapStatsCache(Executor executor) {
-        showAllTypesPage.prefillHeapStatsCache(executor);
+    public void prefillHeapStatsCache() {
+        showAllTypesPage.prefillHeapStatsCache();
     }
 
-    public void clearCache() {showAllTypesPage.clearCache();}
+    /**
+     * Invalidates the cached heap stats so the next request recomputes them.
+     * Should be called after each delta transition.
+     */
+    public void clearCache() {
+        showAllTypesPage.clearCache();
+    }
 
     public String getHeaderDisplayString() {
         return headerDisplayMap.get(HEADER_DISPLAY_STRING);

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/HollowExplorerUI.java
@@ -130,6 +130,8 @@ public class HollowExplorerUI extends HollowUIRouter {
         showAllTypesPage.prefillHeapStatsCache(executor);
     }
 
+    public void clearCache() {showAllTypesPage.clearCache();}
+
     public String getHeaderDisplayString() {
         return headerDisplayMap.get(HEADER_DISPLAY_STRING);
     }

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
@@ -51,6 +51,11 @@ public class ShowAllTypesPage extends HollowExplorerPage {
         super(ui);
     }
 
+    public void clearCache() {
+        cachedRandomizedTag = -1;
+        cachedHeapStats = null;
+    }
+
     public void prefillHeapStatsCache(Executor executor) {
         HollowReadStateEngine engine = ui.getStateEngine();
         long currentTag = engine.getCurrentRandomizedTag();

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
@@ -35,10 +35,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.velocity.VelocityContext;
 
@@ -56,7 +53,7 @@ public class ShowAllTypesPage extends HollowExplorerPage {
         cachedHeapStats = null;
     }
 
-    public void prefillHeapStatsCache(Executor executor) {
+    public void prefillHeapStatsCache() {
         HollowReadStateEngine engine = ui.getStateEngine();
         long currentTag = engine.getCurrentRandomizedTag();
         if (cachedHeapStats != null && currentTag == cachedRandomizedTag) {
@@ -64,26 +61,17 @@ public class ShowAllTypesPage extends HollowExplorerPage {
         }
 
         synchronized (this) {
-            // double null check in case previous monitor holder has completed the computation.
+            // double-checked locking: re-read under the lock in case another thread already populated the cache.
             if (cachedHeapStats != null && currentTag == cachedRandomizedTag) {
                 return;
             }
+
             Collection<HollowTypeReadState> typeStates = engine.getTypeStates();
             ConcurrentHashMap<String, HeapStats> newCache = new ConcurrentHashMap<>(typeStates.size() * 2);
-            if (executor == null) {
-                for (HollowTypeReadState ts : typeStates) {
-                    newCache.put(ts.getSchema().getName(), computeHeapStats(ts));
-                }
-            } else {
-                CompletableFuture<?>[] futures = new CompletableFuture<?>[typeStates.size()];
-                int i = 0;
-                for (HollowTypeReadState ts : typeStates) {
-                    futures[i++] = CompletableFuture.runAsync(
-                            () -> newCache.put(ts.getSchema().getName(), computeHeapStats(ts)),
-                            executor);
-                }
-                CompletableFuture.allOf(futures).join();
+            for (HollowTypeReadState ts : typeStates) {
+                newCache.put(ts.getSchema().getName(), computeHeapStats(ts));
             }
+
             cachedHeapStats = newCache;
             cachedRandomizedTag = currentTag;
         }
@@ -110,18 +98,16 @@ public class ShowAllTypesPage extends HollowExplorerPage {
 
         String sort = req.getParameter("sort") == null ? "primaryKey" : req.getParameter("sort");
 
-        List<TypeOverview> typeOverviews = new ArrayList<TypeOverview>();
-
-
-        prefillHeapStatsCache(null);
-        Map<String, HeapStats> heapStats = cachedHeapStats;
-        HollowReadStateEngine readStateEngine =  ui.getStateEngine();
+        List<TypeOverview> typeOverviews = new ArrayList<>();
+        prefillHeapStatsCache();
+        ConcurrentHashMap<String, HeapStats> heapStatsSnapshot = this.cachedHeapStats;
+        HollowReadStateEngine readStateEngine = ui.getStateEngine();
         for(HollowTypeReadState typeState : readStateEngine.getTypeStates()) {
             String typeName = typeState.getSchema().getName();
             BitSet populatedOrdinals = typeState.getPopulatedOrdinals();
             int numRecords = populatedOrdinals == null ? Integer.MIN_VALUE : populatedOrdinals.cardinality();
             int numHoles = populatedOrdinals == null ? Integer.MIN_VALUE : populatedOrdinals.length()-populatedOrdinals.cardinality();
-            HeapStats stats = heapStats.get(typeName);
+            HeapStats stats = heapStatsSnapshot != null ? heapStatsSnapshot.get(typeName) : null;
             long approxHeapFootprint = stats != null ? stats.approxHeapFootprint : typeState.getApproximateHeapFootprintInBytes();
             long approxHoleFootprint = stats != null ? stats.approxHoleFootprint : typeState.getApproximateHoleCostInBytes();
             PrimaryKey primaryKey = typeState.getSchema().getSchemaType() == SchemaType.OBJECT ? ((HollowObjectSchema)typeState.getSchema()).getPrimaryKey() : null;

--- a/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
+++ b/hollow-explorer-ui/src/main/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPage.java
@@ -19,6 +19,7 @@ package com.netflix.hollow.explorer.ui.pages;
 import static com.netflix.hollow.ui.HollowDiffUtil.formatBytes;
 
 import com.netflix.hollow.core.index.key.PrimaryKey;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
 import com.netflix.hollow.core.schema.HollowSchema.SchemaType;
@@ -30,33 +31,95 @@ import com.netflix.hollow.ui.HollowUISession;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.velocity.VelocityContext;
 
 public class ShowAllTypesPage extends HollowExplorerPage {
 
+    private volatile long cachedRandomizedTag;
+    private volatile ConcurrentHashMap<String, HeapStats> cachedHeapStats;
+
     public ShowAllTypesPage(HollowExplorerUI ui) {
         super(ui);
     }
 
+    public void prefillHeapStatsCache(Executor executor) {
+        HollowReadStateEngine engine = ui.getStateEngine();
+        long currentTag = engine.getCurrentRandomizedTag();
+        if (cachedHeapStats != null && currentTag == cachedRandomizedTag) {
+            return;
+        }
+
+        synchronized (this) {
+            // double null check in case previous monitor holder has completed the computation.
+            if (cachedHeapStats != null && currentTag == cachedRandomizedTag) {
+                return;
+            }
+            Collection<HollowTypeReadState> typeStates = engine.getTypeStates();
+            ConcurrentHashMap<String, HeapStats> newCache = new ConcurrentHashMap<>(typeStates.size() * 2);
+            if (executor == null) {
+                for (HollowTypeReadState ts : typeStates) {
+                    newCache.put(ts.getSchema().getName(), computeHeapStats(ts));
+                }
+            } else {
+                CompletableFuture<?>[] futures = new CompletableFuture<?>[typeStates.size()];
+                int i = 0;
+                for (HollowTypeReadState ts : typeStates) {
+                    futures[i++] = CompletableFuture.runAsync(
+                            () -> newCache.put(ts.getSchema().getName(), computeHeapStats(ts)),
+                            executor);
+                }
+                CompletableFuture.allOf(futures).join();
+            }
+            cachedHeapStats = newCache;
+            cachedRandomizedTag = currentTag;
+        }
+    }
+
+    private static HeapStats computeHeapStats(HollowTypeReadState ts) {
+        return new HeapStats(
+                ts.getApproximateHeapFootprintInBytes(),
+                ts.getApproximateHoleCostInBytes());
+    }
+
+    public static final class HeapStats {
+        final long approxHeapFootprint;
+        final long approxHoleFootprint;
+
+        HeapStats(long approxHeapFootprint, long approxHoleFootprint) {
+            this.approxHeapFootprint = approxHeapFootprint;
+            this.approxHoleFootprint = approxHoleFootprint;
+        }
+    }
+
     @Override
     protected void setUpContext(HttpServletRequest req, HollowUISession session, VelocityContext ctx) {
-        
+
         String sort = req.getParameter("sort") == null ? "primaryKey" : req.getParameter("sort");
-        
+
         List<TypeOverview> typeOverviews = new ArrayList<TypeOverview>();
 
-        for(HollowTypeReadState typeState : ui.getStateEngine().getTypeStates()) {
+
+        prefillHeapStatsCache(null);
+        Map<String, HeapStats> heapStats = cachedHeapStats;
+        HollowReadStateEngine readStateEngine =  ui.getStateEngine();
+        for(HollowTypeReadState typeState : readStateEngine.getTypeStates()) {
             String typeName = typeState.getSchema().getName();
             BitSet populatedOrdinals = typeState.getPopulatedOrdinals();
             int numRecords = populatedOrdinals == null ? Integer.MIN_VALUE : populatedOrdinals.cardinality();
             int numHoles = populatedOrdinals == null ? Integer.MIN_VALUE : populatedOrdinals.length()-populatedOrdinals.cardinality();
-            long approxHoleFootprint = typeState.getApproximateHoleCostInBytes();
+            HeapStats stats = heapStats.get(typeName);
+            long approxHeapFootprint = stats != null ? stats.approxHeapFootprint : typeState.getApproximateHeapFootprintInBytes();
+            long approxHoleFootprint = stats != null ? stats.approxHoleFootprint : typeState.getApproximateHoleCostInBytes();
             PrimaryKey primaryKey = typeState.getSchema().getSchemaType() == SchemaType.OBJECT ? ((HollowObjectSchema)typeState.getSchema()).getPrimaryKey() : null;
-            long approxHeapFootprint = typeState.getApproximateHeapFootprintInBytes();
             HollowSchema schema = typeState.getSchema();
             int numShards = typeState.numShards();
 

--- a/hollow-explorer-ui/src/test/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPageTest.java
+++ b/hollow-explorer-ui/src/test/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPageTest.java
@@ -1,0 +1,168 @@
+package com.netflix.hollow.explorer.ui.pages;
+
+import static com.netflix.hollow.ui.HollowDiffUtil.formatBytes;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.engine.HollowTypeReadState;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import com.netflix.hollow.explorer.ui.HollowExplorerUI;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ShowAllTypesPageTest {
+
+    /**
+     * Captures one row of the rendered table: type name, hole-footprint cell, heap-footprint cell.
+     * The template lays out the cells as: type / records / holes / holeFootprint / heapFootprint / ...
+     */
+    private static final Pattern ROW = Pattern.compile(
+            ">([^<]+)</a></th>\\s*"        // type name (anchor text)
+                    + "<td>[^<]*</td>\\s*"  // records
+                    + "<td>[^<]*</td>\\s*"  // holes
+                    + "<td>([^<]*)</td>\\s*"// hole footprint
+                    + "<td>([^<]*)</td>");  // heap footprint
+
+    private HollowWriteStateEngine writeEngine;
+    private HollowObjectMapper mapper;
+    private HollowReadStateEngine readEngine;
+    private ShowAllTypesPage page;
+
+    @Before
+    public void setUp() throws Exception {
+        writeEngine = new HollowWriteStateEngine();
+        mapper = new HollowObjectMapper(writeEngine);
+
+        // Cycle 1: 10 SampleA + 3 SampleB records.
+        for (int i = 0; i < 10; i++) {
+            mapper.add(new SampleA(i));
+        }
+        for (int i = 0; i < 3; i++) {
+            mapper.add(new SampleB(i * 100L));
+        }
+        readEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeEngine, readEngine);
+
+        // Cycle 2: keep only 5 SampleA, creating 5 holes. SampleB unchanged.
+        for (int i = 0; i < 5; i++) {
+            mapper.add(new SampleA(i));
+        }
+        for (int i = 0; i < 3; i++) {
+            mapper.add(new SampleB(i * 100L));
+        }
+        StateEngineRoundTripper.roundTripDelta(writeEngine, readEngine);
+
+        HollowExplorerUI ui = new HollowExplorerUI("", readEngine);
+        page = new ShowAllTypesPage(ui);
+    }
+
+    @Test
+    public void cacheHitProducesSameFootprintsAcrossRequests() throws Exception {
+        Map<String, Footprints> first = parseRowsFromRender();
+        Map<String, Footprints> second = parseRowsFromRender();
+        assertEquals(first, second);
+        assertFootprintsMatchEngine(second);
+    }
+
+    @Test
+    public void cacheRebuildsAfterStateDelta() throws Exception {
+        Map<String, Footprints> before = parseRowsFromRender();
+        assertFootprintsMatchEngine(before);
+
+        // Cycle 3: remove all remaining SampleA
+        for (int i = 0; i < 3; i++) {
+            mapper.add(new SampleB(i * 100L));
+        }
+        StateEngineRoundTripper.roundTripDelta(writeEngine, readEngine);
+
+        Map<String, Footprints> after = parseRowsFromRender();
+        assertFootprintsMatchEngine(after);
+    }
+
+    @Test
+    public void renderedFootprintsMatchAfterExecutorPrefill() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            page.prefillHeapStatsCache(executor);
+        } finally {
+            executor.shutdown();
+        }
+        assertFootprintsMatchEngine(parseRowsFromRender());
+    }
+
+    private void assertFootprintsMatchEngine(Map<String, Footprints> rendered) {
+        for (HollowTypeReadState ts : readEngine.getTypeStates()) {
+            String name = ts.getSchema().getName();
+            Footprints fp = rendered.get(name);
+            assertNotNull("missing rendered row for " + name, fp);
+            assertEquals("heap footprint for " + name,
+                    formatBytes(ts.getApproximateHeapFootprintInBytes()), fp.heap);
+            assertEquals("hole footprint for " + name,
+                    formatBytes(ts.getApproximateHoleCostInBytes()), fp.hole);
+        }
+    }
+
+    private Map<String, Footprints> parseRowsFromRender() throws Exception {
+        StringWriter body = new StringWriter();
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        when(resp.getWriter()).thenReturn(new PrintWriter(body));
+
+        page.render(req, resp, null);
+
+        Map<String, Footprints> rows = new HashMap<>();
+        Matcher m = ROW.matcher(body.toString());
+        while (m.find()) {
+            rows.put(m.group(1).trim(),
+                    new Footprints(m.group(2).trim(), m.group(3).trim()));
+        }
+        return rows;
+    }
+
+    private static final class Footprints {
+        final String hole;
+        final String heap;
+
+        Footprints(String hole, String heap) {
+            this.hole = hole;
+            this.heap = heap;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Footprints)) return false;
+            Footprints other = (Footprints) o;
+            return hole.equals(other.hole) && heap.equals(other.heap);
+        }
+
+        @Override
+        public int hashCode() {
+            return hole.hashCode() ^ heap.hashCode();
+        }
+    }
+
+    public static class SampleA {
+        int num;
+        SampleA(int num) { this.num = num; }
+    }
+
+    public static class SampleB {
+        long value;
+        SampleB(long value) { this.value = value; }
+    }
+}

--- a/hollow-explorer-ui/src/test/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPageTest.java
+++ b/hollow-explorer-ui/src/test/java/com/netflix/hollow/explorer/ui/pages/ShowAllTypesPageTest.java
@@ -16,8 +16,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
@@ -92,17 +90,6 @@ public class ShowAllTypesPageTest {
 
         Map<String, Footprints> after = parseRowsFromRender();
         assertFootprintsMatchEngine(after);
-    }
-
-    @Test
-    public void renderedFootprintsMatchAfterExecutorPrefill() throws Exception {
-        ExecutorService executor = Executors.newFixedThreadPool(2);
-        try {
-            page.prefillHeapStatsCache(executor);
-        } finally {
-            executor.shutdown();
-        }
-        assertFootprintsMatchEngine(parseRowsFromRender());
     }
 
     private void assertFootprintsMatchEngine(Map<String, Footprints> rendered) {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
@@ -189,6 +189,31 @@ public abstract class HollowTypeReadState implements HollowTypeDataAccess {
     public abstract long getApproximateHoleCostInBytes();
 
     /**
+     * Counts holes per shard and returns the total cost in bytes.
+     * Each element of {@code bitsPerShardRecord} is the fixed-length bits consumed per record in that shard;
+     * var-length data costs are excluded, so the result is an approximation.
+     *
+     * <p>Requires that {@code bitsPerShardRecord.length} is a power of two, which is enforced by
+     * the write side and holds for all valid Hollow type states.
+     */
+    protected long approximateHoleCostInBytes(int[] bitsPerShardRecord) {
+        BitSet populatedOrdinals = getPopulatedOrdinals();
+        int numShards = bitsPerShardRecord.length;
+        int[] shardHoleCnts = new int[numShards];
+        int shardNumberMask = numShards - 1;
+        int holeOrdinal = populatedOrdinals.nextClearBit(0);
+        while (holeOrdinal <= maxOrdinal()) {
+            shardHoleCnts[holeOrdinal & shardNumberMask]++;
+            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
+        }
+        long holeCostInBits = 0;
+        for (int i = 0; i < numShards; i++) {
+            holeCostInBits += (long) shardHoleCnts[i] * bitsPerShardRecord[i];
+        }
+        return holeCostInBits >>> 3;
+    }
+
+    /**
      * @return an approximate accounting of the current heap footprint occupied by each shard of this type state.
      */
     public long getApproximateShardSizeInBytes() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -304,25 +304,11 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
 	@Override
     public long getApproximateHoleCostInBytes() {
         final HollowListTypeReadStateShard[] shards = this.shardsVolatile.shards;
-        BitSet populatedOrdinals = getPopulatedOrdinals();
-        int[] shardHoleCnts = new int[shards.length];
-        int[] shardBitsPerListPointer = new int[shards.length];
+        int[] bitsPerShardRecord = new int[shards.length];
         for (int i = 0; i < shards.length; i++) {
-            shardBitsPerListPointer[i] = shards[i].dataElements.bitsPerListPointer;
+            bitsPerShardRecord[i] = shards[i].dataElements.bitsPerListPointer;
         }
-
-        int shardNumberMask = shards.length - 1;
-        int holeOrdinal = populatedOrdinals.nextClearBit(0);
-        while (holeOrdinal <= maxOrdinal) {
-            shardHoleCnts[holeOrdinal & shardNumberMask]++;
-            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
-        }
-
-        long approximateHoleCostInBits = 0;
-        for (int i = 0; i < shards.length; i++) {
-            approximateHoleCostInBits += (long) shardHoleCnts[i] * shardBitsPerListPointer[i];
-        }
-        return approximateHoleCostInBits >>> 3;
+        return approximateHoleCostInBytes(bitsPerShardRecord);
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -304,14 +304,25 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
 	@Override
     public long getApproximateHoleCostInBytes() {
         final HollowListTypeReadStateShard[] shards = this.shardsVolatile.shards;
-        long totalApproximateHoleCostInBytes = 0;
-        
         BitSet populatedOrdinals = getPopulatedOrdinals();
+        int[] shardHoleCnts = new int[shards.length];
+        int[] shardBitsPerListPointer = new int[shards.length];
+        for (int i = 0; i < shards.length; i++) {
+            shardBitsPerListPointer[i] = shards[i].dataElements.bitsPerListPointer;
+        }
 
-        for(int i=0; i<shards.length; i++)
-            totalApproximateHoleCostInBytes += shards[i].getApproximateHoleCostInBytes(populatedOrdinals, i, shards.length);
-        
-        return totalApproximateHoleCostInBytes;
+        int shardNumberMask = shards.length - 1;
+        int holeOrdinal = populatedOrdinals.nextClearBit(0);
+        while (holeOrdinal <= maxOrdinal) {
+            shardHoleCnts[holeOrdinal & shardNumberMask]++;
+            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
+        }
+
+        long approximateHoleCostInBits = 0;
+        for (int i = 0; i < shards.length; i++) {
+            approximateHoleCostInBits += (long) shardHoleCnts[i] * shardBitsPerListPointer[i];
+        }
+        return approximateHoleCostInBits >>> 3;
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -468,15 +468,26 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     
     @Override
     public long getApproximateHoleCostInBytes() {
-        HollowMapTypeReadStateShard[] shards = this.shardsVolatile.shards;
-        long totalApproximateHoleCostInBytes = 0;
-        
+        final HollowMapTypeReadStateShard[] shards = this.shardsVolatile.shards;
         BitSet populatedOrdinals = getPopulatedOrdinals();
+        int[] shardHoleCnts = new int[shards.length];
+        int[] shardBitsPerFixedLengthMapPortion = new int[shards.length];
+        for (int i = 0; i < shards.length; i++) {
+            shardBitsPerFixedLengthMapPortion[i] = shards[i].dataElements.bitsPerFixedLengthMapPortion;
+        }
 
-        for(int i=0; i<shards.length; i++)
-            totalApproximateHoleCostInBytes += shards[i].getApproximateHoleCostInBytes(populatedOrdinals, i, shards.length);
-        
-        return totalApproximateHoleCostInBytes;
+        int shardNumberMask = shards.length - 1;
+        int holeOrdinal = populatedOrdinals.nextClearBit(0);
+        while (holeOrdinal <= maxOrdinal) {
+            shardHoleCnts[holeOrdinal & shardNumberMask]++;
+            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
+        }
+
+        long approximateHoleCostInBits = 0;
+        for (int i = 0; i < shards.length; i++) {
+            approximateHoleCostInBits += (long) shardHoleCnts[i] * shardBitsPerFixedLengthMapPortion[i];
+        }
+        return approximateHoleCostInBits >>> 3;
     }
     
     public HollowPrimaryKeyValueDeriver getKeyDeriver() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -469,25 +469,11 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     @Override
     public long getApproximateHoleCostInBytes() {
         final HollowMapTypeReadStateShard[] shards = this.shardsVolatile.shards;
-        BitSet populatedOrdinals = getPopulatedOrdinals();
-        int[] shardHoleCnts = new int[shards.length];
-        int[] shardBitsPerFixedLengthMapPortion = new int[shards.length];
+        int[] bitsPerShardRecord = new int[shards.length];
         for (int i = 0; i < shards.length; i++) {
-            shardBitsPerFixedLengthMapPortion[i] = shards[i].dataElements.bitsPerFixedLengthMapPortion;
+            bitsPerShardRecord[i] = shards[i].dataElements.bitsPerFixedLengthMapPortion;
         }
-
-        int shardNumberMask = shards.length - 1;
-        int holeOrdinal = populatedOrdinals.nextClearBit(0);
-        while (holeOrdinal <= maxOrdinal) {
-            shardHoleCnts[holeOrdinal & shardNumberMask]++;
-            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
-        }
-
-        long approximateHoleCostInBits = 0;
-        for (int i = 0; i < shards.length; i++) {
-            approximateHoleCostInBits += (long) shardHoleCnts[i] * shardBitsPerFixedLengthMapPortion[i];
-        }
-        return approximateHoleCostInBits >>> 3;
+        return approximateHoleCostInBytes(bitsPerShardRecord);
     }
     
     public HollowPrimaryKeyValueDeriver getKeyDeriver() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -573,25 +573,11 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
     @Override
     public long getApproximateHoleCostInBytes() {
         final HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
-        BitSet populatedOrdinals = getPopulatedOrdinals();
-        int[] shardHoleCnts = new int[shards.length];
-        int[] shardBitsPerRecords = new int[shards.length];
+        int[] bitsPerShardRecord = new int[shards.length];
         for (int i = 0; i < shards.length; i++) {
-            shardBitsPerRecords[i] = shards[i].dataElements.bitsPerRecord;
+            bitsPerShardRecord[i] = shards[i].dataElements.bitsPerRecord;
         }
-
-        int shardNumberMask = shards.length - 1;
-        int holeOrdinal = populatedOrdinals.nextClearBit(0);
-        while (holeOrdinal <= maxOrdinal) {
-            shardHoleCnts[holeOrdinal & shardNumberMask]++;
-            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
-        }
-
-        long approximateHoleCostInBits = 0;
-        for (int i = 0; i < shards.length; i++) {
-            approximateHoleCostInBits += (long) shardHoleCnts[i] * shardBitsPerRecords[i];
-        }
-        return approximateHoleCostInBits >>> 3;
+        return approximateHoleCostInBytes(bitsPerShardRecord);
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -569,19 +569,30 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
 	    
 	    return totalApproximateHeapFootprintInBytes;
 	}
-	
-	@Override
-	public long getApproximateHoleCostInBytes() {
-        final HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
-	    long totalApproximateHoleCostInBytes = 0;
-	    
-	    BitSet populatedOrdinals = getPopulatedOrdinals();
 
-	    for(int i=0;i<shards.length;i++)
-	        totalApproximateHoleCostInBytes += shards[i].getApproximateHoleCostInBytes(populatedOrdinals, i, shards.length);
-        
-	    return totalApproximateHoleCostInBytes;
-	}
+    @Override
+    public long getApproximateHoleCostInBytes() {
+        final HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;
+        BitSet populatedOrdinals = getPopulatedOrdinals();
+        int[] shardHoleCnts = new int[shards.length];
+        int[] shardBitsPerRecords = new int[shards.length];
+        for (int i = 0; i < shards.length; i++) {
+            shardBitsPerRecords[i] = shards[i].dataElements.bitsPerRecord;
+        }
+
+        int shardNumberMask = shards.length - 1;
+        int holeOrdinal = populatedOrdinals.nextClearBit(0);
+        while (holeOrdinal <= maxOrdinal) {
+            shardHoleCnts[holeOrdinal & shardNumberMask]++;
+            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
+        }
+
+        long approximateHoleCostInBits = 0;
+        for (int i = 0; i < shards.length; i++) {
+            approximateHoleCostInBits += (long) shardHoleCnts[i] * shardBitsPerRecords[i];
+        }
+        return approximateHoleCostInBits >>> 3;
+    }
 
     @Override
     public int numShards() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -412,14 +412,25 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
 	@Override
 	public long getApproximateHoleCostInBytes() {
         final HollowSetTypeReadStateShard[] shards = this.shardsVolatile.shards;
-        long totalApproximateHoleCostInBytes = 0;
-        
         BitSet populatedOrdinals = getPopulatedOrdinals();
+        int[] shardHoleCnts = new int[shards.length];
+        int[] shardBitsPerFixedLengthSetPortion = new int[shards.length];
+        for (int i = 0; i < shards.length; i++) {
+            shardBitsPerFixedLengthSetPortion[i] = shards[i].dataElements.bitsPerFixedLengthSetPortion;
+        }
 
-        for(int i=0;i<shards.length;i++)
-            totalApproximateHoleCostInBytes += shards[i].getApproximateHoleCostInBytes(populatedOrdinals, i, shards.length);
-        
-        return totalApproximateHoleCostInBytes;
+        int shardNumberMask = shards.length - 1;
+        int holeOrdinal = populatedOrdinals.nextClearBit(0);
+        while (holeOrdinal <= maxOrdinal) {
+            shardHoleCnts[holeOrdinal & shardNumberMask]++;
+            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
+        }
+
+        long approximateHoleCostInBits = 0;
+        for (int i = 0; i < shards.length; i++) {
+            approximateHoleCostInBits += (long) shardHoleCnts[i] * shardBitsPerFixedLengthSetPortion[i];
+        }
+        return approximateHoleCostInBits >>> 3;
 	}
 	
 	public HollowPrimaryKeyValueDeriver getKeyDeriver() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -412,25 +412,11 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
 	@Override
 	public long getApproximateHoleCostInBytes() {
         final HollowSetTypeReadStateShard[] shards = this.shardsVolatile.shards;
-        BitSet populatedOrdinals = getPopulatedOrdinals();
-        int[] shardHoleCnts = new int[shards.length];
-        int[] shardBitsPerFixedLengthSetPortion = new int[shards.length];
+        int[] bitsPerShardRecord = new int[shards.length];
         for (int i = 0; i < shards.length; i++) {
-            shardBitsPerFixedLengthSetPortion[i] = shards[i].dataElements.bitsPerFixedLengthSetPortion;
+            bitsPerShardRecord[i] = shards[i].dataElements.bitsPerFixedLengthSetPortion;
         }
-
-        int shardNumberMask = shards.length - 1;
-        int holeOrdinal = populatedOrdinals.nextClearBit(0);
-        while (holeOrdinal <= maxOrdinal) {
-            shardHoleCnts[holeOrdinal & shardNumberMask]++;
-            holeOrdinal = populatedOrdinals.nextClearBit(holeOrdinal + 1);
-        }
-
-        long approximateHoleCostInBits = 0;
-        for (int i = 0; i < shards.length; i++) {
-            approximateHoleCostInBits += (long) shardHoleCnts[i] * shardBitsPerFixedLengthSetPortion[i];
-        }
-        return approximateHoleCostInBits >>> 3;
+        return approximateHoleCostInBytes(bitsPerShardRecord);
 	}
 	
 	public HollowPrimaryKeyValueDeriver getKeyDeriver() {

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateTest.java
@@ -42,8 +42,8 @@ public class HollowListTypeReadStateTest extends AbstractHollowListTypeDataEleme
         assertEquals(2, typeState.numShards());
         assertEquals(2, typeState.getPopulatedOrdinals().cardinality());
         HollowListTypeReadStateShard[] shards = (HollowListTypeReadStateShard[])typeState.getShardsVolatile().getShards();
-        long holeCost = shards[0].dataElements.bitsPerListPointer*2L/8 +
-                shards[1].dataElements.bitsPerListPointer*4L/8;
+        long holeCost = (shards[0].dataElements.bitsPerListPointer*2L +
+                shards[1].dataElements.bitsPerListPointer*4L)/8;
         assertEquals(holeCost, typeState.getApproximateHoleCostInBytes());
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadStateTest.java
@@ -43,7 +43,7 @@ public class HollowListTypeReadStateTest extends AbstractHollowListTypeDataEleme
         assertEquals(2, typeState.getPopulatedOrdinals().cardinality());
         HollowListTypeReadStateShard[] shards = (HollowListTypeReadStateShard[])typeState.getShardsVolatile().getShards();
         long holeCost = (shards[0].dataElements.bitsPerListPointer*2L +
-                shards[1].dataElements.bitsPerListPointer*4L)/8;
+                shards[1].dataElements.bitsPerListPointer*4L) >>> 3;
         assertEquals(holeCost, typeState.getApproximateHoleCostInBytes());
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadStateTest.java
@@ -39,8 +39,8 @@ public class HollowMapTypeReadStateTest extends AbstractHollowMapTypeDataElement
         assertEquals(2, typeState.numShards());
         assertEquals(2, typeState.getPopulatedOrdinals().cardinality());
         HollowMapTypeReadStateShard[] shards = (HollowMapTypeReadStateShard[])typeState.getShardsVolatile().getShards();
-        long holeCost = shards[0].dataElements.bitsPerFixedLengthMapPortion/8L +
-                shards[1].dataElements.bitsPerFixedLengthMapPortion*3L/8;
+        long holeCost = (shards[0].dataElements.bitsPerFixedLengthMapPortion +
+                shards[1].dataElements.bitsPerFixedLengthMapPortion*3L) >>> 3;
         assertEquals(holeCost, typeState.getApproximateHoleCostInBytes());
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateTest.java
@@ -65,7 +65,7 @@ public class HollowObjectTypeReadStateTest extends AbstractHollowObjectTypeDataE
         // Shard 0 (even: 0=hole, 2=pop, 4=pop) -> 1 hole
         // Shard 1 (odd: 1=hole, 3=hole, 5=hole) -> 3 holes
         HollowObjectTypeReadStateShard[] shards = (HollowObjectTypeReadStateShard[])typeState.getShardsVolatile().getShards();
-        long holeCost = shards[0].dataElements.bitsPerRecord/8L + shards[1].dataElements.bitsPerRecord*3L/8;
+        long holeCost = (shards[0].dataElements.bitsPerRecord + shards[1].dataElements.bitsPerRecord*3L) >>> 3;
         assertEquals(holeCost, typeState.getApproximateHoleCostInBytes());
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadStateTest.java
@@ -38,8 +38,8 @@ public class HollowSetTypeReadStateTest extends AbstractHollowSetTypeDataElement
         assertEquals(2, typeState.numShards());
         assertEquals(2, typeState.getPopulatedOrdinals().cardinality());
         HollowSetTypeReadStateShard[] shards = (HollowSetTypeReadStateShard[])typeState.getShardsVolatile().getShards();
-        long holeCost = shards[0].dataElements.bitsPerFixedLengthSetPortion/8L +
-                shards[1].dataElements.bitsPerFixedLengthSetPortion*3L/8;
+        long holeCost = (shards[0].dataElements.bitsPerFixedLengthSetPortion +
+                shards[1].dataElements.bitsPerFixedLengthSetPortion*3L) >>> 3;
         assertEquals(holeCost, typeState.getApproximateHoleCostInBytes());
     }
 


### PR DESCRIPTION
## Problem

In `ShowAllTypesPage`, every request to the \"Show All Types\" page recomputes `getApproximateHeapFootprintInBytes()` and `getApproximateHoleCostInBytes()` for every type in the state engine. For large namespaces with many shards and variable-length fields, this sequential scan over all shards can take close to a minute, making the page effectively unusable.

## Changes
  - Cache heap stats in Explorer UI: ShowAllTypesPage now computes each type's getApproximateHeapFootprintInBytes and getApproximateHoleCostInBytes once per state version (keyed
   by randomizedTag) rather than recalculating on every page request. HollowExplorerUI exposes prefillHeapStatsCache() so callers can warm the cache proactively (e.g. after a
  delta) and clearCache() to invalidate it.
  - Optimise getApproximateHoleCostInBytes for List, Set, and Map types: The previous implementation delegated to each shard's method, causing each shard to iterate all hole
  ordinals and filter by shard index — O(holes × shards) total iterations. The new change should count all the holes only once -- O(holes).