### PR TITLE
fix(protoadapter): handle repeated bytes fields; document Long.MIN_VALUE null sentinel

### DIFF
--- a/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowProtoAdapter.java
+++ b/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowProtoAdapter.java
@@ -544,6 +544,9 @@ import java.util.concurrent.ConcurrentHashMap;
                         case STRING:
                             writeRec.setString(fieldName, value.toString());
                             break;
+                        case BYTES:
+                            writeRec.setBytes(fieldName, ((ByteString) value).toByteArray());
+                            break;
                         default:
                             throw new IOException("Unsupported field type in collection: " + objSchema.getFieldType(fieldPosition));
                     }

--- a/hollow-protoadapter/src/test/java/com/netflix/hollow/protoadapter/HollowProtoAdapterTest.java
+++ b/hollow-protoadapter/src/test/java/com/netflix/hollow/protoadapter/HollowProtoAdapterTest.java
@@ -16,7 +16,11 @@
  */
 package com.netflix.hollow.protoadapter;
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Int64Value;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.util.JsonFormat;
@@ -1647,6 +1651,284 @@ public class HollowProtoAdapterTest {
         @SuppressWarnings("unchecked")
         java.util.List<Message> nestedEntries = (java.util.List<Message>) nestedStructRead.getField(fieldsField);
         assertEquals("nested struct must have 2 entries", 2, nestedEntries.size());
+    }
+
+    /**
+     * Scalar and repeated {@code bytes} fields must round-trip without data loss.
+     * The write path previously lacked a BYTES case in parseCollection and would throw
+     * for repeated bytes; this test guards both paths.
+     */
+    @Test
+    public void testBytesFieldRoundTrip() throws Exception {
+        // Build a minimal proto descriptor with scalar and repeated bytes fields.
+        DescriptorProtos.FileDescriptorProto fileProto = DescriptorProtos.FileDescriptorProto.newBuilder()
+            .setName("test_bytes.proto")
+            .setSyntax("proto3")
+            .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("BinaryData")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("id").setNumber(1)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32)
+                    .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("data").setNumber(2)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_BYTES)
+                    .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("chunks").setNumber(3)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_BYTES)
+                    .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED)))
+            .build();
+        Descriptors.FileDescriptor fileDesc =
+            Descriptors.FileDescriptor.buildFrom(fileProto, new Descriptors.FileDescriptor[0]);
+        Descriptors.Descriptor descriptor = fileDesc.findMessageTypeByName("BinaryData");
+
+        ByteString scalarBytes = ByteString.copyFrom(new byte[]{0x01, 0x02, 0x03, (byte) 0xFF});
+        ByteString chunk0 = ByteString.copyFrom(new byte[]{0x0A, 0x0B});
+        ByteString chunk1 = ByteString.copyFrom(new byte[]{0x0C, 0x0D, 0x0E});
+
+        DynamicMessage message = DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("id"), 1)
+            .setField(descriptor.findFieldByName("data"), scalarBytes)
+            .addRepeatedField(descriptor.findFieldByName("chunks"), chunk0)
+            .addRepeatedField(descriptor.findFieldByName("chunks"), chunk1)
+            .build();
+
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowMessageMapper mapper = new HollowMessageMapper(writeStateEngine);
+        int ordinal = mapper.add(message);
+        assertTrue("Ordinal should be non-negative", ordinal >= 0);
+
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // Verify schema uses BYTES, not STRING
+        HollowObjectSchema schema = (HollowObjectSchema) readStateEngine.getSchema("BinaryData");
+        assertEquals(HollowObjectSchema.FieldType.BYTES, schema.getFieldType(schema.getPosition("data")));
+
+        // Verify scalar bytes
+        HollowObjectTypeReadState readState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("BinaryData");
+        assertArrayEquals(scalarBytes.toByteArray(), readState.readBytes(ordinal, schema.getPosition("data")));
+
+        // Verify repeated bytes via round-trip read
+        Message reconstructed = mapper.readHollowRecord(
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(
+                (com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState) readStateEngine.getTypeState("BinaryData"),
+                ordinal),
+            descriptor);
+        Descriptors.FieldDescriptor chunksField = descriptor.findFieldByName("chunks");
+        assertEquals("repeated bytes must have 2 elements", 2, reconstructed.getRepeatedFieldCount(chunksField));
+        assertEquals(chunk0, reconstructed.getRepeatedField(chunksField, 0));
+        assertEquals(chunk1, reconstructed.getRepeatedField(chunksField, 1));
+    }
+
+    /**
+     * Three-way round-trip for an {@code google.protobuf.Int64Value} field:
+     *
+     * <ol>
+     *   <li>Absent (field never set) → reference ordinal is -1 → reconstructed message has no field
+     *   <li>Normal value (42) → survives intact
+     *   <li>{@code Long.MIN_VALUE} inside a present {@code Int64Value} → data corruption:
+     *       the inner LONG is the Hollow null sentinel so it is stored as null; the wrapper
+     *       reference itself is non-null (the Long record was written), so the field reads back
+     *       as a <em>present</em> {@code Int64Value} with value {@code 0} rather than the
+     *       original {@code Long.MIN_VALUE}.
+     * </ol>
+     */
+    @Test
+    public void testInt64ValueNullAndMinValueRoundTrip() throws Exception {
+        Descriptors.FileDescriptor wrappersFileDesc = Int64Value.getDescriptor().getFile();
+
+        DescriptorProtos.FileDescriptorProto fileProto = DescriptorProtos.FileDescriptorProto.newBuilder()
+            .setName("test_int64value.proto")
+            .setSyntax("proto3")
+            .addDependency("google/protobuf/wrappers.proto")
+            .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("ValueHolder")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("id").setNumber(1)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32)
+                    .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("value").setNumber(2)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
+                    .setTypeName(".google.protobuf.Int64Value")
+                    .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)))
+            .build();
+
+        Descriptors.FileDescriptor fileDesc = Descriptors.FileDescriptor.buildFrom(
+            fileProto, new Descriptors.FileDescriptor[]{wrappersFileDesc});
+        Descriptors.Descriptor descriptor = fileDesc.findMessageTypeByName("ValueHolder");
+        Descriptors.FieldDescriptor idField    = descriptor.findFieldByName("id");
+        Descriptors.FieldDescriptor valueField = descriptor.findFieldByName("value");
+
+        // Case 1: absent — field never set on the message
+        DynamicMessage absentMsg = DynamicMessage.newBuilder(descriptor)
+            .setField(idField, 1)
+            .build();
+
+        // Case 2: normal value
+        DynamicMessage normalMsg = DynamicMessage.newBuilder(descriptor)
+            .setField(idField, 2)
+            .setField(valueField, Int64Value.of(42L))
+            .build();
+
+        // Case 3: Long.MIN_VALUE — the Hollow null sentinel inside a present wrapper
+        DynamicMessage minValueMsg = DynamicMessage.newBuilder(descriptor)
+            .setField(idField, 3)
+            .setField(valueField, Int64Value.of(Long.MIN_VALUE))
+            .build();
+
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowMessageMapper mapper = new HollowMessageMapper(writeStateEngine);
+        int absentOrdinal   = mapper.add(absentMsg);
+        int normalOrdinal   = mapper.add(normalMsg);
+        int minValueOrdinal = mapper.add(minValueMsg);
+
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        HollowObjectTypeReadState readState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("ValueHolder");
+
+        com.netflix.hollow.api.objects.generic.GenericHollowObject absentRecord =
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(readState, absentOrdinal);
+        com.netflix.hollow.api.objects.generic.GenericHollowObject normalRecord =
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(readState, normalOrdinal);
+        com.netflix.hollow.api.objects.generic.GenericHollowObject minValueRecord =
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(readState, minValueOrdinal);
+
+        Message absentReconstructed   = mapper.readHollowRecord(absentRecord,   descriptor);
+        Message normalReconstructed   = mapper.readHollowRecord(normalRecord,   descriptor);
+        Message minValueReconstructed = mapper.readHollowRecord(minValueRecord, descriptor);
+
+        // Case 1: absent → field must not be set on the reconstructed message
+        assertFalse("Absent Int64Value must not appear in the reconstructed message",
+            absentReconstructed.hasField(valueField));
+
+        // Case 2: normal value → exact round-trip
+        assertTrue("Int64Value(42) must be present after round-trip",
+            normalReconstructed.hasField(valueField));
+        Message normalWrapped = (Message) normalReconstructed.getField(valueField);
+        assertEquals(42L, normalWrapped.getField(
+            normalWrapped.getDescriptorForType().findFieldByName("value")));
+
+        // Case 3: Long.MIN_VALUE → the Long wrapper record IS written (non-null reference),
+        // but its inner LONG value is the Hollow null sentinel so it reads back as 0.
+        // The field therefore appears present but with a corrupted value.
+        assertTrue("The Int64Value wrapper reference is present (the Long record was written)",
+            minValueReconstructed.hasField(valueField));
+        Message minValueWrapped = (Message) minValueReconstructed.getField(valueField);
+        assertEquals(
+            "Long.MIN_VALUE is the Hollow null sentinel: the inner value is stored as null "
+                + "and reads back as 0 rather than Long.MIN_VALUE",
+            0L,
+            minValueWrapped.getField(minValueWrapped.getDescriptorForType().findFieldByName("value")));
+    }
+
+    /**
+     * Hollow encodes {@code Long.MIN_VALUE} as the null sentinel for LONG fields.
+     * This means an {@code int64} proto field containing {@code Long.MIN_VALUE} is stored as null
+     * and reads back as 0 (the proto3 default). This is a known data-loss edge case.
+     */
+    @Test
+    public void testLongMinValueIsNullSentinel() throws Exception {
+        DescriptorProtos.FileDescriptorProto fileProto = DescriptorProtos.FileDescriptorProto.newBuilder()
+            .setName("test_long.proto")
+            .setSyntax("proto3")
+            .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("LongHolder")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                    .setName("value").setNumber(1)
+                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT64)
+                    .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)))
+            .build();
+        Descriptors.FileDescriptor fileDesc =
+            Descriptors.FileDescriptor.buildFrom(fileProto, new Descriptors.FileDescriptor[0]);
+        Descriptors.Descriptor descriptor = fileDesc.findMessageTypeByName("LongHolder");
+
+        // Verify that a normal Long value survives the round-trip
+        DynamicMessage normalMessage = DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("value"), 42L)
+            .build();
+
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowMessageMapper mapper = new HollowMessageMapper(writeStateEngine);
+        int normalOrdinal = mapper.add(normalMessage);
+
+        // Write a message with Long.MIN_VALUE — this is the Hollow null sentinel
+        DynamicMessage minValueMessage = DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("value"), Long.MIN_VALUE)
+            .build();
+        int minValueOrdinal = mapper.add(minValueMessage);
+
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // Normal value round-trips correctly
+        HollowObjectTypeReadState readState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("LongHolder");
+        assertEquals(42L, readState.readLong(normalOrdinal, 0));
+
+        // Long.MIN_VALUE is treated as null by Hollow's LONG encoding.
+        // The field is stored as null and reads back as Long.MIN_VALUE (Hollow's null representation),
+        // but the proto read path's isNull() guard skips setting it, so the proto field returns 0.
+        Message reconstructed = mapper.readHollowRecord(
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(
+                (com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState) readStateEngine.getTypeState("LongHolder"),
+                minValueOrdinal),
+            descriptor);
+        Descriptors.FieldDescriptor valueField = descriptor.findFieldByName("value");
+        assertEquals(
+            "Long.MIN_VALUE is the Hollow null sentinel: the field is stored as null "
+                + "and reads back as the proto3 default (0) rather than Long.MIN_VALUE",
+            0L,
+            reconstructed.getField(valueField));
+    }
+
+    /**
+     * A boxed {@code Long} wrapper type (the Hollow object schema that wraps a LONG field,
+     * used for nullable int64 references) also treats {@code Long.MIN_VALUE} as null.
+     * Writing a {@code Long} wrapper with {@code value = Long.MIN_VALUE} stores the value
+     * field as null; reading it back returns 0 instead of {@code Long.MIN_VALUE}.
+     */
+    @Test
+    public void testBoxedLongMinValueIsNullSentinel() throws Exception {
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+
+        // Manually create a "Long" box schema (mirrors what ensurePrimitiveWrapperSchema creates)
+        HollowObjectSchema longBoxSchema = new HollowObjectSchema("Long", 1);
+        longBoxSchema.addField("value", HollowObjectSchema.FieldType.LONG);
+        writeStateEngine.addTypeState(new HollowObjectTypeWriteState(longBoxSchema));
+
+        com.netflix.hollow.core.write.HollowObjectWriteRecord rec =
+            new com.netflix.hollow.core.write.HollowObjectWriteRecord(longBoxSchema);
+
+        // Write Long.MIN_VALUE — the Hollow null sentinel
+        rec.reset();
+        rec.setLong("value", Long.MIN_VALUE);
+        int minOrdinal = ((HollowObjectTypeWriteState) writeStateEngine.getTypeState("Long")).add(rec);
+
+        // Write a control value
+        rec.reset();
+        rec.setLong("value", -1L);
+        int negOneOrdinal = ((HollowObjectTypeWriteState) writeStateEngine.getTypeState("Long")).add(rec);
+
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        HollowObjectTypeReadState longReadState =
+            (HollowObjectTypeReadState) readStateEngine.getTypeState("Long");
+
+        // Control: -1 round-trips correctly
+        assertEquals(-1L, longReadState.readLong(negOneOrdinal, 0));
+
+        // Long.MIN_VALUE is stored as null; getLong on a null long field returns Long.MIN_VALUE
+        // but isNull() returns true — so callers that guard on isNull() will see null, not the value.
+        assertTrue("Long.MIN_VALUE is the Hollow null sentinel: the field is stored as null",
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(longReadState, minOrdinal)
+                .isNull("value"));
     }
 
     private Message buildPersonWithNonce(


### PR DESCRIPTION
## Summary

- **Fix `repeated bytes` write path** — `HollowProtoAdapter.parseCollection()` had no `BYTES` case in its `HollowObjectSchema.FieldType` switch, causing any `repeated bytes` proto field to throw `IOException` instead of being stored. Added the missing case so elements are written as `byte[]` via `setBytes()`.
- **Document `Long.MIN_VALUE` null sentinel** — Hollow's `HollowObjectWriteRecord.setLong()` treats `Long.MIN_VALUE` as null. An `int64` proto field or boxed `Long` wrapper carrying that value is silently stored as null and reads back as `0`. Three regression tests now pin this behavior.

## Test Plan

- [ ] `testBytesFieldRoundTrip` — scalar and repeated `bytes` fields write and read back correctly
- [ ] `testLongMinValueIsNullSentinel` — inline `int64 = Long.MIN_VALUE` reads back as `0` (Hollow null sentinel)
- [ ] `testBoxedLongMinValueIsNullSentinel` — `Long` wrapper with `value = Long.MIN_VALUE` stored as null (`isNull == true`)
- [ ] Full `:hollow-protoadapter:test` suite passes (verified post-rebase)