### PR TITLE
Adds allowDeltaUpdate supplier to HollowPrimaryKeyIndex

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -251,8 +251,7 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
 
     private ValidationResult validateSnapshotBaseline(HollowReadStateEngine stateEngine, PrimaryKey primaryKey,
                                                       String fieldPaths, ValidationResult.ValidationResultBuilder vrb) {
-        previousCycleIndex = new HollowPrimaryKeyIndex(stateEngine, primaryKey,
-                () -> Boolean.TRUE.equals(incrementalEnabled.get()));
+        previousCycleIndex = new HollowPrimaryKeyIndex(stateEngine, primaryKey, incrementalEnabled);
         indexStateEngine = stateEngine;
         cycleAction = CycleAction.BUILT_BASELINE;
         LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': incremental mode, snapshot baseline.", dataTypeName));

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -251,7 +251,8 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
 
     private ValidationResult validateSnapshotBaseline(HollowReadStateEngine stateEngine, PrimaryKey primaryKey,
                                                       String fieldPaths, ValidationResult.ValidationResultBuilder vrb) {
-        previousCycleIndex = new HollowPrimaryKeyIndex(stateEngine, primaryKey);
+        previousCycleIndex = new HollowPrimaryKeyIndex(stateEngine, primaryKey,
+                () -> Boolean.TRUE.equals(incrementalEnabled.get()));
         indexStateEngine = stateEngine;
         cycleAction = CycleAction.BUILT_BASELINE;
         LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': incremental mode, snapshot baseline.", dataTypeName));

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -39,7 +39,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -70,7 +70,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
     private final BitSet specificOrdinalsToIndex;
 
-    private final BooleanSupplier allowDeltaUpdate;
+    private final Supplier<Boolean> allowDeltaUpdate;
 
     private volatile PrimaryKeyIndexHashTable hashTableVolatile;
 
@@ -82,7 +82,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         this(stateEngine, primaryKey, WastefulRecycler.DEFAULT_INSTANCE);
     }
 
-    public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, BooleanSupplier allowDeltaUpdate) {
+    public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, Supplier<Boolean> allowDeltaUpdate) {
         this(stateEngine, primaryKey, WastefulRecycler.DEFAULT_INSTANCE, null, allowDeltaUpdate);
     }
 
@@ -103,10 +103,10 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
      * @param specificOrdinalsToIndex the bit set
      */
     public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, ArraySegmentRecycler memoryRecycler, BitSet specificOrdinalsToIndex) {
-        this(stateEngine, primaryKey, memoryRecycler, specificOrdinalsToIndex, DEFAULT_ALLOW_DELTA_UPDATE);
+        this(stateEngine, primaryKey, memoryRecycler, specificOrdinalsToIndex, SYSTEM_ALLOW_DELTA_UPDATE);
     }
 
-    private HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, ArraySegmentRecycler memoryRecycler, BitSet specificOrdinalsToIndex, BooleanSupplier allowDeltaUpdate) {
+    private HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, ArraySegmentRecycler memoryRecycler, BitSet specificOrdinalsToIndex, Supplier<Boolean> allowDeltaUpdate) {
         requireNonNull(primaryKey, "Hollow Primary Key Index creation failed because primaryKey was null");
         requireNonNull(stateEngine, "Hollow Primary Key Index creation for type [" + primaryKey.getType()
                 + "] failed because read state wasn't initialized");
@@ -472,7 +472,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
     private static final boolean ALLOW_DELTA_UPDATE =
             Boolean.getBoolean("com.netflix.hollow.core.index.HollowPrimaryKeyIndex.allowDeltaUpdate");
-    private static final BooleanSupplier DEFAULT_ALLOW_DELTA_UPDATE = () -> ALLOW_DELTA_UPDATE;
+    private static final Supplier<Boolean> SYSTEM_ALLOW_DELTA_UPDATE = () -> ALLOW_DELTA_UPDATE;
 
     @Override
     public synchronized void endUpdate() {
@@ -486,7 +486,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         int bitsPerElement = (32 - Integer.numberOfLeadingZeros(typeState.maxOrdinal() + 1));
 
         PrimaryKeyIndexHashTable hashTable = hashTableVolatile;
-        if(allowDeltaUpdate.getAsBoolean()
+        if(Boolean.TRUE.equals(allowDeltaUpdate.get())
                 && hashTableSize == hashTable.hashTableSize
                 && bitsPerElement == hashTable.bitsPerElement
                 && shouldPerformDeltaUpdate()) {

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -39,6 +39,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -69,6 +70,8 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
     private final BitSet specificOrdinalsToIndex;
 
+    private final BooleanSupplier allowDeltaUpdate;
+
     private volatile PrimaryKeyIndexHashTable hashTableVolatile;
 
     public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, String type, String... fieldPaths) {
@@ -77,6 +80,10 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
     public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey) {
         this(stateEngine, primaryKey, WastefulRecycler.DEFAULT_INSTANCE);
+    }
+
+    public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, BooleanSupplier allowDeltaUpdate) {
+        this(stateEngine, primaryKey, WastefulRecycler.DEFAULT_INSTANCE, null, allowDeltaUpdate);
     }
 
     public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, ArraySegmentRecycler memoryRecycler, String type, String... fieldPaths) {
@@ -96,11 +103,17 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
      * @param specificOrdinalsToIndex the bit set
      */
     public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, ArraySegmentRecycler memoryRecycler, BitSet specificOrdinalsToIndex) {
+        this(stateEngine, primaryKey, memoryRecycler, specificOrdinalsToIndex, DEFAULT_ALLOW_DELTA_UPDATE);
+    }
+
+    private HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, ArraySegmentRecycler memoryRecycler, BitSet specificOrdinalsToIndex, BooleanSupplier allowDeltaUpdate) {
         requireNonNull(primaryKey, "Hollow Primary Key Index creation failed because primaryKey was null");
         requireNonNull(stateEngine, "Hollow Primary Key Index creation for type [" + primaryKey.getType()
                 + "] failed because read state wasn't initialized");
+        requireNonNull(allowDeltaUpdate, "Hollow Primary Key Index creation failed because allowDeltaUpdate was null");
 
         this.primaryKey = primaryKey;
+        this.allowDeltaUpdate = allowDeltaUpdate;
         this.fieldPathIndexes = new int[primaryKey.numFields()][];
         this.fieldTypes = new FieldType[primaryKey.numFields()];
 
@@ -459,6 +472,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
     private static final boolean ALLOW_DELTA_UPDATE =
             Boolean.getBoolean("com.netflix.hollow.core.index.HollowPrimaryKeyIndex.allowDeltaUpdate");
+    private static final BooleanSupplier DEFAULT_ALLOW_DELTA_UPDATE = () -> ALLOW_DELTA_UPDATE;
 
     @Override
     public synchronized void endUpdate() {
@@ -472,7 +486,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         int bitsPerElement = (32 - Integer.numberOfLeadingZeros(typeState.maxOrdinal() + 1));
 
         PrimaryKeyIndexHashTable hashTable = hashTableVolatile;
-        if(ALLOW_DELTA_UPDATE
+        if(allowDeltaUpdate.getAsBoolean()
                 && hashTableSize == hashTable.hashTableSize
                 && bitsPerElement == hashTable.bitsPerElement
                 && shouldPerformDeltaUpdate()) {


### PR DESCRIPTION
Adds a constructor such that a supplier can be provided for `allowDeltaUpdate`. This way a `HollowPrimaryKeyIndex` can be toggled to use delta updates at runtime. The change remains backwards compatible for any uses settings `ALLOW_DELTA_UPDATE`