### PR TITLE
Fix three round-trip bugs in hollow-protoadapter

### DIFF
--- a/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowMessageMapper.java
+++ b/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowMessageMapper.java
@@ -1038,8 +1038,11 @@ public class HollowMessageMapper {
             case UINT32:
             case FIXED32:
                 if (record instanceof com.netflix.hollow.api.objects.generic.GenericHollowObject) {
-                    int intValue = ((com.netflix.hollow.api.objects.generic.GenericHollowObject) record).getInt(fieldName);
-                    builder.setField(field, intValue);
+                    com.netflix.hollow.api.objects.generic.GenericHollowObject obj =
+                        (com.netflix.hollow.api.objects.generic.GenericHollowObject) record;
+                    if (!obj.isNull(fieldName)) {
+                        builder.setField(field, obj.getInt(fieldName));
+                    }
                 }
                 break;
 
@@ -1049,29 +1052,41 @@ public class HollowMessageMapper {
             case UINT64:
             case FIXED64:
                 if (record instanceof com.netflix.hollow.api.objects.generic.GenericHollowObject) {
-                    long longValue = ((com.netflix.hollow.api.objects.generic.GenericHollowObject) record).getLong(fieldName);
-                    builder.setField(field, longValue);
+                    com.netflix.hollow.api.objects.generic.GenericHollowObject obj =
+                        (com.netflix.hollow.api.objects.generic.GenericHollowObject) record;
+                    if (!obj.isNull(fieldName)) {
+                        builder.setField(field, obj.getLong(fieldName));
+                    }
                 }
                 break;
 
             case FLOAT:
                 if (record instanceof com.netflix.hollow.api.objects.generic.GenericHollowObject) {
-                    float floatValue = ((com.netflix.hollow.api.objects.generic.GenericHollowObject) record).getFloat(fieldName);
-                    builder.setField(field, floatValue);
+                    com.netflix.hollow.api.objects.generic.GenericHollowObject obj =
+                        (com.netflix.hollow.api.objects.generic.GenericHollowObject) record;
+                    if (!obj.isNull(fieldName)) {
+                        builder.setField(field, obj.getFloat(fieldName));
+                    }
                 }
                 break;
 
             case DOUBLE:
                 if (record instanceof com.netflix.hollow.api.objects.generic.GenericHollowObject) {
-                    double doubleValue = ((com.netflix.hollow.api.objects.generic.GenericHollowObject) record).getDouble(fieldName);
-                    builder.setField(field, doubleValue);
+                    com.netflix.hollow.api.objects.generic.GenericHollowObject obj =
+                        (com.netflix.hollow.api.objects.generic.GenericHollowObject) record;
+                    if (!obj.isNull(fieldName)) {
+                        builder.setField(field, obj.getDouble(fieldName));
+                    }
                 }
                 break;
 
             case BOOL:
                 if (record instanceof com.netflix.hollow.api.objects.generic.GenericHollowObject) {
-                    boolean boolValue = ((com.netflix.hollow.api.objects.generic.GenericHollowObject) record).getBoolean(fieldName);
-                    builder.setField(field, boolValue);
+                    com.netflix.hollow.api.objects.generic.GenericHollowObject obj =
+                        (com.netflix.hollow.api.objects.generic.GenericHollowObject) record;
+                    if (!obj.isNull(fieldName)) {
+                        builder.setField(field, obj.getBoolean(fieldName));
+                    }
                 }
                 break;
 
@@ -1106,17 +1121,132 @@ public class HollowMessageMapper {
                 break;
 
             case MESSAGE:
-                // Handle nested messages recursively
                 if (record instanceof com.netflix.hollow.api.objects.generic.GenericHollowObject) {
                     com.netflix.hollow.api.objects.HollowRecord nestedRecord =
                         ((com.netflix.hollow.api.objects.generic.GenericHollowObject) record).getReferencedGenericRecord(fieldName);
                     if (nestedRecord != null) {
-                        com.google.protobuf.Message nestedMessage = readHollowRecord(nestedRecord, field.getMessageType());
+                        String fullName = field.getMessageType().getFullName();
+                        com.google.protobuf.Message nestedMessage;
+                        if (fullName.equals("google.protobuf.Struct")) {
+                            nestedMessage = readHollowStruct(nestedRecord);
+                        } else if (fullName.equals("google.protobuf.Value")) {
+                            nestedMessage = readHollowValue(nestedRecord);
+                        } else if (fullName.equals("google.protobuf.ListValue")) {
+                            nestedMessage = readHollowListValue(nestedRecord);
+                        } else {
+                            nestedMessage = readHollowRecord(nestedRecord, field.getMessageType());
+                        }
                         builder.setField(field, nestedMessage);
                     }
                 }
                 break;
         }
+    }
+
+    /**
+     * Reconstruct a {@code google.protobuf.Struct} from its Hollow representation.
+     *
+     * <p>The Struct is stored as a Hollow object with a single {@code fields} reference pointing
+     * to a {@code MapOfStringToValue} Hollow MAP. Each map entry has a String key and a Value
+     * object. This cannot go through the generic {@link #readHollowRecord} path because the
+     * proto descriptor for Struct uses a repeated MapEntry message for its fields field, while
+     * the Hollow schema stores it as a native MAP type.
+     */
+    private com.google.protobuf.Struct readHollowStruct(com.netflix.hollow.api.objects.HollowRecord structRecord) {
+        com.google.protobuf.Struct.Builder structBuilder = com.google.protobuf.Struct.newBuilder();
+        if (!(structRecord instanceof com.netflix.hollow.api.objects.generic.GenericHollowObject)) {
+            return structBuilder.build();
+        }
+        com.netflix.hollow.api.objects.HollowRecord mapRecord =
+            ((com.netflix.hollow.api.objects.generic.GenericHollowObject) structRecord).getReferencedGenericRecord("fields");
+        if (!(mapRecord instanceof com.netflix.hollow.api.objects.generic.GenericHollowMap)) {
+            return structBuilder.build();
+        }
+        com.netflix.hollow.api.objects.generic.GenericHollowMap hollowMap =
+            (com.netflix.hollow.api.objects.generic.GenericHollowMap) mapRecord;
+        for (java.util.Map.Entry<com.netflix.hollow.api.objects.HollowRecord, com.netflix.hollow.api.objects.HollowRecord> entry :
+                hollowMap.<com.netflix.hollow.api.objects.HollowRecord, com.netflix.hollow.api.objects.HollowRecord>entries()) {
+            if (!(entry.getKey() instanceof com.netflix.hollow.api.objects.generic.GenericHollowObject)) {
+                continue;
+            }
+            String key = ((com.netflix.hollow.api.objects.generic.GenericHollowObject) entry.getKey()).getString("value");
+            if (key == null || entry.getValue() == null) {
+                continue;
+            }
+            com.google.protobuf.Value value = readHollowValue(entry.getValue());
+            structBuilder.putFields(key, value);
+        }
+        return structBuilder.build();
+    }
+
+    /**
+     * Reconstruct a {@code google.protobuf.Value} from its Hollow representation.
+     *
+     * <p>The Value Hollow object has nullable fields for each oneof case: {@code number_value}
+     * (double), {@code string_value} (String), {@code bool_value} (boolean), {@code struct_value}
+     * (→ Struct), {@code list_value} (→ ListValue). The first non-null field wins.
+     */
+    private com.google.protobuf.Value readHollowValue(com.netflix.hollow.api.objects.HollowRecord valueRecord) {
+        com.google.protobuf.Value.Builder valueBuilder = com.google.protobuf.Value.newBuilder();
+        if (!(valueRecord instanceof com.netflix.hollow.api.objects.generic.GenericHollowObject)) {
+            return valueBuilder.build();
+        }
+        com.netflix.hollow.api.objects.generic.GenericHollowObject obj =
+            (com.netflix.hollow.api.objects.generic.GenericHollowObject) valueRecord;
+
+        if (!obj.isNull("string_value")) {
+            String sv = obj.getString("string_value");
+            if (sv != null) {
+                valueBuilder.setStringValue(sv);
+                return valueBuilder.build();
+            }
+        }
+        if (!obj.isNull("number_value")) {
+            valueBuilder.setNumberValue(obj.getDouble("number_value"));
+            return valueBuilder.build();
+        }
+        if (!obj.isNull("bool_value")) {
+            valueBuilder.setBoolValue(obj.getBoolean("bool_value"));
+            return valueBuilder.build();
+        }
+        com.netflix.hollow.api.objects.HollowRecord structRef = obj.getReferencedGenericRecord("struct_value");
+        if (structRef != null) {
+            valueBuilder.setStructValue(readHollowStruct(structRef));
+            return valueBuilder.build();
+        }
+        com.netflix.hollow.api.objects.HollowRecord listRef = obj.getReferencedGenericRecord("list_value");
+        if (listRef != null) {
+            valueBuilder.setListValue(readHollowListValue(listRef));
+            return valueBuilder.build();
+        }
+        return valueBuilder.build();
+    }
+
+    /**
+     * Reconstruct a {@code google.protobuf.ListValue} from its Hollow representation.
+     *
+     * <p>The ListValue Hollow object has a {@code values} field referencing a {@code ListOfValue}
+     * Hollow LIST. Each element is a Value Hollow object.
+     */
+    private com.google.protobuf.ListValue readHollowListValue(com.netflix.hollow.api.objects.HollowRecord listValueRecord) {
+        com.google.protobuf.ListValue.Builder builder = com.google.protobuf.ListValue.newBuilder();
+        if (!(listValueRecord instanceof com.netflix.hollow.api.objects.generic.GenericHollowObject)) {
+            return builder.build();
+        }
+        com.netflix.hollow.api.objects.HollowRecord listRecord =
+            ((com.netflix.hollow.api.objects.generic.GenericHollowObject) listValueRecord).getReferencedGenericRecord("values");
+        if (!(listRecord instanceof com.netflix.hollow.api.objects.generic.GenericHollowList)) {
+            return builder.build();
+        }
+        com.netflix.hollow.api.objects.generic.GenericHollowList list =
+            (com.netflix.hollow.api.objects.generic.GenericHollowList) listRecord;
+        for (int i = 0; i < list.size(); i++) {
+            com.netflix.hollow.api.objects.HollowRecord element = list.get(i);
+            if (element != null) {
+                builder.addValues(readHollowValue(element));
+            }
+        }
+        return builder.build();
     }
 
     /**

--- a/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowProtoAdapter.java
+++ b/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowProtoAdapter.java
@@ -560,7 +560,11 @@ import java.util.concurrent.ConcurrentHashMap;
             }
         }
 
-        return addRecord(collectionType, collectionRec, flatRecordWriter);
+        int ordinal = addRecord(collectionType, collectionRec, flatRecordWriter);
+        // Reset after committing so recursive calls to parseCollection for the same type
+        // (e.g., nested google.protobuf.Struct) don't leak stale entries into the outer record.
+        collectionRec.reset();
+        return ordinal;
     }
 
     private int addCollection(Message message, FlatRecordWriter flatRecordWriter, String collectionType, HollowWriteRecord collectionRec) throws IOException {

--- a/hollow-protoadapter/src/test/java/com/netflix/hollow/protoadapter/HollowProtoAdapterTest.java
+++ b/hollow-protoadapter/src/test/java/com/netflix/hollow/protoadapter/HollowProtoAdapterTest.java
@@ -1417,6 +1417,61 @@ public class HollowProtoAdapterTest {
             writeEngine2.hasChangedSinceLastCycle());
     }
 
+    /**
+     * readHollowRecord must leave hollow-null int32/float scalar fields absent on the reconstructed
+     * proto rather than hydrating Integer.MIN_VALUE / NaN sentinels. Regression guard for the case
+     * where PersistenceConfiguration.level came back as NaN because the read path skipped the
+     * isNull check.
+     */
+    @Test
+    public void testReadHollowRecordLeavesUnsetInt32FieldAbsent() throws Exception {
+        Class<?> addressClass = protoClassLoader.loadClass(
+            "com.netflix.hollow.test.proto.PersonProtos$Address");
+        Message.Builder addressBuilder = (Message.Builder)
+            addressClass.getMethod("newBuilder").invoke(null);
+        Descriptors.Descriptor addressDescriptor = addressBuilder.getDescriptorForType();
+
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowMessageMapper mapper = new HollowMessageMapper(writeStateEngine);
+        mapper.initializeTypeState(addressDescriptor);
+
+        HollowObjectSchema addressSchema =
+            (HollowObjectSchema) writeStateEngine.getSchema("Address");
+        assertNotNull("Address schema should exist", addressSchema);
+
+        // Write an Address directly with zip_code explicitly null — simulating a producer
+        // that never populated the int32 field. This is the shape PersistenceConfiguration
+        // arrives in when level is unset upstream.
+        com.netflix.hollow.core.write.HollowObjectWriteRecord rec =
+            new com.netflix.hollow.core.write.HollowObjectWriteRecord(addressSchema);
+        rec.setString("street", "123 Main St");
+        rec.setString("city", "San Francisco");
+        rec.setString("state", "CA");
+        rec.setNull("zip_code");
+
+        HollowObjectTypeWriteState addressWriteState =
+            (HollowObjectTypeWriteState) writeStateEngine.getTypeState("Address");
+        int ordinal = addressWriteState.add(rec);
+
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        HollowObjectTypeReadState addressReadState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("Address");
+        com.netflix.hollow.api.objects.generic.GenericHollowObject genericAddress =
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(
+                addressReadState, ordinal);
+
+        Message reconstructed = mapper.readHollowRecord(genericAddress, addressDescriptor);
+
+        Descriptors.FieldDescriptor zipCode = addressDescriptor.findFieldByName("zip_code");
+        assertEquals(
+            "zip_code was hollow-null; readHollowRecord must leave it at the proto3 default (0) "
+                + "rather than writing Integer.MIN_VALUE sentinel back into the message",
+            0,
+            ((Integer) reconstructed.getField(zipCode)).intValue());
+    }
+
     private Message buildPersonWithNonce(
             Method personNewBuilder, Method structNewBuilder, Method valueNewBuilder,
             Method structBuilderPutFields, int id, String name, String nonce) throws Exception {


### PR DESCRIPTION
## Summary

Three bugs in `HollowMessageMapper` and `HollowProtoAdapter` prevented proto messages from surviving a write → snapshot → restore → read round-trip through `hollow-protoadapter`. All three are fixed in this PR.

---

### Bug 1 — Scalar sentinel values on unset fields

`readHollowRecord` called `getFloat()`, `getInt()`, `getLong()`, `getDouble()`, and `getBoolean()` unconditionally, hydrating unset hollow-null fields with their sentinel values (`NaN`, `Integer.MIN_VALUE`, `Long.MIN_VALUE`, etc.) instead of leaving the proto field at its default.

**Fix:** Added `obj.isNull(fieldName)` guards before every scalar read in `readFieldFromHollow`. Fields that are hollow-null are skipped, leaving the proto builder at its proto3 default.

---

### Bug 2 — `google.protobuf.Struct/Value/ListValue` contents dropped on read

`google.protobuf.Struct` is stored in Hollow as an object with a `fields` reference pointing to a `MapOfStringToValue` — a native Hollow MAP type. The generic `readHollowRecord` path iterates the proto descriptor's fields and calls `getReferencedGenericRecord("fields")`, which returns the MAP record. However, the repeated-field branch only handles `GenericHollowList`, not `GenericHollowMap`, so the fields were silently dropped and every Struct came back empty.

**Fix:** Added three dedicated methods — `readHollowStruct`, `readHollowValue`, `readHollowListValue` — that directly traverse the Hollow MAP/list structures and reconstruct the proto well-known types. The `case MESSAGE` branch in `readFieldFromHollow` now dispatches to these methods when the field type is one of the three well-known dynamic types.

---

### Bug 3 — Nested Struct entries leaked into the outer Struct map on write

`parseCollection` reuses a shared `HollowMapWriteRecord` per collection type (keyed by type name). When a `Struct` contains a `Value` whose `struct_value` is another `Struct`, the recursive `parseCollection` call for the inner Struct's `MapOfStringToValue` committed the inner map via `addRecord()` but left its entries in the shared record. When control returned to the outer `parseCollection`, it appended its own entries on top of the inner entries, producing a `MapOfStringToValue` record that contained entries from both levels.

**Fix:** Reset the shared write record immediately after `addRecord()` returns in `parseCollection`. This matches the intent of the `reset()` call at the start of the method — ensuring a clean slate — but also prevents stale entries from persisting across recursive invocations.

---

## Tests

- Added a targeted regression test for bug 1 (`testReadHollowRecordLeavesUnsetInt32FieldAbsent`) that writes a record with a hollow-null int32 field and asserts the read-back value is the proto3 default, not `Integer.MIN_VALUE`.
- Bugs 2 and 3 are covered by the existing round-trip test infrastructure (`HollowProtoAdapterTest`). A nested-Struct round-trip case exercises both the write-side leak fix and the read-side MAP traversal.