### PR TITLE
[Improv]:Enrich exception thrown by history key index to show offending types

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowOrdinalMapper.java
@@ -178,6 +178,13 @@ public class HollowOrdinalMapper {
                 continue;
 
             Object objectToStore = readValueInState(typeState, ordinal, i);
+            if (objectToStore == null) {
+                throw new IllegalArgumentException(
+                        "Null value in primary key field for type='" + primaryKey.getType()
+                                + "', fieldPath='" + primaryKey.getFieldPath(i)
+                                + "', recordOrdinal=" + ordinal
+                                + ". Primary key fields cannot be null.");
+            }
             int objectOrdinal = memoizedPool.writeAndGetOrdinal(objectToStore);
             fieldHashToObjectOrdinal[i][index] = objectOrdinal;
         }

--- a/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryKeyIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryKeyIndexTest.java
@@ -133,6 +133,37 @@ public class HollowHistoryKeyIndexTest extends AbstractStateEngineTest {
         assertResults(keyIdx, "B", "five!", 3);
     }
 
+    @Test
+    public void nullPrimaryKeyFieldThrowsWithTypeAndFieldContext() throws IOException {
+        HollowObjectWriteRecord bRec = new HollowObjectWriteRecord(bSchema);
+        bRec.setString("id", null);
+        bRec.setDouble("anotherField", 1.1D);
+        writeStateEngine.add("B", bRec);
+
+        roundTripSnapshot();
+        HollowHistory history = new HollowHistory(readStateEngine, 1L, 1);
+        HollowHistoryKeyIndex keyIdx = new HollowHistoryKeyIndex(history);
+        keyIdx.addTypeIndex("B", "id");
+        keyIdx.indexTypeField("B", "id");
+
+        try {
+            keyIdx.update(readStateEngine, false);
+            Assert.fail("Expected IllegalArgumentException for null primary key field");
+        } catch (RuntimeException e) {
+            Throwable root = e;
+            while (root.getCause() != null && !(root instanceof IllegalArgumentException)) {
+                root = root.getCause();
+            }
+            Assert.assertTrue("Expected IllegalArgumentException, got " + root,
+                    root instanceof IllegalArgumentException);
+            String msg = root.getMessage();
+            Assert.assertNotNull(msg);
+            Assert.assertTrue("Message should include type, was: " + msg, msg.contains("type='B'"));
+            Assert.assertTrue("Message should include fieldPath, was: " + msg, msg.contains("fieldPath='id'"));
+            Assert.assertTrue("Message should include recordOrdinal, was: " + msg, msg.contains("recordOrdinal="));
+        }
+    }
+
     private void assertResults(HollowHistoryKeyIndex keyIdx, String type, String query, int... expectedResults) {
         IntList actualResults = keyIdx.getTypeKeyIndexes().get(type).queryIndexedFields(query);
 


### PR DESCRIPTION
## Summary

- When a null value is encountered in a primary key field during history key index building, throw an `IllegalArgumentException` with context about the type, field path, and record ordinal — instead of an opaque NPE downstream.
- Added a test covering the null primary key field case, verifying the exception message contains the type and field path.

## Notes

> **Note:** This change is more like a patch than a complete fix. Expect to add a few more patches in the future. Need to check later to see if there is a better way to handle such issue when building history.

## Test plan

- [x] `./gradlew :hollow:test --tests "com.netflix.hollow.tools.history.HollowHistoryKeyIndexTest.nullPrimaryKeyFieldThrowsWithTypeAndFieldContext"` passes
- [x] Existing `HollowHistoryKeyIndexTest` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)