### PR TITLE
[Feat] Add JSON endpoint to HollowDiffUI for serving precomputed diff data.

### DIFF
--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/DiffUIServer.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/DiffUIServer.java
@@ -18,8 +18,17 @@
 package com.netflix.hollow.diff.ui;
 
 import com.netflix.hollow.tools.diff.HollowDiff;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportMetadata;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportOptions;
 import com.netflix.hollow.ui.UIServer;
 
 public interface DiffUIServer extends UIServer {
-       HollowDiffUI addDiff(String diffPath, HollowDiff diff, String fromBlobName, String toBlobName);
+
+    HollowDiffUI addDiff(
+            String diffPath,
+            HollowDiff diff,
+            String fromBlobName,
+            String toBlobName,
+            HollowDiffReportMetadata metadata,
+            HollowDiffReportOptions options);
 }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/DiffUIWebServer.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/DiffUIWebServer.java
@@ -1,6 +1,8 @@
 package com.netflix.hollow.diff.ui;
 
 import com.netflix.hollow.tools.diff.HollowDiff;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportMetadata;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportOptions;
 import com.netflix.hollow.ui.HollowUIWebServer;
 import com.netflix.hollow.ui.HttpHandlerWithServletSupport;
 
@@ -12,7 +14,14 @@ class DiffUIWebServer extends HollowUIWebServer implements DiffUIServer {
         this.router = router;
     }
 
-    public HollowDiffUI addDiff(String diffPath, HollowDiff diff, String fromBlobName, String toBlobName) {
-        return this.router.addDiff(diffPath, diff, fromBlobName, toBlobName);
+    @Override
+    public HollowDiffUI addDiff(
+            String diffPath,
+            HollowDiff diff,
+            String fromBlobName,
+            String toBlobName,
+            HollowDiffReportMetadata metadata,
+            HollowDiffReportOptions options) {
+        return router.addDiff(diffPath, diff, fromBlobName, toBlobName, metadata, options);
     }
 }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffJsonSerializer.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffJsonSerializer.java
@@ -1,0 +1,20 @@
+package com.netflix.hollow.diff.ui;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.netflix.hollow.tools.diff.HollowDiff;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportBuilder;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportMetadata;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportOptions;
+
+final class HollowDiffJsonSerializer {
+
+    private static final Gson GSON = new GsonBuilder().create();
+
+    private HollowDiffJsonSerializer() {}
+
+    static String toJson(
+            HollowDiff diff, HollowDiffReportMetadata metadata, HollowDiffReportOptions options) {
+        return GSON.toJson(HollowDiffReportBuilder.build(metadata, diff, options));
+    }
+}

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUI.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUI.java
@@ -32,6 +32,8 @@ import com.netflix.hollow.diffview.effigy.HollowRecordDiffUI;
 import com.netflix.hollow.diffview.effigy.pairer.exact.DiffExactRecordMatcher;
 import com.netflix.hollow.diffview.effigy.pairer.exact.ExactRecordMatcher;
 import com.netflix.hollow.tools.diff.HollowDiff;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportMetadata;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportOptions;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,7 +62,17 @@ public class HollowDiffUI implements HollowRecordDiffUI {
     private final Map<String, CustomHollowEffigyFactory> customHollowEffigyFactories;
     private final ExactRecordMatcher exactRecordMatcher;
 
-    HollowDiffUI(String baseURLPath, String diffUIPath, HollowDiff diff, String fromBlobName, String toBlobName, VelocityEngine ve) {
+    private String diffJson;
+
+    HollowDiffUI(
+            String baseURLPath,
+            String diffUIPath,
+            HollowDiff diff,
+            String fromBlobName,
+            String toBlobName,
+            VelocityEngine ve,
+            HollowDiffReportMetadata metadata,
+            HollowDiffReportOptions options) {
         this.baseURLPath = baseURLPath;
         this.diffUIPath = (diffUIPath == null || diffUIPath.length() == 0) ? baseURLPath : baseURLPath + "/" + diffUIPath;
         this.diff = diff;
@@ -76,6 +88,7 @@ public class HollowDiffUI implements HollowRecordDiffUI {
         this.customHollowEffigyFactories = new HashMap<String, CustomHollowEffigyFactory>();
         this.matchHints = new HashMap<String, PrimaryKey>();
         this.exactRecordMatcher = new DiffExactRecordMatcher(diff.getEqualityMapping());
+        this.diffJson = HollowDiffJsonSerializer.toJson(diff, metadata, options);
     }
     
     public boolean serveRequest(String pageName, HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -84,6 +97,10 @@ public class HollowDiffUI implements HollowRecordDiffUI {
             return true;
         } else if("collapsediffrow".equals(pageName)) {
             diffViewOutputGenerator.collapseRow(req, resp);
+            return true;
+        } else if("json".equals(pageName)) {
+            resp.setContentType("application/json; charset=utf-8");
+            resp.getWriter().write(diffJson);
             return true;
         }
 

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUIRouter.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUIRouter.java
@@ -17,6 +17,8 @@
 package com.netflix.hollow.diff.ui;
 
 import com.netflix.hollow.tools.diff.HollowDiff;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportMetadata;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportOptions;
 import com.netflix.hollow.ui.HollowUIRouter;
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -65,8 +67,15 @@ public class HollowDiffUIRouter extends HollowUIRouter {
         return diffUIs;
     }
 
-    public HollowDiffUI addDiff(String diffPath, HollowDiff diff, String fromBlobName, String toBlobName) {
-        HollowDiffUI diffUI = new HollowDiffUI(baseUrlPath, diffPath, diff, fromBlobName, toBlobName, velocityEngine);
+    public HollowDiffUI addDiff(
+            String diffPath,
+            HollowDiff diff,
+            String fromBlobName,
+            String toBlobName,
+            HollowDiffReportMetadata metadata,
+            HollowDiffReportOptions options) {
+        HollowDiffUI diffUI = new HollowDiffUI(
+                baseUrlPath, diffPath, diff, fromBlobName, toBlobName, velocityEngine, metadata, options);
         diffUIs.put(diffPath, diffUI);
         return diffUI;
     }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUIServer.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/HollowDiffUIServer.java
@@ -17,8 +17,13 @@
 package com.netflix.hollow.diff.ui;
 
 import com.netflix.hollow.tools.diff.HollowDiff;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportMetadata;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportOptions;
 
 public class HollowDiffUIServer {
+
+    static final String DEFAULT_FROM_LABEL = "FROM";
+    static final String DEFAULT_TO_LABEL = "TO";
 
     private final DiffUIServer server;
 
@@ -31,11 +36,25 @@ public class HollowDiffUIServer {
     }
 
     public HollowDiffUI addDiff(String diffPath, HollowDiff diff) {
-        return addDiff(diffPath, diff, "FROM", "TO");
+        return addDiff(diffPath, diff, DEFAULT_FROM_LABEL, DEFAULT_TO_LABEL);
     }
 
     public HollowDiffUI addDiff(String diffPath, HollowDiff diff, String fromBlobName, String toBlobName) {
-        return server.addDiff(diffPath, diff, fromBlobName, toBlobName);
+        return server.addDiff(diffPath, diff, fromBlobName, toBlobName, null, null);
+    }
+
+    public HollowDiffUI addDiff(
+            String diffPath,
+            HollowDiff diff,
+            HollowDiffReportMetadata metadata,
+            HollowDiffReportOptions options) {
+        return server.addDiff(
+                diffPath,
+                diff,
+                blobLabel(metadata != null ? metadata.getFromNamespace() : null, DEFAULT_FROM_LABEL),
+                blobLabel(metadata != null ? metadata.getToNamespace() : null, DEFAULT_TO_LABEL),
+                metadata,
+                options);
     }
 
     public HollowDiffUIServer start() throws Exception {
@@ -52,4 +71,7 @@ public class HollowDiffUIServer {
         server.stop();
     }
 
+    private static String blobLabel(String namespace, String defaultLabel) {
+        return namespace != null ? namespace : defaultLabel;
+    }
 }

--- a/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/jetty/HollowDiffUIServer.java
+++ b/hollow-diff-ui/src/main/java/com/netflix/hollow/diff/ui/jetty/HollowDiffUIServer.java
@@ -18,6 +18,9 @@ package com.netflix.hollow.diff.ui.jetty;
 
 import com.netflix.hollow.diff.ui.HollowDiffUI;
 import com.netflix.hollow.tools.diff.HollowDiff;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportMetadata;
+import com.netflix.hollow.tools.diff.report.HollowDiffReportOptions;
+
 /**
  * @deprecated use {@link com.netflix.hollow.diff.ui.HollowDiffUIServer}. This is deprecated because package name
  * contains "jetty" but jetty-server dep is no longer required. Instead, this class lives on as an adapter
@@ -44,6 +47,14 @@ public class HollowDiffUIServer {
         return server.addDiff(diffPath, diff, fromBlobName, toBlobName);
     }
 
+    public HollowDiffUI addDiff(
+            String diffPath,
+            HollowDiff diff,
+            HollowDiffReportMetadata metadata,
+            HollowDiffReportOptions options) {
+        return server.addDiff(diffPath, diff, metadata, options);
+    }
+
     public HollowDiffUIServer start() throws Exception {
         server.start();
         return this;
@@ -57,5 +68,4 @@ public class HollowDiffUIServer {
     public void stop() throws Exception {
         server.stop();
     }
-
 }

--- a/hollow-diff-ui/src/test/java/com/netflix/hollow/diffview/HollowDiffUIServerTest.java
+++ b/hollow-diff-ui/src/test/java/com/netflix/hollow/diffview/HollowDiffUIServerTest.java
@@ -1,5 +1,6 @@
 package com.netflix.hollow.diffview;
 
+import com.netflix.hollow.diff.ui.HollowDiffUI;
 import com.netflix.hollow.diff.ui.HollowDiffUIServer;
 import com.netflix.hollow.tools.diff.HollowDiff;
 import org.junit.Test;

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/report/HollowDiffReport.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/report/HollowDiffReport.java
@@ -1,0 +1,257 @@
+package com.netflix.hollow.tools.diff.report;
+
+import java.util.List;
+
+/**
+ * Structured export of a calculated {@link com.netflix.hollow.tools.diff.HollowDiff}.
+ */
+public final class HollowDiffReport {
+
+    private String fromNamespace;
+    private String toNamespace;
+    private Long fromVersion;
+    private Long toVersion;
+    private List<BlobHeader> blobHeaders;
+    private List<TypeDiff> typeDiffs;
+
+    public String getFromNamespace() {
+        return fromNamespace;
+    }
+
+    public void setFromNamespace(String fromNamespace) {
+        this.fromNamespace = fromNamespace;
+    }
+
+    public String getToNamespace() {
+        return toNamespace;
+    }
+
+    public void setToNamespace(String toNamespace) {
+        this.toNamespace = toNamespace;
+    }
+
+    public Long getFromVersion() {
+        return fromVersion;
+    }
+
+    public void setFromVersion(Long fromVersion) {
+        this.fromVersion = fromVersion;
+    }
+
+    public Long getToVersion() {
+        return toVersion;
+    }
+
+    public void setToVersion(Long toVersion) {
+        this.toVersion = toVersion;
+    }
+
+    public List<BlobHeader> getBlobHeaders() {
+        return blobHeaders;
+    }
+
+    public void setBlobHeaders(List<BlobHeader> blobHeaders) {
+        this.blobHeaders = blobHeaders;
+    }
+
+    public List<TypeDiff> getTypeDiffs() {
+        return typeDiffs;
+    }
+
+    public void setTypeDiffs(List<TypeDiff> typeDiffs) {
+        this.typeDiffs = typeDiffs;
+    }
+
+    /** Hollow snapshot header tag, as shown in the diff UI &quot;Blob Information&quot; table. */
+    public static final class BlobHeader {
+        private String headerName;
+        private String fromValue;
+        private String toValue;
+
+        public String getHeaderName() {
+            return headerName;
+        }
+
+        public void setHeaderName(String headerName) {
+            this.headerName = headerName;
+        }
+
+        public String getFromValue() {
+            return fromValue;
+        }
+
+        public void setFromValue(String fromValue) {
+            this.fromValue = fromValue;
+        }
+
+        public String getToValue() {
+            return toValue;
+        }
+
+        public void setToValue(String toValue) {
+            this.toValue = toValue;
+        }
+    }
+
+    public static final class TypeDiff {
+        private String type;
+        private int totalMatches;
+        private int totalItemsInFromState;
+        private int totalItemsInToState;
+        private long typeDiffScore;
+        private int unmatchedOrdinalsInFromCount;
+        private int unmatchedOrdinalsInToCount;
+        private List<Integer> unmatchedOrdinalsInFromSample;
+        private List<Integer> unmatchedOrdinalsInToSample;
+        private List<FieldDiff> fieldDiffs;
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public int getTotalMatches() {
+            return totalMatches;
+        }
+
+        public void setTotalMatches(int totalMatches) {
+            this.totalMatches = totalMatches;
+        }
+
+        public int getTotalItemsInFromState() {
+            return totalItemsInFromState;
+        }
+
+        public void setTotalItemsInFromState(int totalItemsInFromState) {
+            this.totalItemsInFromState = totalItemsInFromState;
+        }
+
+        public int getTotalItemsInToState() {
+            return totalItemsInToState;
+        }
+
+        public void setTotalItemsInToState(int totalItemsInToState) {
+            this.totalItemsInToState = totalItemsInToState;
+        }
+
+        public long getTypeDiffScore() {
+            return typeDiffScore;
+        }
+
+        public void setTypeDiffScore(long typeDiffScore) {
+            this.typeDiffScore = typeDiffScore;
+        }
+
+        public int getUnmatchedOrdinalsInFromCount() {
+            return unmatchedOrdinalsInFromCount;
+        }
+
+        public void setUnmatchedOrdinalsInFromCount(int unmatchedOrdinalsInFromCount) {
+            this.unmatchedOrdinalsInFromCount = unmatchedOrdinalsInFromCount;
+        }
+
+        public int getUnmatchedOrdinalsInToCount() {
+            return unmatchedOrdinalsInToCount;
+        }
+
+        public void setUnmatchedOrdinalsInToCount(int unmatchedOrdinalsInToCount) {
+            this.unmatchedOrdinalsInToCount = unmatchedOrdinalsInToCount;
+        }
+
+        public List<Integer> getUnmatchedOrdinalsInFromSample() {
+            return unmatchedOrdinalsInFromSample;
+        }
+
+        public void setUnmatchedOrdinalsInFromSample(List<Integer> unmatchedOrdinalsInFromSample) {
+            this.unmatchedOrdinalsInFromSample = unmatchedOrdinalsInFromSample;
+        }
+
+        public List<Integer> getUnmatchedOrdinalsInToSample() {
+            return unmatchedOrdinalsInToSample;
+        }
+
+        public void setUnmatchedOrdinalsInToSample(List<Integer> unmatchedOrdinalsInToSample) {
+            this.unmatchedOrdinalsInToSample = unmatchedOrdinalsInToSample;
+        }
+
+        public List<FieldDiff> getFieldDiffs() {
+            return fieldDiffs;
+        }
+
+        public void setFieldDiffs(List<FieldDiff> fieldDiffs) {
+            this.fieldDiffs = fieldDiffs;
+        }
+    }
+
+    public static final class FieldDiff {
+        private String fieldPath;
+        private long totalDiffScore;
+        private int numDiffs;
+        private List<FieldDiffPair> pairsSample;
+
+        public String getFieldPath() {
+            return fieldPath;
+        }
+
+        public void setFieldPath(String fieldPath) {
+            this.fieldPath = fieldPath;
+        }
+
+        public long getTotalDiffScore() {
+            return totalDiffScore;
+        }
+
+        public void setTotalDiffScore(long totalDiffScore) {
+            this.totalDiffScore = totalDiffScore;
+        }
+
+        public int getNumDiffs() {
+            return numDiffs;
+        }
+
+        public void setNumDiffs(int numDiffs) {
+            this.numDiffs = numDiffs;
+        }
+
+        public List<FieldDiffPair> getPairsSample() {
+            return pairsSample;
+        }
+
+        public void setPairsSample(List<FieldDiffPair> pairsSample) {
+            this.pairsSample = pairsSample;
+        }
+    }
+
+    public static final class FieldDiffPair {
+        private int fromOrdinal;
+        private int toOrdinal;
+        private int score;
+
+        public int getFromOrdinal() {
+            return fromOrdinal;
+        }
+
+        public void setFromOrdinal(int fromOrdinal) {
+            this.fromOrdinal = fromOrdinal;
+        }
+
+        public int getToOrdinal() {
+            return toOrdinal;
+        }
+
+        public void setToOrdinal(int toOrdinal) {
+            this.toOrdinal = toOrdinal;
+        }
+
+        public int getScore() {
+            return score;
+        }
+
+        public void setScore(int score) {
+            this.score = score;
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/report/HollowDiffReportBuilder.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/report/HollowDiffReportBuilder.java
@@ -1,0 +1,139 @@
+package com.netflix.hollow.tools.diff.report;
+
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.IntList;
+import com.netflix.hollow.tools.diff.HollowDiff;
+import com.netflix.hollow.tools.diff.HollowTypeDiff;
+import com.netflix.hollow.tools.diff.count.HollowFieldDiff;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Builds a {@link HollowDiffReport} from a calculated {@link HollowDiff}.
+ */
+public final class HollowDiffReportBuilder {
+
+    private HollowDiffReportBuilder() {}
+
+    public static HollowDiffReport build(
+            HollowDiffReportMetadata metadata,
+            HollowDiff diff,
+            HollowDiffReportOptions options) {
+        HollowDiffReportMetadata meta =
+                metadata != null ? metadata : HollowDiffReportMetadata.empty();
+        HollowDiffReportOptions opts =
+                options != null ? options : HollowDiffReportOptions.defaults();
+
+        HollowDiffReport out = new HollowDiffReport();
+        out.setBlobHeaders(blobHeaders(diff));
+        if (meta.getFromNamespace() != null) {
+            out.setFromNamespace(meta.getFromNamespace());
+        }
+        if (meta.getToNamespace() != null) {
+            out.setToNamespace(meta.getToNamespace());
+        }
+        if (meta.getFromVersion() != null) {
+            out.setFromVersion(meta.getFromVersion());
+        }
+        if (meta.getToVersion() != null) {
+            out.setToVersion(meta.getToVersion());
+        }
+
+        List<?> typeDiffsRaw = diff.getTypeDiffs();
+        List<HollowDiffReport.TypeDiff> rows = new ArrayList<>(typeDiffsRaw.size());
+        for (Object tdObj : typeDiffsRaw) {
+            HollowTypeDiff td = (HollowTypeDiff) tdObj;
+            HollowDiffReport.TypeDiff tj = new HollowDiffReport.TypeDiff();
+            tj.setType(td.getTypeName());
+            tj.setTotalMatches(td.getTotalNumberOfMatches());
+            tj.setTotalItemsInFromState(td.getTotalItemsInFromState());
+            tj.setTotalItemsInToState(td.getTotalItemsInToState());
+
+            IntList uFrom = td.getUnmatchedOrdinalsInFrom();
+            IntList uTo = td.getUnmatchedOrdinalsInTo();
+            tj.setUnmatchedOrdinalsInFromCount(uFrom.size());
+            tj.setUnmatchedOrdinalsInToCount(uTo.size());
+            tj.setUnmatchedOrdinalsInFromSample(
+                    intListSample(uFrom, opts.getMaxUnmatchedSample()));
+            tj.setUnmatchedOrdinalsInToSample(intListSample(uTo, opts.getMaxUnmatchedSample()));
+
+            tj.setTypeDiffScore(td.getTotalDiffScore());
+
+            List<?> fieldDiffs = td.getFieldDiffs();
+            List<HollowDiffReport.FieldDiff> fjList = new ArrayList<>();
+            if (fieldDiffs != null) {
+                for (Object o : fieldDiffs) {
+                    HollowFieldDiff fd = (HollowFieldDiff) o;
+                    HollowDiffReport.FieldDiff fj = new HollowDiffReport.FieldDiff();
+                    fj.setFieldPath(fd.getFieldIdentifier().toString());
+                    fj.setTotalDiffScore(fd.getTotalDiffScore());
+                    fj.setNumDiffs(fd.getNumDiffs());
+                    fj.setPairsSample(fieldDiffPairsSample(fd, opts.getMaxFieldDiffPairsPerField()));
+                    fjList.add(fj);
+                }
+            }
+            tj.setFieldDiffs(fjList);
+            rows.add(tj);
+        }
+        out.setTypeDiffs(rows);
+        return out;
+    }
+
+    static List<Integer> intListSample(IntList list, int max) {
+        if (list == null || list.size() == 0 || max <= 0) {
+            return Collections.emptyList();
+        }
+        int n = Math.min(list.size(), max);
+        List<Integer> sample = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            sample.add(list.get(i));
+        }
+        return sample;
+    }
+
+    static List<HollowDiffReport.FieldDiffPair> fieldDiffPairsSample(
+            HollowFieldDiff fd, int maxPairs) {
+        int num = fd.getNumDiffs();
+        if (num <= 0 || maxPairs <= 0) {
+            return Collections.emptyList();
+        }
+        int n = Math.min(num, maxPairs);
+        List<HollowDiffReport.FieldDiffPair> pairs = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            HollowDiffReport.FieldDiffPair p = new HollowDiffReport.FieldDiffPair();
+            p.setFromOrdinal(fd.getFromOrdinal(i));
+            p.setToOrdinal(fd.getToOrdinal(i));
+            p.setScore(fd.getPairScore(i));
+            pairs.add(p);
+        }
+        return pairs;
+    }
+
+    static List<HollowDiffReport.BlobHeader> blobHeaders(HollowDiff diff) {
+        HollowReadStateEngine from = diff.getFromStateEngine();
+        HollowReadStateEngine to = diff.getToStateEngine();
+        if (from == null && to == null) {
+            return Collections.emptyList();
+        }
+        Map<String, String> fromTags = from != null ? from.getHeaderTags() : Collections.emptyMap();
+        Map<String, String> toTags = to != null ? to.getHeaderTags() : Collections.emptyMap();
+
+        Set<String> allKeys = new TreeSet<>();
+        allKeys.addAll(fromTags.keySet());
+        allKeys.addAll(toTags.keySet());
+
+        List<HollowDiffReport.BlobHeader> entries = new ArrayList<>(allKeys.size());
+        for (String key : allKeys) {
+            HollowDiffReport.BlobHeader entry = new HollowDiffReport.BlobHeader();
+            entry.setHeaderName(key);
+            entry.setFromValue(fromTags.get(key));
+            entry.setToValue(toTags.get(key));
+            entries.add(entry);
+        }
+        return entries;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/report/HollowDiffReportMetadata.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/report/HollowDiffReportMetadata.java
@@ -1,0 +1,45 @@
+package com.netflix.hollow.tools.diff.report;
+
+/**
+ * Caller-supplied labels for the two sides of a {@link com.netflix.hollow.tools.diff.HollowDiff}.
+ */
+public final class HollowDiffReportMetadata {
+
+    private final String fromNamespace;
+    private final String toNamespace;
+    private final Long fromVersion;
+    private final Long toVersion;
+
+    private HollowDiffReportMetadata(
+            String fromNamespace, Long fromVersion, String toNamespace, Long toVersion) {
+        this.fromNamespace = fromNamespace;
+        this.fromVersion = fromVersion;
+        this.toNamespace = toNamespace;
+        this.toVersion = toVersion;
+    }
+
+    public static HollowDiffReportMetadata of(
+            String fromNamespace, Long fromVersion, String toNamespace, Long toVersion) {
+        return new HollowDiffReportMetadata(fromNamespace, fromVersion, toNamespace, toVersion);
+    }
+
+    public static HollowDiffReportMetadata empty() {
+        return new HollowDiffReportMetadata(null, null, null, null);
+    }
+
+    public String getFromNamespace() {
+        return fromNamespace;
+    }
+
+    public String getToNamespace() {
+        return toNamespace;
+    }
+
+    public Long getFromVersion() {
+        return fromVersion;
+    }
+
+    public Long getToVersion() {
+        return toVersion;
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/report/HollowDiffReportOptions.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/report/HollowDiffReportOptions.java
@@ -1,0 +1,40 @@
+package com.netflix.hollow.tools.diff.report;
+
+/**
+ * Limits applied when exporting a {@link com.netflix.hollow.tools.diff.HollowDiff} to JSON.
+ */
+public final class HollowDiffReportOptions {
+
+    public static final int DEFAULT_MAX_UNMATCHED_SAMPLE = 200;
+    public static final int DEFAULT_MAX_FIELD_DIFF_PAIRS_PER_FIELD = 50;
+    private static final int MAX_CAP = 5000;
+
+    private final int maxUnmatchedSample;
+    private final int maxFieldDiffPairsPerField;
+
+    private HollowDiffReportOptions(int maxUnmatchedSample, int maxFieldDiffPairsPerField) {
+        this.maxUnmatchedSample = cap(maxUnmatchedSample);
+        this.maxFieldDiffPairsPerField = cap(maxFieldDiffPairsPerField);
+    }
+
+    public static HollowDiffReportOptions defaults() {
+        return new HollowDiffReportOptions(
+                DEFAULT_MAX_UNMATCHED_SAMPLE, DEFAULT_MAX_FIELD_DIFF_PAIRS_PER_FIELD);
+    }
+
+    public static HollowDiffReportOptions of(int maxUnmatchedSample, int maxFieldDiffPairsPerField) {
+        return new HollowDiffReportOptions(maxUnmatchedSample, maxFieldDiffPairsPerField);
+    }
+
+    public int getMaxUnmatchedSample() {
+        return maxUnmatchedSample;
+    }
+
+    public int getMaxFieldDiffPairsPerField() {
+        return maxFieldDiffPairsPerField;
+    }
+
+    private static int cap(int value) {
+        return Math.min(Math.max(value, 0), MAX_CAP);
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/tools/diff/report/HollowDiffReportBuilderTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/diff/report/HollowDiffReportBuilderTest.java
@@ -1,0 +1,43 @@
+package com.netflix.hollow.tools.diff.report;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.tools.diff.HollowDiff;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class HollowDiffReportBuilderTest {
+
+    @Test
+    public void build_includesMetadataAndBlobHeaders() {
+        HollowDiff diff = Mockito.mock(HollowDiff.class);
+        Mockito.when(diff.getTypeDiffs()).thenReturn(Collections.emptyList());
+
+        Map<String, String> fromTags = Collections.singletonMap("producer", "a");
+        HollowReadStateEngine from = Mockito.mock(HollowReadStateEngine.class);
+        Mockito.when(from.getHeaderTags()).thenReturn(fromTags);
+        HollowReadStateEngine to = Mockito.mock(HollowReadStateEngine.class);
+        Mockito.when(to.getHeaderTags()).thenReturn(Collections.singletonMap("producer", "b"));
+        Mockito.when(diff.getFromStateEngine()).thenReturn(from);
+        Mockito.when(diff.getToStateEngine()).thenReturn(to);
+
+        HollowDiffReport report = HollowDiffReportBuilder.build(
+                HollowDiffReportMetadata.of("nsA", 1L, "nsB", 2L),
+                diff,
+                HollowDiffReportOptions.defaults());
+
+        assertEquals("nsA", report.getFromNamespace());
+        assertEquals("nsB", report.getToNamespace());
+        assertEquals(Long.valueOf(1L), report.getFromVersion());
+        assertEquals(Long.valueOf(2L), report.getToVersion());
+        assertEquals(1, report.getBlobHeaders().size());
+        assertEquals("producer", report.getBlobHeaders().get(0).getHeaderName());
+        assertEquals("a", report.getBlobHeaders().get(0).getFromValue());
+        assertEquals("b", report.getBlobHeaders().get(0).getToValue());
+        assertTrue(report.getTypeDiffs().isEmpty());
+    }
+}


### PR DESCRIPTION
### Description 
Provide function to generate diff report in JSON format. 

### Changes Made 

1. New `com.netflix.hollow.tools.diff.report package` to store the JSON object before serialization
1.1 `HollowDiffReport.java`: Json Object Class 
1.2 `HollowDiffReportBuilder.java`: helper class to transform diff into the Json Object
1.3 `HollowDiffReportMetadata.java`: Metadata regarding the diff
1.4 `HollowDiffReportOptions.java`: Report config to control how many rows of detail to include in the JSON response. 

2. `main/java/com/netflix/hollow/diff/ui`: Diff→serialized JSON logic 
2.1 Update `HollowDiffUI` constructor  to take in metadata and options parameters. 
2.2 Update `HollowDiffUIRouter` : `addDiff` function would take in the above parameters 
2.3 Update `DiffUIServer`:  `addDiff` function would expect the above parameters 
2.4 Update `DiffUIWebServer`: `addDiff` function would take in the above parameters for its router
2.5 Update `HollowDiffUIServer`: overload a new `addDiff` function to  take in the above parameters. 
