### PR TITLE
DDD validator hardening

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -201,6 +201,9 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
     }
 
     private void dropLaggedIndex() {
+        if (previousCycleIndex != null) {
+            previousCycleIndex.destroy();
+        }
         previousCycleIndex = null;
         indexStateEngine = null;
     }
@@ -254,7 +257,9 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
         previousCycleIndex = new HollowPrimaryKeyIndex(stateEngine, primaryKey, incrementalEnabled);
         indexStateEngine = stateEngine;
         cycleAction = CycleAction.BUILT_BASELINE;
-        LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': incremental mode, snapshot baseline.", dataTypeName));
+        LOG.log(Level.FINE, String.format(
+                "Duplicate detection for type '%s': incremental mode, snapshot baseline (lagged index ~%d bytes).",
+                dataTypeName, previousCycleIndex.approxHeapFootprintInBytes()));
         return checkForDuplicates(previousCycleIndex, fieldPaths, vrb);
     }
 
@@ -280,8 +285,10 @@ public class DuplicateDataDetectionValidator implements ValidatorListener, Resto
         newOrdinals.or(populatedOrdinals);
         newOrdinals.andNot(previousOrdinals);
 
-        LOG.log(Level.FINE, String.format("Duplicate detection for type '%s': incremental mode, delta (%d total, %d new ordinals).",
-                dataTypeName, populatedOrdinals.cardinality(), newOrdinals.cardinality()));
+        LOG.log(Level.FINE, String.format(
+                "Duplicate detection for type '%s': incremental mode, delta (%d total, %d new ordinals, lagged index ~%d bytes).",
+                dataTypeName, populatedOrdinals.cardinality(), newOrdinals.cardinality(),
+                previousCycleIndex.approxHeapFootprintInBytes()));
 
         if (newOrdinals.isEmpty()) {
             return vrb.passed();

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -103,7 +103,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
      * @param specificOrdinalsToIndex the bit set
      */
     public HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, ArraySegmentRecycler memoryRecycler, BitSet specificOrdinalsToIndex) {
-        this(stateEngine, primaryKey, memoryRecycler, specificOrdinalsToIndex, SYSTEM_ALLOW_DELTA_UPDATE);
+        this(stateEngine, primaryKey, memoryRecycler, specificOrdinalsToIndex, DEFAULT_ALLOW_DELTA_UPDATE);
     }
 
     private HollowPrimaryKeyIndex(HollowReadStateEngine stateEngine, PrimaryKey primaryKey, ArraySegmentRecycler memoryRecycler, BitSet specificOrdinalsToIndex, Supplier<Boolean> allowDeltaUpdate) {
@@ -472,7 +472,12 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
     private static final boolean ALLOW_DELTA_UPDATE =
             Boolean.getBoolean("com.netflix.hollow.core.index.HollowPrimaryKeyIndex.allowDeltaUpdate");
-    private static final Supplier<Boolean> SYSTEM_ALLOW_DELTA_UPDATE = () -> ALLOW_DELTA_UPDATE;
+    private static final Supplier<Boolean> DEFAULT_ALLOW_DELTA_UPDATE = () -> false;
+
+    // The property force-enables delta updates; otherwise the per-index supplier decides.
+    boolean isDeltaUpdateAllowed() {
+        return ALLOW_DELTA_UPDATE || Boolean.TRUE.equals(allowDeltaUpdate.get());
+    }
 
     @Override
     public synchronized void endUpdate() {
@@ -486,7 +491,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         int bitsPerElement = (32 - Integer.numberOfLeadingZeros(typeState.maxOrdinal() + 1));
 
         PrimaryKeyIndexHashTable hashTable = hashTableVolatile;
-        if(Boolean.TRUE.equals(allowDeltaUpdate.get())
+        if(isDeltaUpdateAllowed()
                 && hashTableSize == hashTable.hashTableSize
                 && bitsPerElement == hashTable.bitsPerElement
                 && shouldPerformDeltaUpdate()) {

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidatorTests.java
@@ -18,8 +18,12 @@ package com.netflix.hollow.api.producer.validation;
 
 import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+import com.netflix.hollow.core.write.objectmapper.HollowTypeName;
 import com.netflix.hollow.test.InMemoryBlobStore;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Assert;
 import org.junit.Before;
@@ -630,6 +634,115 @@ public class DuplicateDataDetectionValidatorTests {
         }
     }
 
+    @Test
+    public void schemaChangeOnRestoredChainStillCatchesDuplicatesViaSnapshot() {
+        // A schema-evolving redeploy: a second producer restores the same chain, then publishes with an
+        // added field. Restore drops the reused validator's lagged index, so the post-restore cycle runs
+        // the snapshot full-scan path and still catches an introduced duplicate with exact counts.
+        DuplicateDataDetectionValidator validator =
+                new DuplicateDataDetectionValidator(SchemaV1.class, () -> true);
+
+        HollowProducer producer1 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(validator)
+                .build();
+        producer1.initializeDataModel(SchemaV1.class);
+        long v1 = producer1.runCycle(writeState -> {
+            writeState.add(new SchemaV1(1, "A"));
+            writeState.add(new SchemaV1(2, "B"));
+        });
+        // Delta cycle so the validator retains a lagged index bound to producer1's engine.
+        producer1.runCycle(writeState -> {
+            writeState.add(new SchemaV1(1, "A"));
+            writeState.add(new SchemaV1(2, "B"));
+            writeState.add(new SchemaV1(3, "C"));
+        });
+
+        producer1.initializeDataModel(SchemaV2.class);
+
+        HollowProducer producer2 = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(validator)
+                .build();
+        producer2.initializeDataModel(SchemaV2.class);
+        producer2.restore(v1, blobStore);
+        try {
+            producer2.runCycle(writeState -> {
+                writeState.add(new SchemaV2(1, "A", "x"));
+                writeState.add(new SchemaV2(1, "A_dup", "y"));
+            });
+            Assert.fail("Expected ValidationStatusException");
+        } catch (ValidationStatusException expected) {
+            String message = expected.getValidationStatus().getResults().get(0).getMessage();
+            Assert.assertTrue("Schema change must fall back to the snapshot full-scan path (exact counts)",
+                    message.contains("distinct keys that each have duplicate records affecting"));
+            Assert.assertFalse("Must not run the delta path after a schema change",
+                    message.contains("delta check"));
+        }
+    }
+
+    @Test
+    public void schemaChangeFlipsReadStateEngineIdentity() {
+        // Guards the assumption behind dropLaggedIndexIfEngineChanged: a same-schema cycle reuses the
+        // restored read-state engine (delta swap), while a schema change publishes a snapshot and exposes
+        // a fresh engine (no-swap branch). Asserted via a capture listener, independent of the validator.
+        List<HollowReadStateEngine> seen = new ArrayList<>();
+        ValidatorListener capture = new ValidatorListener() {
+            @Override
+            public String getName() {
+                return "engineCapture";
+            }
+
+            @Override
+            public ValidationResult onValidate(HollowProducer.ReadState readState) {
+                seen.add(readState.getStateEngine());
+                return ValidationResult.from(this).passed();
+            }
+        };
+
+        // Seed the chain at v1 with the V1 schema.
+        HollowProducer seed = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+        seed.initializeDataModel(SchemaV1.class);
+        long v1 = seed.runCycle(writeState -> {
+            writeState.add(new SchemaV1(1, "A"));
+            writeState.add(new SchemaV1(2, "B"));
+        });
+
+        // Control: same schema + delta. The swap keeps the restored engine current, so validate() sees it.
+        HollowProducer control = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(capture)
+                .build();
+        control.initializeDataModel(SchemaV1.class);
+        HollowReadStateEngine controlRestored = control.restore(v1, blobStore).getStateEngine();
+        seen.clear();
+        control.runCycle(writeState -> {
+            writeState.add(new SchemaV1(1, "A"));
+            writeState.add(new SchemaV1(2, "B"));
+            writeState.add(new SchemaV1(3, "C"));
+        });
+        Assert.assertSame("A same-schema cycle should reuse the restored engine (delta swap)",
+                controlRestored, seen.get(0));
+
+        // Test: only the schema differs from the control. The change forces a snapshot, so validate() sees
+        // a fresh engine, not the one restored into. A separate blob store isolates it from the control.
+        HollowProducer test = HollowProducer.withPublisher(new InMemoryBlobStore())
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(capture)
+                .build();
+        test.initializeDataModel(SchemaV2.class);
+        HollowReadStateEngine testRestored = test.restore(v1, blobStore).getStateEngine();
+        seen.clear();
+        test.runCycle(writeState -> {
+            writeState.add(new SchemaV2(1, "A", "x"));
+            writeState.add(new SchemaV2(2, "B", "y"));
+        });
+        Assert.assertNotSame("A schema change must flip the read-state engine identity (no-swap branch)",
+                testRestored, seen.get(0));
+    }
+
     // A second validator the test can switch on to fail a cycle after the duplicate check has passed.
     private static final class ToggleValidator implements ValidatorListener {
         final AtomicBoolean fail = new AtomicBoolean(false);
@@ -655,6 +768,34 @@ public class DuplicateDataDetectionValidatorTests {
         TypeWithPrimaryKey(int id, String name) {
             this.id = id;
             this.name = name;
+        }
+    }
+
+    // SchemaV1 and SchemaV2 map to the same Hollow type name but differ by one field, so publishing
+    // SchemaV2 onto a chain built with SchemaV1 is a genuine mid-chain schema change.
+    @HollowTypeName(name = "SchemaEvolvingType")
+    @HollowPrimaryKey(fields = {"id"})
+    static class SchemaV1 {
+        int id;
+        String name;
+
+        SchemaV1(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    @HollowTypeName(name = "SchemaEvolvingType")
+    @HollowPrimaryKey(fields = {"id"})
+    static class SchemaV2 {
+        int id;
+        String name;
+        String extra;
+
+        SchemaV2(int id, String name, String extra) {
+            this.id = id;
+            this.name = name;
+            this.extra = extra;
         }
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/index/PrimaryKeyIndexDeltaIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/PrimaryKeyIndexDeltaIndexTest.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toList;
 import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.index.key.PrimaryKey;
 import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 import java.util.Arrays;
 import java.util.Collections;
@@ -92,5 +93,22 @@ public class PrimaryKeyIndexDeltaIndexTest {
             Assert.assertEquals(upper, matches.length);
             Assert.assertFalse(index.containsDuplicates());
         }
+    }
+
+    @Test
+    public void isDeltaUpdateAllowedFollowsSupplierWhenPropertyUnset() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowProducer p = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+        p.initializeDataModel(X.class);
+        long version = p.runCycle(ws -> ws.add(new X(1)));
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefreshTo(version);
+
+        PrimaryKey pk = new PrimaryKey("X", "id");
+        Assert.assertTrue(new HollowPrimaryKeyIndex(consumer.getStateEngine(), pk, () -> true).isDeltaUpdateAllowed());
+        Assert.assertFalse(new HollowPrimaryKeyIndex(consumer.getStateEngine(), pk, () -> false).isDeltaUpdateAllowed());
     }
 }


### PR DESCRIPTION
Destroy the lagged index when dropping it (off-heap safety), surface the retained index's approximate heap footprint in the FINE logs, and add tests covering schema-change behavior across a restored delta chain.