### PR TITLE
Null check in TypeFilter to exclude types without schema

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/read/filter/TypeFilter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/filter/TypeFilter.java
@@ -380,8 +380,8 @@ final class Resolver {
     private final List<Rule> rules;
 
     private static void warnMissingReferencedType(String fromType, String missingType) {
-        LOG.warning("Type filter: \"" + fromType + "\" references type \"" + missingType
-                + "\" which is not present in the read state (e.g. a type with zero records); ");
+        LOG.warning("Type filter: " + fromType + " references type " + missingType
+                + " which is not present in the read state (e.g. a type with zero records). Skipping recursion for this reference.");
     }
 
     Resolver(List<Rule> rules, List<HollowSchema> schemas) {
@@ -424,7 +424,7 @@ final class Resolver {
                                 String refType = os.getReferencedType(i);
                                 HollowSchema refSchema = schemas.get(refType);
                                 if (refSchema == null) {
-                                    warnMissingReferencedType(type + " (field \"" + field + "\")", refType);
+                                    warnMissingReferencedType(type + " (field '" + field + "')", refType);
                                     return Stream.of(parent, child);
                                 }
                                 Stream<TypeActions> descendants = descendants((t,f) -> descendantAction, refSchema);

--- a/hollow/src/main/java/com/netflix/hollow/core/read/filter/TypeFilter.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/filter/TypeFilter.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.logging.Logger;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -373,8 +374,15 @@ class UnresolvedTypeFilter implements TypeFilter {
 
 @com.netflix.hollow.Internal
 final class Resolver {
+    private static final Logger LOG = Logger.getLogger(Resolver.class.getName());
+
     private final Map<String,HollowSchema> schemas;
     private final List<Rule> rules;
+
+    private static void warnMissingReferencedType(String fromType, String missingType) {
+        LOG.warning("Type filter: \"" + fromType + "\" references type \"" + missingType
+                + "\" which is not present in the read state (e.g. a type with zero records); ");
+    }
 
     Resolver(List<Rule> rules, List<HollowSchema> schemas) {
         assert !rules.isEmpty();
@@ -415,7 +423,10 @@ final class Resolver {
                             if (descendantAction.recursive && os.getFieldType(i) == REFERENCE) {
                                 String refType = os.getReferencedType(i);
                                 HollowSchema refSchema = schemas.get(refType);
-                                assert refSchema != null;
+                                if (refSchema == null) {
+                                    warnMissingReferencedType(type + " (field \"" + field + "\")", refType);
+                                    return Stream.of(parent, child);
+                                }
                                 Stream<TypeActions> descendants = descendants((t,f) -> descendantAction, refSchema);
                                 return Stream.concat(Stream.of(parent, child), descendants);
                             } else {
@@ -431,7 +442,10 @@ final class Resolver {
                     HollowCollectionSchema cs = (HollowCollectionSchema) schema;
 
                     HollowSchema elemSchema = schemas.get(cs.getElementType());
-                    assert elemSchema != null;
+                    if (elemSchema == null) {
+                        warnMissingReferencedType(type, cs.getElementType());
+                        return Stream.of(parent);
+                    }
 
                     Stream<TypeActions> descendants = descendants((t, f) -> action, elemSchema);
                     return Stream.concat(Stream.of(parent), descendants);
@@ -446,9 +460,11 @@ final class Resolver {
                     HollowMapSchema ms = (HollowMapSchema) schema;
                     HollowSchema kSchema = schemas.get(ms.getKeyType());
                     HollowSchema vSchema = schemas.get(ms.getValueType());
+                    if (kSchema == null) warnMissingReferencedType(type + " (map key)", ms.getKeyType());
+                    if (vSchema == null) warnMissingReferencedType(type + " (map value)", ms.getValueType());
                     Stream<TypeActions> descendants = Stream.concat(
-                            descendants((t, f) -> action, kSchema),
-                            descendants((t1, f1) -> action, vSchema));
+                            kSchema == null ? Stream.<TypeActions>empty() : descendants((t, f) -> action, kSchema),
+                            vSchema == null ? Stream.<TypeActions>empty() : descendants((t1, f1) -> action, vSchema));
                     return Stream.concat(Stream.of(parent), descendants);
                 } else {
                     return Stream.of(parent);

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/HollowBlobReaderMissingReferencedTypeTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/HollowBlobReaderMissingReferencedTypeTest.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.read.engine;
+
+import static com.netflix.hollow.core.read.filter.TypeFilter.newTypeFilter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.core.read.HollowBlobInput;
+import com.netflix.hollow.core.read.filter.HollowFilterConfig;
+import com.netflix.hollow.core.write.HollowBlobWriter;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import com.netflix.hollow.tools.filter.FilteredHollowBlobWriter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.junit.Test;
+
+public class HollowBlobReaderMissingReferencedTypeTest {
+
+    @Test
+    public void readsSnapshotWithRecursiveFilterWhenReferencedTypeSchemaIsAbsent() throws IOException {
+        // 1. Produce a normal snapshot where Parent references Child, and both types have records.
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
+        mapper.add(new Parent(1, new Child(11)));
+        mapper.add(new Parent(2, new Child(22)));
+
+        ByteArrayOutputStream snapshot = new ByteArrayOutputStream();
+        new HollowBlobWriter(writeEngine).writeSnapshot(snapshot);
+
+        // 2. Filter-write a blob that DROPS the Child type from the header but keeps Parent (whose
+        //    'child' field still references the now-absent Child) -- the shape RawHollow emits for an
+        //    empty nested type. getFilteredSchemaList does not enforce referential closure, so the
+        //    resulting header legitimately omits a referenced type.
+        HollowFilterConfig excludeChild = new HollowFilterConfig(true); // exclude filter
+        excludeChild.addType("Child");
+        ByteArrayOutputStream filtered = new ByteArrayOutputStream();
+        new FilteredHollowBlobWriter(excludeChild)
+                .filterSnapshot(new ByteArrayInputStream(snapshot.toByteArray()), filtered);
+        byte[] blobMissingChild = filtered.toByteArray();
+
+        // 3. Read that blob with a recursive type filter that walks Parent -> child -> (missing) Child.
+        HollowReadStateEngine readEngine = new HollowReadStateEngine();
+        HollowBlobReader reader = new HollowBlobReader(readEngine);
+
+        assertThatCode(() ->
+                reader.readSnapshot(
+                        HollowBlobInput.serial(blobMissingChild),
+                        newTypeFilter().excludeAll().includeRecursive("Parent").build()))
+                .doesNotThrowAnyException();
+
+        // 4. Parent is loaded and readable; the missing Child type is simply not in the read state.
+        assertThat(readEngine.getSchema("Child")).isNull();
+        assertThat(readEngine.getSchema("Parent")).isNotNull();
+        assertThat(readEngine.getTypeState("Parent")).isNotNull();
+        assertThat(readEngine.getTypeState("Parent").getPopulatedOrdinals().cardinality()).isEqualTo(2);
+
+        int firstOrdinal = readEngine.getTypeState("Parent").getPopulatedOrdinals().nextSetBit(0);
+        assertThat(new GenericHollowObject(readEngine, "Parent", firstOrdinal).getInt("id")).isIn(1, 2);
+    }
+
+    @SuppressWarnings("unused")
+    private static class Parent {
+        int id;
+        Child child;
+
+        Parent(int id, Child child) {
+            this.id = id;
+            this.child = child;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class Child {
+        int value;
+
+        Child(int value) {
+            this.value = value;
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/read/engine/HollowBlobReaderMissingReferencedTypeTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/engine/HollowBlobReaderMissingReferencedTypeTest.java
@@ -20,6 +20,8 @@ import static com.netflix.hollow.core.read.filter.TypeFilter.newTypeFilter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import com.netflix.hollow.api.objects.HollowRecord;
+import com.netflix.hollow.api.objects.generic.GenericHollowMap;
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
 import com.netflix.hollow.core.read.HollowBlobInput;
 import com.netflix.hollow.core.read.filter.HollowFilterConfig;
@@ -30,6 +32,8 @@ import com.netflix.hollow.tools.filter.FilteredHollowBlobWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 
 public class HollowBlobReaderMissingReferencedTypeTest {
@@ -74,6 +78,141 @@ public class HollowBlobReaderMissingReferencedTypeTest {
 
         int firstOrdinal = readEngine.getTypeState("Parent").getPopulatedOrdinals().nextSetBit(0);
         assertThat(new GenericHollowObject(readEngine, "Parent", firstOrdinal).getInt("id")).isIn(1, 2);
+    }
+
+    /**
+     * When a map's value type is absent, the resolved filter keeps the map field/type included.
+     * This verifies that doing so is safe "when actually loading the data".
+     *
+     * <p>A value type with zero records (the RawHollow trigger) has no ordinals, so no map entry can
+     * reference one -- every surviving map instance is empty. Loading only needs the key type
+     * ({@code buildKeyDeriver}); the value type is dereferenced lazily, per entry, so iterating an
+     * empty map never materializes a (missing) value.
+     */
+    @Test
+    public void readsMapWithRecursiveFilterWhenValueTypeSchemaIsAbsent() throws IOException {
+        // Holder with an empty map: the value type MapValue has zero records, mirroring RawHollow.
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
+        mapper.add(new Holder(new HashMap<>()));
+
+        ByteArrayOutputStream snapshot = new ByteArrayOutputStream();
+        new HollowBlobWriter(writeEngine).writeSnapshot(snapshot);
+
+        // Drop the map's value type from the header, keeping Holder and the map type itself.
+        HollowFilterConfig excludeValue = new HollowFilterConfig(true); // exclude filter
+        excludeValue.addType("MapValue");
+        ByteArrayOutputStream filtered = new ByteArrayOutputStream();
+        new FilteredHollowBlobWriter(excludeValue)
+                .filterSnapshot(new ByteArrayInputStream(snapshot.toByteArray()), filtered);
+
+        HollowReadStateEngine readEngine = new HollowReadStateEngine();
+        HollowBlobReader reader = new HollowBlobReader(readEngine);
+
+        // Loading the data with a recursive filter that walks Holder -> m -> map(value = missing).
+        assertThatCode(() ->
+                reader.readSnapshot(
+                        HollowBlobInput.serial(filtered.toByteArray()),
+                        newTypeFilter().excludeAll().includeRecursive("Holder").build()))
+                .doesNotThrowAnyException();
+
+        assertThat(readEngine.getSchema("MapValue")).isNull();
+        assertThat(readEngine.getTypeState("Holder")).isNotNull();
+
+        // Reading the map field and iterating it is safe: the (empty) map materializes no value.
+        int holderOrdinal = readEngine.getTypeState("Holder").getPopulatedOrdinals().nextSetBit(0);
+        GenericHollowObject holder = new GenericHollowObject(readEngine, "Holder", holderOrdinal);
+        assertThatCode(() -> {
+            GenericHollowMap map = holder.getMap("m");
+            int entryCount = 0;
+            for (Map.Entry<HollowRecord, HollowRecord> entry : map.<HollowRecord, HollowRecord>entries()) {
+                entry.getKey();
+                entry.getValue();
+                entryCount++;
+            }
+            assertThat(entryCount).isZero();
+        }).doesNotThrowAnyException();
+    }
+
+    /**
+     * Lifecycle question: if a referenced type that was absent (zero records) at the snapshot the
+     * consumer loaded later gains records, does the consumer pick it up?
+     *
+     * <p>Two mechanisms, verified here:
+     * <ul>
+     *   <li><b>Delta</b>: {@code readTypeStateDelta} discards a delta for a type that has no read
+     *       state ({@code getTypeState == null}); it never creates a new type state. So a long-running
+     *       consumer that applies only deltas will NOT pick up the type until it re-snapshots.</li>
+     *   <li><b>Fresh snapshot</b>: once the type has records, its schema is back in the header, the
+     *       recursive filter re-resolves to include it, and it loads correctly.</li>
+     * </ul>
+     * This is pre-existing Hollow behavior for any type absent at snapshot time (filtered out or
+     * omitted), not a consequence of the null-schema fix.
+     */
+    @Test
+    public void referencedTypeThatGainsRecordsLoadsOnFreshSnapshotButIsDiscardedOnDelta() throws IOException {
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
+        HollowBlobWriter writer = new HollowBlobWriter(writeEngine);
+
+        // Cycle 1: Parent present, no Child -> Child has zero records.
+        mapper.add(new Parent(1, null));
+        ByteArrayOutputStream snapshot1 = new ByteArrayOutputStream();
+        writer.writeSnapshot(snapshot1);
+
+        // Consumer loads a cycle-1 blob with Child dropped from the header (simulating RawHollow
+        // omitting the zero-record type), using a recursive filter.
+        HollowFilterConfig excludeChild = new HollowFilterConfig(true);
+        excludeChild.addType("Child");
+        ByteArrayOutputStream filteredSnap1 = new ByteArrayOutputStream();
+        new FilteredHollowBlobWriter(excludeChild)
+                .filterSnapshot(new ByteArrayInputStream(snapshot1.toByteArray()), filteredSnap1);
+
+        HollowReadStateEngine readEngine = new HollowReadStateEngine();
+        HollowBlobReader reader = new HollowBlobReader(readEngine);
+        reader.readSnapshot(HollowBlobInput.serial(filteredSnap1.toByteArray()),
+                newTypeFilter().excludeAll().includeRecursive("Parent").build());
+        assertThat(readEngine.getSchema("Child")).isNull();
+
+        // Cycle 2: Child gains a record. Producer emits an (unfiltered) delta carrying Child.
+        writeEngine.prepareForNextCycle();
+        mapper.add(new Parent(1, null));
+        mapper.add(new Parent(2, new Child(99)));
+        ByteArrayOutputStream delta = new ByteArrayOutputStream();
+        writer.writeDelta(delta);
+        ByteArrayOutputStream snapshot2 = new ByteArrayOutputStream();
+        writer.writeSnapshot(snapshot2);
+
+        // Applying the delta: Parent's new record applies, but Child's delta is DISCARDED because the
+        // consumer has no Child read state. Child remains absent.
+        reader.applyDelta(HollowBlobInput.serial(delta.toByteArray()));
+        assertThat(readEngine.getSchema("Child")).isNull();
+        assertThat(readEngine.getTypeState("Parent").getPopulatedOrdinals().cardinality()).isEqualTo(2);
+
+        // Re-initializing from the fresh cycle-2 snapshot (where Child now has records) loads Child.
+        HollowReadStateEngine freshEngine = new HollowReadStateEngine();
+        new HollowBlobReader(freshEngine).readSnapshot(HollowBlobInput.serial(snapshot2.toByteArray()),
+                newTypeFilter().excludeAll().includeRecursive("Parent").build());
+        assertThat(freshEngine.getSchema("Child")).isNotNull();
+        assertThat(freshEngine.getTypeState("Child").getPopulatedOrdinals().cardinality()).isEqualTo(1);
+    }
+
+    @SuppressWarnings("unused")
+    private static class Holder {
+        Map<Integer, MapValue> m;
+
+        Holder(Map<Integer, MapValue> m) {
+            this.m = m;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class MapValue {
+        int v;
+
+        MapValue(int v) {
+            this.v = v;
+        }
     }
 
     @SuppressWarnings("unused")

--- a/hollow/src/test/java/com/netflix/hollow/core/read/filter/TypeFilterTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/read/filter/TypeFilterTest.java
@@ -12,8 +12,10 @@ import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowInline;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -286,6 +288,152 @@ public class TypeFilterTest {
     private static <T> List<T> l(T...items) {
         assert items.length > 0;
         return Arrays.asList(items);
+    }
+
+    /**
+     * A type with zero records is omitted from the read state, so a schema that a recursively-included
+     * type references can be absent from the schema set. The resolver must skip the missing subtree
+     * rather than dereference a null schema (which NPEs at {@link HollowSchema#getName()} in
+     * {@code Resolver.descendants}). The following tests cover every path that follows a reference
+     * during resolution: object reference fields (type- and field-recursive, include and exclude),
+     * collection elements, and map keys/values.
+     */
+    @Test
+    public void resolveToleratesMissingReferencedObjectType() {
+        // Alpha -> Beta -> Charlie; Charlie has no records, so its schema is absent.
+        List<HollowSchema> schemas = schemasWithout(l(Alpha.class), "Charlie");
+
+        TypeFilter subject = newTypeFilter()
+                .excludeAll()
+                .includeRecursive("Alpha")
+                .resolve(schemas);
+
+        assertThat(subject.includes("Alpha")).isTrue();
+        assertThat(subject.includes("Beta")).isTrue();
+        // The reference field to the missing type is still included -- identical to an unfiltered read,
+        // where wireTypeStatesToSchemas wires the field's target type state to null.
+        assertThat(subject.includes("Beta", "charlie")).isTrue();
+        // ...but the missing type itself is not included.
+        assertThat(subject.includes("Charlie")).isFalse();
+    }
+
+    @Test
+    public void resolveHaltsRecursionAtMissingIntermediateType() {
+        // Alpha -> Beta -> {Charlie, Long}; the intermediate Beta is absent. Types reachable ONLY
+        // through the missing Beta must not be pulled in (they would be empty in the read state too).
+        List<HollowSchema> schemas = schemasWithout(l(Alpha.class), "Beta");
+
+        TypeFilter subject = newTypeFilter()
+                .excludeAll()
+                .includeRecursive("Alpha")
+                .resolve(schemas);
+
+        assertThat(subject.includes("Alpha")).isTrue();
+        assertThat(subject.includes("Alpha", "beta")).isTrue();
+        assertThat(subject.includes("Charlie")).isFalse();
+        assertThat(subject.includes("Long")).isFalse();
+    }
+
+    @Test
+    public void resolveToleratesMissingReferencedTypeForFieldRecursiveInclude() {
+        // Field-recursive include drives the recursion from the field action (fa.recursive) rather
+        // than an inherited type action -- a distinct entry into the guarded reference lookup.
+        List<HollowSchema> schemas = schemasWithout(l(Beta.class), "Charlie");
+
+        TypeFilter subject = newTypeFilter()
+                .excludeAll()
+                .includeRecursive("Beta", "charlie")
+                .resolve(schemas);
+
+        assertThat(subject.includes("Beta")).isTrue();
+        assertThat(subject.includes("Beta", "charlie")).isTrue();
+        assertThat(subject.includes("Charlie")).isFalse();
+    }
+
+    @Test
+    public void resolveToleratesMissingReferencedTypeUnderExcludeRecursive() {
+        // The guard must also hold when the walk is driven by an exclude (not include) action.
+        // Echo is disjoint from Alpha's hierarchy and must remain included by the include-all base.
+        List<HollowSchema> schemas = schemasWithout(l(Alpha.class, Echo.class), "Charlie");
+
+        TypeFilter subject = newTypeFilter()
+                .excludeRecursive("Alpha")
+                .resolve(schemas);
+
+        assertThat(subject.includes("Echo")).isTrue();
+        assertThat(subject.includes("Alpha")).isFalse();
+        assertThat(subject.includes("Beta")).isFalse();
+    }
+
+    @Test
+    public void resolveToleratesMissingCollectionElementType() {
+        // Omega -> ListOfLE (element LE); LE is absent. LERef is reachable only through LE.
+        List<HollowSchema> schemas = schemasWithout(l(Omega.class), "LE");
+
+        TypeFilter subject = newTypeFilter()
+                .excludeAll()
+                .includeRecursive("Omega")
+                .resolve(schemas);
+
+        assertThat(subject.includes("Omega")).isTrue();
+        assertThat(subject.includes("ListOfLE")).isTrue();
+        assertThat(subject.includes("LERef")).isFalse();
+    }
+
+    @Test
+    public void resolveToleratesMissingMapValueTypeAndKeepsKeySubtree() {
+        // Omega -> MapOfKToV; value type V is absent. The key subtree (K, KRef) must survive because
+        // the two map guards are independent.
+        List<HollowSchema> schemas = schemasWithout(l(Omega.class), "V");
+
+        TypeFilter subject = newTypeFilter()
+                .excludeAll()
+                .includeRecursive("Omega")
+                .resolve(schemas);
+
+        assertThat(subject.includes("MapOfKToV")).isTrue();
+        assertThat(subject.includes("K")).isTrue();
+        assertThat(subject.includes("KRef")).isTrue();
+        assertThat(subject.includes("VRef")).isFalse(); // reachable only through the missing V
+    }
+
+    @Test
+    public void resolveToleratesMissingMapKeyTypeAndKeepsValueSubtree() {
+        // Mirror of the previous test: key type K is absent; the value subtree (V, VRef) must survive.
+        List<HollowSchema> schemas = schemasWithout(l(Omega.class), "K");
+
+        TypeFilter subject = newTypeFilter()
+                .excludeAll()
+                .includeRecursive("Omega")
+                .resolve(schemas);
+
+        assertThat(subject.includes("MapOfKToV")).isTrue();
+        assertThat(subject.includes("V")).isTrue();
+        assertThat(subject.includes("VRef")).isTrue();
+        assertThat(subject.includes("KRef")).isFalse(); // reachable only through the missing K
+    }
+
+    @Test
+    public void resolveToleratesMissingMapKeyAndValueTypes() {
+        // Both key and value absent -> exercises both guarded ternary branches at once.
+        List<HollowSchema> schemas = schemasWithout(l(Omega.class), "K", "V");
+
+        TypeFilter subject = newTypeFilter()
+                .excludeAll()
+                .includeRecursive("Omega")
+                .resolve(schemas);
+
+        assertThat(subject.includes("Omega")).isTrue();
+        assertThat(subject.includes("MapOfKToV")).isTrue();
+        assertThat(subject.includes("KRef")).isFalse();
+        assertThat(subject.includes("VRef")).isFalse();
+    }
+
+    private static List<HollowSchema> schemasWithout(List<Class<?>> models, String... missingTypes) {
+        Set<String> missing = new HashSet<>(asList(missingTypes));
+        List<HollowSchema> schemas = new ArrayList<>(generateSchema(models));
+        schemas.removeIf(s -> missing.contains(s.getName()));
+        return schemas;
     }
 
     private static List<HollowSchema> generateSchema(List<Class<?>> models) {


### PR DESCRIPTION
`TypeFilter` throws NPE when a referenced type does not have a schema. This may happen when the referenced type does not have data. This PR is an attempt to gracefully handle that case instead of failing-early.

