### PR TITLE
Refresh consumer on subscribe if a version is already announced

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemAnnouncementWatcher.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemAnnouncementWatcher.java
@@ -104,6 +104,11 @@ public class HollowFilesystemAnnouncementWatcher implements HollowConsumer.Annou
     @Override
     public void subscribeToUpdates(final HollowConsumer consumer) {
         subscribedConsumers.add(consumer);
+
+        // Trigger a refresh right away if a version is already known, so that a consumer
+        // does not sit on no data (or stale data) until the next change is announced.
+        if (latestVersion != NO_ANNOUNCEMENT_AVAILABLE)
+            consumer.triggerAsyncRefresh();
     }
 
     private long readLatestVersion() {

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemConsumerTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/fs/HollowFilesystemConsumerTest.java
@@ -3,11 +3,13 @@ package com.netflix.hollow.api.consumer.fs;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
 import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowFilesystemAnnouncer;
 import com.netflix.hollow.api.producer.fs.HollowFilesystemPublisher;
 import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -44,6 +46,42 @@ public class HollowFilesystemConsumerTest {
 
         Assert.assertEquals(1, obj1.getInt("id"));
         Assert.assertEquals(4, obj4.getInt("id"));
+    }
+
+    @Test
+    public void testConsumerIsRefreshedOnSubscribeWithoutWaitingForNextAnnouncement() throws Exception {
+        File localDir = createLocalDir();
+        HollowFilesystemPublisher pub = new HollowFilesystemPublisher(localDir.toPath());
+        HollowFilesystemAnnouncer announcer = new HollowFilesystemAnnouncer(localDir.toPath());
+
+        HollowProducer producer = HollowProducer.withPublisher(pub)
+                .withAnnouncer(announcer)
+                .build();
+
+        long version = producer.runCycle(state -> {
+            state.add(new Entity(1));
+            state.add(new Entity(2));
+        });
+
+        // The announcement file already exists with a version by the time the watcher is created,
+        // so a consumer subscribing to it should be refreshed right away, without needing to wait
+        // for the watcher to observe a subsequent change to the announcement file.
+        HollowFilesystemAnnouncementWatcher watcher = new HollowFilesystemAnnouncementWatcher(localDir.toPath());
+        HollowFilesystemBlobRetriever retriever = new HollowFilesystemBlobRetriever(localDir.toPath());
+        HollowConsumer consumer = HollowConsumer.newHollowConsumer()
+                .withBlobRetriever(retriever)
+                .withAnnouncementWatcher(watcher)
+                .build();
+
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        while (consumer.getCurrentVersionId() != version && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+
+        Assert.assertEquals(version, consumer.getCurrentVersionId());
+
+        GenericHollowObject obj1 = new GenericHollowObject(consumer.getStateEngine(), "Entity", 0);
+        Assert.assertEquals(1, obj1.getInt("id"));
     }
 
     static File createLocalDir() throws IOException {


### PR DESCRIPTION
Fixes #273

HollowFilesystemAnnouncementWatcher reads the current announced version in its constructor and stores it in latestVersion, but subscribeToUpdates just adds the consumer to the list and does nothing else. The watch loop only triggers a refresh when it sees the announcement file's mtime change and the version actually differs from the stored latestVersion. Since latestVersion was already set to the current version at construction time, the first watch tick reads the same version again, the comparison is equal, and no refresh fires. So a consumer built with this watcher sits without any data until the announcement file changes again at some point in the future.

This contradicts the documented contract for AnnouncementWatcher (see the 3.3.0 release notes linked in the issue): the watcher implementation is supposed to call triggerRefresh or triggerAsyncRefresh itself so consumers don't need an explicit call.

Fix: in subscribeToUpdates, if a version is already known (latestVersion != NO_ANNOUNCEMENT_AVAILABLE), trigger an async refresh for that consumer right away.

Tested with a new test in HollowFilesystemConsumerTest: build a producer, publish and announce a version, then construct a fresh watcher and a consumer against it, and assert the consumer picks up the version without waiting for a subsequent announcement. I checked this test actually reproduces the bug by running it against the unpatched code first, it timed out after 10 seconds with the consumer stuck at no version, then reran it with the fix applied and it passed immediately. Also ran the full HollowFilesystemConsumerTest class, both tests pass.