### PR TITLE
Fix DDD Validator to update lagged index during a failed cycle

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -200,7 +200,6 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
         return NAME + "_" + dataTypeName;
     }
 
-    // Drop the retained lagged index (and its engine binding) so the next cycle rebuilds a baseline.
     private void dropLaggedIndex() {
         previousCycleIndex = null;
         indexStateEngine = null;
@@ -211,18 +210,18 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
         ValidationResult.ValidationResultBuilder vrb = ValidationResult.from(this);
         vrb.detail(DATA_TYPE_NAME, dataTypeName);
 
+        HollowReadStateEngine stateEngine = readState.getStateEngine();
+
         PrimaryKey primaryKey;
         if (fieldPathNames == null) {
-            HollowSchema schema = readState.getStateEngine().getSchema(dataTypeName);
+            HollowSchema schema = stateEngine.getSchema(dataTypeName);
             if (schema == null) {
                 return vrb.failed(String.format(NO_SCHEMA_FOUND_MSG_FORMAT, dataTypeName));
             }
             if (schema.getSchemaType() != SchemaType.OBJECT) {
                 return vrb.failed(String.format(NOT_AN_OBJECT_ERROR_MSG_FORMAT, dataTypeName));
             }
-
-            HollowObjectSchema oSchema = (HollowObjectSchema) schema;
-            primaryKey = oSchema.getPrimaryKey();
+            primaryKey = ((HollowObjectSchema) schema).getPrimaryKey();
             if (primaryKey == null) {
                 return vrb.failed(String.format(NO_PRIMARY_KEY_ERROR_MSG_FORMAT, dataTypeName));
             }
@@ -233,79 +232,73 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
         String fieldPaths = Arrays.toString(primaryKey.getFieldPaths());
         vrb.detail(FIELD_PATH_NAME, fieldPaths);
 
-        HollowReadStateEngine stateEngine = readState.getStateEngine();
-        boolean useIncremental = Boolean.TRUE.equals(incrementalEnabled.get());
+        if (!Boolean.TRUE.equals(incrementalEnabled.get())) {
+            return validateFullScan(stateEngine, primaryKey, fieldPaths, vrb);
+        }
 
-        if (!useIncremental) {
-            // Full-scan-per-cycle path. Drop any stale lagged index so a later flip back to
-            // incremental rebuilds from a fresh baseline. The fresh index built here is discarded.
-            dropLaggedIndex();
-            LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': full-scan mode.", dataTypeName));
-            HollowPrimaryKeyIndex index = new HollowPrimaryKeyIndex(stateEngine, primaryKey);
-            Collection<DuplicateKeyInfo> duplicateKeys = index.getDuplicateKeys(MAX_DISPLAYED_DUPLICATE_KEYS);
-            if (!duplicateKeys.isEmpty()) {
-                return vrb.failed(String.format(DUPLICATE_KEYS_FOUND_ERRRO_MSG_FORMAT, dataTypeName, fieldPaths,
-                        duplicateKeysToString(duplicateKeys)));
-            }
+        dropLaggedIndexIfEngineChanged(stateEngine);
+        return previousCycleIndex == null
+                ? validateSnapshotBaseline(stateEngine, primaryKey, fieldPaths, vrb)
+                : validateDelta(stateEngine, fieldPaths, vrb);
+    }
+
+    private ValidationResult validateFullScan(HollowReadStateEngine stateEngine, PrimaryKey primaryKey,
+                                              String fieldPaths, ValidationResult.ValidationResultBuilder vrb) {
+        dropLaggedIndex();
+        LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': full-scan mode.", dataTypeName));
+        return checkForDuplicates(new HollowPrimaryKeyIndex(stateEngine, primaryKey), fieldPaths, vrb);
+    }
+
+    private ValidationResult validateSnapshotBaseline(HollowReadStateEngine stateEngine, PrimaryKey primaryKey,
+                                                      String fieldPaths, ValidationResult.ValidationResultBuilder vrb) {
+        previousCycleIndex = new HollowPrimaryKeyIndex(stateEngine, primaryKey);
+        indexStateEngine = stateEngine;
+        cycleAction = CycleAction.BUILT_BASELINE;
+        LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': incremental mode, snapshot baseline.", dataTypeName));
+        return checkForDuplicates(previousCycleIndex, fieldPaths, vrb);
+    }
+
+    private ValidationResult checkForDuplicates(HollowPrimaryKeyIndex index, String fieldPaths,
+                                                ValidationResult.ValidationResultBuilder vrb) {
+        Collection<DuplicateKeyInfo> duplicateKeys = index.getDuplicateKeys(MAX_DISPLAYED_DUPLICATE_KEYS);
+        if (!duplicateKeys.isEmpty()) {
+            return vrb.failed(String.format(DUPLICATE_KEYS_FOUND_ERRRO_MSG_FORMAT, dataTypeName, fieldPaths,
+                    duplicateKeysToString(duplicateKeys)));
+        }
+        return vrb.passed();
+    }
+
+    private ValidationResult validateDelta(HollowReadStateEngine stateEngine, String fieldPaths,
+                                           ValidationResult.ValidationResultBuilder vrb) {
+        cycleAction = CycleAction.RAN_DELTA;
+        HollowTypeReadState typeState = stateEngine.getTypeState(dataTypeName);
+        PopulatedOrdinalListener listener = typeState.getListener(PopulatedOrdinalListener.class);
+        BitSet populatedOrdinals = listener.getPopulatedOrdinals();
+        BitSet previousOrdinals = listener.getPreviousOrdinals();
+
+        BitSet newOrdinals = new BitSet(Math.max(populatedOrdinals.size(), previousOrdinals.size()));
+        newOrdinals.or(populatedOrdinals);
+        newOrdinals.andNot(previousOrdinals);
+
+        LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': incremental mode, delta (%d total, %d new ordinals).",
+                dataTypeName, populatedOrdinals.cardinality(), newOrdinals.cardinality()));
+
+        if (newOrdinals.isEmpty()) {
             return vrb.passed();
         }
+        List<Object[]> duplicateKeys = findDuplicateKeysInDelta(previousCycleIndex, newOrdinals, populatedOrdinals);
+        if (!duplicateKeys.isEmpty()) {
+            return vrb.failed(String.format(DUPLICATE_KEYS_FOUND_DELTA_MSG_FORMAT, dataTypeName, fieldPaths,
+                    deltaDuplicateKeysToString(duplicateKeys)));
+        }
+        return vrb.passed();
+    }
 
+    // A new engine instance (restore / reinit / schema change) leaves the lagged index's ordinals stale.
+    private void dropLaggedIndexIfEngineChanged(HollowReadStateEngine stateEngine) {
         if (previousCycleIndex != null && stateEngine != indexStateEngine) {
-            // Read-state engine swapped (restore / reinit / schema change / snapshot) — the lagged
-            // index's ordinal space no longer matches it. Drop it so this cycle rebuilds a baseline.
             dropLaggedIndex();
         }
-
-        ValidationResult result;
-        if (previousCycleIndex == null) {
-            // Incremental mode, first cycle (or after restore / kill-switch toggle): full snapshot,
-            // and retain the index so subsequent cycles can run the delta path.
-            previousCycleIndex = new HollowPrimaryKeyIndex(stateEngine, primaryKey);
-            indexStateEngine = stateEngine;
-            cycleAction = CycleAction.BUILT_BASELINE;
-            LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': incremental mode, snapshot baseline.",
-                    dataTypeName));
-
-            Collection<DuplicateKeyInfo> duplicateKeys = previousCycleIndex.getDuplicateKeys(MAX_DISPLAYED_DUPLICATE_KEYS);
-            if (!duplicateKeys.isEmpty()) {
-                String message = String.format(DUPLICATE_KEYS_FOUND_ERRRO_MSG_FORMAT, dataTypeName, fieldPaths,
-                        duplicateKeysToString(duplicateKeys));
-                result = vrb.failed(message);
-            } else {
-                result = vrb.passed();
-            }
-        } else {
-            cycleAction = CycleAction.RAN_DELTA;
-            HollowTypeReadState typeState = stateEngine.getTypeState(dataTypeName);
-            PopulatedOrdinalListener listener = typeState.getListener(PopulatedOrdinalListener.class);
-            BitSet populatedOrdinals = listener.getPopulatedOrdinals();
-            BitSet previousOrdinals = listener.getPreviousOrdinals();
-
-            // Pre-size to avoid resizing during the or/andNot below; BitSet.size() returns allocated
-            // bit capacity (a multiple of 64), which is what the BitSet(int) constructor expects.
-            BitSet newOrdinals = new BitSet(Math.max(populatedOrdinals.size(), previousOrdinals.size()));
-            newOrdinals.or(populatedOrdinals);
-            newOrdinals.andNot(previousOrdinals);
-
-            LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': incremental mode, delta (%d total, %d new ordinals).",
-                    dataTypeName, populatedOrdinals.cardinality(), newOrdinals.cardinality()));
-
-            if (!newOrdinals.isEmpty()) {
-                List<Object[]> duplicateKeys = findDuplicateKeysInDelta(
-                        previousCycleIndex, newOrdinals, populatedOrdinals);
-                if (!duplicateKeys.isEmpty()) {
-                    String message = String.format(DUPLICATE_KEYS_FOUND_DELTA_MSG_FORMAT, dataTypeName, fieldPaths,
-                            deltaDuplicateKeysToString(duplicateKeys));
-                    result = vrb.failed(message);
-                } else {
-                    result = vrb.passed();
-                }
-            } else {
-                result = vrb.passed();
-            }
-        }
-
-        return result;
     }
 
     /**
@@ -389,8 +382,7 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
                 previousCycleIndex.endUpdate();
             }
         } else if (cycleAction == CycleAction.BUILT_BASELINE) {
-            // the cycle did not succed and therefore we need to drop
-            // the now outdated index.
+            // A baseline built this cycle was rolled back; drop it so the next cycle rebuilds.
             dropLaggedIndex();
         }
         cycleAction = CycleAction.NONE;

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -107,6 +107,9 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
     private enum CycleAction { NONE, BUILT_BASELINE, RAN_DELTA }
     private CycleAction cycleAction = CycleAction.NONE;
 
+    // The read-state engine previousCycleIndex is bound to; a change means the lagged index is stale.
+    private HollowReadStateEngine indexStateEngine;
+
     /**
      * Creates a validator to detect duplicate records of the type that corresponds to the given data type class
      * annotated with {@link HollowPrimaryKey}.
@@ -197,6 +200,12 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
         return NAME + "_" + dataTypeName;
     }
 
+    // Drop the retained lagged index (and its engine binding) so the next cycle rebuilds a baseline.
+    private void dropLaggedIndex() {
+        previousCycleIndex = null;
+        indexStateEngine = null;
+    }
+
     @Override
     public ValidationResult onValidate(ReadState readState) {
         ValidationResult.ValidationResultBuilder vrb = ValidationResult.from(this);
@@ -230,7 +239,7 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
         if (!useIncremental) {
             // Full-scan-per-cycle path. Drop any stale lagged index so a later flip back to
             // incremental rebuilds from a fresh baseline. The fresh index built here is discarded.
-            previousCycleIndex = null;
+            dropLaggedIndex();
             LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': full-scan mode.", dataTypeName));
             HollowPrimaryKeyIndex index = new HollowPrimaryKeyIndex(stateEngine, primaryKey);
             Collection<DuplicateKeyInfo> duplicateKeys = index.getDuplicateKeys(MAX_DISPLAYED_DUPLICATE_KEYS);
@@ -241,11 +250,18 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
             return vrb.passed();
         }
 
+        if (previousCycleIndex != null && stateEngine != indexStateEngine) {
+            // Read-state engine swapped (restore / reinit / schema change / snapshot) — the lagged
+            // index's ordinal space no longer matches it. Drop it so this cycle rebuilds a baseline.
+            dropLaggedIndex();
+        }
+
         ValidationResult result;
         if (previousCycleIndex == null) {
             // Incremental mode, first cycle (or after restore / kill-switch toggle): full snapshot,
             // and retain the index so subsequent cycles can run the delta path.
             previousCycleIndex = new HollowPrimaryKeyIndex(stateEngine, primaryKey);
+            indexStateEngine = stateEngine;
             cycleAction = CycleAction.BUILT_BASELINE;
             LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': incremental mode, snapshot baseline.",
                     dataTypeName));
@@ -289,7 +305,6 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
             }
         }
 
-        // Index is advanced in onCycleComplete, gated on cycle success — not on this check passing.
         return result;
     }
 
@@ -352,7 +367,7 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
             LOG.info(String.format(
                     "Incremental duplicate data detection for type '%s': dropping lagged index due to producer restore to version %d.",
                     dataTypeName, restoreVersion));
-            previousCycleIndex = null;
+            dropLaggedIndex();
         }
     }
 
@@ -374,8 +389,9 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
                 previousCycleIndex.endUpdate();
             }
         } else if (cycleAction == CycleAction.BUILT_BASELINE) {
-            // Baseline built this cycle reflects a rolled-back state; drop it so the next cycle rebuilds.
-            previousCycleIndex = null;
+            // the cycle did not succed and therefore we need to drop
+            // the now outdated index.
+            dropLaggedIndex();
         }
         cycleAction = CycleAction.NONE;
     }

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -379,7 +379,15 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
         if (status.getType() == Status.StatusType.SUCCESS) {
             // Advance a delta cycle's index to the committed state; a fresh baseline already reflects it.
             if (cycleAction == CycleAction.RAN_DELTA && previousCycleIndex != null) {
-                previousCycleIndex.endUpdate();
+                try {
+                    previousCycleIndex.endUpdate();
+                } catch (RuntimeException e) {
+                    LOG.log(Level.WARNING, String.format(
+                            "Incremental duplicate data detection for type '%s': failed to advance lagged index "
+                                    + "to version %d; dropping it so the next cycle rebuilds from a snapshot baseline.",
+                            dataTypeName, version), e);
+                    dropLaggedIndex();
+                }
             }
         } else if (cycleAction == CycleAction.BUILT_BASELINE) {
             // A baseline built this cycle was rolled back; drop it so the next cycle rebuilds.

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -19,6 +19,7 @@ package com.netflix.hollow.api.producer.validation;
 import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.api.producer.HollowProducer.ReadState;
 import com.netflix.hollow.api.producer.Status;
+import com.netflix.hollow.api.producer.listener.CycleListener;
 import com.netflix.hollow.api.producer.listener.RestoreListener;
 import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
 import com.netflix.hollow.core.index.HollowPrimaryKeyIndex.DuplicateKeyInfo;
@@ -58,7 +59,7 @@ import java.util.stream.Collectors;
  * stage will be naturally de-duped resulting in just one record present.  Therefore a validator created for such a
  * record's type will never fail.
  */
-public class DuplicateDataDetectionValidator implements ValidatorListener, RestoreListener {
+public class DuplicateDataDetectionValidator implements ValidatorListener, RestoreListener, CycleListener {
     private static final Logger LOG = Logger.getLogger(DuplicateDataDetectionValidator.class.getName());
     private static final int MAX_DISPLAYED_DUPLICATE_KEYS = 100;
     private static final String DUPLICATE_KEYS_FOUND_ERRRO_MSG_FORMAT =
@@ -99,8 +100,12 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
      */
     private final Supplier<Boolean> incrementalEnabled;
 
-    /** Lagged index reflecting the last successful cycle; advanced via {@code endUpdate()} on pass. */
+    /** Lagged index reflecting the last committed cycle; advanced via {@code endUpdate()}. */
     private HollowPrimaryKeyIndex previousCycleIndex;
+
+    // What onValidate did this cycle; consumed by onCycleComplete to advance/reset previousCycleIndex.
+    private enum CycleAction { NONE, BUILT_BASELINE, RAN_DELTA }
+    private CycleAction cycleAction = CycleAction.NONE;
 
     /**
      * Creates a validator to detect duplicate records of the type that corresponds to the given data type class
@@ -241,6 +246,7 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
             // Incremental mode, first cycle (or after restore / kill-switch toggle): full snapshot,
             // and retain the index so subsequent cycles can run the delta path.
             previousCycleIndex = new HollowPrimaryKeyIndex(stateEngine, primaryKey);
+            cycleAction = CycleAction.BUILT_BASELINE;
             LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': incremental mode, snapshot baseline.",
                     dataTypeName));
 
@@ -253,6 +259,7 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
                 result = vrb.passed();
             }
         } else {
+            cycleAction = CycleAction.RAN_DELTA;
             HollowTypeReadState typeState = stateEngine.getTypeState(dataTypeName);
             PopulatedOrdinalListener listener = typeState.getListener(PopulatedOrdinalListener.class);
             BitSet populatedOrdinals = listener.getPopulatedOrdinals();
@@ -282,11 +289,7 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
             }
         }
 
-        // Advance index only on pass — failed cycles don't change published state
-        if (result.isPassed()) {
-            previousCycleIndex.endUpdate();
-        }
-
+        // Index is advanced in onCycleComplete, gated on cycle success — not on this check passing.
         return result;
     }
 
@@ -355,6 +358,35 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
 
     @Override
     public void onProducerRestoreComplete(Status status, long versionDesired, long versionReached, Duration elapsed) {
+        // no-op
+    }
+
+    @Override
+    public void onCycleStart(long version) {
+        cycleAction = CycleAction.NONE;
+    }
+
+    @Override
+    public void onCycleComplete(Status status, ReadState readState, long version, Duration elapsed) {
+        if (status.getType() == Status.StatusType.SUCCESS) {
+            // Advance a delta cycle's index to the committed state; a fresh baseline already reflects it.
+            if (cycleAction == CycleAction.RAN_DELTA && previousCycleIndex != null) {
+                previousCycleIndex.endUpdate();
+            }
+        } else if (cycleAction == CycleAction.BUILT_BASELINE) {
+            // Baseline built this cycle reflects a rolled-back state; drop it so the next cycle rebuilds.
+            previousCycleIndex = null;
+        }
+        cycleAction = CycleAction.NONE;
+    }
+
+    @Override
+    public void onNewDeltaChain(long version) {
+        // no-op
+    }
+
+    @Override
+    public void onCycleSkip(CycleListener.CycleSkipReason reason) {
         // no-op
     }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -393,7 +393,9 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
             // A baseline built this cycle was rolled back; drop it so the next cycle rebuilds.
             dropLaggedIndex();
         }
-        cycleAction = CycleAction.NONE;
+        // A failed RAN_DELTA cycle needs no action: the producer rolls the delta back to the prior
+        // version, which previousCycleIndex still reflects (it was never advanced). cycleAction is
+        // reset by onCycleStart, which the producer guarantees runs before the next cycle.
     }
 
     @Override

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
@@ -567,6 +567,52 @@ public class DuplicateDataDetectionValidatorTests {
         });
     }
 
+    /**
+     * A retained validator reused across a producer reinit (new read-state engine, no restore event)
+     * must detect the engine change and rebuild a baseline rather than run a delta against the stale
+     * engine the lagged index was bound to. Asserts the snapshot (full-scan) path is taken.
+     */
+    @Test
+    public void producerReinitRebuildsBaselineViaEngineChange() {
+        DuplicateDataDetectionValidator validator =
+                new DuplicateDataDetectionValidator(TypeWithPrimaryKey.class, () -> true);
+
+        // Producer 1: baseline + delta, so the validator retains a lagged index bound to its engine.
+        HollowProducer producer1 = HollowProducer.withPublisher(new InMemoryBlobStore())
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(validator)
+                .build();
+        producer1.runCycle(ws -> {
+            ws.add(new TypeWithPrimaryKey(1, "A"));
+            ws.add(new TypeWithPrimaryKey(2, "B"));
+        });
+        producer1.runCycle(ws -> {
+            ws.add(new TypeWithPrimaryKey(1, "A"));
+            ws.add(new TypeWithPrimaryKey(2, "B"));
+            ws.add(new TypeWithPrimaryKey(3, "C"));
+        });
+
+        // Producer 2 reuses the SAME validator but has a brand-new read-state engine. The retained
+        // index is bound to producer 1's engine, so the validator must rebuild a baseline (snapshot
+        // path) instead of running a delta against the stale engine. A duplicate must be caught with
+        // snapshot-path (full count) semantics, proving the baseline was rebuilt.
+        HollowProducer producer2 = HollowProducer.withPublisher(new InMemoryBlobStore())
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(validator)
+                .build();
+        try {
+            producer2.runCycle(ws -> {
+                ws.add(new TypeWithPrimaryKey(1, "A"));
+                ws.add(new TypeWithPrimaryKey(1, "A_dup"));
+            });
+            Assert.fail("Expected ValidationStatusException");
+        } catch (ValidationStatusException expected) {
+            String message = expected.getValidationStatus().getResults().get(0).getMessage();
+            Assert.assertTrue("Engine change should force the snapshot path, not a stale delta",
+                    message.contains("distinct keys that each have duplicate records affecting"));
+        }
+    }
+
     @HollowPrimaryKey(fields = {"id"})
     static class TypeWithPrimaryKey {
         int id;

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
@@ -500,49 +500,28 @@ public class DuplicateDataDetectionValidatorTests {
         }
     }
 
-    /**
-     * Regression for the production false positives on the incremental DDD circuit-breaker path: a
-     * cycle whose duplicate check PASSES can still fail because another validator trips. The producer
-     * then rolls the read state back via the reverse delta, and follow-mode re-runs the same version.
-     * The lagged index must NOT have advanced on the failed cycle, otherwise the retry's delta check
-     * flags every genuinely-new record as a duplicate. The data here never contains a real duplicate
-     * primary key, so any failure of the duplicate validator on the retry is a false positive.
-     */
     @Test
     public void deltaIndexNotAdvancedWhenAnotherValidatorFailsTheCycle() {
-        AtomicBoolean failOtherValidator = new AtomicBoolean(false);
+        ToggleValidator otherValidator = new ToggleValidator();
         HollowProducer producer = HollowProducer.withPublisher(blobStore)
                 .withBlobStager(new HollowInMemoryBlobStager())
                 .withListener(new DuplicateDataDetectionValidator(TypeWithPrimaryKey.class, () -> true))
-                // A second, unrelated validator tripped on demand to fail the cycle AFTER the duplicate
-                // check has already passed (mirrors e.g. a cardinality circuit breaker).
-                .withListener(new ValidatorListener() {
-                    @Override public String getName() { return "FailOnDemandValidator"; }
-                    @Override public ValidationResult onValidate(HollowProducer.ReadState readState) {
-                        return failOtherValidator.get()
-                                ? ValidationResult.from(this).failed("forced failure")
-                                : ValidationResult.from(this).passed();
-                    }
-                })
+                .withListener(otherValidator)
                 .build();
 
-        // Cycle 1 (snapshot baseline): unique records — passes.
+        // Snapshot baseline, then a clean delta: the lagged index advances to {1,2,3}.
         producer.runCycle(writeState -> {
             writeState.add(new TypeWithPrimaryKey(1, "A"));
             writeState.add(new TypeWithPrimaryKey(2, "B"));
         });
-
-        // Cycle 2 (delta): unique records — passes; lagged index advances to {1,2,3}.
         producer.runCycle(writeState -> {
             writeState.add(new TypeWithPrimaryKey(1, "A"));
             writeState.add(new TypeWithPrimaryKey(2, "B"));
             writeState.add(new TypeWithPrimaryKey(3, "C"));
         });
 
-        // Cycle 3 (delta): adds key 4 (no real duplicate), but the OTHER validator trips and fails the
-        // cycle. The duplicate check passes here, so the broken version advanced the lagged index to
-        // {1,2,3,4}; the producer then rolls the read state back to {1,2,3}.
-        failOtherValidator.set(true);
+        // Delta adds key 4 (no duplicate); the duplicate check passes but the other validator fails the cycle.
+        otherValidator.fail.set(true);
         try {
             producer.runCycle(writeState -> {
                 writeState.add(new TypeWithPrimaryKey(1, "A"));
@@ -550,15 +529,13 @@ public class DuplicateDataDetectionValidatorTests {
                 writeState.add(new TypeWithPrimaryKey(3, "C"));
                 writeState.add(new TypeWithPrimaryKey(4, "D"));
             });
-            Assert.fail("Expected the cycle to fail due to the other validator");
+            Assert.fail("Expected ValidationStatusException");
         } catch (ValidationStatusException expected) {
-            // expected — failure comes from FailOnDemandValidator, not the duplicate validator
+            // the other validator failed, not the duplicate check
         }
 
-        // Cycle 4 (retry of the same data): the other validator passes now. The duplicate validator
-        // must NOT report a false positive — there has never been a duplicate primary key. Before the
-        // fix the lagged index was a version ahead of the rolled-back read state and key 4 was flagged.
-        failOtherValidator.set(false);
+        // Retry of the same data must not report a false duplicate.
+        otherValidator.fail.set(false);
         producer.runCycle(writeState -> {
             writeState.add(new TypeWithPrimaryKey(1, "A"));
             writeState.add(new TypeWithPrimaryKey(2, "B"));
@@ -567,49 +544,106 @@ public class DuplicateDataDetectionValidatorTests {
         });
     }
 
-    /**
-     * A retained validator reused across a producer reinit (new read-state engine, no restore event)
-     * must detect the engine change and rebuild a baseline rather than run a delta against the stale
-     * engine the lagged index was bound to. Asserts the snapshot (full-scan) path is taken.
-     */
+    @Test
+    public void baselineDroppedWhenAnotherValidatorFailsTheCycle() {
+        AtomicBoolean incremental = new AtomicBoolean(true);
+        ToggleValidator otherValidator = new ToggleValidator();
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new DuplicateDataDetectionValidator(TypeWithPrimaryKey.class, incremental::get))
+                .withListener(otherValidator)
+                .build();
+
+        // Incremental baseline, then a full-scan cycle that drops the retained index.
+        producer.runCycle(writeState -> {
+            writeState.add(new TypeWithPrimaryKey(1, "A"));
+            writeState.add(new TypeWithPrimaryKey(2, "B"));
+        });
+        incremental.set(false);
+        producer.runCycle(writeState -> {
+            writeState.add(new TypeWithPrimaryKey(1, "A"));
+            writeState.add(new TypeWithPrimaryKey(2, "B"));
+            writeState.add(new TypeWithPrimaryKey(3, "C"));
+        });
+
+        // Back to incremental: this cycle rebuilds the baseline, but the other validator fails the cycle.
+        incremental.set(true);
+        otherValidator.fail.set(true);
+        try {
+            producer.runCycle(writeState -> {
+                writeState.add(new TypeWithPrimaryKey(1, "A"));
+                writeState.add(new TypeWithPrimaryKey(2, "B"));
+                writeState.add(new TypeWithPrimaryKey(3, "C"));
+                writeState.add(new TypeWithPrimaryKey(4, "D"));
+            });
+            Assert.fail("Expected ValidationStatusException");
+        } catch (ValidationStatusException expected) {
+            // the other validator failed, not the duplicate check
+        }
+
+        // Retry of the same data must not report a false duplicate (the dropped baseline is rebuilt).
+        otherValidator.fail.set(false);
+        producer.runCycle(writeState -> {
+            writeState.add(new TypeWithPrimaryKey(1, "A"));
+            writeState.add(new TypeWithPrimaryKey(2, "B"));
+            writeState.add(new TypeWithPrimaryKey(3, "C"));
+            writeState.add(new TypeWithPrimaryKey(4, "D"));
+        });
+    }
+
     @Test
     public void producerReinitRebuildsBaselineViaEngineChange() {
         DuplicateDataDetectionValidator validator =
                 new DuplicateDataDetectionValidator(TypeWithPrimaryKey.class, () -> true);
 
-        // Producer 1: baseline + delta, so the validator retains a lagged index bound to its engine.
-        HollowProducer producer1 = HollowProducer.withPublisher(new InMemoryBlobStore())
+        // First producer: baseline + delta, so the validator retains an index bound to this engine.
+        HollowProducer producer1 = HollowProducer.withPublisher(blobStore)
                 .withBlobStager(new HollowInMemoryBlobStager())
                 .withListener(validator)
                 .build();
-        producer1.runCycle(ws -> {
-            ws.add(new TypeWithPrimaryKey(1, "A"));
-            ws.add(new TypeWithPrimaryKey(2, "B"));
+        producer1.runCycle(writeState -> {
+            writeState.add(new TypeWithPrimaryKey(1, "A"));
+            writeState.add(new TypeWithPrimaryKey(2, "B"));
         });
-        producer1.runCycle(ws -> {
-            ws.add(new TypeWithPrimaryKey(1, "A"));
-            ws.add(new TypeWithPrimaryKey(2, "B"));
-            ws.add(new TypeWithPrimaryKey(3, "C"));
+        producer1.runCycle(writeState -> {
+            writeState.add(new TypeWithPrimaryKey(1, "A"));
+            writeState.add(new TypeWithPrimaryKey(2, "B"));
+            writeState.add(new TypeWithPrimaryKey(3, "C"));
         });
 
-        // Producer 2 reuses the SAME validator but has a brand-new read-state engine. The retained
-        // index is bound to producer 1's engine, so the validator must rebuild a baseline (snapshot
-        // path) instead of running a delta against the stale engine. A duplicate must be caught with
-        // snapshot-path (full count) semantics, proving the baseline was rebuilt.
+        // A second producer reuses the same validator but has a new engine (reinit, not a restore).
+        // The stale index must be dropped and a baseline rebuilt, so a duplicate is caught on the
+        // snapshot path (exact counts) rather than missed by a delta against the old engine.
         HollowProducer producer2 = HollowProducer.withPublisher(new InMemoryBlobStore())
                 .withBlobStager(new HollowInMemoryBlobStager())
                 .withListener(validator)
                 .build();
         try {
-            producer2.runCycle(ws -> {
-                ws.add(new TypeWithPrimaryKey(1, "A"));
-                ws.add(new TypeWithPrimaryKey(1, "A_dup"));
+            producer2.runCycle(writeState -> {
+                writeState.add(new TypeWithPrimaryKey(1, "A"));
+                writeState.add(new TypeWithPrimaryKey(1, "A_dup"));
             });
             Assert.fail("Expected ValidationStatusException");
         } catch (ValidationStatusException expected) {
             String message = expected.getValidationStatus().getResults().get(0).getMessage();
-            Assert.assertTrue("Engine change should force the snapshot path, not a stale delta",
-                    message.contains("distinct keys that each have duplicate records affecting"));
+            Assert.assertTrue(message.contains("distinct keys that each have duplicate records affecting"));
+        }
+    }
+
+    // A second validator the test can switch on to fail a cycle after the duplicate check has passed.
+    private static final class ToggleValidator implements ValidatorListener {
+        final AtomicBoolean fail = new AtomicBoolean(false);
+
+        @Override
+        public String getName() {
+            return "ToggleValidator";
+        }
+
+        @Override
+        public ValidationResult onValidate(HollowProducer.ReadState readState) {
+            return fail.get()
+                    ? ValidationResult.from(this).failed("forced failure")
+                    : ValidationResult.from(this).passed();
         }
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
@@ -500,6 +500,73 @@ public class DuplicateDataDetectionValidatorTests {
         }
     }
 
+    /**
+     * Regression for the production false positives on the incremental DDD circuit-breaker path: a
+     * cycle whose duplicate check PASSES can still fail because another validator trips. The producer
+     * then rolls the read state back via the reverse delta, and follow-mode re-runs the same version.
+     * The lagged index must NOT have advanced on the failed cycle, otherwise the retry's delta check
+     * flags every genuinely-new record as a duplicate. The data here never contains a real duplicate
+     * primary key, so any failure of the duplicate validator on the retry is a false positive.
+     */
+    @Test
+    public void deltaIndexNotAdvancedWhenAnotherValidatorFailsTheCycle() {
+        AtomicBoolean failOtherValidator = new AtomicBoolean(false);
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new DuplicateDataDetectionValidator(TypeWithPrimaryKey.class, () -> true))
+                // A second, unrelated validator tripped on demand to fail the cycle AFTER the duplicate
+                // check has already passed (mirrors e.g. a cardinality circuit breaker).
+                .withListener(new ValidatorListener() {
+                    @Override public String getName() { return "FailOnDemandValidator"; }
+                    @Override public ValidationResult onValidate(HollowProducer.ReadState readState) {
+                        return failOtherValidator.get()
+                                ? ValidationResult.from(this).failed("forced failure")
+                                : ValidationResult.from(this).passed();
+                    }
+                })
+                .build();
+
+        // Cycle 1 (snapshot baseline): unique records — passes.
+        producer.runCycle(writeState -> {
+            writeState.add(new TypeWithPrimaryKey(1, "A"));
+            writeState.add(new TypeWithPrimaryKey(2, "B"));
+        });
+
+        // Cycle 2 (delta): unique records — passes; lagged index advances to {1,2,3}.
+        producer.runCycle(writeState -> {
+            writeState.add(new TypeWithPrimaryKey(1, "A"));
+            writeState.add(new TypeWithPrimaryKey(2, "B"));
+            writeState.add(new TypeWithPrimaryKey(3, "C"));
+        });
+
+        // Cycle 3 (delta): adds key 4 (no real duplicate), but the OTHER validator trips and fails the
+        // cycle. The duplicate check passes here, so the broken version advanced the lagged index to
+        // {1,2,3,4}; the producer then rolls the read state back to {1,2,3}.
+        failOtherValidator.set(true);
+        try {
+            producer.runCycle(writeState -> {
+                writeState.add(new TypeWithPrimaryKey(1, "A"));
+                writeState.add(new TypeWithPrimaryKey(2, "B"));
+                writeState.add(new TypeWithPrimaryKey(3, "C"));
+                writeState.add(new TypeWithPrimaryKey(4, "D"));
+            });
+            Assert.fail("Expected the cycle to fail due to the other validator");
+        } catch (ValidationStatusException expected) {
+            // expected — failure comes from FailOnDemandValidator, not the duplicate validator
+        }
+
+        // Cycle 4 (retry of the same data): the other validator passes now. The duplicate validator
+        // must NOT report a false positive — there has never been a duplicate primary key. Before the
+        // fix the lagged index was a version ahead of the rolled-back read state and key 4 was flagged.
+        failOtherValidator.set(false);
+        producer.runCycle(writeState -> {
+            writeState.add(new TypeWithPrimaryKey(1, "A"));
+            writeState.add(new TypeWithPrimaryKey(2, "B"));
+            writeState.add(new TypeWithPrimaryKey(3, "C"));
+            writeState.add(new TypeWithPrimaryKey(4, "D"));
+        });
+    }
+
     @HollowPrimaryKey(fields = {"id"})
     static class TypeWithPrimaryKey {
         int id;


### PR DESCRIPTION
Before the DDD validator would update the lagged index based on it succeeding or failing for the current cycle. This makes the assumption that if this DDD validator succeeds, then the cycle succeeded. In reality when you have multiple validators another can fail and cause the cycle to fail. In that case this index could have been incorrectly updated as if the cycle would succeed.

To address this the PR introduces 

- CycleListener and handles index updates based on the cycle succeeding, not just this validator.
- A check `dropLaggedIndexIfEngineChanged` in case the read state engine changes