### PR TITLE
Allow heterogeneous Value types for the same Struct field name

### DIFF
--- a/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowMessageMapper.java
+++ b/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowMessageMapper.java
@@ -74,11 +74,6 @@ public class HollowMessageMapper {
     private final Map<String, HollowProtoAdapter> adapters = new ConcurrentHashMap<String, HollowProtoAdapter>();
     private boolean ignoreListOrdering = false;
 
-    // Track field types for Struct fields to validate consistency across instances
-    // Maps "ParentType.fieldPath.structFieldName" -> Value type (e.g., "Person.metadata.age" -> "numberValue")
-    // Thread-safe: uses ConcurrentHashMap with atomic putIfAbsent for conflict detection
-    private final ConcurrentHashMap<String, String> structFieldTypes = new ConcurrentHashMap<String, String>();
-
     // Lock objects for schema creation synchronization
     private final Object valueSchemaLock = new Object();
     private final Object structSchemaLock = new Object();
@@ -422,78 +417,22 @@ public class HollowMessageMapper {
     }
 
     /**
-     * Ensure schema for google.protobuf.Struct based on actual field values.
-     * Struct is an object with a map<string, Value> field.
-     * Also validates that field types are consistent across all instances.
+     * Ensure schema for google.protobuf.Struct.
+     *
+     * <p>{@code google.protobuf.Struct} is an object with a {@code map<string, Value>} field. Each
+     * {@code Value} is a {@code oneof} that may hold any scalar, list, struct, or null. The Hollow
+     * {@code Value} object schema declares one nullable column per oneof case (number_value,
+     * string_value, bool_value, struct_value, list_value, null_value), so a single Hollow Value
+     * record can express any oneof case and the reader picks whichever case is non-null. That is
+     * already the design that was put in place for Value schema generation.
+     *
+     * <p>Therefore the same Struct field name (e.g. {@code config.data_ttl_secs}) is allowed to be
+     * a number in one record and a string in another — both round-trip correctly through Hollow.
+     * Earlier versions of this code rejected that as a conflict, which broke any namespace dataset
+     * where the same Struct key legitimately holds different scalar types across rows.
      */
     private void ensureStructSchema(com.google.protobuf.Message structMessage, String parentTypeName, String fieldPath) {
-        // Ensure Value schema exists (will create if needed)
         ensureValueSchemaExists();
-
-        // Validate field type consistency across instances
-        validateStructFields(structMessage, parentTypeName, fieldPath);
-    }
-
-    /**
-     * Validate that Struct field types are consistent across all instances.
-     * Throws IllegalStateException if the same field name has different types.
-     */
-    private void validateStructFields(com.google.protobuf.Message structMessage, String parentTypeName, String fieldPath) {
-        Descriptors.Descriptor descriptor = structMessage.getDescriptorForType();
-        Descriptors.FieldDescriptor fieldsDescriptor = descriptor.findFieldByName("fields");
-
-        if (fieldsDescriptor == null) return;
-
-        // Get the fields map from the Struct
-        Object fieldsObj = structMessage.getField(fieldsDescriptor);
-        if (!(fieldsObj instanceof java.util.List)) return;
-
-        @SuppressWarnings("unchecked")
-        java.util.List<com.google.protobuf.Message> entries = (java.util.List<com.google.protobuf.Message>) fieldsObj;
-
-        for (com.google.protobuf.Message entry : entries) {
-            // Each entry has "key" (string) and "value" (Value message)
-            Descriptors.Descriptor entryDescriptor = entry.getDescriptorForType();
-            Descriptors.FieldDescriptor keyField = entryDescriptor.findFieldByName("key");
-            Descriptors.FieldDescriptor valueField = entryDescriptor.findFieldByName("value");
-
-            if (keyField == null || valueField == null) continue;
-
-            String key = (String) entry.getField(keyField);
-            com.google.protobuf.Message value = (com.google.protobuf.Message) entry.getField(valueField);
-
-            // Determine which Value type this is
-            String valueType = getValueType(value);
-            if (valueType == null) continue;
-
-            // Check for conflicts using atomic putIfAbsent for thread safety
-            String fieldKey = parentTypeName + "." + fieldPath + "." + key;
-            String existingType = structFieldTypes.putIfAbsent(fieldKey, valueType);
-
-            // If putIfAbsent returned non-null, the field already existed - check for conflict
-            if (existingType != null && !existingType.equals(valueType)) {
-                throw new IllegalStateException(
-                    "Conflicting types for Struct field '" + key + "' in " + parentTypeName + "." + fieldPath +
-                    ": previously " + existingType + ", now " + valueType);
-            }
-        }
-    }
-
-    /**
-     * Determine which type a Value message contains.
-     * Returns the field name (e.g., "numberValue", "stringValue") or null if empty.
-     */
-    private String getValueType(com.google.protobuf.Message value) {
-        Descriptors.Descriptor descriptor = value.getDescriptorForType();
-
-        // Check each possible Value field
-        for (Descriptors.FieldDescriptor field : descriptor.getFields()) {
-            if (value.hasField(field)) {
-                return field.getName();
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/hollow-protoadapter/src/test/java/com/netflix/hollow/protoadapter/HollowProtoAdapterTest.java
+++ b/hollow-protoadapter/src/test/java/com/netflix/hollow/protoadapter/HollowProtoAdapterTest.java
@@ -798,9 +798,17 @@ public class HollowProtoAdapterTest {
      * Test that conflicting types for the same Struct field are detected and rejected.
      * If two instances have the same field name with different types, an error should be thrown.
      */
+    /**
+     * google.protobuf.Struct allows the same field name to hold different Value types across
+     * different Struct instances — that is the entire point of Struct, which is how dgw-control's
+     * persistence_config holds heterogeneous data such as ttls being numeric in some namespaces
+     * and string in others. The Hollow Value object schema declares one nullable column per
+     * Value oneof case, so any case round-trips through the same Hollow type. This test pins
+     * that contract: heterogeneous Struct field types must write and read back without error
+     * and preserve the exact Value oneof case per record.
+     */
     @Test
-    public void testStructFieldTypeConflictDetection() throws Exception {
-        // Load Person and Struct classes
+    public void testStructFieldHeterogeneousTypesRoundTrip() throws Exception {
         Class<?> personClass = protoClassLoader.loadClass("com.netflix.hollow.test.proto.PersonProtos$Person");
         Class<?> structClass = protoClassLoader.loadClass("com.google.protobuf.Struct");
         Class<?> valueClass = protoClassLoader.loadClass("com.google.protobuf.Value");
@@ -813,55 +821,141 @@ public class HollowProtoAdapterTest {
         HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
         HollowMessageMapper mapper = new HollowMessageMapper(writeStateEngine);
 
-        // Person 1: age as NUMBER
+        // Person 1: age as NUMBER (35.0)
         Message.Builder person1Builder = (Message.Builder) personNewBuilder.invoke(null);
         Message.Builder struct1Builder = (Message.Builder) structNewBuilder.invoke(null);
-
-        Message.Builder numberValueBuilder = (Message.Builder) valueNewBuilder.invoke(null);
-        numberValueBuilder.setField(
-            numberValueBuilder.getDescriptorForType().findFieldByName("number_value"),
-            35.0);
-        structBuilderPutFields.invoke(struct1Builder, "age", numberValueBuilder.build());
-
+        structBuilderPutFields.invoke(struct1Builder, "age", createNumberValue(valueNewBuilder, 35.0));
         person1Builder.setField(person1Builder.getDescriptorForType().findFieldByName("id"), 1);
         person1Builder.setField(person1Builder.getDescriptorForType().findFieldByName("name"), "Person 1");
         person1Builder.setField(person1Builder.getDescriptorForType().findFieldByName("metadata"), struct1Builder.build());
+        int ordinal1 = mapper.add(person1Builder.build());
 
-        mapper.add(person1Builder.build());
-
-        // Person 2: age as STRING (conflict!)
+        // Person 2: age as STRING ("twenty-eight") — same field name, different oneof case
         Message.Builder person2Builder = (Message.Builder) personNewBuilder.invoke(null);
         Message.Builder struct2Builder = (Message.Builder) structNewBuilder.invoke(null);
-
-        Message.Builder stringValueBuilder = (Message.Builder) valueNewBuilder.invoke(null);
-        stringValueBuilder.setField(
-            stringValueBuilder.getDescriptorForType().findFieldByName("string_value"),
-            "twenty-eight");
-        structBuilderPutFields.invoke(struct2Builder, "age", stringValueBuilder.build());
-
+        structBuilderPutFields.invoke(struct2Builder, "age", createStringValue(valueNewBuilder, "twenty-eight"));
         person2Builder.setField(person2Builder.getDescriptorForType().findFieldByName("id"), 2);
         person2Builder.setField(person2Builder.getDescriptorForType().findFieldByName("name"), "Person 2");
         person2Builder.setField(person2Builder.getDescriptorForType().findFieldByName("metadata"), struct2Builder.build());
+        int ordinal2 = mapper.add(person2Builder.build());
 
-        // Should throw RuntimeException wrapping IllegalStateException due to conflicting types for "age"
-        try {
-            mapper.add(person2Builder.build());
-            fail("Expected RuntimeException for conflicting Struct field types");
-        } catch (RuntimeException e) {
-            Throwable cause = e.getCause();
-            assertNotNull("Should have a cause", cause);
-            assertTrue("Cause should be IllegalStateException",
-                cause instanceof IllegalStateException);
-            String message = cause.getMessage();
-            assertTrue("Error message should mention conflicting types",
-                message.contains("Conflicting types"));
-            assertTrue("Error message should mention the field name 'age'",
-                message.contains("age"));
-            assertTrue("Error message should mention number_value",
-                message.contains("number_value"));
-            assertTrue("Error message should mention string_value",
-                message.contains("string_value"));
+        // Person 3: age as BOOL (true) — third oneof case for the same key
+        Message.Builder person3Builder = (Message.Builder) personNewBuilder.invoke(null);
+        Message.Builder struct3Builder = (Message.Builder) structNewBuilder.invoke(null);
+        structBuilderPutFields.invoke(struct3Builder, "age", createBoolValue(valueNewBuilder, true));
+        person3Builder.setField(person3Builder.getDescriptorForType().findFieldByName("id"), 3);
+        person3Builder.setField(person3Builder.getDescriptorForType().findFieldByName("name"), "Person 3");
+        person3Builder.setField(person3Builder.getDescriptorForType().findFieldByName("metadata"), struct3Builder.build());
+        int ordinal3 = mapper.add(person3Builder.build());
+
+        // Round-trip and read back
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // Each Person's metadata Struct -> Struct.fields map -> Value entry for "age"
+        // should have only the corresponding oneof case populated on Hollow Value.
+        assertAgeValueCase(readStateEngine, ordinal1, "number_value", 35.0);
+        assertAgeValueCase(readStateEngine, ordinal2, "string_value", "twenty-eight");
+        assertAgeValueCase(readStateEngine, ordinal3, "bool_value", true);
+
+        // Sanity: full readHollowRecord round-trip rebuilds the exact proto Value case
+        Descriptors.Descriptor personDescriptor = ((Message) personClass.getMethod("getDefaultInstance")
+            .invoke(null)).getDescriptorForType();
+        Message reconstructed1 = mapper.readHollowRecord(
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(readStateEngine, "Person", ordinal1),
+            personDescriptor);
+        Message reconstructed2 = mapper.readHollowRecord(
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(readStateEngine, "Person", ordinal2),
+            personDescriptor);
+        Message reconstructed3 = mapper.readHollowRecord(
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(readStateEngine, "Person", ordinal3),
+            personDescriptor);
+
+        assertEquals(35.0, getStructFieldNumber(reconstructed1, "age"), 0.0);
+        assertEquals("twenty-eight", getStructFieldString(reconstructed2, "age"));
+        assertEquals(Boolean.TRUE, getStructFieldBool(reconstructed3, "age"));
+    }
+
+    private void assertAgeValueCase(HollowReadStateEngine readStateEngine, int personOrdinal,
+                                    String expectedSetField, Object expectedValue) {
+        HollowObjectTypeReadState personState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("Person");
+        int metadataPos = personState.getSchema().getPosition("metadata");
+        int structOrdinal = personState.readOrdinal(personOrdinal, metadataPos);
+        assertTrue("Struct ordinal should be valid for person " + personOrdinal, structOrdinal >= 0);
+
+        HollowObjectTypeReadState structState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("Struct");
+        // Struct.fields is a map field; iterate via the map type to find the "age" entry.
+        // Simpler path: scan Struct's fields list type for an entry whose key is "age".
+        int fieldsPos = structState.getSchema().getPosition("fields");
+        int fieldsOrdinal = structState.readOrdinal(structOrdinal, fieldsPos);
+        assertTrue("fields ordinal should be valid", fieldsOrdinal >= 0);
+
+        // Find the Value referenced by key "age"
+        com.netflix.hollow.core.read.engine.map.HollowMapTypeReadState mapState =
+            (com.netflix.hollow.core.read.engine.map.HollowMapTypeReadState)
+                readStateEngine.getTypeState(structState.getSchema().getReferencedType(fieldsPos));
+        com.netflix.hollow.api.objects.generic.GenericHollowMap mapObj =
+            new com.netflix.hollow.api.objects.generic.GenericHollowMap(mapState, fieldsOrdinal);
+        com.netflix.hollow.api.objects.generic.GenericHollowObject ageValueObj = null;
+        for (java.util.Map.Entry<com.netflix.hollow.api.objects.HollowRecord, com.netflix.hollow.api.objects.HollowRecord> entry : mapObj.entrySet()) {
+            com.netflix.hollow.api.objects.generic.GenericHollowObject key =
+                (com.netflix.hollow.api.objects.generic.GenericHollowObject) entry.getKey();
+            if ("age".equals(key.getString("value"))) {
+                ageValueObj = (com.netflix.hollow.api.objects.generic.GenericHollowObject) entry.getValue();
+                break;
+            }
         }
+        assertNotNull("Should have an 'age' entry in Struct.fields", ageValueObj);
+
+        // Exactly the expected oneof column should be populated; the others must be null.
+        for (String field : new String[]{"number_value", "string_value", "bool_value", "null_value", "struct_value", "list_value"}) {
+            boolean isNull = ageValueObj.isNull(field);
+            if (field.equals(expectedSetField)) {
+                assertFalse("Expected " + field + " to be set", isNull);
+            } else {
+                assertTrue("Expected " + field + " to be null when " + expectedSetField + " is set",
+                    isNull);
+            }
+        }
+        if ("number_value".equals(expectedSetField)) {
+            assertEquals(((Number) expectedValue).doubleValue(), ageValueObj.getDouble("number_value"), 0.0);
+        } else if ("string_value".equals(expectedSetField)) {
+            assertEquals(expectedValue, ageValueObj.getString("string_value"));
+        } else if ("bool_value".equals(expectedSetField)) {
+            assertEquals(((Boolean) expectedValue).booleanValue(), ageValueObj.getBoolean("bool_value"));
+        }
+    }
+
+    private double getStructFieldNumber(Message message, String key) throws Exception {
+        Message valueMessage = getStructFieldValue(message, key);
+        return (double) valueMessage.getField(valueMessage.getDescriptorForType().findFieldByName("number_value"));
+    }
+
+    private String getStructFieldString(Message message, String key) throws Exception {
+        Message valueMessage = getStructFieldValue(message, key);
+        return (String) valueMessage.getField(valueMessage.getDescriptorForType().findFieldByName("string_value"));
+    }
+
+    private Boolean getStructFieldBool(Message message, String key) throws Exception {
+        Message valueMessage = getStructFieldValue(message, key);
+        return (Boolean) valueMessage.getField(valueMessage.getDescriptorForType().findFieldByName("bool_value"));
+    }
+
+    private Message getStructFieldValue(Message personMessage, String key) {
+        Message metadataStruct = (Message) personMessage.getField(
+            personMessage.getDescriptorForType().findFieldByName("metadata"));
+        Descriptors.FieldDescriptor fieldsDescriptor = metadataStruct.getDescriptorForType().findFieldByName("fields");
+        @SuppressWarnings("unchecked")
+        java.util.List<Message> entries = (java.util.List<Message>) metadataStruct.getField(fieldsDescriptor);
+        for (Message entry : entries) {
+            String entryKey = (String) entry.getField(entry.getDescriptorForType().findFieldByName("key"));
+            if (key.equals(entryKey)) {
+                return (Message) entry.getField(entry.getDescriptorForType().findFieldByName("value"));
+            }
+        }
+        throw new AssertionError("No Struct entry for key " + key);
     }
 
     /**


### PR DESCRIPTION
## Summary

\`google.protobuf.Struct\` is explicitly designed to allow the same field name to hold different \`Value\` oneof cases across different Struct instances — that is the whole point of Struct as a flexible JSON-like container. The previous code rejected this with \`IllegalStateException(\"Conflicting types for Struct field...\")\`, which broke any namespace dataset where the same \`persistence_config\` key legitimately holds different scalar types across rows (e.g. \`data_ttl_secs\` as a number in one namespace and a string in another).

This was found in production: dgw-control's KV cinder producer was failing every cycle with:
\`\`\`
java.lang.IllegalStateException: Conflicting types for Struct field 'data_ttl_secs' in NamespaceInternal.config: previously number_value, now string_value
  at com.netflix.hollow.protoadapter.HollowMessageMapper.validateStructFields(HollowMessageMapper.java:475)
\`\`\`

The Hollow \`Value\` object schema already declares one nullable column per oneof case (\`number_value\`, \`string_value\`, \`bool_value\`, \`struct_value\`, \`list_value\`, \`null_value\`), so any case round-trips through the same Hollow type. \`validateStructFields\` was preventing legitimate writes that the read side already handles correctly.

## Changes

- Remove \`validateStructFields\` and the \`structFieldTypes\` tracking map.
- Replace the existing \`testStructFieldTypeConflictDetection\` (which asserted the bad behaviour) with \`testStructFieldHeterogeneousTypesRoundTrip\`, which writes three Person records whose \`Struct.metadata.age\` is a number, a string, and a bool respectively, and asserts every record reads back with only the expected oneof column populated and full \`readHollowRecord\` round-trip preserves the exact Value case.

## Test plan

- [x] \`./gradlew :hollow-protoadapter:test\` — all tests pass (including the new round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)