### PR TITLE
Skip sorting in compact when there are no removals/replacements

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -102,6 +102,7 @@ abstract class AbstractHollowProducer {
 
     private final long targetMaxTypeShardSize;
     private final boolean focusHoleFillInFewestShards;
+    private final boolean opportunisticCompact;
     private final boolean allowTypeResharding;
     private final boolean forceCoverageOfTypeResharding;   // exercise re-sharding often (for testing)
     private final Supplier<Boolean> ignoreSoftLimits;
@@ -121,7 +122,7 @@ abstract class AbstractHollowProducer {
                 new VersionMinterWithCounter(), null, 0,
                 DEFAULT_TARGET_MAX_TYPE_SHARD_SIZE, false, false, false, false, null,
                 new DummyBlobStorageCleaner(), new BasicSingleProducerEnforcer(),
-                null, true, HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE, null, () -> false);
+                null, true, HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE, null, () -> false, false);
     }
 
     // The only constructor should be that which accepts a builder
@@ -135,7 +136,7 @@ abstract class AbstractHollowProducer {
                 b.allowTypeResharding, b.forceCoverageOfTypeResharding, b.partitionedOrdinalMap,
                 b.metricsCollector, b.blobStorageCleaner, b.singleProducerEnforcer,
                 b.hashCodeFinder, b.doIntegrityCheck, b.updatePlanBlobVerifier, b.ignoreSoftLimits,
-                b.skipValidation);
+                b.skipValidation, b.opportunisticCompact);
     }
 
     private final HollowProducerListener producerMetricsListener;
@@ -163,7 +164,8 @@ abstract class AbstractHollowProducer {
             boolean doIntegrityCheck,
             HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier,
             Supplier<Boolean> ignoreSoftLimits,
-            Supplier<Boolean> skipValidation) {
+            Supplier<Boolean> skipValidation,
+            boolean opportunisticCompact) {
         this.publisher = publisher;
         this.announcer = announcer;
         this.versionMinter = versionMinter;
@@ -180,6 +182,7 @@ abstract class AbstractHollowProducer {
         this.ignoreSoftLimits = ignoreSoftLimits;
         this.partitionedOrdinalMap = partitionedOrdinalMap;
         this.skipValidation = skipValidation;
+        this.opportunisticCompact = opportunisticCompact;
 
         HollowWriteStateEngine writeEngine = hashCodeFinder == null
                 ? new HollowWriteStateEngine()
@@ -189,6 +192,7 @@ abstract class AbstractHollowProducer {
         writeEngine.setFocusHoleFillInFewestShards(focusHoleFillInFewestShards);
         writeEngine.setIgnoreOrdinalLimits(ignoreSoftLimits);
         writeEngine.setPartitionedOrdinalMap(partitionedOrdinalMap);
+        writeEngine.setOpportunisticCompact(opportunisticCompact);
 
         this.objectMapper = new HollowObjectMapper(writeEngine);
         if (hashCodeFinder != null) {
@@ -356,6 +360,7 @@ abstract class AbstractHollowProducer {
                 writeEngine.setFocusHoleFillInFewestShards(focusHoleFillInFewestShards);
                 writeEngine.setIgnoreOrdinalLimits(ignoreSoftLimits);
                 writeEngine.setPartitionedOrdinalMap(partitionedOrdinalMap);
+                writeEngine.setOpportunisticCompact(opportunisticCompact);
                 HollowWriteStateCreator.populateStateEngineWithTypeWriteStates(writeEngine, schemas);
                 HollowObjectMapper newObjectMapper = new HollowObjectMapper(writeEngine);
                 if (hashCodeFinder != null) {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -743,6 +743,7 @@ public class HollowProducer extends AbstractHollowProducer {
         Executor snapshotPublishExecutor = null;
         int numStatesBetweenSnapshots = 0;
         boolean focusHoleFillInFewestShards = false;
+        boolean opportunisticCompact = false;
         boolean allowTypeResharding = false;
         boolean forceCoverageOfTypeResharding = false;
         long targetMaxTypeShardSize = DEFAULT_TARGET_MAX_TYPE_SHARD_SIZE;
@@ -911,6 +912,14 @@ public class HollowProducer extends AbstractHollowProducer {
          */
         public B withFocusHoleFillInFewestShards(boolean focusHoleFillInFewestShards) {
             this.focusHoleFillInFewestShards = focusHoleFillInFewestShards;
+            return (B) this;
+        }
+
+        /**
+         * Opt-in: when a cycle frees no ordinals for a type, skip the compact sort+rehash for that type.
+         */
+        public B withOpportunisticCompact(boolean opportunisticCompact) {
+            this.opportunisticCompact = opportunisticCompact;
             return (B) this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
@@ -21,6 +21,7 @@ import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.memory.pool.WastefulRecycler;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -54,6 +55,11 @@ public class ByteArrayOrdinalMap {
     /// ordinal's value space and forcing a broken delta chain.
     /// NOTE: not using final to allow value modification through reflection for test purpose.
     private static int SOFT_ORDINAL_LIMIT = 1 << (BITS_PER_ORDINAL - 1);
+
+    // Opt-in (default off): skip the compact sort+rehash when no ordinals are freed.
+    static boolean COMPACT_SKIP_WHEN_NO_FREES =
+            Boolean.getBoolean("com.netflix.hollow.core.memory.ByteArrayOrdinalMap.enableCompactSkip");
+    static final AtomicLong COMPACT_SKIP_COUNT = new AtomicLong();
 
     /// Thread safety:  We need volatile access semantics to the individual elements in the
     /// pointersAndOrdinals array.
@@ -463,13 +469,33 @@ public class ByteArrayOrdinalMap {
         long[] populatedReverseKeys = new long[size];
 
         int counter = 0;
+        boolean anyFreed = false;
         AtomicLongArray pao = pointersAndOrdinals;
 
         for (int i = 0; i < pao.length(); i++) {
             long key = pao.get(i);
             if (key != EMPTY_BUCKET_VALUE) {
                 populatedReverseKeys[counter++] = key << BITS_PER_ORDINAL | key >>> BITS_PER_POINTER;
+                if (COMPACT_SKIP_WHEN_NO_FREES && !anyFreed) {
+                    int ordinal = (int) (key >>> BITS_PER_POINTER);
+                    if (!usedGlobalOrdinals.get((ordinal << mapIndexBits) | mapIdx)) {
+                        anyFreed = true;
+                    }
+                }
             }
+        }
+
+        // Nothing freed => no holes to reclaim and the hash mapping is unchanged.
+        if (COMPACT_SKIP_WHEN_NO_FREES && !anyFreed) {
+            if (focusHoleFillInFewestShards && numShards > 1) {
+                freeOrdinalTracker.sort(numShards, mapIndexBits, mapIdx);
+            } else {
+                freeOrdinalTracker.sort();
+            }
+            pointersByOrdinal = null;
+            unusedPreviousOrdinals = null;
+            COMPACT_SKIP_COUNT.incrementAndGet();
+            return;
         }
 
         Arrays.sort(populatedReverseKeys);

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
@@ -56,10 +56,11 @@ public class ByteArrayOrdinalMap {
     /// NOTE: not using final to allow value modification through reflection for test purpose.
     private static int SOFT_ORDINAL_LIMIT = 1 << (BITS_PER_ORDINAL - 1);
 
-    // Opt-in (default off): skip the compact sort+rehash when no ordinals are freed.
-    static boolean COMPACT_SKIP_WHEN_NO_FREES =
-            Boolean.getBoolean("com.netflix.hollow.core.memory.ByteArrayOrdinalMap.enableCompactSkip");
-    static final AtomicLong COMPACT_SKIP_COUNT = new AtomicLong();
+    // Opt-in (default off): when a cycle frees no ordinals there are no holes to reclaim and the hash
+    // mapping is unchanged, so the sort+rehash portion of compact() can be skipped.
+    static boolean OPPORTUNISTIC_COMPACT =
+            Boolean.getBoolean("com.netflix.hollow.core.memory.ByteArrayOrdinalMap.opportunisticCompact");
+    static final AtomicLong OPPORTUNISTIC_COMPACT_COUNT = new AtomicLong();
 
     /// Thread safety:  We need volatile access semantics to the individual elements in the
     /// pointersAndOrdinals array.
@@ -476,7 +477,7 @@ public class ByteArrayOrdinalMap {
             long key = pao.get(i);
             if (key != EMPTY_BUCKET_VALUE) {
                 populatedReverseKeys[counter++] = key << BITS_PER_ORDINAL | key >>> BITS_PER_POINTER;
-                if (COMPACT_SKIP_WHEN_NO_FREES && !anyFreed) {
+                if (OPPORTUNISTIC_COMPACT && !anyFreed) {
                     int ordinal = (int) (key >>> BITS_PER_POINTER);
                     if (!usedGlobalOrdinals.get((ordinal << mapIndexBits) | mapIdx)) {
                         anyFreed = true;
@@ -485,16 +486,15 @@ public class ByteArrayOrdinalMap {
             }
         }
 
-        // Nothing freed => no holes to reclaim and the hash mapping is unchanged.
-        if (COMPACT_SKIP_WHEN_NO_FREES && !anyFreed) {
-            if (focusHoleFillInFewestShards && numShards > 1) {
-                freeOrdinalTracker.sort(numShards, mapIndexBits, mapIdx);
-            } else {
-                freeOrdinalTracker.sort();
-            }
+        // Nothing freed => no holes to reclaim and the hash mapping is unchanged, so skip the sort+rehash.
+        if (OPPORTUNISTIC_COMPACT && !anyFreed) {
+            sortFreeOrdinals(numShards, mapIndexBits, mapIdx, focusHoleFillInFewestShards);
             pointersByOrdinal = null;
             unusedPreviousOrdinals = null;
-            COMPACT_SKIP_COUNT.incrementAndGet();
+            long skippedCount = OPPORTUNISTIC_COMPACT_COUNT.incrementAndGet();
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.fine("Opportunistic compact fast path: no ordinals freed, skipped sort+rehash (count=" + skippedCount + ")");
+            }
             return;
         }
 
@@ -529,10 +529,7 @@ public class ByteArrayOrdinalMap {
 
         byteData.setPosition(currentCopyPointer);
 
-        if(focusHoleFillInFewestShards && numShards > 1)
-            freeOrdinalTracker.sort(numShards, mapIndexBits, mapIdx);
-        else
-            freeOrdinalTracker.sort();
+        sortFreeOrdinals(numShards, mapIndexBits, mapIdx, focusHoleFillInFewestShards);
 
         // Reset the array then fill with compacted values
         // Volatile store not required, could use plain store
@@ -545,6 +542,21 @@ public class ByteArrayOrdinalMap {
 
         pointersByOrdinal = null;
         unusedPreviousOrdinals = null;
+    }
+
+    private void sortFreeOrdinals(int numShards, int mapIndexBits, int mapIdx, boolean focusHoleFillInFewestShards) {
+        if (focusHoleFillInFewestShards && numShards > 1)
+            freeOrdinalTracker.sort(numShards, mapIndexBits, mapIdx);
+        else
+            freeOrdinalTracker.sort();
+    }
+
+    /**
+     * Number of {@link #compact} calls that took the opportunistic fast path — cycles in which no ordinals
+     * were freed, so the sort+rehash was skipped. Exposed for observability.
+     */
+    public static long getOpportunisticCompactCount() {
+        return OPPORTUNISTIC_COMPACT_COUNT.get();
     }
 
     public long getPointerForData(int ordinal) {

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMap.java
@@ -21,7 +21,6 @@ import com.netflix.hollow.core.memory.encoding.VarInt;
 import com.netflix.hollow.core.memory.pool.WastefulRecycler;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -55,12 +54,6 @@ public class ByteArrayOrdinalMap {
     /// ordinal's value space and forcing a broken delta chain.
     /// NOTE: not using final to allow value modification through reflection for test purpose.
     private static int SOFT_ORDINAL_LIMIT = 1 << (BITS_PER_ORDINAL - 1);
-
-    // Opt-in (default off): when a cycle frees no ordinals there are no holes to reclaim and the hash
-    // mapping is unchanged, so the sort+rehash portion of compact() can be skipped.
-    static boolean OPPORTUNISTIC_COMPACT =
-            Boolean.getBoolean("com.netflix.hollow.core.memory.ByteArrayOrdinalMap.opportunisticCompact");
-    static final AtomicLong OPPORTUNISTIC_COMPACT_COUNT = new AtomicLong();
 
     /// Thread safety:  We need volatile access semantics to the individual elements in the
     /// pointersAndOrdinals array.
@@ -466,36 +459,24 @@ public class ByteArrayOrdinalMap {
      *
      * @param usedGlobalOrdinals a bit set representing the ordinals which are currently referenced.
      */
-    public void compact(ThreadSafeBitSet usedGlobalOrdinals, int numShards, boolean focusHoleFillInFewestShards, int mapIdx, int mapIndexBits) {
-        long[] populatedReverseKeys = new long[size];
-
-        int counter = 0;
-        boolean anyFreed = false;
+    public boolean compact(ThreadSafeBitSet usedGlobalOrdinals, int numShards, boolean focusHoleFillInFewestShards, int mapIdx, int mapIndexBits, boolean opportunisticCompact) {
         AtomicLongArray pao = pointersAndOrdinals;
 
+        // No ordinals freed => no holes to reclaim and the hash mapping is unchanged, so skip the sort+rehash.
+        if (opportunisticCompact && !anyOrdinalFreed(pao, usedGlobalOrdinals, mapIdx, mapIndexBits)) {
+            sortFreeOrdinals(numShards, mapIndexBits, mapIdx, focusHoleFillInFewestShards);
+            pointersByOrdinal = null;
+            unusedPreviousOrdinals = null;
+            return true;
+        }
+
+        long[] populatedReverseKeys = new long[size];
+        int counter = 0;
         for (int i = 0; i < pao.length(); i++) {
             long key = pao.get(i);
             if (key != EMPTY_BUCKET_VALUE) {
                 populatedReverseKeys[counter++] = key << BITS_PER_ORDINAL | key >>> BITS_PER_POINTER;
-                if (OPPORTUNISTIC_COMPACT && !anyFreed) {
-                    int ordinal = (int) (key >>> BITS_PER_POINTER);
-                    if (!usedGlobalOrdinals.get((ordinal << mapIndexBits) | mapIdx)) {
-                        anyFreed = true;
-                    }
-                }
             }
-        }
-
-        // Nothing freed => no holes to reclaim and the hash mapping is unchanged, so skip the sort+rehash.
-        if (OPPORTUNISTIC_COMPACT && !anyFreed) {
-            sortFreeOrdinals(numShards, mapIndexBits, mapIdx, focusHoleFillInFewestShards);
-            pointersByOrdinal = null;
-            unusedPreviousOrdinals = null;
-            long skippedCount = OPPORTUNISTIC_COMPACT_COUNT.incrementAndGet();
-            if (LOG.isLoggable(Level.FINE)) {
-                LOG.fine("Opportunistic compact fast path: no ordinals freed, skipped sort+rehash (count=" + skippedCount + ")");
-            }
-            return;
         }
 
         Arrays.sort(populatedReverseKeys);
@@ -542,6 +523,19 @@ public class ByteArrayOrdinalMap {
 
         pointersByOrdinal = null;
         unusedPreviousOrdinals = null;
+        return false;
+    }
+
+    private boolean anyOrdinalFreed(AtomicLongArray pao, ThreadSafeBitSet usedGlobalOrdinals, int mapIdx, int mapIndexBits) {
+        for (int i = 0; i < pao.length(); i++) {
+            long key = pao.get(i);
+            if (key != EMPTY_BUCKET_VALUE) {
+                int ordinal = (int) (key >>> BITS_PER_POINTER);
+                if (!usedGlobalOrdinals.get((ordinal << mapIndexBits) | mapIdx))
+                    return true;
+            }
+        }
+        return false;
     }
 
     private void sortFreeOrdinals(int numShards, int mapIndexBits, int mapIdx, boolean focusHoleFillInFewestShards) {
@@ -549,14 +543,6 @@ public class ByteArrayOrdinalMap {
             freeOrdinalTracker.sort(numShards, mapIndexBits, mapIdx);
         else
             freeOrdinalTracker.sort();
-    }
-
-    /**
-     * Number of {@link #compact} calls that took the opportunistic fast path — cycles in which no ordinals
-     * were freed, so the sort+rehash was skipped. Exposed for observability.
-     */
-    public static long getOpportunisticCompactCount() {
-        return OPPORTUNISTIC_COMPACT_COUNT.get();
     }
 
     public long getPointerForData(int ordinal) {

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowTypeWriteState.java
@@ -240,7 +240,7 @@ public abstract class HollowTypeWriteState {
         if(restoredReadState == null) {
             currentCyclePopulated.clearAll();
             for (int i = 0; i < ordinalMapNum; i++) {
-                ordinalMaps[i].compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards(), i, ordinalMapIndexBits);
+                ordinalMaps[i].compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards(), i, ordinalMapIndexBits, stateEngine.isOpportunisticCompact());
                 ordinalMaps[i].setIgnoreSoftLimits(
                         ignoreSoftLimits == null || ignoreSoftLimits.get());
                 ordinalMaps[i].resetLogSoftLimitsBreach();
@@ -250,7 +250,7 @@ public abstract class HollowTypeWriteState {
             currentCyclePopulated.clearAll();
             previousCyclePopulated.clearAll();
             for (int i = 0; i < ordinalMapNum; i++) {
-                ordinalMaps[i].compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards(), i, ordinalMapIndexBits);
+                ordinalMaps[i].compact(previousCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards(), i, ordinalMapIndexBits, stateEngine.isOpportunisticCompact());
                 ordinalMaps[i].setIgnoreSoftLimits(
                         ignoreSoftLimits == null || ignoreSoftLimits.get());
                 ordinalMaps[i].resetLogSoftLimitsBreach();
@@ -387,7 +387,9 @@ public abstract class HollowTypeWriteState {
     public void prepareForNextCycle() {
         // Compact each ordinal map independently
         for (int i = 0; i < ordinalMapNum; i++) {
-            ordinalMaps[i].compact(currentCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards(), i, ordinalMapIndexBits);
+            boolean fastPath = ordinalMaps[i].compact(currentCyclePopulated, numShards, stateEngine.isFocusHoleFillInFewestShards(), i, ordinalMapIndexBits, stateEngine.isOpportunisticCompact());
+            if (fastPath && LOG.isLoggable(Level.FINE))
+                LOG.fine("Opportunistic compact fast path for type " + getSchema().getName() + " (ordinal map " + i + ")");
             ordinalMaps[i].setIgnoreSoftLimits(
                     ignoreSoftLimits == null || ignoreSoftLimits.get());
             ordinalMaps[i].resetLogSoftLimitsBreach();

--- a/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/write/HollowWriteStateEngine.java
@@ -74,6 +74,8 @@ public class HollowWriteStateEngine implements HollowStateEngine {
     private long targetMaxTypeShardSize = Long.MAX_VALUE;
     //// focus filling ordinal holes in as few shards as possible to make delta application more efficient for consumers
     private boolean focusHoleFillInFewestShards = false;
+    //// skip the compact sort+rehash for a type in cycles that free no ordinals
+    private boolean opportunisticCompact = false;
     //// adjust number of shards per type during the course of the delta chain to realize consumer-side delta applications at constant space overhead
     private boolean allowTypeResharding = false;
     //// supplier to determine whether to ignore ordinal threshold breaches (log instead of throwing exception)
@@ -476,6 +478,14 @@ public class HollowWriteStateEngine implements HollowStateEngine {
 
     boolean isFocusHoleFillInFewestShards() {
         return focusHoleFillInFewestShards;
+    }
+
+    public void setOpportunisticCompact(boolean opportunisticCompact) {
+        this.opportunisticCompact = opportunisticCompact;
+    }
+
+    boolean isOpportunisticCompact() {
+        return opportunisticCompact;
     }
 
     /**

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerCompactSkipTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerCompactSkipTest.java
@@ -23,47 +23,17 @@ import com.netflix.hollow.api.consumer.HollowConsumer;
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
 import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
-import com.netflix.hollow.core.memory.ByteArrayOrdinalMap;
 import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
 import com.netflix.hollow.test.InMemoryBlobStore;
-import java.lang.reflect.Field;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class HollowProducerCompactSkipTest {
 
-    private boolean originalSkip;
-
-    @Before
-    public void setUp() throws Exception {
-        originalSkip = getSkip();
-        setSkip(true);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        setSkip(originalSkip);
-    }
-
-    private static Field skipField() throws Exception {
-        Field f = ByteArrayOrdinalMap.class.getDeclaredField("OPPORTUNISTIC_COMPACT");
-        f.setAccessible(true);
-        return f;
-    }
-
-    private static boolean getSkip() throws Exception {
-        return skipField().getBoolean(null);
-    }
-
-    private static void setSkip(boolean v) throws Exception {
-        skipField().setBoolean(null, v);
-    }
-
-    private static HollowProducer producer(InMemoryBlobStore store, boolean partitionedOrdinalMap) {
+    private static HollowProducer producer(InMemoryBlobStore store, boolean partitionedOrdinalMap, boolean opportunisticCompact) {
         HollowProducer.Builder<?> b = HollowProducer.withPublisher(store)
                 .withBlobStager(new HollowInMemoryBlobStager())
-                .withAnnouncer((HollowProducer.Announcer) v -> {});
+                .withAnnouncer((HollowProducer.Announcer) v -> {})
+                .withOpportunisticCompact(opportunisticCompact);
         if (partitionedOrdinalMap) {
             b.withPartitionedOrdinalMap(true);
         }
@@ -85,7 +55,7 @@ public class HollowProducerCompactSkipTest {
     @Test
     public void addOnlyCyclesAreReadable() {
         InMemoryBlobStore store = new InMemoryBlobStore();
-        HollowProducer producer = producer(store, false);
+        HollowProducer producer = producer(store, false, true);
 
         long v1 = producer.runCycle(ws -> ws.add(new Rec(1, 1)));
         long v2 = producer.runCycle(ws -> { ws.add(new Rec(1, 1)); ws.add(new Rec(2, 2)); });
@@ -106,7 +76,7 @@ public class HollowProducerCompactSkipTest {
     @Test
     public void deleteAndReplaceCyclesAreCorrect() {
         InMemoryBlobStore store = new InMemoryBlobStore();
-        HollowProducer producer = producer(store, false);
+        HollowProducer producer = producer(store, false, true);
 
         producer.runCycle(ws -> { ws.add(new Rec(1, 10)); ws.add(new Rec(2, 20)); ws.add(new Rec(3, 30)); });
         long vDel = producer.runCycle(ws -> { ws.add(new Rec(1, 10)); ws.add(new Rec(3, 30)); });   // delete 2
@@ -127,7 +97,7 @@ public class HollowProducerCompactSkipTest {
     @Test
     public void noOpCyclesDoNotCorruptState() {
         InMemoryBlobStore store = new InMemoryBlobStore();
-        HollowProducer producer = producer(store, false);
+        HollowProducer producer = producer(store, false, true);
 
         long v1 = producer.runCycle(ws -> ws.add(new Rec(1, 1)));
         producer.runCycle(ws -> ws.add(new Rec(1, 1)));                          // no-op (unchanged)
@@ -144,7 +114,7 @@ public class HollowProducerCompactSkipTest {
     @Test
     public void partitionedOrdinalMapMixedChurnIsCorrect() {
         InMemoryBlobStore store = new InMemoryBlobStore();
-        HollowProducer producer = producer(store, true);
+        HollowProducer producer = producer(store, true, true);
 
         HollowProducer.Populator[] seq = mixedChurnSequence();
         long last = 0;
@@ -161,7 +131,7 @@ public class HollowProducerCompactSkipTest {
     }
 
     @Test
-    public void skipOnMatchesSkipOffAcrossMixedChurn() throws Exception {
+    public void skipOnMatchesSkipOffAcrossMixedChurn() {
         long[] vOn = runSequenceWithSkip(true);
         long[] vOff = runSequenceWithSkip(false);
         assertEquals(vOn.length, vOff.length);
@@ -178,15 +148,14 @@ public class HollowProducerCompactSkipTest {
     private InMemoryBlobStore onStore;
     private InMemoryBlobStore offStore;
 
-    private long[] runSequenceWithSkip(boolean skip) throws Exception {
-        setSkip(skip);
+    private long[] runSequenceWithSkip(boolean skip) {
         InMemoryBlobStore store = new InMemoryBlobStore();
         if (skip) {
             onStore = store;
         } else {
             offStore = store;
         }
-        HollowProducer producer = producer(store, false);
+        HollowProducer producer = producer(store, false, skip);
         HollowProducer.Populator[] seq = mixedChurnSequence();
         long[] versions = new long[seq.length];
         for (int i = 0; i < seq.length; i++) {

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerCompactSkipTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerCompactSkipTest.java
@@ -47,7 +47,7 @@ public class HollowProducerCompactSkipTest {
     }
 
     private static Field skipField() throws Exception {
-        Field f = ByteArrayOrdinalMap.class.getDeclaredField("COMPACT_SKIP_WHEN_NO_FREES");
+        Field f = ByteArrayOrdinalMap.class.getDeclaredField("OPPORTUNISTIC_COMPACT");
         f.setAccessible(true);
         return f;
     }

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerCompactSkipTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowProducerCompactSkipTest.java
@@ -1,0 +1,239 @@
+/*
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
+import com.netflix.hollow.core.memory.ByteArrayOrdinalMap;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+import com.netflix.hollow.test.InMemoryBlobStore;
+import java.lang.reflect.Field;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HollowProducerCompactSkipTest {
+
+    private boolean originalSkip;
+
+    @Before
+    public void setUp() throws Exception {
+        originalSkip = getSkip();
+        setSkip(true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        setSkip(originalSkip);
+    }
+
+    private static Field skipField() throws Exception {
+        Field f = ByteArrayOrdinalMap.class.getDeclaredField("COMPACT_SKIP_WHEN_NO_FREES");
+        f.setAccessible(true);
+        return f;
+    }
+
+    private static boolean getSkip() throws Exception {
+        return skipField().getBoolean(null);
+    }
+
+    private static void setSkip(boolean v) throws Exception {
+        skipField().setBoolean(null, v);
+    }
+
+    private static HollowProducer producer(InMemoryBlobStore store, boolean partitionedOrdinalMap) {
+        HollowProducer.Builder<?> b = HollowProducer.withPublisher(store)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withAnnouncer((HollowProducer.Announcer) v -> {});
+        if (partitionedOrdinalMap) {
+            b.withPartitionedOrdinalMap(true);
+        }
+        return b.build();
+    }
+
+    // Every cycle produces a delta: add-only cycles exercise the skip path, delete/replace the full path.
+    private static HollowProducer.Populator[] mixedChurnSequence() {
+        return new HollowProducer.Populator[] {
+            ws -> { ws.add(new Rec(1, 10)); ws.add(new Rec(2, 20)); ws.add(new Rec(3, 30)); },
+            ws -> { ws.add(new Rec(1, 10)); ws.add(new Rec(2, 20)); ws.add(new Rec(3, 30)); ws.add(new Rec(4, 40)); }, // add-only
+            ws -> { ws.add(new Rec(1, 10)); ws.add(new Rec(3, 30)); ws.add(new Rec(4, 40)); },                          // delete 2
+            ws -> { ws.add(new Rec(1, 100)); ws.add(new Rec(3, 30)); ws.add(new Rec(4, 40)); },                         // replace 1
+            ws -> { ws.add(new Rec(1, 100)); ws.add(new Rec(3, 30)); ws.add(new Rec(4, 40)); ws.add(new Rec(5, 50)); }, // add-only
+            ws -> { ws.add(new Rec(3, 30)); ws.add(new Rec(5, 50)); }                                                   // delete 1 & 4
+        };
+    }
+
+    @Test
+    public void addOnlyCyclesAreReadable() {
+        InMemoryBlobStore store = new InMemoryBlobStore();
+        HollowProducer producer = producer(store, false);
+
+        long v1 = producer.runCycle(ws -> ws.add(new Rec(1, 1)));
+        long v2 = producer.runCycle(ws -> { ws.add(new Rec(1, 1)); ws.add(new Rec(2, 2)); });
+        long v3 = producer.runCycle(ws -> { ws.add(new Rec(1, 1)); ws.add(new Rec(2, 2)); ws.add(new Rec(3, 3)); });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(store).build();
+        consumer.triggerRefreshTo(v1);
+        assertValue(consumer, 1, 1L);
+        consumer.triggerRefreshTo(v2);
+        assertValue(consumer, 1, 1L);
+        assertValue(consumer, 2, 2L);
+        consumer.triggerRefreshTo(v3);
+        assertValue(consumer, 1, 1L);
+        assertValue(consumer, 2, 2L);
+        assertValue(consumer, 3, 3L);
+    }
+
+    @Test
+    public void deleteAndReplaceCyclesAreCorrect() {
+        InMemoryBlobStore store = new InMemoryBlobStore();
+        HollowProducer producer = producer(store, false);
+
+        producer.runCycle(ws -> { ws.add(new Rec(1, 10)); ws.add(new Rec(2, 20)); ws.add(new Rec(3, 30)); });
+        long vDel = producer.runCycle(ws -> { ws.add(new Rec(1, 10)); ws.add(new Rec(3, 30)); });   // delete 2
+        long vRep = producer.runCycle(ws -> { ws.add(new Rec(1, 100)); ws.add(new Rec(3, 30)); });  // replace 1
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(store).build();
+        consumer.triggerRefreshTo(vDel);
+        assertValue(consumer, 1, 10L);
+        assertMissing(consumer, 2);
+        assertValue(consumer, 3, 30L);
+
+        consumer.triggerRefreshTo(vRep);
+        assertValue(consumer, 1, 100L);   // replaced, no duplicate
+        assertMissing(consumer, 2);
+        assertValue(consumer, 3, 30L);
+    }
+
+    @Test
+    public void noOpCyclesDoNotCorruptState() {
+        InMemoryBlobStore store = new InMemoryBlobStore();
+        HollowProducer producer = producer(store, false);
+
+        long v1 = producer.runCycle(ws -> ws.add(new Rec(1, 1)));
+        producer.runCycle(ws -> ws.add(new Rec(1, 1)));                          // no-op (unchanged)
+        long v3 = producer.runCycle(ws -> { ws.add(new Rec(1, 1)); ws.add(new Rec(2, 2)); });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(store).build();
+        consumer.triggerRefreshTo(v1);
+        assertValue(consumer, 1, 1L);
+        consumer.triggerRefreshTo(v3);
+        assertValue(consumer, 1, 1L);
+        assertValue(consumer, 2, 2L);
+    }
+
+    @Test
+    public void partitionedOrdinalMapMixedChurnIsCorrect() {
+        InMemoryBlobStore store = new InMemoryBlobStore();
+        HollowProducer producer = producer(store, true);
+
+        HollowProducer.Populator[] seq = mixedChurnSequence();
+        long last = 0;
+        for (HollowProducer.Populator p : seq) {
+            last = producer.runCycle(p);
+        }
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(store).build();
+        consumer.triggerRefreshTo(last);
+        assertMissing(consumer, 1);
+        assertValue(consumer, 3, 30L);
+        assertMissing(consumer, 4);
+        assertValue(consumer, 5, 50L);
+    }
+
+    @Test
+    public void skipOnMatchesSkipOffAcrossMixedChurn() throws Exception {
+        long[] vOn = runSequenceWithSkip(true);
+        long[] vOff = runSequenceWithSkip(false);
+        assertEquals(vOn.length, vOff.length);
+
+        HollowConsumer cOn = HollowConsumer.withBlobRetriever(onStore).build();
+        HollowConsumer cOff = HollowConsumer.withBlobRetriever(offStore).build();
+        for (int i = 0; i < vOn.length; i++) {
+            cOn.triggerRefreshTo(vOn[i]);
+            cOff.triggerRefreshTo(vOff[i]);
+            assertSameRecData(cOn, cOff);
+        }
+    }
+
+    private InMemoryBlobStore onStore;
+    private InMemoryBlobStore offStore;
+
+    private long[] runSequenceWithSkip(boolean skip) throws Exception {
+        setSkip(skip);
+        InMemoryBlobStore store = new InMemoryBlobStore();
+        if (skip) {
+            onStore = store;
+        } else {
+            offStore = store;
+        }
+        HollowProducer producer = producer(store, false);
+        HollowProducer.Populator[] seq = mixedChurnSequence();
+        long[] versions = new long[seq.length];
+        for (int i = 0; i < seq.length; i++) {
+            versions[i] = producer.runCycle(seq[i]);
+        }
+        return versions;
+    }
+
+    // ---------- helpers ----------
+
+    private static int ordinalOf(HollowConsumer consumer, int id) {
+        if (consumer.getStateEngine().getTypeState("Rec") == null) {
+            return -1;
+        }
+        return new HollowPrimaryKeyIndex(consumer.getStateEngine(), "Rec", "id").getMatchingOrdinal(id);
+    }
+
+    private static void assertValue(HollowConsumer consumer, int id, long expected) {
+        int ordinal = ordinalOf(consumer, id);
+        assertNotEquals("record " + id + " should be present", -1, ordinal);
+        assertEquals(expected, new GenericHollowObject(consumer.getStateEngine(), "Rec", ordinal).getLong("value"));
+    }
+
+    private static void assertMissing(HollowConsumer consumer, int id) {
+        assertEquals("record " + id + " should be absent", -1, ordinalOf(consumer, id));
+    }
+
+    private static void assertSameRecData(HollowConsumer a, HollowConsumer b) {
+        for (int id = 0; id <= 6; id++) {
+            int oa = ordinalOf(a, id);
+            int ob = ordinalOf(b, id);
+            assertEquals("presence mismatch for Rec " + id, oa == -1, ob == -1);
+            if (oa != -1) {
+                long va = new GenericHollowObject(a.getStateEngine(), "Rec", oa).getLong("value");
+                long vb = new GenericHollowObject(b.getStateEngine(), "Rec", ob).getLong("value");
+                assertEquals("value mismatch for Rec " + id, va, vb);
+            }
+        }
+    }
+
+    @HollowPrimaryKey(fields = "id")
+    private static class Rec {
+        private final int id;
+        private final long value;
+        Rec(int id, long value) {
+            this.id = id;
+            this.value = value;
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMapCompactSkipTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMapCompactSkipTest.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.memory;
+
+import static com.netflix.hollow.core.memory.ByteArrayOrdinalTest.createBuffer;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ByteArrayOrdinalMapCompactSkipTest {
+
+    private boolean originalSkip;
+
+    @Before
+    public void setUp() {
+        originalSkip = ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES;
+        ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES = true;
+        ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.set(0);
+    }
+
+    @After
+    public void tearDown() {
+        ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES = originalSkip;
+    }
+
+    private static ThreadSafeBitSet used(int... globalOrdinals) {
+        ThreadSafeBitSet b = new ThreadSafeBitSet();
+        for (int o : globalOrdinals) {
+            b.set(o);
+        }
+        return b;
+    }
+
+    private static ByteArrayOrdinalMap mapOf(String... records) {
+        ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
+        for (String r : records) {
+            m.getOrAssignOrdinal(createBuffer(r));
+        }
+        return m;
+    }
+
+    @Test
+    public void skipsCompactWhenNothingFreed() {
+        ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
+        int a = m.getOrAssignOrdinal(createBuffer("A"));
+        int b = m.getOrAssignOrdinal(createBuffer("B"));
+        int c = m.getOrAssignOrdinal(createBuffer("C"));
+        m.prepareForWrite();
+
+        m.compact(used(a, b, c), 1, false, 0, 0);
+
+        assertEquals(1, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(a, m.get(createBuffer("A")));
+        assertEquals(b, m.get(createBuffer("B")));
+        assertEquals(c, m.get(createBuffer("C")));
+    }
+
+    @Test
+    public void doesNotSkipWhenOrdinalFreed() {
+        ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
+        int a = m.getOrAssignOrdinal(createBuffer("A"));
+        int b = m.getOrAssignOrdinal(createBuffer("B"));
+        int c = m.getOrAssignOrdinal(createBuffer("C"));
+        m.prepareForWrite();
+
+        m.compact(used(a, c), 1, false, 0, 0); // drop B
+
+        assertEquals(0, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(a, m.get(createBuffer("A")));
+        assertEquals(-1, m.get(createBuffer("B")));
+        assertEquals(c, m.get(createBuffer("C")));
+    }
+
+    @Test
+    public void skipDisabledFallsBackToFullCompact() {
+        ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES = false;
+        ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
+        int a = m.getOrAssignOrdinal(createBuffer("A"));
+        int b = m.getOrAssignOrdinal(createBuffer("B"));
+        m.prepareForWrite();
+
+        m.compact(used(a, b), 1, false, 0, 0);
+
+        assertEquals(0, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(a, m.get(createBuffer("A")));
+        assertEquals(b, m.get(createBuffer("B")));
+    }
+
+    @Test
+    public void fastAndFullPathProduceIdenticalLayout() {
+        ByteArrayOrdinalMap fast = mapOf("A", "B", "C");
+        ByteArrayOrdinalMap full = mapOf("A", "B", "C");
+        int a = fast.get(createBuffer("A"));
+        int b = fast.get(createBuffer("B"));
+        int c = fast.get(createBuffer("C"));
+        fast.prepareForWrite();
+        full.prepareForWrite();
+
+        ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES = true;
+        fast.compact(used(a, b, c), 1, false, 0, 0);
+        ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES = false;
+        full.compact(used(a, b, c), 1, false, 0, 0);
+
+        fast.prepareForWrite();
+        full.prepareForWrite();
+        for (String s : new String[] {"A", "B", "C"}) {
+            int ordFast = fast.get(createBuffer(s));
+            int ordFull = full.get(createBuffer(s));
+            assertEquals(ordFull, ordFast);
+            assertEquals(full.getPointerForData(ordFull), fast.getPointerForData(ordFast));
+        }
+    }
+
+    @Test
+    public void detectsFreesWithPartitionedOrdinalMapIndexBits() {
+        int mapIdx = 1;
+        int mapIndexBits = 2; // one of 4 partitioned maps
+        ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
+        int a = m.getOrAssignOrdinal(createBuffer("A"));
+        int b = m.getOrAssignOrdinal(createBuffer("B"));
+        m.prepareForWrite();
+
+        m.compact(used((a << mapIndexBits) | mapIdx, (b << mapIndexBits) | mapIdx), 1, false, mapIdx, mapIndexBits);
+        assertEquals(1, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+
+        m.prepareForWrite();
+        m.compact(used((a << mapIndexBits) | mapIdx), 1, false, mapIdx, mapIndexBits); // drop B
+        assertEquals(1, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get()); // full path, unchanged
+        assertEquals(a, m.get(createBuffer("A")));
+        assertEquals(-1, m.get(createBuffer("B")));
+    }
+
+    @Test
+    public void reclaimedOrdinalReusedThenSkip() {
+        ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
+        int a = m.getOrAssignOrdinal(createBuffer("A"));
+        int b = m.getOrAssignOrdinal(createBuffer("B"));
+        m.prepareForWrite();
+
+        m.compact(used(a), 1, false, 0, 0); // free B via full compact
+        assertEquals(0, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(-1, m.get(createBuffer("B")));
+
+        int d = m.getOrAssignOrdinal(createBuffer("D")); // reuses freed ordinal
+        assertEquals(b, d);
+        m.prepareForWrite();
+
+        m.compact(used(a, d), 1, false, 0, 0); // nothing freed -> skip
+        assertEquals(1, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(a, m.get(createBuffer("A")));
+        assertEquals(d, m.get(createBuffer("D")));
+        assertEquals(-1, m.get(createBuffer("B")));
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMapCompactSkipTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMapCompactSkipTest.java
@@ -29,14 +29,14 @@ public class ByteArrayOrdinalMapCompactSkipTest {
 
     @Before
     public void setUp() {
-        originalSkip = ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES;
-        ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES = true;
-        ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.set(0);
+        originalSkip = ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT;
+        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT = true;
+        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.set(0);
     }
 
     @After
     public void tearDown() {
-        ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES = originalSkip;
+        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT = originalSkip;
     }
 
     private static ThreadSafeBitSet used(int... globalOrdinals) {
@@ -65,7 +65,7 @@ public class ByteArrayOrdinalMapCompactSkipTest {
 
         m.compact(used(a, b, c), 1, false, 0, 0);
 
-        assertEquals(1, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(1, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
         assertEquals(a, m.get(createBuffer("A")));
         assertEquals(b, m.get(createBuffer("B")));
         assertEquals(c, m.get(createBuffer("C")));
@@ -81,7 +81,7 @@ public class ByteArrayOrdinalMapCompactSkipTest {
 
         m.compact(used(a, c), 1, false, 0, 0); // drop B
 
-        assertEquals(0, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(0, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
         assertEquals(a, m.get(createBuffer("A")));
         assertEquals(-1, m.get(createBuffer("B")));
         assertEquals(c, m.get(createBuffer("C")));
@@ -89,7 +89,7 @@ public class ByteArrayOrdinalMapCompactSkipTest {
 
     @Test
     public void skipDisabledFallsBackToFullCompact() {
-        ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES = false;
+        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT = false;
         ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
         int a = m.getOrAssignOrdinal(createBuffer("A"));
         int b = m.getOrAssignOrdinal(createBuffer("B"));
@@ -97,7 +97,7 @@ public class ByteArrayOrdinalMapCompactSkipTest {
 
         m.compact(used(a, b), 1, false, 0, 0);
 
-        assertEquals(0, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(0, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
         assertEquals(a, m.get(createBuffer("A")));
         assertEquals(b, m.get(createBuffer("B")));
     }
@@ -112,9 +112,9 @@ public class ByteArrayOrdinalMapCompactSkipTest {
         fast.prepareForWrite();
         full.prepareForWrite();
 
-        ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES = true;
+        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT = true;
         fast.compact(used(a, b, c), 1, false, 0, 0);
-        ByteArrayOrdinalMap.COMPACT_SKIP_WHEN_NO_FREES = false;
+        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT = false;
         full.compact(used(a, b, c), 1, false, 0, 0);
 
         fast.prepareForWrite();
@@ -137,11 +137,11 @@ public class ByteArrayOrdinalMapCompactSkipTest {
         m.prepareForWrite();
 
         m.compact(used((a << mapIndexBits) | mapIdx, (b << mapIndexBits) | mapIdx), 1, false, mapIdx, mapIndexBits);
-        assertEquals(1, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(1, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
 
         m.prepareForWrite();
         m.compact(used((a << mapIndexBits) | mapIdx), 1, false, mapIdx, mapIndexBits); // drop B
-        assertEquals(1, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get()); // full path, unchanged
+        assertEquals(1, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get()); // full path, unchanged
         assertEquals(a, m.get(createBuffer("A")));
         assertEquals(-1, m.get(createBuffer("B")));
     }
@@ -154,7 +154,7 @@ public class ByteArrayOrdinalMapCompactSkipTest {
         m.prepareForWrite();
 
         m.compact(used(a), 1, false, 0, 0); // free B via full compact
-        assertEquals(0, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(0, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
         assertEquals(-1, m.get(createBuffer("B")));
 
         int d = m.getOrAssignOrdinal(createBuffer("D")); // reuses freed ordinal
@@ -162,9 +162,24 @@ public class ByteArrayOrdinalMapCompactSkipTest {
         m.prepareForWrite();
 
         m.compact(used(a, d), 1, false, 0, 0); // nothing freed -> skip
-        assertEquals(1, ByteArrayOrdinalMap.COMPACT_SKIP_COUNT.get());
+        assertEquals(1, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
         assertEquals(a, m.get(createBuffer("A")));
         assertEquals(d, m.get(createBuffer("D")));
         assertEquals(-1, m.get(createBuffer("B")));
+    }
+
+    @Test
+    public void getterReflectsOpportunisticCompactCount() {
+        assertEquals(0, ByteArrayOrdinalMap.getOpportunisticCompactCount());
+        ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
+        int a = m.getOrAssignOrdinal(createBuffer("A"));
+        int b = m.getOrAssignOrdinal(createBuffer("B"));
+        m.prepareForWrite();
+
+        m.compact(used(a, b), 1, false, 0, 0); // nothing freed -> fast path
+
+        assertEquals(1, ByteArrayOrdinalMap.getOpportunisticCompactCount());
+        assertEquals(ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get(),
+                ByteArrayOrdinalMap.getOpportunisticCompactCount());
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMapCompactSkipTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/ByteArrayOrdinalMapCompactSkipTest.java
@@ -18,26 +18,12 @@ package com.netflix.hollow.core.memory;
 
 import static com.netflix.hollow.core.memory.ByteArrayOrdinalTest.createBuffer;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class ByteArrayOrdinalMapCompactSkipTest {
-
-    private boolean originalSkip;
-
-    @Before
-    public void setUp() {
-        originalSkip = ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT;
-        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT = true;
-        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.set(0);
-    }
-
-    @After
-    public void tearDown() {
-        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT = originalSkip;
-    }
 
     private static ThreadSafeBitSet used(int... globalOrdinals) {
         ThreadSafeBitSet b = new ThreadSafeBitSet();
@@ -63,9 +49,8 @@ public class ByteArrayOrdinalMapCompactSkipTest {
         int c = m.getOrAssignOrdinal(createBuffer("C"));
         m.prepareForWrite();
 
-        m.compact(used(a, b, c), 1, false, 0, 0);
+        assertTrue(m.compact(used(a, b, c), 1, false, 0, 0, true)); // fast path taken
 
-        assertEquals(1, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
         assertEquals(a, m.get(createBuffer("A")));
         assertEquals(b, m.get(createBuffer("B")));
         assertEquals(c, m.get(createBuffer("C")));
@@ -79,25 +64,22 @@ public class ByteArrayOrdinalMapCompactSkipTest {
         int c = m.getOrAssignOrdinal(createBuffer("C"));
         m.prepareForWrite();
 
-        m.compact(used(a, c), 1, false, 0, 0); // drop B
+        assertFalse(m.compact(used(a, c), 1, false, 0, 0, true)); // drop B -> full path
 
-        assertEquals(0, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
         assertEquals(a, m.get(createBuffer("A")));
         assertEquals(-1, m.get(createBuffer("B")));
         assertEquals(c, m.get(createBuffer("C")));
     }
 
     @Test
-    public void skipDisabledFallsBackToFullCompact() {
-        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT = false;
+    public void disabledAlwaysTakesFullCompact() {
         ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
         int a = m.getOrAssignOrdinal(createBuffer("A"));
         int b = m.getOrAssignOrdinal(createBuffer("B"));
         m.prepareForWrite();
 
-        m.compact(used(a, b), 1, false, 0, 0);
+        assertFalse(m.compact(used(a, b), 1, false, 0, 0, false)); // opportunistic disabled
 
-        assertEquals(0, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
         assertEquals(a, m.get(createBuffer("A")));
         assertEquals(b, m.get(createBuffer("B")));
     }
@@ -112,10 +94,8 @@ public class ByteArrayOrdinalMapCompactSkipTest {
         fast.prepareForWrite();
         full.prepareForWrite();
 
-        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT = true;
-        fast.compact(used(a, b, c), 1, false, 0, 0);
-        ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT = false;
-        full.compact(used(a, b, c), 1, false, 0, 0);
+        assertTrue(fast.compact(used(a, b, c), 1, false, 0, 0, true));
+        assertFalse(full.compact(used(a, b, c), 1, false, 0, 0, false));
 
         fast.prepareForWrite();
         full.prepareForWrite();
@@ -136,12 +116,10 @@ public class ByteArrayOrdinalMapCompactSkipTest {
         int b = m.getOrAssignOrdinal(createBuffer("B"));
         m.prepareForWrite();
 
-        m.compact(used((a << mapIndexBits) | mapIdx, (b << mapIndexBits) | mapIdx), 1, false, mapIdx, mapIndexBits);
-        assertEquals(1, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
+        assertTrue(m.compact(used((a << mapIndexBits) | mapIdx, (b << mapIndexBits) | mapIdx), 1, false, mapIdx, mapIndexBits, true));
 
         m.prepareForWrite();
-        m.compact(used((a << mapIndexBits) | mapIdx), 1, false, mapIdx, mapIndexBits); // drop B
-        assertEquals(1, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get()); // full path, unchanged
+        assertFalse(m.compact(used((a << mapIndexBits) | mapIdx), 1, false, mapIdx, mapIndexBits, true)); // drop B
         assertEquals(a, m.get(createBuffer("A")));
         assertEquals(-1, m.get(createBuffer("B")));
     }
@@ -153,33 +131,16 @@ public class ByteArrayOrdinalMapCompactSkipTest {
         int b = m.getOrAssignOrdinal(createBuffer("B"));
         m.prepareForWrite();
 
-        m.compact(used(a), 1, false, 0, 0); // free B via full compact
-        assertEquals(0, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
+        assertFalse(m.compact(used(a), 1, false, 0, 0, true)); // free B via full compact
         assertEquals(-1, m.get(createBuffer("B")));
 
         int d = m.getOrAssignOrdinal(createBuffer("D")); // reuses freed ordinal
         assertEquals(b, d);
         m.prepareForWrite();
 
-        m.compact(used(a, d), 1, false, 0, 0); // nothing freed -> skip
-        assertEquals(1, ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get());
+        assertTrue(m.compact(used(a, d), 1, false, 0, 0, true)); // nothing freed -> skip
         assertEquals(a, m.get(createBuffer("A")));
         assertEquals(d, m.get(createBuffer("D")));
         assertEquals(-1, m.get(createBuffer("B")));
-    }
-
-    @Test
-    public void getterReflectsOpportunisticCompactCount() {
-        assertEquals(0, ByteArrayOrdinalMap.getOpportunisticCompactCount());
-        ByteArrayOrdinalMap m = new ByteArrayOrdinalMap();
-        int a = m.getOrAssignOrdinal(createBuffer("A"));
-        int b = m.getOrAssignOrdinal(createBuffer("B"));
-        m.prepareForWrite();
-
-        m.compact(used(a, b), 1, false, 0, 0); // nothing freed -> fast path
-
-        assertEquals(1, ByteArrayOrdinalMap.getOpportunisticCompactCount());
-        assertEquals(ByteArrayOrdinalMap.OPPORTUNISTIC_COMPACT_COUNT.get(),
-                ByteArrayOrdinalMap.getOpportunisticCompactCount());
     }
 }


### PR DESCRIPTION
Each producer cycle unconditionally sorts the ordinal map for each type as part of `prepareForNextCycle`. This sorting can be skipped when there are no removed/replaced ordinals in a cycle. Flame graph from an internal cycle

<img width="1164" height="750" alt="Screenshot 2026-08-10 at 12 47 00 PM" src="https://github.com/user-attachments/assets/4b32d040-056f-41e9-9a25-3afaa1d972af" />
