### PR TITLE
add null check before calling method on diff object

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/tools/diff/count/HollowDiffCountingNode.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/diff/count/HollowDiffCountingNode.java
@@ -47,7 +47,7 @@ public abstract class HollowDiffCountingNode {
     public HollowDiffCountingNode(HollowDiff diff, HollowTypeDiff topLevelTypeDiff, HollowDiffNodeIdentifier nodeId) {
         this.diff = diff;
         this.topLevelTypeDiff = topLevelTypeDiff;
-        this.equalityMapping = diff.getEqualityMapping();
+        this.equalityMapping = diff == null ? null : diff.getEqualityMapping();
         this.nodeId = nodeId;
     }
 


### PR DESCRIPTION
one of the subclass is HollowDiffMissingCountingNode will through NPE when calling super class constructor