### PR TITLE
feat(protoadapter): map repeated fields to keyed Hollow Sets via hollow_hash_key

### DIFF
--- a/hollow-protoadapter/README.md
+++ b/hollow-protoadapter/README.md
@@ -200,6 +200,46 @@ RecordPrimaryKey key = mapper.extractPrimaryKey(myMessage);
 
 If no `hollow_primary_key` option is specified, all scalar (non-repeated, non-message) fields are used as the primary key.
 
+## Hash Keys (Keyed Sets)
+
+Mark a `repeated` field with the `hollow_hash_key` field option to store it as a Hollow **Set** (instead of a List) with a hash key, enabling keyed lookup of elements within that field's scope. This mirrors `@HollowHashKey(fields = {...})` on a `Set<T>` field in the POJO mapper, and the generated Set type is named `SetOf<Element>` to match `HollowObjectMapper` — so the same data round-trips across the proto and POJO mappers.
+
+```protobuf
+import "hollow_options.proto";
+
+message NetworkInterface {
+  option (com.netflix.hollow.hollow_primary_key) = {fields: ["name"]};
+
+  string name = 1;
+  // Stored as a Hollow Set "SetOfNeighbor" keyed by the element's addr field.
+  repeated Neighbor neighbors = 2 [(com.netflix.hollow.hollow_hash_key) = {fields: ["addr"]}];
+}
+
+message Neighbor {
+  // Globally unique by its own composite primary key ...
+  option (com.netflix.hollow.hollow_primary_key) = {fields: ["target", "addr"]};
+
+  string target = 1;
+  string addr = 2;   // ... but keyed by addr alone within a NetworkInterface's set
+}
+```
+
+On the read side the field is still a normal repeated field; the hash key powers `findElement` lookups on the underlying Hollow Set:
+
+```java
+GenericHollowSet neighbors = (GenericHollowSet)
+    networkInterfaceRecord.getReferencedGenericRecord("neighbors");
+HollowRecord neighbor = neighbors.findElement("10.0.0.2"); // look up by addr
+```
+
+**Notes:**
+- The element type's own `hollow_primary_key` is independent of the set's hash key — both can coexist (as above).
+- Hash-key field paths reference the element's (proto) field names.
+- An empty `fields` list produces an unkeyed Set hashed by element ordinal.
+- Without this option, a repeated field maps to a Hollow `LIST` (element order preserved).
+
+Similar to `@HollowHashKey` in Java.
+
 ## Field Path Remapping
 
 Remap field paths if your Hollow schema structure differs from your Protocol Buffer structure:
@@ -259,6 +299,7 @@ import "hollow_options.proto";
 
 **Available options:**
 - `hollow_primary_key` (message option): Define primary key fields
+- `hollow_hash_key` (field option): Store a repeated field as a keyed Hollow Set
 - `hollow_ignore_list_ordering` (field option): Reserved for future per-field control
 
 **Note**: Currently, `ignoreListOrdering()` applies globally to all repeated fields. The field-level option is defined for future use but not yet implemented.

--- a/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowMessageMapper.java
+++ b/hollow-protoadapter/src/main/java/com/netflix/hollow/protoadapter/HollowMessageMapper.java
@@ -20,9 +20,11 @@ import com.google.protobuf.Descriptors;
 import com.netflix.hollow.core.schema.HollowListSchema;
 import com.netflix.hollow.core.schema.HollowMapSchema;
 import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowSetSchema;
 import com.netflix.hollow.core.write.HollowListTypeWriteState;
 import com.netflix.hollow.core.write.HollowMapTypeWriteState;
 import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowSetTypeWriteState;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 
 import java.util.HashSet;
@@ -217,8 +219,6 @@ public class HollowMessageMapper {
             String fieldName = field.getName();
 
             if (field.isRepeated()) {
-                // Repeated fields map to Hollow lists
-                String listTypeName = "ListOf" + getElementTypeName(field);
                 String elementType = getElementTypeName(field);
 
                 // Ensure the element type schema exists
@@ -230,13 +230,28 @@ public class HollowMessageMapper {
                     ensurePrimitiveWrapperSchema(elementType);
                 }
 
-                // Create list schema if not exists
-                if (stateEngine.getSchema(listTypeName) == null) {
-                    HollowListSchema listSchema = new HollowListSchema(listTypeName, elementType);
-                    stateEngine.addTypeState(new HollowListTypeWriteState(listSchema));
+                String[] hashKeyFields = readHollowHashKeyFields(field);
+                if (hashKeyFields != null) {
+                    // A hollow_hash_key option promotes the repeated field to a Hollow Set
+                    // (keyed lookup of elements within the set's scope), mirroring
+                    // @HollowHashKey on a Set<T> field in the POJO mapper. The type name
+                    // matches HollowObjectMapper's POJO naming ("SetOf<Element>") so the same
+                    // data can round-trip across the proto and POJO mappers.
+                    String setTypeName = "SetOf" + elementType;
+                    if (stateEngine.getSchema(setTypeName) == null) {
+                        HollowSetSchema setSchema = new HollowSetSchema(setTypeName, elementType, hashKeyFields);
+                        stateEngine.addTypeState(new HollowSetTypeWriteState(setSchema));
+                    }
+                    schema.addField(fieldName, HollowObjectSchema.FieldType.REFERENCE, setTypeName);
+                } else {
+                    // Default: repeated fields map to Hollow lists (element order preserved)
+                    String listTypeName = "ListOf" + elementType;
+                    if (stateEngine.getSchema(listTypeName) == null) {
+                        HollowListSchema listSchema = new HollowListSchema(listTypeName, elementType);
+                        stateEngine.addTypeState(new HollowListTypeWriteState(listSchema));
+                    }
+                    schema.addField(fieldName, HollowObjectSchema.FieldType.REFERENCE, listTypeName);
                 }
-
-                schema.addField(fieldName, HollowObjectSchema.FieldType.REFERENCE, listTypeName);
 
             } else {
                 // Check if field has hollow_type_name option (for namespaced wrapper types)
@@ -881,6 +896,27 @@ public class HollowMessageMapper {
         return new String[0];
     }
 
+    /**
+     * Reads the {@code hollow_hash_key} field option, which promotes a repeated field to a
+     * Hollow Set keyed by the given element field paths (mirrors {@code @HollowHashKey} on a
+     * {@code Set<T>} field in the POJO mapper). Returns the hash-key field paths when the
+     * option is present (an empty array means an unkeyed Set hashed by element ordinal), or
+     * {@code null} when the option is absent (the repeated field stays a Hollow List).
+     */
+    private static String[] readHollowHashKeyFields(Descriptors.FieldDescriptor field) {
+        try {
+            com.google.protobuf.DescriptorProtos.FieldOptions options = field.getOptions();
+            if (options.hasExtension(HollowOptions.hollowHashKey)) {
+                HollowOptions.HollowHashKey hashKeyOption =
+                    options.getExtension(HollowOptions.hollowHashKey);
+                return hashKeyOption.getFieldsList().toArray(new String[0]);
+            }
+        } catch (Exception e) {
+            // HollowOptions extension not available on the classpath — treat as no hash key.
+        }
+        return null;
+    }
+
     public com.netflix.hollow.core.write.objectmapper.RecordPrimaryKey extractPrimaryKey(
             com.google.protobuf.Message message) {
 
@@ -960,9 +996,21 @@ public class HollowMessageMapper {
                         (com.netflix.hollow.api.objects.generic.GenericHollowList) listRecord;
 
                     for (int i = 0; i < list.size(); i++) {
-                        Object element = readListElement(list, i, field);
+                        Object element = convertCollectionElement(list.get(i), field);
                         if (element != null) {
                             builder.addRepeatedField(field, element);
+                        }
+                    }
+                } else if (listRecord instanceof com.netflix.hollow.api.objects.generic.GenericHollowSet) {
+                    // A field marked with hollow_hash_key is stored as a Hollow Set; iterate its
+                    // element objects (the proto field is still repeated on the read side).
+                    com.netflix.hollow.api.objects.generic.GenericHollowSet set =
+                        (com.netflix.hollow.api.objects.generic.GenericHollowSet) listRecord;
+
+                    for (com.netflix.hollow.api.objects.generic.GenericHollowObject element : set.objects()) {
+                        Object converted = convertCollectionElement(element, field);
+                        if (converted != null) {
+                            builder.addRepeatedField(field, converted);
                         }
                     }
                 }
@@ -1189,14 +1237,13 @@ public class HollowMessageMapper {
     }
 
     /**
-     * Read an element from a Hollow list and convert to the appropriate protobuf type.
+     * Convert a single Hollow collection element (from a List or Set) to the appropriate
+     * protobuf value for a repeated field.
      */
-    private Object readListElement(
-            com.netflix.hollow.api.objects.generic.GenericHollowList list,
-            int index,
+    private Object convertCollectionElement(
+            com.netflix.hollow.api.objects.HollowRecord element,
             Descriptors.FieldDescriptor field) {
 
-        com.netflix.hollow.api.objects.HollowRecord element = list.get(index);
         if (element == null) {
             return null;
         }
@@ -1300,6 +1347,17 @@ public class HollowMessageMapper {
 
                 for (int i = 0; i < list.size(); i++) {
                     Object element = readFlatListElement(list.get(i), field);
+                    if (element != null) {
+                        builder.addRepeatedField(field, element);
+                    }
+                }
+            } else if (listNode instanceof com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalSetNode) {
+                // A field marked with hollow_hash_key is stored as a Hollow Set.
+                com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalSetNode set =
+                    (com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalSetNode) listNode;
+
+                for (com.netflix.hollow.core.write.objectmapper.flatrecords.traversal.FlatRecordTraversalNode elementNode : set) {
+                    Object element = readFlatListElement(elementNode, field);
                     if (element != null) {
                         builder.addRepeatedField(field, element);
                     }

--- a/hollow-protoadapter/src/main/proto/hollow_options.proto
+++ b/hollow-protoadapter/src/main/proto/hollow_options.proto
@@ -12,6 +12,11 @@ message HollowPrimaryKey {
   repeated string fields = 1;
 }
 
+// Message type for hollow set hash key configuration
+message HollowHashKey {
+  repeated string fields = 1;
+}
+
 // Custom message option to define primary key field paths
 // Similar to @HollowPrimaryKey(fields = {"id", "version"}) in Java
 // Usage: option (com.netflix.hollow.hollow_primary_key) = {fields: ["account_id", "region"]};
@@ -44,4 +49,15 @@ extend google.protobuf.FieldOptions {
   // Example: uint32 value 3000000000 (0xB2D05E00) becomes -1294967296 in signed int32
   // Set to true to explicitly acknowledge this behavior and allow the field
   bool hollow_unsigned_to_signed = 50004;
+
+  // Custom field option to map a repeated field to a Hollow Set (instead of a List)
+  // with a hash key, enabling keyed lookup of elements within the set's scope.
+  // Similar to @HollowHashKey(fields = {...}) in Java, which annotates a Set field.
+  // The presence of this option makes the repeated field a Hollow Set named
+  // "SetOf<Element>" (matching HollowObjectMapper's POJO naming); the listed fields
+  // become the set's hash key (paths into the element type). An empty fields list
+  // produces an unkeyed Set hashed by element ordinal.
+  // Example:
+  //   repeated Neighbor neighbors = 2 [(com.netflix.hollow.hollow_hash_key) = {fields: ["addr"]}];
+  HollowHashKey hollow_hash_key = 50005;
 }

--- a/hollow-protoadapter/src/test/java/com/netflix/hollow/protoadapter/HollowProtoAdapterTest.java
+++ b/hollow-protoadapter/src/test/java/com/netflix/hollow/protoadapter/HollowProtoAdapterTest.java
@@ -202,6 +202,79 @@ public class HollowProtoAdapterTest {
             new String[] {"account_id", "region"}, accountPk.getFieldPaths());
     }
 
+    /**
+     * The {@code hollow_hash_key} field option promotes a repeated field to a Hollow Set
+     * (named {@code SetOf<Element>} to match the POJO mapper) carrying the given hash key,
+     * mirroring {@code @HollowHashKey(fields={...})} on a {@code Set<T>} field. This verifies
+     * the schema shape, the round-trip through the proto field, and that the hash key is
+     * functional via {@code findElement} keyed lookup within the set's scope.
+     */
+    @Test
+    public void testHollowHashKeyProducesKeyedSet() throws Exception {
+        Class<?> niClass = protoClassLoader.loadClass(
+            "com.netflix.hollow.test.proto.PersonProtos$NetworkInterface");
+        Message.Builder niBuilder = (Message.Builder) niClass.getMethod("newBuilder").invoke(null);
+        JsonFormat.parser().merge(
+            "{ \"name\": \"eth0\", \"neighbors\": ["
+                + " {\"target\": \"r1\", \"addr\": \"10.0.0.1\"},"
+                + " {\"target\": \"r2\", \"addr\": \"10.0.0.2\"} ] }",
+            niBuilder);
+        Message networkInterface = niBuilder.build();
+
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowMessageMapper mapper = new HollowMessageMapper(writeStateEngine);
+        mapper.initializeTypeState(networkInterface.getDescriptorForType());
+
+        // The neighbors field must be inferred as a Hollow Set, not a List.
+        com.netflix.hollow.core.schema.HollowSchema neighborsSchema =
+            writeStateEngine.getSchema("SetOfNeighbor");
+        assertNotNull("hollow_hash_key must produce a SetOf<Element> schema", neighborsSchema);
+        assertTrue("a repeated field with hollow_hash_key must be a Hollow Set, not a List",
+            neighborsSchema instanceof com.netflix.hollow.core.schema.HollowSetSchema);
+        com.netflix.hollow.core.schema.HollowSetSchema setSchema =
+            (com.netflix.hollow.core.schema.HollowSetSchema) neighborsSchema;
+        assertEquals("Neighbor", setSchema.getElementType());
+        com.netflix.hollow.core.index.key.PrimaryKey hashKey = setSchema.getHashKey();
+        assertNotNull("the Set must carry the hash key declared by hollow_hash_key", hashKey);
+        assertArrayEquals(new String[] {"addr"}, hashKey.getFieldPaths());
+        assertNull("a plain List type must not be created for a hash-keyed field",
+            writeStateEngine.getSchema("ListOfNeighbor"));
+
+        // The parent object references the Set type.
+        HollowObjectSchema niSchema = (HollowObjectSchema) writeStateEngine.getSchema("NetworkInterface");
+        assertEquals("SetOfNeighbor",
+            niSchema.getReferencedType(niSchema.getPosition("neighbors")));
+
+        // Round-trip the data.
+        int ordinal = mapper.add(networkInterface);
+        assertTrue("Ordinal should be non-negative", ordinal >= 0);
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine);
+
+        // Both neighbors round-trip back through the (still repeated) proto field.
+        Message readBack = mapper.readHollowRecord(
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(
+                readStateEngine, "NetworkInterface", ordinal),
+            networkInterface.getDescriptorForType());
+        Descriptors.FieldDescriptor neighborsField =
+            networkInterface.getDescriptorForType().findFieldByName("neighbors");
+        assertEquals("both set elements must round-trip", 2,
+            readBack.getRepeatedFieldCount(neighborsField));
+
+        // The hash key is functional: look up an element by addr within the set's scope.
+        com.netflix.hollow.api.objects.generic.GenericHollowObject niRecord =
+            new com.netflix.hollow.api.objects.generic.GenericHollowObject(
+                readStateEngine, "NetworkInterface", ordinal);
+        com.netflix.hollow.api.objects.generic.GenericHollowSet neighborSet =
+            (com.netflix.hollow.api.objects.generic.GenericHollowSet)
+                niRecord.getReferencedGenericRecord("neighbors");
+        assertNotNull("neighbors must be a Set on the read side", neighborSet);
+        com.netflix.hollow.api.objects.HollowRecord found = neighborSet.findElement("10.0.0.2");
+        assertNotNull("findElement by hash key (addr) must locate the neighbor", found);
+        assertEquals("10.0.0.2",
+            ((com.netflix.hollow.api.objects.generic.GenericHollowObject) found).getString("addr"));
+    }
+
     @Test
     public void testHollowTypeNameOption() throws Exception {
         // Load Product proto class

--- a/hollow-protoadapter/src/test/resources/test_person.proto
+++ b/hollow-protoadapter/src/test/resources/test_person.proto
@@ -114,3 +114,21 @@ message BadUnsigned {
   int32 id = 1;
   uint32 counter = 2;  // Missing required annotation - should fail
 }
+
+// Test messages for the hollow_hash_key option — a keyed Hollow Set.
+// Mirrors @HollowHashKey(fields={"addr"}) on a Set<Neighbor> in the POJO model:
+// Neighbor has its own compound primary key (globally unique), but within a
+// NetworkInterface the neighbors are a Set keyed by addr (unique in that scope).
+message NetworkInterface {
+  option (com.netflix.hollow.hollow_primary_key) = {fields: ["name"]};
+
+  string name = 1;
+  repeated Neighbor neighbors = 2 [(com.netflix.hollow.hollow_hash_key) = {fields: ["addr"]}];
+}
+
+message Neighbor {
+  option (com.netflix.hollow.hollow_primary_key) = {fields: ["target", "addr"]};
+
+  string target = 1;
+  string addr = 2;
+}


### PR DESCRIPTION
## Summary

Adds a `hollow_hash_key` **field option** to the proto adaptor that promotes a `repeated` field to a Hollow **Set** (instead of a List) carrying a hash key, enabling keyed lookup of elements within that field's scope. This is the proto mirror of `@HollowHashKey(fields = {...})` on a `Set<T>` field in `HollowObjectMapper`.

Field-scoped to match the POJO annotation (which sits on the field), just as the existing message-scoped `hollow_primary_key` mirrors the type-level `@HollowPrimaryKey`:

```protobuf
message NetworkInterface {
  option (com.netflix.hollow.hollow_primary_key) = {fields: ["name"]};
  string name = 1;
  // Stored as Hollow Set "SetOfNeighbor" keyed by the element's addr field
  repeated Neighbor neighbors = 2 [(com.netflix.hollow.hollow_hash_key) = {fields: ["addr"]}];
}

message Neighbor {
  option (com.netflix.hollow.hollow_primary_key) = {fields: ["target", "addr"]}; // globally unique
  string target = 1;
  string addr = 2; // ...but keyed by addr alone within a NetworkInterface's set
}
```

## Why a literal Set (not list-dedup)

`hollow_ignore_list_ordering` only sorts ordinals into a `HollowListWriteRecord` — the schema stays a `LIST`, which cannot carry a hash key. A real `HollowSetSchema` is required for keyed lookup, and it's what makes proto ↔ Hollow ↔ POJO data interchangeable.

## Round-trip fidelity

The generated Set type is named `SetOf<Element>`, matching `HollowTypeMapper.getDefaultTypeName`, so proto-produced and POJO-produced data share the same schema. The element type's own `hollow_primary_key` is independent of the set's hash key — both coexist (as above).

> Note: hash-key field paths reference the element's **proto** field names (snake_case), consistent with how `hollow_primary_key` already works. Proto-side schemas therefore use proto field names while POJO-side use Java names — a pre-existing characteristic of the adaptor, not introduced here.

## Changes

- **`hollow_options.proto`**: new `HollowHashKey` message + `hollow_hash_key` field option (ext `50005`).
- **`HollowMessageMapper`**: when the option is present, infer a `HollowSetSchema` + `HollowSetTypeWriteState` with the hash key instead of a List; new `readHollowHashKeyFields` helper; read path gains a `GenericHollowSet` branch (snapshot/delta) and a `FlatRecordTraversalSetNode` branch (flat records); `readListElement` refactored into a shared `convertCollectionElement`.
- The **write path needed no changes** — it was already generic over `HollowCollectionSchema`.
- Without the option, repeated fields still map to a Hollow `LIST` (element order preserved) — no behavior change for existing protos.
- README + `test_person.proto` (`NetworkInterface`/`Neighbor`) updated.

## Test Plan

- [x] `testHollowHashKeyProducesKeyedSet` — asserts the field infers a `HollowSetSchema` with hash key `[addr]` (and no `ListOfNeighbor` type), round-trips both elements through the proto field, and that `findElement("10.0.0.2")` keyed lookup works.
- [x] Full `:hollow-protoadapter:test` suite passes (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)