### PR TITLE
Use single-read getElementValue for readLong when field fits in <=56 bits

### DIFF
--- a/hollow-perf/src/jmh/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateLongBenchmark.java
+++ b/hollow-perf/src/jmh/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateLongBenchmark.java
@@ -1,0 +1,90 @@
+package com.netflix.hollow.core.read.engine.object;
+
+import com.netflix.hollow.core.read.dataaccess.HollowObjectTypeDataAccess;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * End-to-end benchmark of {@link HollowObjectTypeDataAccess#readLong} across a range of value
+ * magnitudes. The field's bitsPerField is derived from the maximum encoded value, so maxBits
+ * controls whether the read takes the single-read (getElementValue, <=56 bits) or two-word
+ * (getLargeElementValue) path in HollowObjectTypeReadStateShard.readLong.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 8, time = 1)
+@Measurement(iterations = 8, time = 1)
+@Fork(2)
+public class HollowObjectTypeReadStateLongBenchmark {
+
+    public static class LongHolder {
+        long value;
+        LongHolder(long value) { this.value = value; }
+    }
+
+    @Param({ "1000000" })
+    int countRecordsDb;
+
+    @Param({ "1000000" })
+    int countReads;
+
+    // max encoded bits: 40 -> fast path (<=56), 62 -> large path (>56)
+    @Param({ "40", "62" })
+    int maxBits;
+
+    HollowObjectTypeDataAccess dataAccess;
+    int[] readOrder;
+
+    @Setup
+    public void setUp() throws IOException {
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowObjectMapper objectMapper = new HollowObjectMapper(writeStateEngine);
+        objectMapper.initializeTypeState(LongHolder.class);
+
+        Random r = new Random(42);
+        // Zig-zag encoding roughly doubles magnitude, so cap at maxBits-1 raw to land around maxBits encoded.
+        long bound = 1L << Math.max(1, maxBits - 1);
+        for (int i = 0; i < countRecordsDb; i++) {
+            long v = (r.nextLong() & (bound - 1));
+            objectMapper.add(new LongHolder(v));
+        }
+
+        readOrder = new int[countReads];
+        for (int i = 0; i < countReads; i++) {
+            readOrder[i] = r.nextInt(countRecordsDb);
+        }
+
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        StateEngineRoundTripper.roundTripSnapshot(writeStateEngine, readStateEngine, null);
+        dataAccess = (HollowObjectTypeDataAccess) readStateEngine.getTypeDataAccess("LongHolder", 0);
+    }
+
+    @Benchmark
+    public void readLong(Blackhole bh) {
+        HollowObjectTypeDataAccess da = dataAccess;
+        int[] order = readOrder;
+        long sum = 0;
+        for (int i = 0; i < order.length; i++) {
+            sum += da.readLong(order[i], 0);
+        }
+        bh.consume(sum);
+    }
+}

--- a/hollow-perf/src/jmh/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateLongBenchmark.java
+++ b/hollow-perf/src/jmh/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateLongBenchmark.java
@@ -62,7 +62,10 @@ public class HollowObjectTypeReadStateLongBenchmark {
         Random r = new Random(42);
         // Zig-zag encoding roughly doubles magnitude, so cap at maxBits-1 raw to land around maxBits encoded.
         long bound = 1L << Math.max(1, maxBits - 1);
-        for (int i = 0; i < countRecordsDb; i++) {
+        // Pin the maximum magnitude so bitsPerField deterministically equals maxBits (and thus the
+        // intended readLong path is exercised), independent of record count / seed / sampling.
+        objectMapper.add(new LongHolder(bound - 1));
+        for (int i = 1; i < countRecordsDb; i++) {
             long v = (r.nextLong() & (bound - 1));
             objectMapper.add(new LongHolder(v));
         }

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
@@ -79,11 +79,7 @@ class HollowObjectTypeReadStateShard implements HollowTypeReadStateShard {
     }
 
     public long readLong(int ordinal, int fieldIndex) {
-        long bitOffset = fieldOffset(ordinal, fieldIndex);
-        int numBitsForField = dataElements.bitsPerField[fieldIndex];
-        return numBitsForField <= 56 ?
-                dataElements.fixedLengthData.getElementValue(bitOffset, numBitsForField)
-                : dataElements.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
+        return readValue(ordinal, fieldIndex);
     }
 
     public long readBoolean(int ordinal, int fieldIndex) {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateShard.java
@@ -81,7 +81,9 @@ class HollowObjectTypeReadStateShard implements HollowTypeReadStateShard {
     public long readLong(int ordinal, int fieldIndex) {
         long bitOffset = fieldOffset(ordinal, fieldIndex);
         int numBitsForField = dataElements.bitsPerField[fieldIndex];
-        return dataElements.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
+        return numBitsForField <= 56 ?
+                dataElements.fixedLengthData.getElementValue(bitOffset, numBitsForField)
+                : dataElements.fixedLengthData.getLargeElementValue(bitOffset, numBitsForField);
     }
 
     public long readBoolean(int ordinal, int fieldIndex) {

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateReadLongTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateReadLongTest.java
@@ -12,6 +12,7 @@ import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.write.HollowBlobWriter;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import com.netflix.hollow.core.write.objectmapper.HollowShardLargeType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -33,6 +34,9 @@ import org.junit.Test;
  */
 public class HollowObjectTypeReadStateReadLongTest {
 
+    // Pinned to a single shard so that ordinals never span shards: bitsPerField is then uniform
+    // across the (only) shard, making the shard[0] path assertions below valid and deterministic.
+    @HollowShardLargeType(numShards = 1)
     public static class LongHolder {
         long value;
         LongHolder(long value) { this.value = value; }

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateReadLongTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadStateReadLongTest.java
@@ -1,0 +1,143 @@
+package com.netflix.hollow.core.read.engine.object;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.netflix.hollow.core.memory.MemoryMode;
+import com.netflix.hollow.core.memory.encoding.EncodedLongBuffer;
+import com.netflix.hollow.core.memory.encoding.FixedLengthElementArray;
+import com.netflix.hollow.core.read.HollowBlobInput;
+import com.netflix.hollow.core.read.engine.HollowBlobReader;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.write.HollowBlobWriter;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Verifies {@link HollowObjectTypeReadStateShard#readLong} returns identical values whether the
+ * field's bitsPerField lands on the fast single-read path (getElementValue, {@code <= 56} bits) or
+ * the wide two-word path (getLargeElementValue). The bitsPerField of a long field is derived from
+ * the widest zig-zag-encoded value in the type, so we drive each path by controlling the maximum
+ * magnitude present, and assert the actual path taken by inspecting bitsPerField.
+ *
+ * Each dataset is checked in both consumer memory modes, since {@code readLong} reads through the
+ * {@link com.netflix.hollow.core.memory.FixedLengthData} interface which is a
+ * {@link FixedLengthElementArray} on-heap and an {@link EncodedLongBuffer} in shared-memory mode.
+ */
+public class HollowObjectTypeReadStateReadLongTest {
+
+    public static class LongHolder {
+        long value;
+        LongHolder(long value) { this.value = value; }
+    }
+
+    @Test
+    public void readLong_fastPath_matches() throws Exception {
+        // All magnitudes small enough that zig-zag encoding stays within 56 bits -> fast path.
+        List<Long> values = new ArrayList<>();
+        values.add(0L);
+        values.add(1L);
+        values.add(-1L);
+        values.add(Long.MIN_VALUE >> 12); // large negative, still well under 56 encoded bits
+        values.add(Long.MAX_VALUE >> 12); // large positive
+        for (int shift = 0; shift <= 54; shift++) {
+            values.add(1L << shift);
+            values.add(-(1L << shift));
+        }
+        assertReadLongRoundTrips(values, /*expectFastPath=*/true);
+    }
+
+    @Test
+    public void readLong_widePath_matches() throws Exception {
+        // Presence of full-width values forces bitsPerField > 56 -> wide path, unchanged behavior.
+        List<Long> values = new ArrayList<>();
+        values.add(0L);
+        values.add(1L);
+        values.add(-1L);
+        values.add(Long.MAX_VALUE);
+        values.add(Long.MIN_VALUE);
+        values.add(Long.MAX_VALUE - 1);
+        values.add(1L << 57);
+        values.add(-(1L << 57));
+        assertReadLongRoundTrips(values, /*expectFastPath=*/false);
+    }
+
+    private void assertReadLongRoundTrips(List<Long> values, boolean expectFastPath) throws Exception {
+        HollowWriteStateEngine writeStateEngine = new HollowWriteStateEngine();
+        HollowObjectMapper objectMapper = new HollowObjectMapper(writeStateEngine);
+        objectMapper.initializeTypeState(LongHolder.class);
+
+        int[] ordinals = new int[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            ordinals[i] = objectMapper.add(new LongHolder(values.get(i)));
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new HollowBlobWriter(writeStateEngine).writeSnapshot(baos);
+        byte[] snapshot = baos.toByteArray();
+
+        verify(readOnHeap(snapshot), values, ordinals, expectFastPath, /*sharedMemory=*/false);
+        verify(readSharedMemory(snapshot), values, ordinals, expectFastPath, /*sharedMemory=*/true);
+    }
+
+    private static HollowReadStateEngine readOnHeap(byte[] snapshot) throws Exception {
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        HollowBlobReader reader = new HollowBlobReader(readStateEngine);
+        try (HollowBlobInput in = HollowBlobInput.serial(new ByteArrayInputStream(snapshot))) {
+            reader.readSnapshot(in);
+        }
+        return readStateEngine;
+    }
+
+    private static HollowReadStateEngine readSharedMemory(byte[] snapshot) throws Exception {
+        File blobFile = File.createTempFile("readlong-shm-snapshot", ".bin");
+        blobFile.deleteOnExit();
+        try (FileOutputStream fos = new FileOutputStream(blobFile)) {
+            fos.write(snapshot);
+        }
+        HollowReadStateEngine readStateEngine = new HollowReadStateEngine();
+        HollowBlobReader reader = new HollowBlobReader(readStateEngine, MemoryMode.SHARED_MEMORY_LAZY);
+        try (HollowBlobInput in = HollowBlobInput.randomAccess(blobFile)) {
+            reader.readSnapshot(in);
+        }
+        return readStateEngine;
+    }
+
+    private static void verify(HollowReadStateEngine readStateEngine, List<Long> values, int[] ordinals,
+                              boolean expectFastPath, boolean sharedMemory) {
+        HollowObjectTypeReadState readState =
+                (HollowObjectTypeReadState) readStateEngine.getTypeState("LongHolder");
+        int fieldIndex = readState.getSchema().getPosition("value");
+
+        HollowObjectTypeReadStateShard shard =
+                ((HollowObjectTypeReadStateShard[]) readState.getShardsVolatile().getShards())[0];
+
+        // Confirm this run actually exercises the intended FixedLengthData implementation.
+        if (sharedMemory) {
+            assertTrue("expected EncodedLongBuffer in shared-memory mode",
+                    shard.dataElements.fixedLengthData instanceof EncodedLongBuffer);
+        } else {
+            assertTrue("expected FixedLengthElementArray on-heap",
+                    shard.dataElements.fixedLengthData instanceof FixedLengthElementArray);
+        }
+
+        int bitsPerField = shard.dataElements.bitsPerField[fieldIndex];
+        if (expectFastPath) {
+            assertTrue("expected fast path but bitsPerField=" + bitsPerField, bitsPerField <= 56);
+        } else {
+            assertTrue("expected wide path but bitsPerField=" + bitsPerField, bitsPerField > 56);
+        }
+
+        for (int i = 0; i < values.size(); i++) {
+            assertEquals("value at ordinal " + ordinals[i] + " sharedMemory=" + sharedMemory,
+                    (long) values.get(i), readState.readLong(ordinals[i], fieldIndex));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`HollowObjectTypeReadStateShard.readLong` always used the two-word `getLargeElementValue`. For long fields that encode in `<=56` bits it can use the faster single-read `getElementValue` instead — the same fast/slow split `readValue()` and the delta/copy paths already use. `readLong` is a hot read primitive, and the wide path also has a data-dependent branch that mispredicts at medium widths; the single-read path is branchless.

`<=56` is safe for arbitrarily-aligned object fields (7-bit max offset + 57 = 64; 56 keeps the existing margin). `>56`-bit fields are untouched.

## Correctness

`HollowObjectTypeReadStateReadLongTest` verifies `readLong` returns identical values on both sides of the 56-bit boundary (`0/±1`, powers of two, `Long.MIN/MAX_VALUE`), in both memory modes — on-heap (`FixedLengthElementArray`) and shared-memory (`EncodedLongBuffer`), with an `instanceof` check so each is actually exercised. Existing read-engine and object-mapper tests pass.

## Benchmarks (JDK 25)

Baseline = this branch with only `readLong` reverted to always-`getLargeElementValue`. `maxBits=40` hits the fast path; `maxBits=62` is the unchanged-path control.

**x86-64** (AMD EPYC 9R14, 16 MiB L3) — end-to-end `readLong`, µs/op ±99.9% CI:

| records | maxBits | baseline | change | delta |
|---|---|---|---|---|
| 1M (in-cache) | 40 | 16,312 ± 217 | 9,305 ± 76 | **−43%** |
| 1M | 62 (control) | 15,932 ± 659 | 15,405 ± 531 | unchanged |
| 2.9M (cache-miss) | 40 | 32,541 ± 2,180 | 21,853 ± 2,075 | **−33%** |
| 2.9M | 62 (control) | 45,521 ± 1,997 | 45,574 ± 1,710 | unchanged |

Fast-path CIs don't overlap in either regime; controls are flat. Primitive `getElementValue` vs `getLargeElementValue`: 1.50–1.72× at 32/48/56 bits. (Shared 4-vCPU VM, so the 2.9M points carry ~7–10% error.)

**arm64** (Apple M2, directional): ~39% end-to-end for ≤56-bit fields; 1.9–2.2× primitive; control unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
