### PR TITLE
Added support for caching previous image

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowAPIFactory.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowAPIFactory.java
@@ -61,6 +61,7 @@ public interface HollowAPIFactory {
         private final Class<T> generatedAPIClass;
         private final Set<String> cachedTypes;
         private final boolean retainRemovedOrdinals;
+        private final Constructor<T> retainAwareConstructor;
 
         public ForGeneratedAPI(Class<T> generatedAPIClass) {
             this(generatedAPIClass, new String[0]);
@@ -72,11 +73,21 @@ public interface HollowAPIFactory {
 
         public ForGeneratedAPI(Class<T> generatedAPIClass, boolean retainRemovedOrdinals, String... cachedTypes) {
             this.generatedAPIClass = generatedAPIClass;
-            this.cachedTypes = new HashSet<String>(Arrays.asList(cachedTypes));
+            this.cachedTypes = new HashSet<>(Arrays.asList(cachedTypes));
             this.retainRemovedOrdinals = retainRemovedOrdinals;
+            this.retainAwareConstructor = retainRemovedOrdinals ? resolveRetainAwareConstructor(generatedAPIClass) : null;
         }
 
-        
+        private static <T> Constructor<T> resolveRetainAwareConstructor(Class<T> generatedAPIClass) {
+            try {
+                return generatedAPIClass.getConstructor(HollowDataAccess.class, Set.class, Map.class, generatedAPIClass, boolean.class);
+            } catch (NoSuchMethodException e) {
+                throw new IllegalStateException(generatedAPIClass.getName()
+                        + " was generated with a version of Hollow that does not support retainRemovedOrdinals;"
+                        + " regenerate the API with a newer Hollow version to retain before images in the object cache", e);
+            }
+        }
+
         @Override
         public T createAPI(HollowDataAccess dataAccess) {
             try {
@@ -95,16 +106,8 @@ public interface HollowAPIFactory {
         @Override
         public T createAPI(HollowDataAccess dataAccess, HollowAPI previousCycleAPI) {
             if (retainRemovedOrdinals) {
-                Constructor<T> constructor;
                 try {
-                    constructor = generatedAPIClass.getConstructor(HollowDataAccess.class, Set.class, Map.class, generatedAPIClass, boolean.class);
-                } catch (NoSuchMethodException e) {
-                    throw new IllegalStateException(generatedAPIClass.getName()
-                            + " was generated with a version of Hollow that does not support retainRemovedOrdinals;"
-                            + " regenerate the API with a newer Hollow version to retain before images in the object cache", e);
-                }
-                try {
-                    return constructor.newInstance(dataAccess, cachedTypes, Collections.emptyMap(), previousCycleAPI, retainRemovedOrdinals);
+                    return retainAwareConstructor.newInstance(dataAccess, cachedTypes, Collections.emptyMap(), previousCycleAPI, true);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowAPIFactory.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowAPIFactory.java
@@ -104,7 +104,7 @@ public interface HollowAPIFactory {
                             + " regenerate the API with a newer Hollow version to retain before images in the object cache", e);
                 }
                 try {
-                    return constructor.newInstance(dataAccess, cachedTypes, Collections.emptyMap(), previousCycleAPI, true);
+                    return constructor.newInstance(dataAccess, cachedTypes, Collections.emptyMap(), previousCycleAPI, retainRemovedOrdinals);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowAPIFactory.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowAPIFactory.java
@@ -60,14 +60,20 @@ public interface HollowAPIFactory {
 
         private final Class<T> generatedAPIClass;
         private final Set<String> cachedTypes;
-        
+        private final boolean retainRemovedOrdinals;
+
         public ForGeneratedAPI(Class<T> generatedAPIClass) {
             this(generatedAPIClass, new String[0]);
         }
-        
+
         public ForGeneratedAPI(Class<T> generatedAPIClass, String... cachedTypes) {
+            this(generatedAPIClass, false, cachedTypes);
+        }
+
+        public ForGeneratedAPI(Class<T> generatedAPIClass, boolean retainRemovedOrdinals, String... cachedTypes) {
             this.generatedAPIClass = generatedAPIClass;
             this.cachedTypes = new HashSet<String>(Arrays.asList(cachedTypes));
+            this.retainRemovedOrdinals = retainRemovedOrdinals;
         }
 
         
@@ -88,6 +94,21 @@ public interface HollowAPIFactory {
 
         @Override
         public T createAPI(HollowDataAccess dataAccess, HollowAPI previousCycleAPI) {
+            if (retainRemovedOrdinals) {
+                Constructor<T> constructor;
+                try {
+                    constructor = generatedAPIClass.getConstructor(HollowDataAccess.class, Set.class, Map.class, generatedAPIClass, boolean.class);
+                } catch (NoSuchMethodException e) {
+                    throw new IllegalStateException(generatedAPIClass.getName()
+                            + " was generated with a version of Hollow that does not support retainRemovedOrdinals;"
+                            + " regenerate the API with a newer Hollow version to retain before images in the object cache", e);
+                }
+                try {
+                    return constructor.newInstance(dataAccess, cachedTypes, Collections.emptyMap(), previousCycleAPI, true);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
             try {
                 Constructor<T> constructor = generatedAPIClass.getConstructor(HollowDataAccess.class, Set.class, Map.class, generatedAPIClass);
                 return constructor.newInstance(dataAccess, cachedTypes, Collections.emptyMap(), previousCycleAPI);

--- a/hollow/src/main/java/com/netflix/hollow/api/client/HollowAPIFactory.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/client/HollowAPIFactory.java
@@ -107,7 +107,7 @@ public interface HollowAPIFactory {
         public T createAPI(HollowDataAccess dataAccess, HollowAPI previousCycleAPI) {
             if (retainRemovedOrdinals) {
                 try {
-                    return retainAwareConstructor.newInstance(dataAccess, cachedTypes, Collections.emptyMap(), previousCycleAPI, true);
+                    return retainAwareConstructor.newInstance(dataAccess, cachedTypes, Collections.emptyMap(), previousCycleAPI, retainRemovedOrdinals);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIClassJavaGenerator.java
@@ -153,6 +153,10 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
         builder.append("    }\n\n");
 
         builder.append("    public ").append(className).append("(HollowDataAccess dataAccess, Set<String> cachedTypes, Map<String, HollowFactory<?>> factoryOverrides, ").append(className).append(" previousCycleAPI) {\n");
+        builder.append("        this(dataAccess, cachedTypes, factoryOverrides, previousCycleAPI, false);\n");
+        builder.append("    }\n\n");
+
+        builder.append("    public ").append(className).append("(HollowDataAccess dataAccess, Set<String> cachedTypes, Map<String, HollowFactory<?>> factoryOverrides, ").append(className).append(" previousCycleAPI, boolean retainRemovedOrdinalsInCache) {\n");
         builder.append("        super(dataAccess);\n");
         builder.append("        HollowTypeDataAccess typeDataAccess;\n");
         builder.append("        HollowFactory factory;\n\n");
@@ -188,7 +192,7 @@ public class HollowAPIClassJavaGenerator extends HollowConsumerJavaFileGenerator
             builder.append("            HollowObjectCacheProvider previousCacheProvider = null;\n");
             builder.append("            if(previousCycleAPI != null && (previousCycleAPI.").append(hollowObjectProviderName(schema.getName())).append(" instanceof HollowObjectCacheProvider))\n");
             builder.append("                previousCacheProvider = (HollowObjectCacheProvider) previousCycleAPI.").append(hollowObjectProviderName(schema.getName())).append(";\n");
-            builder.append("            ").append(hollowObjectProviderName(schema.getName())).append(" = new HollowObjectCacheProvider(typeDataAccess, ").append(lowercase(typeAPIClassname(schema.getName()))).append(", factory, previousCacheProvider);\n");
+            builder.append("            ").append(hollowObjectProviderName(schema.getName())).append(" = new HollowObjectCacheProvider(typeDataAccess, ").append(lowercase(typeAPIClassname(schema.getName()))).append(", factory, previousCacheProvider, retainRemovedOrdinalsInCache);\n");
             builder.append("        } else {\n");
             builder.append("            ").append(hollowObjectProviderName(schema.getName())).append(" = new HollowObjectFactoryProvider(typeDataAccess, ").append(lowercase(typeAPIClassname(schema.getName()))).append(", factory);\n");
             builder.append("        }\n\n");

--- a/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/consumer/HollowConsumer.java
@@ -1285,6 +1285,36 @@ public class HollowConsumer {
         public B withGeneratedAPIClass(Class<? extends HollowAPI> generatedAPIClass,
                                        String cachedType,
                                        String... additionalCachedTypes) {
+            return withGeneratedAPIClass(generatedAPIClass, false, cachedType, additionalCachedTypes);
+        }
+
+        /**
+         * As {@link #withGeneratedAPIClass(Class, String, String...)}, but additionally controls whether the object
+         * caches retain the "before image" of records removed in the latest cycle.
+         *
+         * <p>When {@code retainRemovedOrdinalsInCache} is {@code true}, a record removed in a cycle remains
+         * queryable from the cache for one more cycle, so change listeners can look up its prior value. This mirrors
+         * the behavior of {@code HollowPerfAPICache} and costs roughly one extra cycle of removed cached instances.
+         * Requires an API generated with a version of Hollow that supports it; otherwise consumer refresh fails with
+         * an {@link IllegalStateException}.
+         *
+         * <p>This only takes effect when object longevity is enabled (see {@link ObjectLongevityConfig}), which is
+         * the mode that rebuilds the API each cycle. Without it, deltas are applied to the cache in place and the
+         * flag has no effect.
+         *
+         * @param generatedAPIClass the code generated API class
+         * @param retainRemovedOrdinalsInCache whether removed records' before images are retained for one cycle
+         * @param cachedType the type to enable object caching on
+         * @param additionalCachedTypes more types to enable object caching on
+         *
+         * @return this builder
+         *
+         * @see <a href="https://hollow.how/advanced-topics/#caching">https://hollow.how/advanced-topics/#caching</a>
+         */
+        public B withGeneratedAPIClass(Class<? extends HollowAPI> generatedAPIClass,
+                                       boolean retainRemovedOrdinalsInCache,
+                                       String cachedType,
+                                       String... additionalCachedTypes) {
             if (HollowAPI.class.equals(generatedAPIClass))
                 throw new IllegalArgumentException("must provide a code generated API class");
             generatedAPIClass = Objects.requireNonNull(generatedAPIClass, "API class cannot be null");
@@ -1299,7 +1329,7 @@ public class HollowConsumer {
             }
             if (!nulls.isEmpty())
                 throw new NullPointerException("cached types cannot be null; argsWithNull=" + nulls.toString());
-            this.apiFactory = new HollowAPIFactory.ForGeneratedAPI<>(generatedAPIClass, cachedTypes);
+            this.apiFactory = new HollowAPIFactory.ForGeneratedAPI<>(generatedAPIClass, retainRemovedOrdinalsInCache, cachedTypes);
             return (B)this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProvider.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProvider.java
@@ -41,12 +41,18 @@ public class HollowObjectCacheProvider<T> extends HollowObjectProvider<T> implem
     private volatile HollowFactory<T> factory;
     private volatile HollowTypeAPI typeAPI;
     private volatile HollowTypeReadState typeReadState;
+    private final boolean retainRemovedOrdinals;
 
     public HollowObjectCacheProvider(HollowTypeDataAccess typeDataAccess, HollowTypeAPI typeAPI, HollowFactory<T> factory) {
         this(typeDataAccess, typeAPI, factory, null);
     }
 
     public HollowObjectCacheProvider(HollowTypeDataAccess typeDataAccess, HollowTypeAPI typeAPI, HollowFactory<T> factory, HollowObjectCacheProvider<T> previous) {
+        this(typeDataAccess, typeAPI, factory, previous, false);
+    }
+
+    public HollowObjectCacheProvider(HollowTypeDataAccess typeDataAccess, HollowTypeAPI typeAPI, HollowFactory<T> factory, HollowObjectCacheProvider<T> previous, boolean retainRemovedOrdinals) {
+        this.retainRemovedOrdinals = retainRemovedOrdinals;
         if(typeDataAccess != null) {
             PopulatedOrdinalListener listener = typeDataAccess.getTypeState().getListener(PopulatedOrdinalListener.class);
             BitSet populatedOrdinals = listener.getPopulatedOrdinals();
@@ -59,12 +65,18 @@ public class HollowObjectCacheProvider<T> extends HollowObjectProvider<T> implem
                 while(ordinal >= arr.size())
                     arr.add(null);
 
-                if(previous != null && previousOrdinals.get(ordinal) && populatedOrdinals.get(ordinal)) {
+                boolean previouslyPopulated = previous != null && previousOrdinals.get(ordinal);
+                boolean currentlyPopulated = populatedOrdinals.get(ordinal);
+                if(previouslyPopulated && (currentlyPopulated || retainRemovedOrdinals)) {
+                    // Reuse the previously cached object. When still populated the content is identical (changed
+                    // content is assigned a new ordinal); when removed-only this preserves the before image. Either
+                    // way the cached delegate must be re-pointed at the current type api so lazy reference fields
+                    // resolve against the current read state.
                     T cached = previous.getHollowObject(ordinal);
                     arr.set(ordinal, cached);
                     if(cached instanceof HollowRecord)
                         ((HollowCachedDelegate)((HollowRecord)cached).getDelegate()).updateTypeAPI(typeAPI);
-                } else if(populatedOrdinals.get(ordinal)){
+                } else if(currentlyPopulated){
                     arr.set(ordinal, instantiateCachedObject(factory, typeDataAccess, typeAPI, ordinal));
                 }
             }

--- a/hollow/src/main/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProvider.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProvider.java
@@ -41,7 +41,6 @@ public class HollowObjectCacheProvider<T> extends HollowObjectProvider<T> implem
     private volatile HollowFactory<T> factory;
     private volatile HollowTypeAPI typeAPI;
     private volatile HollowTypeReadState typeReadState;
-    private final boolean retainRemovedOrdinals;
 
     public HollowObjectCacheProvider(HollowTypeDataAccess typeDataAccess, HollowTypeAPI typeAPI, HollowFactory<T> factory) {
         this(typeDataAccess, typeAPI, factory, null);
@@ -52,7 +51,6 @@ public class HollowObjectCacheProvider<T> extends HollowObjectProvider<T> implem
     }
 
     public HollowObjectCacheProvider(HollowTypeDataAccess typeDataAccess, HollowTypeAPI typeAPI, HollowFactory<T> factory, HollowObjectCacheProvider<T> previous, boolean retainRemovedOrdinals) {
-        this.retainRemovedOrdinals = retainRemovedOrdinals;
         if(typeDataAccess != null) {
             PopulatedOrdinalListener listener = typeDataAccess.getTypeState().getListener(PopulatedOrdinalListener.class);
             BitSet populatedOrdinals = listener.getPopulatedOrdinals();

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowAPIFactoryTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowAPIFactoryTest.java
@@ -53,6 +53,19 @@ public class HollowAPIFactoryTest {
     }
 
     @Test
+    public void createAPI_firstCycleWithoutPrevious_ignoresRetainFlag() {
+        // the initial snapshot load has no previous api to retain from, so it must use the standard
+        // 2-arg constructor and never attempt (or require) the retain-aware constructor
+        ForGeneratedAPI<RetentionAwareAPI> factory =
+                new ForGeneratedAPI<>(RetentionAwareAPI.class, true, "TypeA");
+
+        RetentionAwareAPI api = factory.createAPI(null);
+
+        assertEquals(2, api.constructorArgCount);
+        assertFalse(api.retainRemovedOrdinalsReceived);
+    }
+
+    @Test
     public void createAPI_whenRetainRequestedButApiWasGeneratedWithoutSupport_throwsClearError() {
         ForGeneratedAPI<LegacyAPI> factory =
                 new ForGeneratedAPI<>(LegacyAPI.class, true, "TypeA");

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowAPIFactoryTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowAPIFactoryTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.netflix.hollow.api.client.HollowAPIFactory.ForGeneratedAPI;
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class HollowAPIFactoryTest {
+
+    @Test
+    public void createAPI_withRetainRemovedOrdinals_usesFiveArgConstructorAndPassesTrue() {
+        ForGeneratedAPI<RetentionAwareAPI> factory =
+                new ForGeneratedAPI<>(RetentionAwareAPI.class, true, "TypeA");
+
+        RetentionAwareAPI api = factory.createAPI(null, null);
+
+        assertEquals(5, api.constructorArgCount);
+        assertTrue(api.retainRemovedOrdinalsReceived);
+    }
+
+    @Test
+    public void createAPI_withoutRetainRemovedOrdinals_usesFourArgConstructor() {
+        ForGeneratedAPI<RetentionAwareAPI> factory =
+                new ForGeneratedAPI<>(RetentionAwareAPI.class, false, "TypeA");
+
+        RetentionAwareAPI api = factory.createAPI(null, null);
+
+        assertEquals(4, api.constructorArgCount);
+        assertFalse(api.retainRemovedOrdinalsReceived);
+    }
+
+    @Test
+    public void createAPI_whenRetainRequestedButApiWasGeneratedWithoutSupport_throwsClearError() {
+        ForGeneratedAPI<LegacyAPI> factory =
+                new ForGeneratedAPI<>(LegacyAPI.class, true, "TypeA");
+
+        try {
+            factory.createAPI(null, null);
+            fail("expected IllegalStateException because the generated API has no retain-aware constructor");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("retainRemovedOrdinals"));
+        }
+    }
+
+    /** Stub standing in for a generated API produced with the new codegen (has the 5-arg constructor). */
+    public static class RetentionAwareAPI extends HollowAPI {
+        final int constructorArgCount;
+        final boolean retainRemovedOrdinalsReceived;
+
+        public RetentionAwareAPI(HollowDataAccess dataAccess) {
+            super(dataAccess);
+            this.constructorArgCount = 1;
+            this.retainRemovedOrdinalsReceived = false;
+        }
+
+        public RetentionAwareAPI(HollowDataAccess dataAccess, Set<String> cachedTypes) {
+            super(dataAccess);
+            this.constructorArgCount = 2;
+            this.retainRemovedOrdinalsReceived = false;
+        }
+
+        public RetentionAwareAPI(HollowDataAccess dataAccess, Set<String> cachedTypes,
+                Map<String, Object> factoryOverrides, RetentionAwareAPI previousCycleAPI) {
+            super(dataAccess);
+            this.constructorArgCount = 4;
+            this.retainRemovedOrdinalsReceived = false;
+        }
+
+        public RetentionAwareAPI(HollowDataAccess dataAccess, Set<String> cachedTypes,
+                Map<String, Object> factoryOverrides, RetentionAwareAPI previousCycleAPI,
+                boolean retainRemovedOrdinals) {
+            super(dataAccess);
+            this.constructorArgCount = 5;
+            this.retainRemovedOrdinalsReceived = retainRemovedOrdinals;
+        }
+    }
+
+    /** Stub standing in for an API produced with the old codegen (no retain-aware constructor). */
+    public static class LegacyAPI extends HollowAPI {
+        public LegacyAPI(HollowDataAccess dataAccess) {
+            super(dataAccess);
+        }
+
+        public LegacyAPI(HollowDataAccess dataAccess, Set<String> cachedTypes) {
+            super(dataAccess);
+        }
+
+        public LegacyAPI(HollowDataAccess dataAccess, Set<String> cachedTypes,
+                Map<String, Object> factoryOverrides, LegacyAPI previousCycleAPI) {
+            super(dataAccess);
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/api/client/HollowAPIFactoryTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/client/HollowAPIFactoryTest.java
@@ -66,12 +66,9 @@ public class HollowAPIFactoryTest {
     }
 
     @Test
-    public void createAPI_whenRetainRequestedButApiWasGeneratedWithoutSupport_throwsClearError() {
-        ForGeneratedAPI<LegacyAPI> factory =
-                new ForGeneratedAPI<>(LegacyAPI.class, true, "TypeA");
-
+    public void construction_whenRetainRequestedButApiWasGeneratedWithoutSupport_failsFastWithClearError() {
         try {
-            factory.createAPI(null, null);
+            new ForGeneratedAPI<>(LegacyAPI.class, true, "TypeA");
             fail("expected IllegalStateException because the generated API has no retain-aware constructor");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage(), expected.getMessage().contains("retainRemovedOrdinals"));

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPICachingCodeGenTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPICachingCodeGenTest.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.codegen;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class HollowAPICachingCodeGenTest extends AbstractHollowAPIGeneratorTest {
+
+    @Test
+    public void generatedApiSupportsRetainRemovedOrdinals() throws Exception {
+        runGenerator("API", "codegen.api", MyClass.class, b -> b);
+
+        // The generated API must expose the retain-aware constructor that
+        // HollowAPIFactory.ForGeneratedAPI reflectively invokes when retainRemovedOrdinals is enabled.
+        ClassLoader cl = new URLClassLoader(new URL[]{new File(clazzFolder).toURI().toURL()});
+        Class<?> apiClass = cl.loadClass("codegen.api.API");
+        assertNotNull(apiClass.getConstructor(
+                HollowDataAccess.class, Set.class, Map.class, apiClass, boolean.class));
+
+        // ...and the flag must be threaded into the object cache providers it builds.
+        String generated = new String(
+                Files.readAllBytes(Paths.get(sourceFolder, "codegen/api/API.java")), StandardCharsets.UTF_8);
+        assertTrue("generated API should pass retainRemovedOrdinalsInCache to HollowObjectCacheProvider",
+                generated.contains("new HollowObjectCacheProvider(")
+                        && generated.contains("retainRemovedOrdinalsInCache"));
+    }
+
+    @SuppressWarnings("unused")
+    private static class MyClass {
+        int id;
+        String foo;
+
+        MyClass(int id, String foo) {
+            this.id = id;
+            this.foo = foo;
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPICachingCodeGenTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/codegen/HollowAPICachingCodeGenTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.junit.Test;
 
 public class HollowAPICachingCodeGenTest extends AbstractHollowAPIGeneratorTest {
@@ -43,12 +44,14 @@ public class HollowAPICachingCodeGenTest extends AbstractHollowAPIGeneratorTest 
         assertNotNull(apiClass.getConstructor(
                 HollowDataAccess.class, Set.class, Map.class, apiClass, boolean.class));
 
-        // ...and the flag must be threaded into the object cache providers it builds.
+        // ...and the flag must be threaded into the object cache providers it builds, as an actual constructor
+        // argument (not merely mentioned somewhere in the source, e.g. in a comment or unused variable).
         String generated = new String(
                 Files.readAllBytes(Paths.get(sourceFolder, "codegen/api/API.java")), StandardCharsets.UTF_8);
-        assertTrue("generated API should pass retainRemovedOrdinalsInCache to HollowObjectCacheProvider",
-                generated.contains("new HollowObjectCacheProvider(")
-                        && generated.contains("retainRemovedOrdinalsInCache"));
+        Pattern newCacheProviderWithFlag = Pattern.compile(
+                "new HollowObjectCacheProvider\\([^)]*retainRemovedOrdinalsInCache[^)]*\\)");
+        assertTrue("generated API should pass retainRemovedOrdinalsInCache as an argument to HollowObjectCacheProvider",
+                newCacheProviderWithFlag.matcher(generated).find());
     }
 
     @SuppressWarnings("unused")

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowConsumerBuilderTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowConsumerBuilderTest.java
@@ -2,6 +2,8 @@ package com.netflix.hollow.api.consumer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.netflix.hollow.api.consumer.index.HashIndex;
@@ -87,6 +89,68 @@ public class HollowConsumerBuilderTest {
 
         assertEquals(4, api.constructorArgCount);
         assertFalse(api.retainRemovedOrdinalsReceived);
+    }
+
+    @Test
+    public void retainedBeforeImage_referenceTraversal_resolvesToBeforeImagesWithoutError() throws IOException {
+        TestHollowConsumer consumer = longevityBuilder()
+                .withGeneratedAPIClass(AwardsAPI.class, true, "Award", "Movie", "SetOfMovie")
+                .build();
+
+        com.netflix.hollow.test.model.Movie winner = new com.netflix.hollow.test.model.Movie(10, "winner", 2023);
+        com.netflix.hollow.test.model.Movie nominee = new com.netflix.hollow.test.model.Movie(20, "nominee", 2023);
+        com.netflix.hollow.test.model.Award a1 = new com.netflix.hollow.test.model.Award(1, winner,
+                new HashSet<com.netflix.hollow.test.model.Movie>() {{ add(nominee); }});
+
+        // v1: the award (ordinal 0) and its referenced movies are present
+        consumer.addSnapshot(1l, new HollowWriteStateEngineBuilder().add(a1).build());
+        consumer.triggerRefreshTo(1l);
+
+        // v2: the award and its movies are removed; a different award takes fresh ordinals (the one-cycle
+        // reuse gap keeps a1 at ordinal 0), so a1 becomes a removed-only "before image"
+        com.netflix.hollow.test.model.Movie w2 = new com.netflix.hollow.test.model.Movie(30, "w2", 2024);
+        com.netflix.hollow.test.model.Award a2 = new com.netflix.hollow.test.model.Award(2, w2,
+                new HashSet<com.netflix.hollow.test.model.Movie>());
+        consumer.addDelta(1l, 2l, new HollowWriteStateEngineBuilder().add(a2).build());
+        consumer.triggerRefreshTo(2l);
+
+        AwardsAPI api = (AwardsAPI) consumer.getAPI();
+
+        // the removed award is still queryable as a before image
+        Award beforeImage = api.getAward(0);
+        assertNotNull(beforeImage);
+        assertEquals(1L, beforeImage.getId());
+
+        // traversing its reference fields must not error and must resolve to the referenced before images
+        Movie beforeWinner = beforeImage.getWinner();
+        assertNotNull(beforeWinner);
+        assertEquals(10L, beforeWinner.getId());
+
+        assertEquals(1L, beforeImage.getNominees().stream().count());
+        assertEquals(20L, beforeImage.getNominees().stream().findFirst().get().getId());
+    }
+
+    @Test
+    public void withoutRetain_removedAwardBeforeImageIsHoledOut() throws IOException {
+        TestHollowConsumer consumer = longevityBuilder()
+                .withGeneratedAPIClass(AwardsAPI.class, "Award", "Movie", "SetOfMovie")
+                .build();
+
+        com.netflix.hollow.test.model.Movie winner = new com.netflix.hollow.test.model.Movie(10, "winner", 2023);
+        com.netflix.hollow.test.model.Award a1 = new com.netflix.hollow.test.model.Award(1, winner,
+                new HashSet<com.netflix.hollow.test.model.Movie>());
+        consumer.addSnapshot(1l, new HollowWriteStateEngineBuilder().add(a1).build());
+        consumer.triggerRefreshTo(1l);
+
+        com.netflix.hollow.test.model.Movie w2 = new com.netflix.hollow.test.model.Movie(30, "w2", 2024);
+        com.netflix.hollow.test.model.Award a2 = new com.netflix.hollow.test.model.Award(2, w2,
+                new HashSet<com.netflix.hollow.test.model.Movie>());
+        consumer.addDelta(1l, 2l, new HollowWriteStateEngineBuilder().add(a2).build());
+        consumer.triggerRefreshTo(2l);
+
+        AwardsAPI api = (AwardsAPI) consumer.getAPI();
+        // without the flag, the removed record's slot is holed out
+        assertNull(api.getAward(0));
     }
 
     // Object longevity forces a fresh API instance per cycle via createAPI(dataAccess, previous) -- the rotation

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowConsumerBuilderTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowConsumerBuilderTest.java
@@ -9,6 +9,9 @@ import static org.junit.Assert.assertTrue;
 import com.netflix.hollow.api.consumer.index.HashIndex;
 import com.netflix.hollow.api.custom.HollowAPI;
 import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
+import com.netflix.hollow.core.read.engine.HollowTypeReadState;
+import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
+import java.util.BitSet;
 import com.netflix.hollow.test.HollowWriteStateEngineBuilder;
 import com.netflix.hollow.test.consumer.TestBlobRetriever;
 import com.netflix.hollow.test.consumer.TestHollowConsumer;
@@ -151,6 +154,147 @@ public class HollowConsumerBuilderTest {
         AwardsAPI api = (AwardsAPI) consumer.getAPI();
         // without the flag, the removed record's slot is holed out
         assertNull(api.getAward(0));
+    }
+
+    // An updated record removes its old ordinal and adds a new one. With retention enabled, the before image at
+    // the removed ordinal and the after image at the added ordinal are both queryable in the same refresh.
+    @Test
+    public void updatedRecord_beforeAndAfterImagesQueryableViaOrdinalDiff() throws IOException {
+        TestHollowConsumer consumer = longevityBuilder()
+                .withGeneratedAPIClass(AwardsAPI.class, true, "Movie")
+                .build();
+
+        // v1: record with id=100 at ordinal 0
+        consumer.addSnapshot(1l, new HollowWriteStateEngineBuilder()
+                .add(new com.netflix.hollow.test.model.Movie(100, "old title", 2020)).build());
+        consumer.triggerRefreshTo(1l);
+
+        // v2: the same record is UPDATED (title changes) -> new ordinal added, old ordinal removed
+        consumer.addDelta(1l, 2l, new HollowWriteStateEngineBuilder()
+                .add(new com.netflix.hollow.test.model.Movie(100, "new title", 2020)).build());
+        consumer.triggerRefreshTo(2l);
+
+        AwardsAPI api = (AwardsAPI) consumer.getAPI();
+
+        // diff ordinals exactly as a change listener would
+        PopulatedOrdinalListener listener = movieOrdinalListener(consumer);
+        BitSet removed = (BitSet) listener.getPreviousOrdinals().clone();
+        removed.andNot(listener.getPopulatedOrdinals());
+        BitSet added = (BitSet) listener.getPopulatedOrdinals().clone();
+        added.andNot(listener.getPreviousOrdinals());
+
+        int removedOrdinal = removed.nextSetBit(0);
+        int addedOrdinal = added.nextSetBit(0);
+        assertTrue("expected an updated record to remove one ordinal", removedOrdinal >= 0);
+        assertTrue("expected an updated record to add one ordinal", addedOrdinal >= 0);
+
+        // before image (removed ordinal) is still queryable and holds the prior value
+        Movie before = api.getMovie(removedOrdinal);
+        assertNotNull(before);
+        assertEquals(100L, before.getId());
+        assertEquals("old title", before.getTitle());
+
+        // after image (added ordinal) holds the new value
+        Movie after = api.getMovie(addedOrdinal);
+        assertNotNull(after);
+        assertEquals(100L, after.getId());
+        assertEquals("new title", after.getTitle());
+    }
+
+    @Test
+    public void updatedRecord_withoutRetain_beforeImageIsLost() throws IOException {
+        TestHollowConsumer consumer = longevityBuilder()
+                .withGeneratedAPIClass(AwardsAPI.class, "Movie")
+                .build();
+
+        consumer.addSnapshot(1l, new HollowWriteStateEngineBuilder()
+                .add(new com.netflix.hollow.test.model.Movie(100, "old title", 2020)).build());
+        consumer.triggerRefreshTo(1l);
+        consumer.addDelta(1l, 2l, new HollowWriteStateEngineBuilder()
+                .add(new com.netflix.hollow.test.model.Movie(100, "new title", 2020)).build());
+        consumer.triggerRefreshTo(2l);
+
+        AwardsAPI api = (AwardsAPI) consumer.getAPI();
+        PopulatedOrdinalListener listener = movieOrdinalListener(consumer);
+        BitSet removed = (BitSet) listener.getPreviousOrdinals().clone();
+        removed.andNot(listener.getPopulatedOrdinals());
+        int removedOrdinal = removed.nextSetBit(0);
+        assertTrue(removedOrdinal >= 0);
+
+        // without the flag, the before image of the updated record is holed out
+        assertNull(api.getMovie(removedOrdinal));
+    }
+
+    // A before image is retained for exactly one cycle: after a second, unrelated delta it is no longer queryable.
+    // A stable record keeps the low ordinal populated so the checked slot stays in bounds regardless of reuse.
+    @Test
+    public void updatedRecord_beforeImageRetainedForOnlyOneCycle() throws IOException {
+        TestHollowConsumer consumer = longevityBuilder()
+                .withGeneratedAPIClass(AwardsAPI.class, true, "Movie")
+                .build();
+
+        com.netflix.hollow.test.model.Movie stable = new com.netflix.hollow.test.model.Movie(1, "stable", 2020);
+        consumer.addSnapshot(1l, new HollowWriteStateEngineBuilder()
+                .add(stable).add(new com.netflix.hollow.test.model.Movie(2, "t1", 2020)).build());
+        consumer.triggerRefreshTo(1l);
+
+        // cycle 1: update record id=2 -> its old ordinal becomes a removed-only before image
+        consumer.addDelta(1l, 2l, new HollowWriteStateEngineBuilder()
+                .add(stable).add(new com.netflix.hollow.test.model.Movie(2, "t2", 2020)).build());
+        consumer.triggerRefreshTo(2l);
+
+        PopulatedOrdinalListener listener = movieOrdinalListener(consumer);
+        BitSet removed = (BitSet) listener.getPreviousOrdinals().clone();
+        removed.andNot(listener.getPopulatedOrdinals());
+        int t1Ordinal = removed.nextSetBit(0);
+        assertTrue(t1Ordinal >= 0);
+        assertEquals("t1", ((AwardsAPI) consumer.getAPI()).getMovie(t1Ordinal).getTitle());
+
+        // cycle 2: an unrelated add -> the previous before image must no longer be retained
+        consumer.addDelta(2l, 3l, new HollowWriteStateEngineBuilder()
+                .add(stable).add(new com.netflix.hollow.test.model.Movie(2, "t2", 2020))
+                .add(new com.netflix.hollow.test.model.Movie(3, "filler", 2020)).build());
+        consumer.triggerRefreshTo(3l);
+
+        Movie stale = ((AwardsAPI) consumer.getAPI()).getMovie(t1Ordinal);
+        assertTrue("before image should be dropped after one cycle", stale == null || !"t1".equals(stale.getTitle()));
+    }
+
+    private static PopulatedOrdinalListener movieOrdinalListener(TestHollowConsumer consumer) {
+        HollowTypeReadState movieState = consumer.getStateEngine().getTypeState("Movie");
+        return movieState.getListener(PopulatedOrdinalListener.class);
+    }
+
+    @Test
+    public void retainedBeforeImage_traversalToNonCachedReference_resolvesGhost() throws IOException {
+        // Only the parent (Award) is cached/retained; the referenced Movie is NOT cached, so getWinner()
+        // resolves through the factory provider against the current read state. This probes the "ghost read"
+        // path for a removed reference of a non-cached type.
+        TestHollowConsumer consumer = longevityBuilder()
+                .withGeneratedAPIClass(AwardsAPI.class, true, "Award")
+                .build();
+
+        com.netflix.hollow.test.model.Movie winner = new com.netflix.hollow.test.model.Movie(10, "winner", 2023);
+        com.netflix.hollow.test.model.Award a1 = new com.netflix.hollow.test.model.Award(1, winner,
+                new HashSet<com.netflix.hollow.test.model.Movie>());
+        consumer.addSnapshot(1l, new HollowWriteStateEngineBuilder().add(a1).build());
+        consumer.triggerRefreshTo(1l);
+
+        com.netflix.hollow.test.model.Movie w2 = new com.netflix.hollow.test.model.Movie(30, "w2", 2024);
+        com.netflix.hollow.test.model.Award a2 = new com.netflix.hollow.test.model.Award(2, w2,
+                new HashSet<com.netflix.hollow.test.model.Movie>());
+        consumer.addDelta(1l, 2l, new HollowWriteStateEngineBuilder().add(a2).build());
+        consumer.triggerRefreshTo(2l);
+
+        AwardsAPI api = (AwardsAPI) consumer.getAPI();
+        Award beforeImage = api.getAward(0);
+        assertNotNull(beforeImage);
+        assertEquals(1L, beforeImage.getId());
+
+        // traverse to the removed, non-cached Movie reference -- must not error
+        Movie beforeWinner = beforeImage.getWinner();
+        assertNotNull(beforeWinner);
+        assertEquals(10L, beforeWinner.getId());
     }
 
     // Object longevity forces a fresh API instance per cycle via createAPI(dataAccess, previous) -- the rotation

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowConsumerBuilderTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowConsumerBuilderTest.java
@@ -1,9 +1,12 @@
 package com.netflix.hollow.api.consumer;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.netflix.hollow.api.consumer.index.HashIndex;
+import com.netflix.hollow.api.custom.HollowAPI;
+import com.netflix.hollow.core.read.dataaccess.HollowDataAccess;
 import com.netflix.hollow.test.HollowWriteStateEngineBuilder;
 import com.netflix.hollow.test.consumer.TestBlobRetriever;
 import com.netflix.hollow.test.consumer.TestHollowConsumer;
@@ -13,6 +16,8 @@ import com.netflix.hollow.test.generated.Movie;
 import com.netflix.hollow.test.generated.MoviePrimaryKeyIndex;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -56,6 +61,93 @@ public class HollowConsumerBuilderTest {
                 .withGeneratedAPIClass(AwardsAPI.class)
                 .build();
         testConsumerCache(false, false, consumer);
+    }
+
+    @Test
+    public void retainRemovedOrdinals_wiresFlagThroughToGeneratedApi() throws IOException {
+        TestHollowConsumer consumer = longevityBuilder()
+                .withGeneratedAPIClass(RetentionRecordingAPI.class, true, "Movie")
+                .build();
+
+        RetentionRecordingAPI api = refreshThroughDelta(consumer);
+
+        // the delta refresh builds the api via createAPI(dataAccess, previous), which must reach the 5-arg
+        // retain-aware constructor with the flag set
+        assertEquals(5, api.constructorArgCount);
+        assertTrue(api.retainRemovedOrdinalsReceived);
+    }
+
+    @Test
+    public void withoutRetainRemovedOrdinals_usesStandardConstructor() throws IOException {
+        TestHollowConsumer consumer = longevityBuilder()
+                .withGeneratedAPIClass(RetentionRecordingAPI.class, "Movie")
+                .build();
+
+        RetentionRecordingAPI api = refreshThroughDelta(consumer);
+
+        assertEquals(4, api.constructorArgCount);
+        assertFalse(api.retainRemovedOrdinalsReceived);
+    }
+
+    // Object longevity forces a fresh API instance per cycle via createAPI(dataAccess, previous) -- the rotation
+    // path that the retainRemovedOrdinals flag targets. Without it, deltas are applied in place and no new API is built.
+    private static TestHollowConsumer.Builder longevityBuilder() {
+        return new TestHollowConsumer.Builder()
+                .withBlobRetriever(new TestBlobRetriever())
+                .withObjectLongevityConfig(new HollowConsumer.ObjectLongevityConfig() {
+                    public long usageDetectionPeriodMillis() { return 1_000L; }
+                    public long gracePeriodMillis() { return 2L * 60 * 60 * 1000; }
+                    public boolean forceDropData() { return true; }
+                    public boolean enableLongLivedObjectSupport() { return true; }
+                    public boolean enableExpiredUsageStackTraces() { return false; }
+                    public boolean dropDataAutomatically() { return true; }
+                });
+    }
+
+    private RetentionRecordingAPI refreshThroughDelta(TestHollowConsumer consumer) throws IOException {
+        com.netflix.hollow.test.model.Movie m1 = new com.netflix.hollow.test.model.Movie(1, "test movie 1", 2023);
+        com.netflix.hollow.test.model.Award a1 = new com.netflix.hollow.test.model.Award(1, m1,
+                new HashSet<com.netflix.hollow.test.model.Movie>());
+
+        consumer.addSnapshot(1l, new HollowWriteStateEngineBuilder().add(a1).build());
+        consumer.triggerRefreshTo(1l);
+        consumer.addDelta(1l, 2l, new HollowWriteStateEngineBuilder().add(a1).build());
+        consumer.triggerRefreshTo(2l);
+
+        return (RetentionRecordingAPI) consumer.getAPI();
+    }
+
+    /** Stub generated API that records which constructor the factory invoked. */
+    public static class RetentionRecordingAPI extends HollowAPI {
+        final int constructorArgCount;
+        final boolean retainRemovedOrdinalsReceived;
+
+        public RetentionRecordingAPI(HollowDataAccess dataAccess) {
+            super(dataAccess);
+            this.constructorArgCount = 1;
+            this.retainRemovedOrdinalsReceived = false;
+        }
+
+        public RetentionRecordingAPI(HollowDataAccess dataAccess, Set<String> cachedTypes) {
+            super(dataAccess);
+            this.constructorArgCount = 2;
+            this.retainRemovedOrdinalsReceived = false;
+        }
+
+        public RetentionRecordingAPI(HollowDataAccess dataAccess, Set<String> cachedTypes,
+                Map<String, Object> factoryOverrides, RetentionRecordingAPI previousCycleAPI) {
+            super(dataAccess);
+            this.constructorArgCount = 4;
+            this.retainRemovedOrdinalsReceived = false;
+        }
+
+        public RetentionRecordingAPI(HollowDataAccess dataAccess, Set<String> cachedTypes,
+                Map<String, Object> factoryOverrides, RetentionRecordingAPI previousCycleAPI,
+                boolean retainRemovedOrdinals) {
+            super(dataAccess);
+            this.constructorArgCount = 5;
+            this.retainRemovedOrdinalsReceived = retainRemovedOrdinals;
+        }
     }
 
     private void testConsumerCache(boolean hasCache, boolean detachCache, TestHollowConsumer consumer) throws IOException {

--- a/hollow/src/test/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProviderTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProviderTest.java
@@ -20,9 +20,13 @@ import static com.netflix.hollow.api.objects.provider.Util.memoize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.netflix.hollow.api.custom.HollowTypeAPI;
+import com.netflix.hollow.api.objects.HollowRecord;
+import com.netflix.hollow.api.objects.delegate.HollowCachedDelegate;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.read.engine.PopulatedOrdinalListener;
 import java.util.function.Supplier;
@@ -120,9 +124,85 @@ public class HollowObjectCacheProviderTest {
         } catch (IllegalStateException expected) {}
     }
 
+    @Test
+    public void rotation_dropsRemovedOrdinal_byDefault() {
+        TypeA a0 = typeA(0);
+        TypeA a1 = typeA(1);
+        TypeA a2 = typeA(2);
+        prepopulate(a0, a1, a2);
+        HollowObjectCacheProvider<TypeA> previous =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory);
+
+        // delta: ordinal 2 removed
+        removeOrdinals(2);
+
+        HollowObjectCacheProvider<TypeA> current =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory, previous);
+
+        assertEquals(a0, current.getHollowObject(0));
+        assertEquals(a1, current.getHollowObject(1));
+        // removed-only ordinal is holed out on rotation, so the before image is lost
+        assertNull(current.getHollowObject(2));
+    }
+
+    @Test
+    public void rotation_retainsRemovedOrdinalForOneCycle_whenEnabled() {
+        TypeA a0 = typeA(0);
+        TypeA a1 = typeA(1);
+        TypeA a2 = typeA(2);
+        prepopulate(a0, a1, a2);
+        HollowObjectCacheProvider<TypeA> previous =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory);
+
+        // delta: ordinal 2 removed
+        removeOrdinals(2);
+
+        HollowObjectCacheProvider<TypeA> current =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory, previous, true);
+
+        assertEquals(a0, current.getHollowObject(0));
+        assertEquals(a1, current.getHollowObject(1));
+        // the before image of the removed record survives one cycle for change listeners
+        assertEquals(a2, current.getHollowObject(2));
+    }
+
+    @Test
+    public void rotation_repointsRetainedRemovedOrdinalToCurrentTypeApi() {
+        @SuppressWarnings("unchecked")
+        HollowFactory<HollowRecord> recordFactory = mock(HollowFactory.class);
+        HollowRecord record = mock(HollowRecord.class);
+        HollowCachedDelegate delegate = mock(HollowCachedDelegate.class);
+        when(record.getDelegate()).thenReturn(delegate);
+        when(recordFactory.newCachedHollowObject(typeReadState, typeAPI, 0)).thenReturn(record);
+
+        // previous cycle: ordinal 0 populated
+        populatedOrdinalListener.addedOrdinal(0);
+        HollowObjectCacheProvider<HollowRecord> previous =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, recordFactory);
+
+        // delta: ordinal 0 removed
+        removeOrdinals(0);
+
+        // rotate onto a new type api; the retained before image must be repointed to it so
+        // that lazy reference fields resolve against the current read state
+        HollowTypeAPI newTypeAPI = mock(HollowTypeAPI.class);
+        HollowObjectCacheProvider<HollowRecord> current =
+                new HollowObjectCacheProvider<>(typeReadState, newTypeAPI, recordFactory, previous, true);
+
+        assertEquals(record, current.getHollowObject(0));
+        verify(delegate).updateTypeAPI(newTypeAPI);
+    }
+
     private void prepopulate(TypeA...population) {
         for (TypeA a : population)
             populatedOrdinalListener.addedOrdinal(a.ordinal);
+    }
+
+    private void removeOrdinals(int...removed) {
+        populatedOrdinalListener.beginUpdate();
+        for (int ordinal : removed)
+            populatedOrdinalListener.removedOrdinal(ordinal);
+        populatedOrdinalListener.endUpdate();
     }
 
     private void notifyAdded(TypeA...added) {

--- a/hollow/src/test/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProviderTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/objects/provider/HollowObjectCacheProviderTest.java
@@ -18,6 +18,7 @@ package com.netflix.hollow.api.objects.provider;
 
 import static com.netflix.hollow.api.objects.provider.Util.memoize;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -193,6 +194,68 @@ public class HollowObjectCacheProviderTest {
         verify(delegate).updateTypeAPI(newTypeAPI);
     }
 
+    @Test
+    public void rotation_retainedRemovedOrdinalIsDroppedAfterOneCycle() {
+        TypeA a0 = typeA(0);
+        TypeA a1 = typeA(1);
+        TypeA a2 = typeA(2);
+        TypeA a3 = typeA(3);
+        prepopulate(a0, a1, a2, a3);
+        HollowObjectCacheProvider<TypeA> v1 =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory);
+
+        // cycle 1: ordinal 2 removed -> retained as the before image
+        removeOrdinals(2);
+        HollowObjectCacheProvider<TypeA> v2 =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory, v1, true);
+        assertEquals(a2, v2.getHollowObject(2));
+
+        // cycle 2: ordinal 2 stays removed -> retention window has elapsed, before image is gone
+        // (ordinal 3 keeps the array sized so the slot is a hole rather than out of bounds)
+        advanceCycleWithNoChanges();
+        HollowObjectCacheProvider<TypeA> v3 =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory, v2, true);
+        assertNull(v3.getHollowObject(2));
+    }
+
+    @Test
+    public void rotation_reusedOrdinalReturnsFreshRecordNotStaleBeforeImage() {
+        TypeA a0 = typeA(0);
+        TypeA a1 = typeA(1);
+        TypeA a2Old = typeA(2);
+        prepopulate(a0, a1, a2Old);
+        HollowObjectCacheProvider<TypeA> v1 =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory);
+
+        // cycle 1: ordinal 2 removed -> retained as the before image
+        removeOrdinals(2);
+        HollowObjectCacheProvider<TypeA> v2 =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory, v1, true);
+        assertEquals(a2Old, v2.getHollowObject(2));
+
+        // cycle 2: ordinal 2 is reused for a different record -> the fresh record wins, not the before image
+        TypeA a2New = typeA(2);
+        addOrdinals(2);
+        HollowObjectCacheProvider<TypeA> v3 =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory, v2, true);
+
+        assertEquals(a2New, v3.getHollowObject(2));
+        assertNotSame(a2Old, v3.getHollowObject(2));
+    }
+
+    @Test
+    public void retainEnabled_withNoPreviousCache_behavesNormally() {
+        TypeA a0 = typeA(0);
+        TypeA a1 = typeA(1);
+        prepopulate(a0, a1);
+
+        HollowObjectCacheProvider<TypeA> provider =
+                new HollowObjectCacheProvider<>(typeReadState, typeAPI, factory, null, true);
+
+        assertEquals(a0, provider.getHollowObject(0));
+        assertEquals(a1, provider.getHollowObject(1));
+    }
+
     private void prepopulate(TypeA...population) {
         for (TypeA a : population)
             populatedOrdinalListener.addedOrdinal(a.ordinal);
@@ -202,6 +265,18 @@ public class HollowObjectCacheProviderTest {
         populatedOrdinalListener.beginUpdate();
         for (int ordinal : removed)
             populatedOrdinalListener.removedOrdinal(ordinal);
+        populatedOrdinalListener.endUpdate();
+    }
+
+    private void addOrdinals(int...added) {
+        populatedOrdinalListener.beginUpdate();
+        for (int ordinal : added)
+            populatedOrdinalListener.addedOrdinal(ordinal);
+        populatedOrdinalListener.endUpdate();
+    }
+
+    private void advanceCycleWithNoChanges() {
+        populatedOrdinalListener.beginUpdate();
         populatedOrdinalListener.endUpdate();
     }
 

--- a/hollow/src/test/java/com/netflix/hollow/test/generated/AwardsAPI.java
+++ b/hollow/src/test/java/com/netflix/hollow/test/generated/AwardsAPI.java
@@ -53,6 +53,10 @@ public class AwardsAPI extends HollowAPI implements  HollowConsumerAPI.StringRet
     }
 
     public AwardsAPI(HollowDataAccess dataAccess, Set<String> cachedTypes, Map<String, HollowFactory<?>> factoryOverrides, AwardsAPI previousCycleAPI) {
+        this(dataAccess, cachedTypes, factoryOverrides, previousCycleAPI, false);
+    }
+
+    public AwardsAPI(HollowDataAccess dataAccess, Set<String> cachedTypes, Map<String, HollowFactory<?>> factoryOverrides, AwardsAPI previousCycleAPI, boolean retainRemovedOrdinalsInCache) {
         super(dataAccess);
         HollowTypeDataAccess typeDataAccess;
         HollowFactory factory;
@@ -73,7 +77,7 @@ public class AwardsAPI extends HollowAPI implements  HollowConsumerAPI.StringRet
             HollowObjectCacheProvider previousCacheProvider = null;
             if(previousCycleAPI != null && (previousCycleAPI.stringProvider instanceof HollowObjectCacheProvider))
                 previousCacheProvider = (HollowObjectCacheProvider) previousCycleAPI.stringProvider;
-            stringProvider = new HollowObjectCacheProvider(typeDataAccess, stringTypeAPI, factory, previousCacheProvider);
+            stringProvider = new HollowObjectCacheProvider(typeDataAccess, stringTypeAPI, factory, previousCacheProvider, retainRemovedOrdinalsInCache);
         } else {
             stringProvider = new HollowObjectFactoryProvider(typeDataAccess, stringTypeAPI, factory);
         }
@@ -92,7 +96,7 @@ public class AwardsAPI extends HollowAPI implements  HollowConsumerAPI.StringRet
             HollowObjectCacheProvider previousCacheProvider = null;
             if(previousCycleAPI != null && (previousCycleAPI.movieProvider instanceof HollowObjectCacheProvider))
                 previousCacheProvider = (HollowObjectCacheProvider) previousCycleAPI.movieProvider;
-            movieProvider = new HollowObjectCacheProvider(typeDataAccess, movieTypeAPI, factory, previousCacheProvider);
+            movieProvider = new HollowObjectCacheProvider(typeDataAccess, movieTypeAPI, factory, previousCacheProvider, retainRemovedOrdinalsInCache);
         } else {
             movieProvider = new HollowObjectFactoryProvider(typeDataAccess, movieTypeAPI, factory);
         }
@@ -111,7 +115,7 @@ public class AwardsAPI extends HollowAPI implements  HollowConsumerAPI.StringRet
             HollowObjectCacheProvider previousCacheProvider = null;
             if(previousCycleAPI != null && (previousCycleAPI.setOfMovieProvider instanceof HollowObjectCacheProvider))
                 previousCacheProvider = (HollowObjectCacheProvider) previousCycleAPI.setOfMovieProvider;
-            setOfMovieProvider = new HollowObjectCacheProvider(typeDataAccess, setOfMovieTypeAPI, factory, previousCacheProvider);
+            setOfMovieProvider = new HollowObjectCacheProvider(typeDataAccess, setOfMovieTypeAPI, factory, previousCacheProvider, retainRemovedOrdinalsInCache);
         } else {
             setOfMovieProvider = new HollowObjectFactoryProvider(typeDataAccess, setOfMovieTypeAPI, factory);
         }
@@ -130,7 +134,7 @@ public class AwardsAPI extends HollowAPI implements  HollowConsumerAPI.StringRet
             HollowObjectCacheProvider previousCacheProvider = null;
             if(previousCycleAPI != null && (previousCycleAPI.awardProvider instanceof HollowObjectCacheProvider))
                 previousCacheProvider = (HollowObjectCacheProvider) previousCycleAPI.awardProvider;
-            awardProvider = new HollowObjectCacheProvider(typeDataAccess, awardTypeAPI, factory, previousCacheProvider);
+            awardProvider = new HollowObjectCacheProvider(typeDataAccess, awardTypeAPI, factory, previousCacheProvider, retainRemovedOrdinalsInCache);
         } else {
             awardProvider = new HollowObjectFactoryProvider(typeDataAccess, awardTypeAPI, factory);
         }


### PR DESCRIPTION
When object longevity is enabled, Hollow does not cache the removed records in the prior version. This PR adds support for caching it, matching what `HollowPerfAPICache` does already. It is enabled via an opt-in flag in the generated API class. The change is backward-compatible and there is no change to the existing path.