### PR TITLE
fix: correct a misleading field name in HollowPrimaryKeyIndex null-PK error

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -675,10 +675,9 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         }
 
         if (ordinal == ORDINAL_NONE) {
-            HollowObjectSchema parentSchema =  this.typeState.getSchema();
-            throw new NullPointerException("Cannot hash null field " +
-                    parentSchema.getFieldName(fieldIdx) + " in type " +
-                    parentSchema.getName() + " at ordinal " + parentOrdinal);
+            throw new NullPointerException("Cannot hash null primary-key field \"" +
+                    primaryKey.getFieldPath(fieldIdx) + "\" in type " +
+                    primaryKey.getType() + " at ordinal " + parentOrdinal);
         }
 
         int hashCode = HollowReadFieldUtils.fieldHashCode(typeState, ordinal, fieldPathIndexes[fieldIdx][lastFieldPath]);


### PR DESCRIPTION
Prior to this PR, the diagnostic in fieldHash passed the primary-key position to `HollowObjectSchema.getFieldName`, which expects a schema column index. This means the message always named the schema's first declared field instead of the PK field that was actually null. This PR changes the error message to actually name the null primary key field.