### PR TITLE
Chunk generated API constructor to avoid 64KB method limit for large data models

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
@@ -46,6 +46,7 @@ import com.netflix.hollow.core.read.dataaccess.missing.HollowSetMissingDataAcces
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.schema.HollowSchemaSorter;
 import com.netflix.hollow.core.util.AllHollowRecordCollection;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -61,6 +62,18 @@ import java.util.Set;
 public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator {
     public static final String SUB_PACKAGE_NAME = "";
 
+    /**
+     * When a data model has more than this many types, the per-type initialization that is normally
+     * inlined into the API constructor is instead split across {@code init_N(...)} helper methods.
+     * This avoids the JVM 64KB per-method bytecode limit ("code too large"), which the inlined
+     * constructor reaches somewhere past ~460 types. The threshold is set conservatively below that
+     * empirical limit; at or below it the generated source is byte-for-byte identical to before.
+     */
+    public static final int CONSTRUCTOR_CHUNKING_THRESHOLD = 250;
+
+    /** Number of types initialized per generated {@code init_N} / {@code detachCaches_N} helper. */
+    private static final int TYPES_PER_HELPER_METHOD = 50;
+
     private final boolean parameterizeClassNames;
 
     public HollowAPIClassJavaGenerator(String packageName, String apiClassname, HollowDataset dataset, boolean parameterizeClassNames, CodeGeneratorConfig config) {
@@ -72,6 +85,15 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
     @Override
     public String generate() {
         List<HollowSchema> schemaList = HollowSchemaSorter.dependencyOrderedSchemaList(dataset);
+
+        List<HollowSchema> includedSchemas = new ArrayList<HollowSchema>();
+        for (HollowSchema schema : schemaList) {
+            if (includeType(schema, dataset))
+                includedSchemas.add(schema);
+        }
+        // For very large data models, split the per-type initialization out of the constructor to
+        // stay under the JVM 64KB method size limit. Below the threshold, generate exactly as before.
+        boolean chunkInitialization = includedSchemas.size() > CONSTRUCTOR_CHUNKING_THRESHOLD;
 
         StringBuilder builder = new StringBuilder();
         appendPackageAndCommonImports(builder);
@@ -123,10 +145,14 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
 
         builder.append("    private final HollowObjectCreationSampler objectCreationSampler;\n\n");
 
+        // When initialization is chunked into helper methods, these fields can no longer be final
+        // (a final field must be assigned in the constructor itself, not in a helper method).
+        String fieldModifier = chunkInitialization ? "private " : "private final ";
+
         for (HollowSchema schema : schemaList) {
             if (!includeType(schema, dataset))
                 continue;
-            builder.append("    private final " + typeAPIClassname(schema.getName())).append(" ").append(lowercase(typeAPIClassname(schema.getName()))).append(";\n");
+            builder.append("    " + fieldModifier + typeAPIClassname(schema.getName())).append(" ").append(lowercase(typeAPIClassname(schema.getName()))).append(";\n");
         }
 
         builder.append("\n");
@@ -134,7 +160,7 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
         for(HollowSchema schema : schemaList) {
             if (!includeType(schema, dataset))
                 continue;
-            builder.append("    private final HollowObjectProvider ").append(hollowObjectProviderName(schema.getName())).append(";\n");
+            builder.append("    " + fieldModifier + "HollowObjectProvider ").append(hollowObjectProviderName(schema.getName())).append(";\n");
         }
 
         builder.append("\n");
@@ -154,58 +180,67 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
 
         builder.append("    public ").append(className).append("(HollowDataAccess dataAccess, Set<String> cachedTypes, Map<String, HollowFactory<?>> factoryOverrides, ").append(className).append(" previousCycleAPI) {\n");
         builder.append("        super(dataAccess);\n");
-        builder.append("        HollowTypeDataAccess typeDataAccess;\n");
-        builder.append("        HollowFactory factory;\n\n");
-        builder.append("        objectCreationSampler = new HollowObjectCreationSampler(");
-        for(int i=0;i<schemaList.size();i++) {
-            if (!includeType(schemaList.get(i), dataset))
-                continue;
-
-            builder.append("\"").append(schemaList.get(i).getName()).append("\"");
-            builder.append(",");
+        if (!chunkInitialization) {
+            builder.append("        HollowTypeDataAccess typeDataAccess;\n");
+            builder.append("        HollowFactory factory;\n\n");
         }
+        appendObjectCreationSampler(builder, schemaList);
 
-        if (builder.charAt(builder.length()-1) == ',') {
-            builder.deleteCharAt(builder.length()-1);
+        if (!chunkInitialization) {
+            for (HollowSchema schema : schemaList) {
+                if (!includeType(schema, dataset))
+                    continue;
+                appendTypeInitializer(builder, schema);
+            }
+            builder.append("    }\n\n");
+        } else {
+            int numInitMethods = (includedSchemas.size() + TYPES_PER_HELPER_METHOD - 1) / TYPES_PER_HELPER_METHOD;
+            for (int m = 0; m < numInitMethods; m++) {
+                builder.append("        init_").append(m).append("(dataAccess, cachedTypes, factoryOverrides, previousCycleAPI);\n");
+            }
+            builder.append("    }\n\n");
+
+            for (int m = 0; m < numInitMethods; m++) {
+                int from = m * TYPES_PER_HELPER_METHOD;
+                int to = Math.min(from + TYPES_PER_HELPER_METHOD, includedSchemas.size());
+                builder.append("    private void init_").append(m).append("(HollowDataAccess dataAccess, Set<String> cachedTypes, Map<String, HollowFactory<?>> factoryOverrides, ").append(className).append(" previousCycleAPI) {\n");
+                builder.append("        HollowTypeDataAccess typeDataAccess;\n");
+                builder.append("        HollowFactory factory;\n\n");
+                for (int i = from; i < to; i++) {
+                    appendTypeInitializer(builder, includedSchemas.get(i));
+                }
+                builder.append("    }\n\n");
+            }
         }
-
-        builder.append(");\n\n");
-
-        for (HollowSchema schema : schemaList) {
-            if (!includeType(schema, dataset))
-                continue;
-            builder.append("        typeDataAccess = dataAccess.getTypeDataAccess(\"").append(schema.getName()).append("\");\n");
-            builder.append("        if(typeDataAccess != null) {\n");
-            builder.append("            ").append(lowercase(typeAPIClassname(schema.getName()))).append(" = new ").append(typeAPIClassname(schema.getName())).append("(this, (Hollow").append(schemaType(schema)).append("TypeDataAccess)typeDataAccess);\n");
-            builder.append("        } else {\n");
-            builder.append("            ").append(lowercase(typeAPIClassname(schema.getName()))).append(" = new ").append(typeAPIClassname(schema.getName())).append("(this, new Hollow").append(schemaType(schema)).append("MissingDataAccess(dataAccess, \"").append(schema.getName()).append("\"));\n");
-            builder.append("        }\n");
-            builder.append("        addTypeAPI(").append(lowercase(typeAPIClassname(schema.getName()))).append(");\n");
-            builder.append("        factory = factoryOverrides.get(\"").append(schema.getName()).append("\");\n");
-            builder.append("        if(factory == null)\n");
-            builder.append("            factory = new ").append(hollowFactoryClassname(schema.getName())).append("();\n");
-            builder.append("        if(cachedTypes.contains(\"").append(schema.getName()).append("\")) {\n");
-            builder.append("            HollowObjectCacheProvider previousCacheProvider = null;\n");
-            builder.append("            if(previousCycleAPI != null && (previousCycleAPI.").append(hollowObjectProviderName(schema.getName())).append(" instanceof HollowObjectCacheProvider))\n");
-            builder.append("                previousCacheProvider = (HollowObjectCacheProvider) previousCycleAPI.").append(hollowObjectProviderName(schema.getName())).append(";\n");
-            builder.append("            ").append(hollowObjectProviderName(schema.getName())).append(" = new HollowObjectCacheProvider(typeDataAccess, ").append(lowercase(typeAPIClassname(schema.getName()))).append(", factory, previousCacheProvider);\n");
-            builder.append("        } else {\n");
-            builder.append("            ").append(hollowObjectProviderName(schema.getName())).append(" = new HollowObjectFactoryProvider(typeDataAccess, ").append(lowercase(typeAPIClassname(schema.getName()))).append(", factory);\n");
-            builder.append("        }\n\n");
-        }
-
-        builder.append("    }\n\n");
 
         builder.append("/*\n * Cached objects are no longer accessible after this method is called and an attempt to access them will cause an IllegalStateException.\n */\n");
 
-        builder.append("    public void detachCaches() {\n");
-        for(HollowSchema schema : schemaList) {
-            if (!includeType(schema, dataset))
-                continue;
-            builder.append("        if(").append(hollowObjectProviderName(schema.getName())).append(" instanceof HollowObjectCacheProvider)\n");
-            builder.append("            ((HollowObjectCacheProvider)").append(hollowObjectProviderName(schema.getName())).append(").detach();\n");
+        if (!chunkInitialization) {
+            builder.append("    public void detachCaches() {\n");
+            for(HollowSchema schema : schemaList) {
+                if (!includeType(schema, dataset))
+                    continue;
+                appendDetachCacheStatements(builder, schema);
+            }
+            builder.append("    }\n\n");
+        } else {
+            int numDetachMethods = (includedSchemas.size() + TYPES_PER_HELPER_METHOD - 1) / TYPES_PER_HELPER_METHOD;
+            builder.append("    public void detachCaches() {\n");
+            for (int m = 0; m < numDetachMethods; m++) {
+                builder.append("        detachCaches_").append(m).append("();\n");
+            }
+            builder.append("    }\n\n");
+
+            for (int m = 0; m < numDetachMethods; m++) {
+                int from = m * TYPES_PER_HELPER_METHOD;
+                int to = Math.min(from + TYPES_PER_HELPER_METHOD, includedSchemas.size());
+                builder.append("    private void detachCaches_").append(m).append("() {\n");
+                for (int i = from; i < to; i++) {
+                    appendDetachCacheStatements(builder, includedSchemas.get(i));
+                }
+                builder.append("    }\n\n");
+            }
         }
-        builder.append("    }\n\n");
 
 
         for (HollowSchema schema : schemaList) {
@@ -265,6 +300,49 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
         builder.append("}\n");
 
         return builder.toString();
+    }
+
+    private void appendObjectCreationSampler(StringBuilder builder, List<HollowSchema> schemaList) {
+        builder.append("        objectCreationSampler = new HollowObjectCreationSampler(");
+        for(int i=0;i<schemaList.size();i++) {
+            if (!includeType(schemaList.get(i), dataset))
+                continue;
+
+            builder.append("\"").append(schemaList.get(i).getName()).append("\"");
+            builder.append(",");
+        }
+
+        if (builder.charAt(builder.length()-1) == ',') {
+            builder.deleteCharAt(builder.length()-1);
+        }
+
+        builder.append(");\n\n");
+    }
+
+    private void appendTypeInitializer(StringBuilder builder, HollowSchema schema) {
+        builder.append("        typeDataAccess = dataAccess.getTypeDataAccess(\"").append(schema.getName()).append("\");\n");
+        builder.append("        if(typeDataAccess != null) {\n");
+        builder.append("            ").append(lowercase(typeAPIClassname(schema.getName()))).append(" = new ").append(typeAPIClassname(schema.getName())).append("(this, (Hollow").append(schemaType(schema)).append("TypeDataAccess)typeDataAccess);\n");
+        builder.append("        } else {\n");
+        builder.append("            ").append(lowercase(typeAPIClassname(schema.getName()))).append(" = new ").append(typeAPIClassname(schema.getName())).append("(this, new Hollow").append(schemaType(schema)).append("MissingDataAccess(dataAccess, \"").append(schema.getName()).append("\"));\n");
+        builder.append("        }\n");
+        builder.append("        addTypeAPI(").append(lowercase(typeAPIClassname(schema.getName()))).append(");\n");
+        builder.append("        factory = factoryOverrides.get(\"").append(schema.getName()).append("\");\n");
+        builder.append("        if(factory == null)\n");
+        builder.append("            factory = new ").append(hollowFactoryClassname(schema.getName())).append("();\n");
+        builder.append("        if(cachedTypes.contains(\"").append(schema.getName()).append("\")) {\n");
+        builder.append("            HollowObjectCacheProvider previousCacheProvider = null;\n");
+        builder.append("            if(previousCycleAPI != null && (previousCycleAPI.").append(hollowObjectProviderName(schema.getName())).append(" instanceof HollowObjectCacheProvider))\n");
+        builder.append("                previousCacheProvider = (HollowObjectCacheProvider) previousCycleAPI.").append(hollowObjectProviderName(schema.getName())).append(";\n");
+        builder.append("            ").append(hollowObjectProviderName(schema.getName())).append(" = new HollowObjectCacheProvider(typeDataAccess, ").append(lowercase(typeAPIClassname(schema.getName()))).append(", factory, previousCacheProvider);\n");
+        builder.append("        } else {\n");
+        builder.append("            ").append(hollowObjectProviderName(schema.getName())).append(" = new HollowObjectFactoryProvider(typeDataAccess, ").append(lowercase(typeAPIClassname(schema.getName()))).append(", factory);\n");
+        builder.append("        }\n\n");
+    }
+
+    private void appendDetachCacheStatements(StringBuilder builder, HollowSchema schema) {
+        builder.append("        if(").append(hollowObjectProviderName(schema.getName())).append(" instanceof HollowObjectCacheProvider)\n");
+        builder.append("            ((HollowObjectCacheProvider)").append(hollowObjectProviderName(schema.getName())).append(").detach();\n");
     }
 
     private String schemaType(HollowSchema schema) {

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowLargeDataModelAPIGeneratorTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowLargeDataModelAPIGeneratorTest.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.netflix.hollow.api.codegen;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+/**
+ * Verifies that the generated API class scales past the JVM 64KB per-method limit, which the stock
+ * (inlined) constructor reaches somewhere past ~460 types. See
+ * {@link HollowAPIClassJavaGenerator#CONSTRUCTOR_CHUNKING_THRESHOLD}.
+ */
+public class HollowLargeDataModelAPIGeneratorTest extends AbstractHollowAPIGeneratorTest {
+
+    private static final String PACKAGE_NAME = "codegen.large";
+
+    private static String schemaWithTypes(int typeCount) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < typeCount; i++) {
+            sb.append("Type").append(i).append(" { long id; int value; }\n");
+        }
+        return sb.toString();
+    }
+
+    private String generatedApiSource(String apiClassName) throws Exception {
+        File apiFile = Paths.get(sourceFolder, PACKAGE_NAME.split("\\.")).resolve(apiClassName + ".java").toFile();
+        assertTrue("expected generated API at " + apiFile, apiFile.exists());
+        return new String(Files.readAllBytes(apiFile.toPath()));
+    }
+
+    @Test
+    public void largeDataModelCompilesViaChunkedConstructor() throws Exception {
+        // 600 types is comfortably past the point where the old inlined constructor failed with
+        // "code too large". This call compiles the generated sources, so it fails if the limit is hit.
+        int typeCount = 600;
+        runGeneratorFromSchemaString("LargeOfflineAPI", PACKAGE_NAME, schemaWithTypes(typeCount), b -> b);
+
+        String src = generatedApiSource("LargeOfflineAPI");
+        assertTrue("large model should use chunked init helpers", src.contains("private void init_0("));
+        assertTrue("large model should chunk detachCaches too", src.contains("private void detachCaches_0("));
+        // Fields can no longer be final once init moves into helper methods.
+        assertFalse("chunked fields must not be final", src.contains("private final HollowObjectProvider"));
+    }
+
+    @Test
+    public void smallDataModelKeepsInlinedConstructor() throws Exception {
+        // At/below the threshold the output must be unchanged: inlined constructor, final fields, no helpers.
+        runGeneratorFromSchemaString("SmallOfflineAPI", PACKAGE_NAME, schemaWithTypes(10), b -> b);
+
+        String src = generatedApiSource("SmallOfflineAPI");
+        assertFalse("small model must not be chunked", src.contains("private void init_0("));
+        assertTrue("small model keeps final provider fields", src.contains("private final HollowObjectProvider"));
+    }
+}

--- a/hollow/src/test/resources/findbugs_exclude.xml
+++ b/hollow/src/test/resources/findbugs_exclude.xml
@@ -9,4 +9,10 @@
     <Field name="fieldNames" />
     <Bug pattern="MS_PKGPROTECT" />
   </Match>
+
+  <!-- Generated APIs for very large data models can exceed the size FindBugs is willing to
+       analyze; this is an informational "class too big" skip, not a real defect. -->
+  <Match>
+    <Bug pattern="SKIPPED_CLASS_TOO_BIG" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Problem

The generated `HollowAPI` implementation inlines per-type initialization (type API construction, `addTypeAPI`, factory lookup, and provider setup) directly into a single constructor in `HollowAPIClassJavaGenerator`. Past a few hundred types this constructor's bytecode exceeds the JVM 64KB per-method limit and the generated source fails to compile with **"code too large"** (observed around ~460 types). Today the only workaround is to shard a data model into smaller sub-APIs, which doesn't scale as a model grows.

## Change

When a data model has more than `CONSTRUCTOR_CHUNKING_THRESHOLD` (250) types, the per-type initialization is split across `init_N(...)` helper methods (and `detachCaches()` is likewise chunked), each handling a bounded batch of types. The per-type fields are non-final in this mode, since they are assigned from helper methods.

**At or below the threshold, the generated source is byte-for-byte identical to before** — the existing code path is unchanged; the per-type/sampler/detach snippets were extracted into helpers that the original path calls verbatim. So only models that previously failed to compile change shape.

## Tests

`HollowLargeDataModelAPIGeneratorTest`:
- `largeDataModelCompilesViaChunkedConstructor` — generates **and compiles** a 600-type model (previously failed with "code too large").
- `smallDataModelKeepsInlinedConstructor` — asserts a small model keeps the inlined constructor and `final` fields (no-regression guard).

The full `com.netflix.hollow.api.codegen.*` suite passes, confirming sub-threshold output is unchanged. A FindBugs filter entry excludes the experimental `SKIPPED_CLASS_TOO_BIG` info report that fires when analyzing the intentionally-large generated test class.