### PR TITLE
Skip validation for a cycle

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -106,6 +106,9 @@ abstract class AbstractHollowProducer {
     private final boolean forceCoverageOfTypeResharding;   // exercise re-sharding often (for testing)
     private final Supplier<Boolean> ignoreSoftLimits;
     private final boolean partitionedOrdinalMap;
+    // Evaluated at the start of each cycle's validation stage; when it returns true the entire
+    // validation stage is skipped for that cycle (all ValidatorListeners are bypassed).
+    private final Supplier<Boolean> skipValidation;
 
     @Deprecated
     public AbstractHollowProducer(
@@ -116,7 +119,7 @@ abstract class AbstractHollowProducer {
                 new VersionMinterWithCounter(), null, 0,
                 DEFAULT_TARGET_MAX_TYPE_SHARD_SIZE, false, false, false, false, null,
                 new DummyBlobStorageCleaner(), new BasicSingleProducerEnforcer(),
-                null, true, HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE, null);
+                null, true, HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE, null, null);
     }
 
     // The only constructor should be that which accepts a builder
@@ -129,7 +132,8 @@ abstract class AbstractHollowProducer {
                 b.numStatesBetweenSnapshots, b.targetMaxTypeShardSize, b.focusHoleFillInFewestShards,
                 b.allowTypeResharding, b.forceCoverageOfTypeResharding, b.partitionedOrdinalMap,
                 b.metricsCollector, b.blobStorageCleaner, b.singleProducerEnforcer,
-                b.hashCodeFinder, b.doIntegrityCheck, b.updatePlanBlobVerifier, b.ignoreSoftLimits);
+                b.hashCodeFinder, b.doIntegrityCheck, b.updatePlanBlobVerifier, b.ignoreSoftLimits,
+                b.skipValidation);
     }
 
     private final HollowProducerListener producerMetricsListener;
@@ -156,7 +160,8 @@ abstract class AbstractHollowProducer {
             HollowObjectHashCodeFinder hashCodeFinder,
             boolean doIntegrityCheck,
             HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier,
-            Supplier<Boolean> ignoreSoftLimits) {
+            Supplier<Boolean> ignoreSoftLimits,
+            Supplier<Boolean> skipValidation) {
         this.publisher = publisher;
         this.announcer = announcer;
         this.versionMinter = versionMinter;
@@ -172,6 +177,7 @@ abstract class AbstractHollowProducer {
         this.focusHoleFillInFewestShards = focusHoleFillInFewestShards;
         this.ignoreSoftLimits = ignoreSoftLimits;
         this.partitionedOrdinalMap = partitionedOrdinalMap;
+        this.skipValidation = skipValidation;
 
         HollowWriteStateEngine writeEngine = hashCodeFinder == null
                 ? new HollowWriteStateEngine()
@@ -968,6 +974,14 @@ abstract class AbstractHollowProducer {
 
         ValidationStatus status = null;
         try {
+            if (skipValidation != null && Boolean.TRUE.equals(skipValidation.get())) {
+                log.info("Skipping validation stage for this cycle; skipValidation supplier returned true. "
+                        + "All validators are bypassed for this cycle only.");
+                status = new ValidationStatus(Collections.emptyList());
+                psb.success();
+                return;
+            }
+
             // Stream over the concatenation of the old and new validators
             List<ValidationResult> results =
                     listeners.getListeners(ValidatorListener.class)

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -106,8 +106,11 @@ abstract class AbstractHollowProducer {
     private final boolean forceCoverageOfTypeResharding;   // exercise re-sharding often (for testing)
     private final Supplier<Boolean> ignoreSoftLimits;
     private final boolean partitionedOrdinalMap;
-    // Evaluated at the start of each cycle's validation stage; when it returns true, no
-    // ValidatorListener runs for that cycle and validation is reported as passed.
+    // Evaluated at the start of each cycle, before the validate stage would otherwise begin; when it
+    // returns true the validate stage does not run at all for that cycle -- no ValidatorListener runs,
+    // and no Validate stage start/complete event is fired to CycleListeners/ValidationStatusListeners
+    // (so beacon/cycle log tooling shows no Validate stage entry for that cycle, rather than an
+    // artificial "passed with zero results" entry).
     private final Supplier<Boolean> skipValidation;
 
     @Deprecated
@@ -970,21 +973,21 @@ abstract class AbstractHollowProducer {
     }
 
     private void validate(ProducerListeners listeners, HollowProducer.ReadState readState) {
+        if (skipValidation != null && Boolean.TRUE.equals(skipValidation.get())) {
+            // Return before firing validation-start at all: no ValidatorListener runs, and no Validate
+            // stage start/complete event reaches CycleListeners/ValidationStatusListeners for this
+            // cycle. Beacon/cycle log tooling will show no Validate stage entry for this cycle, rather
+            // than a synthetic "passed with zero results" entry that reads the same as "zero
+            // validators configured".
+            log.info("skipValidation supplier returned true; the validate stage does not run for this "
+                    + "cycle (no ValidatorListener runs, and no Validate stage event is reported).");
+            return;
+        }
+
         Status.StageWithStateBuilder psb = listeners.fireValidationStart(readState);
 
         ValidationStatus status = null;
         try {
-            if (skipValidation != null && Boolean.TRUE.equals(skipValidation.get())) {
-                log.info("skipValidation supplier returned true; no ValidatorListener will run for this "
-                        + "cycle and validation is reported as passed.");
-                // status/psb.success() here plus the fireValidationComplete(psb, status) call in the
-                // finally block below make the beacon and cycle log look the same as a normal,
-                // fully-passing validation stage, so listener bookkeeping stays consistent.
-                status = new ValidationStatus(Collections.emptyList());
-                psb.success();
-                return;
-            }
-
             // Stream over the concatenation of the old and new validators
             List<ValidationResult> results =
                     listeners.getListeners(ValidatorListener.class)

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -108,8 +108,8 @@ abstract class AbstractHollowProducer {
     private final boolean partitionedOrdinalMap;
     // Evaluated at the start of the validate stage; when it returns true no ValidatorListener runs for
     // that cycle and the stage is skipped entirely -- no validation event is fired to
-    // HollowProducerListeners or ValidationStatusListeners, so the validate stage is absent from the
-    // beacon/cycle log rather than reported as an empty pass.
+    // HollowProducerListeners or ValidationStatusListeners, so consumers of those events see no
+    // validate stage for that cycle rather than an empty, passing one.
     private final Supplier<Boolean> skipValidation;
 
     @Deprecated
@@ -974,8 +974,8 @@ abstract class AbstractHollowProducer {
     private void validate(ProducerListeners listeners, HollowProducer.ReadState readState) {
         if (skipValidation != null && Boolean.TRUE.equals(skipValidation.get())) {
             // Return before firing validation-start: no ValidatorListener runs and no validation event
-            // reaches HollowProducerListeners/ValidationStatusListeners, so the validate stage is absent
-            // from the beacon/cycle log rather than reported as an empty pass.
+            // reaches HollowProducerListeners/ValidationStatusListeners, so consumers of those events
+            // see no validate stage for this cycle rather than an empty, passing one.
             log.info("skipValidation returned true; skipping the validate stage for version "
                     + readState.getVersion() + " (no validators run, no validation event reported).");
             return;

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -106,8 +106,8 @@ abstract class AbstractHollowProducer {
     private final boolean forceCoverageOfTypeResharding;   // exercise re-sharding often (for testing)
     private final Supplier<Boolean> ignoreSoftLimits;
     private final boolean partitionedOrdinalMap;
-    // Evaluated at the start of each cycle's validation stage; when it returns true the entire
-    // validation stage is skipped for that cycle (all ValidatorListeners are bypassed).
+    // Evaluated at the start of each cycle's validation stage; when it returns true, no
+    // ValidatorListener runs for that cycle and validation is reported as passed.
     private final Supplier<Boolean> skipValidation;
 
     @Deprecated
@@ -119,7 +119,7 @@ abstract class AbstractHollowProducer {
                 new VersionMinterWithCounter(), null, 0,
                 DEFAULT_TARGET_MAX_TYPE_SHARD_SIZE, false, false, false, false, null,
                 new DummyBlobStorageCleaner(), new BasicSingleProducerEnforcer(),
-                null, true, HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE, null, null);
+                null, true, HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE, null, () -> false);
     }
 
     // The only constructor should be that which accepts a builder
@@ -975,8 +975,11 @@ abstract class AbstractHollowProducer {
         ValidationStatus status = null;
         try {
             if (skipValidation != null && Boolean.TRUE.equals(skipValidation.get())) {
-                log.info("Skipping validation stage for this cycle; skipValidation supplier returned true. "
-                        + "All validators are bypassed for this cycle only.");
+                log.info("skipValidation supplier returned true; no ValidatorListener will run for this "
+                        + "cycle and validation is reported as passed.");
+                // status/psb.success() here plus the fireValidationComplete(psb, status) call in the
+                // finally block below make the beacon and cycle log look the same as a normal,
+                // fully-passing validation stage, so listener bookkeeping stays consistent.
                 status = new ValidationStatus(Collections.emptyList());
                 psb.success();
                 return;

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -106,11 +106,10 @@ abstract class AbstractHollowProducer {
     private final boolean forceCoverageOfTypeResharding;   // exercise re-sharding often (for testing)
     private final Supplier<Boolean> ignoreSoftLimits;
     private final boolean partitionedOrdinalMap;
-    // Evaluated at the start of each cycle, before the validate stage would otherwise begin; when it
-    // returns true the validate stage does not run at all for that cycle -- no ValidatorListener runs,
-    // and no Validate stage start/complete event is fired to CycleListeners/ValidationStatusListeners
-    // (so beacon/cycle log tooling shows no Validate stage entry for that cycle, rather than an
-    // artificial "passed with zero results" entry).
+    // Evaluated at the start of the validate stage; when it returns true no ValidatorListener runs for
+    // that cycle and the stage is skipped entirely -- no validation event is fired to
+    // HollowProducerListeners or ValidationStatusListeners, so the validate stage is absent from the
+    // beacon/cycle log rather than reported as an empty pass.
     private final Supplier<Boolean> skipValidation;
 
     @Deprecated
@@ -974,13 +973,11 @@ abstract class AbstractHollowProducer {
 
     private void validate(ProducerListeners listeners, HollowProducer.ReadState readState) {
         if (skipValidation != null && Boolean.TRUE.equals(skipValidation.get())) {
-            // Return before firing validation-start at all: no ValidatorListener runs, and no Validate
-            // stage start/complete event reaches CycleListeners/ValidationStatusListeners for this
-            // cycle. Beacon/cycle log tooling will show no Validate stage entry for this cycle, rather
-            // than a synthetic "passed with zero results" entry that reads the same as "zero
-            // validators configured".
-            log.info("skipValidation supplier returned true; the validate stage does not run for this "
-                    + "cycle (no ValidatorListener runs, and no Validate stage event is reported).");
+            // Return before firing validation-start: no ValidatorListener runs and no validation event
+            // reaches HollowProducerListeners/ValidationStatusListeners, so the validate stage is absent
+            // from the beacon/cycle log rather than reported as an empty pass.
+            log.info("skipValidation returned true; skipping the validate stage for version "
+                    + readState.getVersion() + " (no validators run, no validation event reported).");
             return;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -755,7 +755,6 @@ public class HollowProducer extends AbstractHollowProducer {
         ProducerOptionalBlobPartConfig optionalPartConfig = null;
         HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier = HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE;
         Supplier<Boolean> ignoreSoftLimits = null;
-        // Defaults to a supplier that never skips; validation always runs unless overridden.
         Supplier<Boolean> skipValidation = () -> false;
 
         protected HollowProducerEventListener customProducerMetricsListener = null;
@@ -1002,18 +1001,17 @@ public class HollowProducer extends AbstractHollowProducer {
         }
 
         /**
-         * Register a supplier that decides, per cycle, whether to skip the producer's validation stage.
+         * Registers a supplier evaluated once at the start of each cycle's validation stage. When it
+         * returns {@code true}, no {@link com.netflix.hollow.api.producer.validation.ValidatorListener}
+         * runs for that cycle -- regardless of whether it was added via the builder or
+         * {@link HollowProducer#addListener} -- and validation is reported as passed. Re-evaluated every
+         * cycle, so the next cycle validates normally unless the supplier again returns {@code true}.
          * <p>
-         * The supplier is evaluated once at the start of each cycle's validation stage. When it returns
-         * {@code true}, that single cycle skips validation entirely: every registered
-         * {@link com.netflix.hollow.api.producer.validation.ValidatorListener} is bypassed, regardless of
-         * whether it was added via the builder or via {@link HollowProducer#addListener}. The skip lasts for
-         * one cycle only; the next cycle validates normally unless the supplier again returns {@code true}.
-         * <p>
-         * This is useful for one-shot operator overrides where the decision of <em>when</em> to skip lives
-         * outside the producer. When unset (the default), validation always runs.
+         * Useful for one-shot operator overrides where the decision of <em>when</em> to validate lives
+         * outside the producer. Defaults to always validating.
          *
-         * @param skipValidation supplier returning {@code true} to skip validation for the upcoming cycle
+         * @param skipValidation supplier returning {@code true} to report validation as passed without
+         *         running any validator for the upcoming cycle
          * @return this builder
          */
         public B withSkipValidation(Supplier<Boolean> skipValidation) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -1005,8 +1005,8 @@ public class HollowProducer extends AbstractHollowProducer {
          * {@code true}, no {@link com.netflix.hollow.api.producer.validation.ValidatorListener} runs for
          * that cycle -- whether added via the builder or {@link HollowProducer#addListener} -- and the
          * validate stage is skipped entirely: no validation event is fired to {@link HollowProducerListener}s
-         * or {@link com.netflix.hollow.api.producer.validation.ValidationStatusListener}s, so the stage is
-         * absent from that cycle's beacon/cycle log rather than reported as an empty pass. Re-evaluated
+         * or {@link com.netflix.hollow.api.producer.validation.ValidationStatusListener}s, so consumers of
+         * those events see no validate stage for that cycle rather than an empty, passing one. Re-evaluated
          * every cycle. Defaults to always validating.
          *
          * @param skipValidation supplier returning {@code true} to skip the validate stage for the

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -1001,21 +1001,16 @@ public class HollowProducer extends AbstractHollowProducer {
         }
 
         /**
-         * Registers a supplier evaluated once per cycle, before the validate stage would otherwise
-         * begin. When it returns {@code true}, the validate stage does not run at all for that cycle:
-         * no {@link com.netflix.hollow.api.producer.validation.ValidatorListener} runs -- regardless of
-         * whether it was added via the builder or {@link HollowProducer#addListener} -- and no Validate
-         * stage event is reported to {@link com.netflix.hollow.api.producer.listener.CycleListener}s or
-         * {@link com.netflix.hollow.api.producer.validation.ValidationStatusListener}s, so the stage is
-         * simply absent from that cycle's beacon/cycle log rather than reported as an empty pass.
-         * Re-evaluated every cycle, so the next cycle validates normally unless the supplier again
-         * returns {@code true}.
-         * <p>
-         * Useful for one-shot operator overrides where the decision of <em>when</em> to validate lives
-         * outside the producer. Defaults to always validating.
+         * Registers a supplier evaluated at the start of each cycle's validate stage. When it returns
+         * {@code true}, no {@link com.netflix.hollow.api.producer.validation.ValidatorListener} runs for
+         * that cycle -- whether added via the builder or {@link HollowProducer#addListener} -- and the
+         * validate stage is skipped entirely: no validation event is fired to {@link HollowProducerListener}s
+         * or {@link com.netflix.hollow.api.producer.validation.ValidationStatusListener}s, so the stage is
+         * absent from that cycle's beacon/cycle log rather than reported as an empty pass. Re-evaluated
+         * every cycle. Defaults to always validating.
          *
-         * @param skipValidation supplier returning {@code true} to skip the validate stage entirely
-         *         (no validators run, no Validate stage is reported) for the upcoming cycle
+         * @param skipValidation supplier returning {@code true} to skip the validate stage for the
+         *         upcoming cycle
          * @return this builder
          */
         public B withSkipValidation(Supplier<Boolean> skipValidation) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -1001,17 +1001,21 @@ public class HollowProducer extends AbstractHollowProducer {
         }
 
         /**
-         * Registers a supplier evaluated once at the start of each cycle's validation stage. When it
-         * returns {@code true}, no {@link com.netflix.hollow.api.producer.validation.ValidatorListener}
-         * runs for that cycle -- regardless of whether it was added via the builder or
-         * {@link HollowProducer#addListener} -- and validation is reported as passed. Re-evaluated every
-         * cycle, so the next cycle validates normally unless the supplier again returns {@code true}.
+         * Registers a supplier evaluated once per cycle, before the validate stage would otherwise
+         * begin. When it returns {@code true}, the validate stage does not run at all for that cycle:
+         * no {@link com.netflix.hollow.api.producer.validation.ValidatorListener} runs -- regardless of
+         * whether it was added via the builder or {@link HollowProducer#addListener} -- and no Validate
+         * stage event is reported to {@link com.netflix.hollow.api.producer.listener.CycleListener}s or
+         * {@link com.netflix.hollow.api.producer.validation.ValidationStatusListener}s, so the stage is
+         * simply absent from that cycle's beacon/cycle log rather than reported as an empty pass.
+         * Re-evaluated every cycle, so the next cycle validates normally unless the supplier again
+         * returns {@code true}.
          * <p>
          * Useful for one-shot operator overrides where the decision of <em>when</em> to validate lives
          * outside the producer. Defaults to always validating.
          *
-         * @param skipValidation supplier returning {@code true} to report validation as passed without
-         *         running any validator for the upcoming cycle
+         * @param skipValidation supplier returning {@code true} to skip the validate stage entirely
+         *         (no validators run, no Validate stage is reported) for the upcoming cycle
          * @return this builder
          */
         public B withSkipValidation(Supplier<Boolean> skipValidation) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -755,6 +755,8 @@ public class HollowProducer extends AbstractHollowProducer {
         ProducerOptionalBlobPartConfig optionalPartConfig = null;
         HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier = HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE;
         Supplier<Boolean> ignoreSoftLimits = null;
+        // Defaults to a supplier that never skips; validation always runs unless overridden.
+        Supplier<Boolean> skipValidation = () -> false;
 
         protected HollowProducerEventListener customProducerMetricsListener = null;
 
@@ -996,6 +998,26 @@ public class HollowProducer extends AbstractHollowProducer {
          */
         public B withIgnoreSoftLimits(Supplier<Boolean> ignoreSoftLimits) {
             this.ignoreSoftLimits = ignoreSoftLimits;
+            return (B) this;
+        }
+
+        /**
+         * Register a supplier that decides, per cycle, whether to skip the producer's validation stage.
+         * <p>
+         * The supplier is evaluated once at the start of each cycle's validation stage. When it returns
+         * {@code true}, that single cycle skips validation entirely: every registered
+         * {@link com.netflix.hollow.api.producer.validation.ValidatorListener} is bypassed, regardless of
+         * whether it was added via the builder or via {@link HollowProducer#addListener}. The skip lasts for
+         * one cycle only; the next cycle validates normally unless the supplier again returns {@code true}.
+         * <p>
+         * This is useful for one-shot operator overrides where the decision of <em>when</em> to skip lives
+         * outside the producer. When unset (the default), validation always runs.
+         *
+         * @param skipValidation supplier returning {@code true} to skip validation for the upcoming cycle
+         * @return this builder
+         */
+        public B withSkipValidation(Supplier<Boolean> skipValidation) {
+            this.skipValidation = skipValidation;
             return (B) this;
         }
 

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/SkipValidationTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/SkipValidationTest.java
@@ -1,0 +1,139 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer.validation;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+import com.netflix.hollow.test.InMemoryBlobStore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies {@link HollowProducer.Builder#withSkipValidation} bypasses the entire validation stage for a
+ * single cycle, covering every registered validator regardless of how it was added.
+ */
+public class SkipValidationTest {
+    private InMemoryBlobStore blobStore;
+
+    @Before
+    public void setUp() {
+        blobStore = new InMemoryBlobStore();
+    }
+
+    @Test
+    public void skipTrue_bypassesFailingValidator() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new DuplicateDataDetectionValidator("TypeWithPrimaryKey"))
+                .withSkipValidation(() -> true)
+                .build();
+
+        // Two records share primary key id=1; DuplicateDataDetectionValidator would normally fail this
+        // cycle, but validation is skipped so the cycle publishes successfully.
+        producer.runCycle(newState -> {
+            newState.add(new TypeWithPrimaryKey(1, "a"));
+            newState.add(new TypeWithPrimaryKey(1, "b"));
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefresh();
+        Assert.assertEquals(2, consumer.getStateEngine().getTypeState("TypeWithPrimaryKey")
+                .getPopulatedOrdinals().cardinality());
+    }
+
+    @Test
+    public void skipFalse_stillValidates() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new DuplicateDataDetectionValidator("TypeWithPrimaryKey"))
+                .withSkipValidation(() -> false)
+                .build();
+
+        try {
+            producer.runCycle(newState -> {
+                newState.add(new TypeWithPrimaryKey(1, "a"));
+                newState.add(new TypeWithPrimaryKey(1, "b"));
+            });
+            Assert.fail("expected validation to fail when skip supplier returns false");
+        } catch (ValidationStatusException expected) {
+            // validators ran, as expected
+        }
+    }
+
+    @Test
+    public void defaultSupplier_alwaysValidates() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(new DuplicateDataDetectionValidator("TypeWithPrimaryKey"))
+                .build();
+
+        try {
+            producer.runCycle(newState -> {
+                newState.add(new TypeWithPrimaryKey(1, "a"));
+                newState.add(new TypeWithPrimaryKey(1, "b"));
+            });
+            Assert.fail("expected validation to fail when no skip supplier is configured");
+        } catch (ValidationStatusException expected) {
+            // validators ran, as expected
+        }
+    }
+
+    @Test
+    public void skipTogglesPerCycle_andCoversExternallyAddedValidator() {
+        AtomicBoolean skip = new AtomicBoolean(true);
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withSkipValidation(skip::get)
+                .build();
+
+        // Validator added AFTER build (not via the builder) - the skip must still cover it.
+        producer.addListener(new DuplicateDataDetectionValidator("TypeWithPrimaryKey"));
+
+        // Cycle 1: skip=true, duplicate id=1 is allowed through.
+        producer.runCycle(newState -> {
+            newState.add(new TypeWithPrimaryKey(1, "a"));
+            newState.add(new TypeWithPrimaryKey(1, "b"));
+        });
+
+        // Cycle 2: skip=false, the externally-added validator now runs and fails on the duplicate.
+        skip.set(false);
+        try {
+            producer.runCycle(newState -> {
+                newState.add(new TypeWithPrimaryKey(2, "a"));
+                newState.add(new TypeWithPrimaryKey(2, "b"));
+            });
+            Assert.fail("expected externally-added validator to fail once skip disabled");
+        } catch (ValidationStatusException expected) {
+            // validators ran, as expected
+        }
+    }
+
+    @HollowPrimaryKey(fields = {"id"})
+    static class TypeWithPrimaryKey {
+        int id;
+        String name;
+
+        TypeWithPrimaryKey(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/SkipValidationTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/SkipValidationTest.java
@@ -21,7 +21,9 @@ import com.netflix.hollow.api.producer.HollowProducer;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
 import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 import com.netflix.hollow.test.InMemoryBlobStore;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -124,6 +126,40 @@ public class SkipValidationTest {
         } catch (ValidationStatusException expected) {
             // validators ran, as expected
         }
+    }
+
+    @Test
+    public void skipTrue_reportsNoValidateStageEvent() {
+        AtomicInteger startCount = new AtomicInteger();
+        AtomicInteger completeCount = new AtomicInteger();
+        ValidationStatusListener counter = new ValidationStatusListener() {
+            @Override
+            public void onValidationStatusStart(long version) {
+                startCount.incrementAndGet();
+            }
+
+            @Override
+            public void onValidationStatusComplete(ValidationStatus status, long version, Duration elapsed) {
+                completeCount.incrementAndGet();
+            }
+        };
+
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withListener(counter)
+                .withListener(new DuplicateDataDetectionValidator("TypeWithPrimaryKey"))
+                .withSkipValidation(() -> true)
+                .build();
+
+        // Skipped cycle: neither the ValidationStatusListener nor the (failing) ValidatorListener
+        // should observe any event -- the validate stage does not run at all, so tooling built on
+        // these events (e.g. beacon/cycle log) sees no Validate stage entry for this cycle.
+        producer.runCycle(newState -> {
+            newState.add(new TypeWithPrimaryKey(1, "a"));
+            newState.add(new TypeWithPrimaryKey(1, "b"));
+        });
+        Assert.assertEquals(0, startCount.get());
+        Assert.assertEquals(0, completeCount.get());
     }
 
     @HollowPrimaryKey(fields = {"id"})

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/validation/SkipValidationTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/validation/SkipValidationTest.java
@@ -152,8 +152,8 @@ public class SkipValidationTest {
                 .build();
 
         // Skipped cycle: neither the ValidationStatusListener nor the (failing) ValidatorListener
-        // should observe any event -- the validate stage does not run at all, so tooling built on
-        // these events (e.g. beacon/cycle log) sees no Validate stage entry for this cycle.
+        // should observe any event -- the validate stage does not run at all, so consumers of these
+        // events see no validate stage for this cycle.
         producer.runCycle(newState -> {
             newState.add(new TypeWithPrimaryKey(1, "a"));
             newState.add(new TypeWithPrimaryKey(1, "b"));


### PR DESCRIPTION
## Description

### What changes:

Introduce an optional `Supplier<Boolean>` on `HollowProducer.Builder`, threaded through `AbstractHollowProducer` the same way as `ignoreSoftLimits`. It is evaluated at the start of each cycle's validate stage; when it returns `true`, the validate stage is **skipped entirely** for that one cycle: the producer returns before firing validation-start, so no `ValidatorListener` runs (regardless of whether it was added via the builder or `HollowProducer.addListener()`), and no validation event is fired to `HollowProducerListener`s / `ValidationStatusListener`s.

Because nothing is fired, consumers of those events see **no validate stage for that cycle** — rather than an empty, passing stage (which would otherwise be indistinguishable from "zero validators configured"). Re-evaluated every cycle, so the next cycle validates normally unless the supplier again returns `true`. Defaults to never skipping, so behavior is unchanged unless a supplier is configured.

### Why changes:

Useful for one-shot operator overrides where the decision of *when* to skip validation lives outside the producer.
