### PR TITLE
fix: unescape colon in history explorer primary key lookup

### DIFF
--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUI.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUI.java
@@ -79,6 +79,12 @@ public class HollowDiffUI implements HollowRecordDiffUI {
     }
     
     public boolean serveRequest(String pageName, HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        if ("diffresult".equals(pageName)) {
+            resp.setContentType("text/json");
+            resp.getWriter().write("json object");
+            return true;
+        }
+
         if("diffrowdata".equals(pageName)) {
             diffViewOutputGenerator.uncollapseRow(req, resp);
             return true;

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUI.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUI.java
@@ -79,12 +79,6 @@ public class HollowDiffUI implements HollowRecordDiffUI {
     }
     
     public boolean serveRequest(String pageName, HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        if ("diffresult".equals(pageName)) {
-            resp.setContentType("text/json");
-            resp.getWriter().write("json object");
-            return true;
-        }
-
         if("diffrowdata".equals(pageName)) {
             diffViewOutputGenerator.uncollapseRow(req, resp);
             return true;

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -257,10 +257,15 @@ public class HollowHistoryTypeKeyIndex {
         }
 
         String[] keyComponents = query.split("(?<!\\\\)" + MULTI_FIELD_KEY_DELIMITER, primaryKey.numFields());
+
         if (keyComponents.length > 1 && keyComponents.length == primaryKey.numFields()) {
+            for (int i = 0; i < keyComponents.length; i++) {
+                keyComponents[i] = keyComponents[i].replace("\\:", ":");
+            }
             return queryIndexedFieldsForCompositeKey(keyComponents);
         } else {
-            return queryIndexedFieldsForNonCompositeKey(query);
+            String unescapedQuery = query.replace("\\:", ":");
+            return queryIndexedFieldsForNonCompositeKey(unescapedQuery);
         }
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/history/keyindex/HollowHistoryTypeKeyIndex.java
@@ -195,7 +195,7 @@ public class HollowHistoryTypeKeyIndex {
                 break;
             case STRING:
                 hashCode = HashCodes.hashCode(strVal);
-                objectToFind = strVal.replaceAll(ESCAPED_MULTI_FIELD_KEY_DELIMITER, MULTI_FIELD_KEY_DELIMITER);
+                objectToFind = strVal;
                 break;
             case DOUBLE:
                 final double queryDouble = Double.parseDouble(strVal);
@@ -260,11 +260,11 @@ public class HollowHistoryTypeKeyIndex {
 
         if (keyComponents.length > 1 && keyComponents.length == primaryKey.numFields()) {
             for (int i = 0; i < keyComponents.length; i++) {
-                keyComponents[i] = keyComponents[i].replace("\\:", ":");
+                keyComponents[i] = keyComponents[i].replaceAll(ESCAPED_MULTI_FIELD_KEY_DELIMITER, MULTI_FIELD_KEY_DELIMITER);
             }
             return queryIndexedFieldsForCompositeKey(keyComponents);
         } else {
-            String unescapedQuery = query.replace("\\:", ":");
+            String unescapedQuery = query.replaceAll(ESCAPED_MULTI_FIELD_KEY_DELIMITER, MULTI_FIELD_KEY_DELIMITER);
             return queryIndexedFieldsForNonCompositeKey(unescapedQuery);
         }
     }

--- a/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryKeyIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/history/HollowHistoryKeyIndexTest.java
@@ -134,6 +134,40 @@ public class HollowHistoryKeyIndexTest extends AbstractStateEngineTest {
     }
 
     @Test
+    public void escapedColonInKeyIsUnescapedBeforeLookup() throws IOException {
+        // B has a single-field STRING primary key; A has a composite float:string key.
+        // When a key value contains ':', the UI requires the user to type '\:'.
+        // The escaped form must be unescaped before hash-index lookup, otherwise the
+        // hash of "Video\:1234" != hash of stored "Video:1234" and no match is found.
+        HollowReadStateEngine readEngine = StateEngineRoundTripper.roundTripSnapshot(writeStateEngine);
+        HollowHistory history = new HollowHistory(readEngine, 1L, 1);
+        HollowHistoryKeyIndex keyIdx = new HollowHistoryKeyIndex(history);
+        keyIdx.addTypeIndex("A", "id", "bRef.id");
+        keyIdx.addTypeIndex("B", "id");
+        keyIdx.indexTypeField("A", "bRef");
+        keyIdx.indexTypeField("A", "id");
+        keyIdx.indexTypeField("B", "id");
+
+        addRecord(1.0F, "Video:1234", 1L, 1.0D);
+        addRecord(2.0F, "A:B:C", 2L, 2.0D);
+
+        roundTripSnapshot();
+        keyIdx.update(readStateEngine, false);
+
+        // Non-composite path (single-field STRING PK): escaped colon is unescaped before hash lookup
+        assertResults(keyIdx, "B", "Video\\:1234", 0);
+        assertResults(keyIdx, "B", "A\\:B\\:C", 1);
+
+        // Composite path (float:string PK): escaped colon in the string component is unescaped
+        assertResults(keyIdx, "A", "1.0:Video\\:1234", 0);
+        assertResults(keyIdx, "A", "2.0:A\\:B\\:C", 1);
+
+        // Non-existent key returns no results
+        assertResults(keyIdx, "B", "notfound");
+        assertResults(keyIdx, "A", "9.9:notfound");
+    }
+
+    @Test
     public void nullPrimaryKeyFieldThrowsWithTypeAndFieldContext() throws IOException {
         HollowObjectWriteRecord bRec = new HollowObjectWriteRecord(bSchema);
         bRec.setString("id", null);


### PR DESCRIPTION
## Problem

In the Hollow History Explorer UI, primary key fields whose values contain a colon (e.g. `Video:1234`) require the user to escape the colon as `Video\:1234`, because `:` is the multi-field key delimiter.

This escaping worked correctly in the regular Explorer key lookup, but was **not applied** in the History lookup path (`HollowHistoryTypeKeyIndex.queryIndexedFields`). As a result, the escaped form `Video\:1234` was passed verbatim to the hash index, which hashed `"Video\:1234"` instead of the stored value `"Video:1234"`, causing a hash miss and no results returned.

## Root Cause

`queryIndexedFields` splits the query on unescaped colons (using a `(?<!\\):`  lookbehind regex) but never stripped the escape prefix from the resulting components before passing them to `getMatchesForField`. The hash code was therefore computed from the escaped string, not the stored plain value — a mismatch even though `objectToFind` was being unescaped correctly inside `getMatchesForField`.

## Changes

**`HollowHistoryTypeKeyIndex.queryIndexedFields`**
- Unescape `\:` → `:` in both the composite-key path (each split component) and the non-composite path (full query) before dispatching to the hash-index lookup, so the hash is computed against the plain stored value.
- Use `replaceAll(ESCAPED_MULTI_FIELD_KEY_DELIMITER, MULTI_FIELD_KEY_DELIMITER)` (centralized constants from `SearchUtils`) instead of a hardcoded literal, keeping unescape logic change-proof.

**`HollowHistoryTypeKeyIndex.getMatchesForField` (STRING case)**
- Remove the now-dead `replaceAll` on `objectToFind` — all callers unescape before reaching this point, so the second pass was a no-op and a maintenance hazard.

**`HollowDiffUI.serveRequest`**
- Remove accidentally committed stub handler for `"diffresult"` that returned the literal string `"json object"` with a non-standard `text/json` content type.

**`HollowHistoryKeyIndexTest`**
- Add `escapedColonInKeyIsUnescapedBeforeLookup` covering both the non-composite path (single-field STRING PK like `B`) and the composite path (float:string PK like `A`), with single and multiple colons in key values.

## Test Plan
- [x] `./gradlew :hollow:test` passes (including new `escapedColonInKeyIsUnescapedBeforeLookup` test)
- [x] Manual: in Hollow History Explorer UI, search for a record whose primary key contains `:` using the `\:` escape — confirm match is found