### PR TITLE
Parallel integ check in producer cycle

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowProducer.java
@@ -94,6 +94,7 @@ abstract class AbstractHollowProducer {
     long lastSuccessfulCycle = 0;
     final HollowObjectHashCodeFinder hashCodeFinder;
     final boolean doIntegrityCheck;
+    final boolean parallelPerShardChecksum;
     // Count to track number of cycles run by a primary producer. In the future, this can be useful in determining stickiness of a
     // producer instance.
     int cycleCountSincePrimaryStatus = 0;
@@ -121,7 +122,7 @@ abstract class AbstractHollowProducer {
                 new VersionMinterWithCounter(), null, 0,
                 DEFAULT_TARGET_MAX_TYPE_SHARD_SIZE, false, false, false, false, null,
                 new DummyBlobStorageCleaner(), new BasicSingleProducerEnforcer(),
-                null, true, HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE, null, () -> false);
+                null, true, HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE, null, () -> false, false);
     }
 
     // The only constructor should be that which accepts a builder
@@ -135,7 +136,7 @@ abstract class AbstractHollowProducer {
                 b.allowTypeResharding, b.forceCoverageOfTypeResharding, b.partitionedOrdinalMap,
                 b.metricsCollector, b.blobStorageCleaner, b.singleProducerEnforcer,
                 b.hashCodeFinder, b.doIntegrityCheck, b.updatePlanBlobVerifier, b.ignoreSoftLimits,
-                b.skipValidation);
+                b.skipValidation, b.parallelPerShardChecksum);
     }
 
     private final HollowProducerListener producerMetricsListener;
@@ -163,7 +164,8 @@ abstract class AbstractHollowProducer {
             boolean doIntegrityCheck,
             HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier,
             Supplier<Boolean> ignoreSoftLimits,
-            Supplier<Boolean> skipValidation) {
+            Supplier<Boolean> skipValidation,
+            boolean parallelPerShardChecksum) {
         this.publisher = publisher;
         this.announcer = announcer;
         this.versionMinter = versionMinter;
@@ -180,6 +182,7 @@ abstract class AbstractHollowProducer {
         this.ignoreSoftLimits = ignoreSoftLimits;
         this.partitionedOrdinalMap = partitionedOrdinalMap;
         this.skipValidation = skipValidation;
+        this.parallelPerShardChecksum = parallelPerShardChecksum;
 
         HollowWriteStateEngine writeEngine = hashCodeFinder == null
                 ? new HollowWriteStateEngine()
@@ -888,10 +891,11 @@ abstract class AbstractHollowProducer {
                 HollowReadStateEngine current = readStates.current().getStateEngine();
 
                 log.info("CHECKSUMS");
-                HollowChecksum currentChecksum = HollowChecksum.forStateEngineWithCommonSchemas(current, pending);
+                // Use the same producer-configured checksum mode (HollowProducer.Builder.withParallelPerShardChecksum) across all blob types.
+                HollowChecksum currentChecksum = HollowChecksum.forStateEngineWithCommonSchemas(current, pending, parallelPerShardChecksum);
                 log.info("  CUR        " + currentChecksum);
 
-                HollowChecksum pendingChecksum = HollowChecksum.forStateEngineWithCommonSchemas(pending, current);
+                HollowChecksum pendingChecksum = HollowChecksum.forStateEngineWithCommonSchemas(pending, current, parallelPerShardChecksum);
                 log.info("         PND " + pendingChecksum);
 
                 if (artifacts.hasDelta()) {
@@ -901,14 +905,14 @@ abstract class AbstractHollowProducer {
 
                     // FIXME: timt: future cycles will fail unless both deltas validate
                     applyDelta(artifacts.delta, current);
-                    HollowChecksum forwardChecksum = HollowChecksum.forStateEngineWithCommonSchemas(current, pending);
+                    HollowChecksum forwardChecksum = HollowChecksum.forStateEngineWithCommonSchemas(current, pending, parallelPerShardChecksum);
                     //out.format("  CUR => PND %s\n", forwardChecksum);
                     if (!forwardChecksum.equals(pendingChecksum)) {
                         throw new HollowProducer.ChecksumValidationException(HollowProducer.Blob.Type.DELTA, forwardChecksum, pendingChecksum);
                     }
 
                     applyDelta(artifacts.reverseDelta, pending);
-                    HollowChecksum reverseChecksum = HollowChecksum.forStateEngineWithCommonSchemas(pending, current);
+                    HollowChecksum reverseChecksum = HollowChecksum.forStateEngineWithCommonSchemas(pending, current, parallelPerShardChecksum);
                     //out.format("  CUR <= PND %s\n", reverseChecksum);
                     if (!reverseChecksum.equals(currentChecksum)) {
                         throw new HollowProducer.ChecksumValidationException(HollowProducer.Blob.Type.REVERSE_DELTA, reverseChecksum, currentChecksum);

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -751,6 +751,7 @@ public class HollowProducer extends AbstractHollowProducer {
         SingleProducerEnforcer singleProducerEnforcer = new BasicSingleProducerEnforcer();
         HollowObjectHashCodeFinder hashCodeFinder = null;
         boolean doIntegrityCheck = true;
+        boolean parallelPerShardChecksum = false;
         boolean partitionedOrdinalMap = false;
         ProducerOptionalBlobPartConfig optionalPartConfig = null;
         HollowConsumer.UpdatePlanBlobVerifier updatePlanBlobVerifier = HollowConsumer.UpdatePlanBlobVerifier.DEFAULT_INSTANCE;
@@ -969,6 +970,18 @@ public class HollowProducer extends AbstractHollowProducer {
         
         public B noIntegrityCheck() {
             this.doIntegrityCheck = false;
+            return (B) this;
+        }
+
+        /**
+         * When enabled, the integrity checksum fans out one task per (type, shard) instead of per type,
+         * so a type dominated by a single large shard parallelizes across its shards. Useful only when type-sharding
+         * is enabled. Defaults to off (legacy per-type).
+         *
+         * @param parallelPerShardChecksum whether to compute the integrity checksum per (type, shard)
+         */
+        public B withParallelPerShardChecksum(boolean parallelPerShardChecksum) {
+            this.parallelPerShardChecksum = parallelPerShardChecksum;
             return (B) this;
         }
 

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
@@ -174,19 +174,10 @@ public abstract class HollowTypeReadState implements HollowTypeDataAccess {
     protected abstract void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema);
 
     /**
-     * Computes the checksum of a single shard of this type in isolation. The returned checksum incorporates only the
-     * records that reside in the given shard (i.e. those whose ordinal maps to {@code shardNumber}). Combining the
-     * per-shard checksums for every shard in ascending shard order reproduces this type's contribution to the overall
-     * state-engine checksum, which lets the checksum of a type be computed one shard at a time and in parallel.
-     * <p>
-     * The caller must ensure the type's shard structure is not concurrently mutated (e.g. by a delta application that
-     * reshards) for the duration of the checksum: {@code numShards()} and the shards it walks are read independently,
-     * so a concurrent reshard could observe an inconsistent view. This holds for the producer's integrity check, where
-     * the engines being checksummed are quiescent.
+     * Computes the checksum of one shard, {@code shardNumber} in {@code [0, numShards())}. Folding every shard's
+     * checksum in ascending order (via {@link HollowChecksum#applyInt}) gives this type's contribution in per-shard
+     * mode; that value differs from {@link #getChecksum}, so never compare checksums across the two modes.
      *
-     * @param withSchema the (possibly narrower) common schema to compute the checksum against
-     * @param shardNumber the shard index, in {@code [0, numShards())}
-     * @return the partial checksum for the requested shard
      * @throws IllegalArgumentException if {@code shardNumber} is outside {@code [0, numShards())}
      */
     public HollowChecksum getShardChecksum(HollowSchema withSchema, int shardNumber) {
@@ -199,7 +190,13 @@ public abstract class HollowTypeReadState implements HollowTypeDataAccess {
         return cksum;
     }
 
-    protected abstract void applyShardToChecksum(HollowChecksum checksum, HollowSchema withSchema, int shardNumber);
+    /**
+     * Applies one shard's checksum contribution. The default is not sharded: it folds the whole type (via
+     * {@link #applyToChecksum}) for every shard, which is correct but redundant; override to isolate a single shard.
+     */
+    protected void applyShardToChecksum(HollowChecksum checksum, HollowSchema withSchema, int shardNumber) {
+        applyToChecksum(checksum, withSchema);
+    }
 
     @Override
     public HollowTypeReadState getTypeState() {

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/HollowTypeReadState.java
@@ -173,6 +173,34 @@ public abstract class HollowTypeReadState implements HollowTypeDataAccess {
 
     protected abstract void applyToChecksum(HollowChecksum checksum, HollowSchema withSchema);
 
+    /**
+     * Computes the checksum of a single shard of this type in isolation. The returned checksum incorporates only the
+     * records that reside in the given shard (i.e. those whose ordinal maps to {@code shardNumber}). Combining the
+     * per-shard checksums for every shard in ascending shard order reproduces this type's contribution to the overall
+     * state-engine checksum, which lets the checksum of a type be computed one shard at a time and in parallel.
+     * <p>
+     * The caller must ensure the type's shard structure is not concurrently mutated (e.g. by a delta application that
+     * reshards) for the duration of the checksum: {@code numShards()} and the shards it walks are read independently,
+     * so a concurrent reshard could observe an inconsistent view. This holds for the producer's integrity check, where
+     * the engines being checksummed are quiescent.
+     *
+     * @param withSchema the (possibly narrower) common schema to compute the checksum against
+     * @param shardNumber the shard index, in {@code [0, numShards())}
+     * @return the partial checksum for the requested shard
+     * @throws IllegalArgumentException if {@code shardNumber} is outside {@code [0, numShards())}
+     */
+    public HollowChecksum getShardChecksum(HollowSchema withSchema, int shardNumber) {
+        int numShards = numShards();
+        if(shardNumber < 0 || shardNumber >= numShards)
+            throw new IllegalArgumentException("shardNumber " + shardNumber + " is out of range [0, " + numShards
+                    + ") for type " + getSchema().getName());
+        HollowChecksum cksum = new HollowChecksum();
+        applyShardToChecksum(cksum, withSchema, shardNumber);
+        return cksum;
+    }
+
+    protected abstract void applyShardToChecksum(HollowChecksum checksum, HollowSchema withSchema, int shardNumber);
+
     @Override
     public HollowTypeReadState getTypeState() {
         return this;

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/list/HollowListTypeReadState.java
@@ -290,6 +290,16 @@ public class HollowListTypeReadState extends HollowCollectionTypeReadState imple
             shards[i].applyShardToChecksum(checksum, populatedOrdinals, i, shards.length);
     }
 
+    @Override
+    protected void applyShardToChecksum(HollowChecksum checksum, HollowSchema withSchema, int shardNumber) {
+        final HollowListTypeReadStateShard[] shards = this.shardsVolatile.shards;
+        if(!getSchema().equals(withSchema))
+            throw new IllegalArgumentException("HollowListTypeReadState cannot calculate checksum with unequal schemas: " + getSchema().getName());
+
+        BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
+        shards[shardNumber].applyShardToChecksum(checksum, populatedOrdinals, shardNumber, shards.length);
+    }
+
 	@Override
 	public long getApproximateHeapFootprintInBytes() {
         final HollowListTypeReadStateShard[] shards = this.shardsVolatile.shards;

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/map/HollowMapTypeReadState.java
@@ -456,6 +456,16 @@ public class HollowMapTypeReadState extends HollowTypeReadState implements Hollo
     }
 
     @Override
+    protected void applyShardToChecksum(HollowChecksum checksum, HollowSchema withSchema, int shardNumber) {
+        HollowMapTypeReadStateShard[] shards = this.shardsVolatile.shards;
+        if(!getSchema().equals(withSchema))
+            throw new IllegalArgumentException("HollowMapTypeReadState cannot calculate checksum with unequal schemas: " + getSchema().getName());
+
+        BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
+        shards[shardNumber].applyShardToChecksum(checksum, populatedOrdinals, shardNumber, shards.length);
+    }
+
+    @Override
     public long getApproximateHeapFootprintInBytes() {
         HollowMapTypeReadStateShard[] shards = this.shardsVolatile.shards;
         long totalApproximateHeapFootprintInBytes = 0;

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/object/HollowObjectTypeReadState.java
@@ -559,6 +559,18 @@ public class HollowObjectTypeReadState extends HollowTypeReadState implements Ho
         }
     }
 
+    @Override
+    protected void applyShardToChecksum(HollowChecksum checksum, HollowSchema withSchema, int shardNumber) {
+        final HollowObjectTypeShardsHolder shardsHolder = this.shardsVolatile;
+        final HollowObjectTypeReadStateShard[] shards = shardsHolder.shards;
+        int shardNumberMask = shardsHolder.shardNumberMask;
+        if(!(withSchema instanceof HollowObjectSchema))
+            throw new IllegalArgumentException("HollowObjectTypeReadState can only calculate checksum with a HollowObjectSchema: " + getSchema().getName());
+
+        BitSet populatedOrdinals = getPopulatedOrdinals();
+        shards[shardNumber].applyShardToChecksum(checksum, withSchema, populatedOrdinals, shardNumber, shardNumberMask);
+    }
+
 	@Override
 	public long getApproximateHeapFootprintInBytes() {
         final HollowObjectTypeReadStateShard[] shards = this.shardsVolatile.shards;

--- a/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/read/engine/set/HollowSetTypeReadState.java
@@ -398,6 +398,17 @@ public class HollowSetTypeReadState extends HollowCollectionTypeReadState implem
             shards[i].applyShardToChecksum(checksum, populatedOrdinals, i, shards.length);
     }
 
+    @Override
+    protected void applyShardToChecksum(HollowChecksum checksum, HollowSchema withSchema, int shardNumber) {
+        final HollowSetTypeShardsHolder shardsHolder = this.shardsVolatile;
+        final HollowSetTypeReadStateShard[] shards = shardsHolder.shards;
+        if(!getSchema().equals(withSchema))
+            throw new IllegalArgumentException("HollowSetTypeReadState cannot calculate checksum with unequal schemas: " + getSchema().getName());
+
+        BitSet populatedOrdinals = getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
+        shards[shardNumber].applyShardToChecksum(checksum, populatedOrdinals, shardNumber, shards.length);
+    }
+
 	@Override
 	public long getApproximateHeapFootprintInBytes() {
         final HollowSetTypeReadStateShard[] shards = this.shardsVolatile.shards;

--- a/hollow/src/main/java/com/netflix/hollow/tools/checksum/HollowChecksum.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/checksum/HollowChecksum.java
@@ -21,7 +21,9 @@ import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
 import com.netflix.hollow.core.read.engine.HollowTypeReadState;
 import com.netflix.hollow.core.schema.HollowSchema;
 import com.netflix.hollow.core.util.SimultaneousExecutor;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Vector;
 
@@ -86,8 +88,29 @@ public class HollowChecksum {
     public static HollowChecksum forStateEngine(HollowReadStateEngine stateEngine) {
         return forStateEngineWithCommonSchemas(stateEngine, stateEngine);
     }
-    
+
+    public static HollowChecksum forStateEngine(HollowReadStateEngine stateEngine, boolean parallelPerShard) {
+        return forStateEngineWithCommonSchemas(stateEngine, stateEngine, parallelPerShard);
+    }
+
     public static HollowChecksum forStateEngineWithCommonSchemas(HollowReadStateEngine stateEngine, HollowReadStateEngine commonSchemasWithState) {
+        return forStateEngineWithCommonSchemas(stateEngine, commonSchemasWithState, false);
+    }
+
+    /**
+     * Overload that takes the per-shard mode explicitly. When {@code true}, the checksum fans out one task per
+     * (type, shard) and combines the per-shard partials, so a type dominated by a single large shard parallelizes
+     * across its shards.
+     *
+     * @param parallelPerShard {@code true} to fan out per (type, shard); {@code false} for the legacy per-type path
+     */
+    public static HollowChecksum forStateEngineWithCommonSchemas(HollowReadStateEngine stateEngine, HollowReadStateEngine commonSchemasWithState, boolean parallelPerShard) {
+        if(parallelPerShard)
+            return forStateEngineParallelPerShard(stateEngine, commonSchemasWithState);
+        return forStateEngineParallelPerType(stateEngine, commonSchemasWithState);
+    }
+
+    private static HollowChecksum forStateEngineParallelPerType(HollowReadStateEngine stateEngine, HollowReadStateEngine commonSchemasWithState) {
         final Vector<TypeChecksum> typeChecksums = new Vector<TypeChecksum>();
         SimultaneousExecutor executor = new SimultaneousExecutor(HollowChecksum.class, "checksum-common-schemas");
 
@@ -118,6 +141,67 @@ public class HollowChecksum {
         }
 
         return totalChecksum;
+    }
+
+    private static HollowChecksum forStateEngineParallelPerShard(HollowReadStateEngine stateEngine, HollowReadStateEngine commonSchemasWithState) {
+        SimultaneousExecutor executor = new SimultaneousExecutor(HollowChecksum.class, "checksum-common-schemas");
+
+        // Fan out one task per (type, shard) rather than per type. Types that are dominated by a single large
+        // type-shard therefore parallelize across their shards instead of running the whole type on one thread.
+        // Each shard's partial checksum is stored by shard index so it can be combined deterministically (in
+        // ascending shard order) regardless of the order in which the tasks happen to complete.
+        final List<TypeShardChecksums> allTypeChecksums = new ArrayList<TypeShardChecksums>();
+        for(final HollowTypeReadState typeState : stateEngine.getTypeStates()) {
+            HollowTypeReadState commonSchemasWithType = commonSchemasWithState.getTypeState(typeState.getSchema().getName());
+            if(commonSchemasWithType != null) {
+                final HollowSchema commonSchemasWith = commonSchemasWithType.getSchema();
+                final int[] shardChecksums = new int[typeState.numShards()];
+                allTypeChecksums.add(new TypeShardChecksums(typeState.getSchema().getName(), shardChecksums));
+                for(int shard = 0; shard < shardChecksums.length; shard++) {
+                    final int shardNumber = shard;
+                    executor.execute(new Runnable() {
+                        public void run() {
+                            shardChecksums[shardNumber] = typeState.getShardChecksum(commonSchemasWith, shardNumber).intValue();
+                        }
+                    });
+                }
+            }
+        }
+
+        try {
+            executor.awaitSuccessfulCompletion();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        // Combine each type's per-shard partials in ascending shard order into a per-type checksum, then combine
+        // the per-type checksums in sorted type-name order into the total (as before).
+        Vector<TypeChecksum> typeChecksums = new Vector<TypeChecksum>();
+        for(TypeShardChecksums typeShardChecksums : allTypeChecksums) {
+            HollowChecksum typeChecksum = new HollowChecksum();
+            for(int shardChecksum : typeShardChecksums.shardChecksums)
+                typeChecksum.applyInt(shardChecksum);
+            typeChecksums.addElement(new TypeChecksum(typeShardChecksums.typeName, typeChecksum));
+        }
+
+        Collections.sort(typeChecksums);
+
+        HollowChecksum totalChecksum = new HollowChecksum();
+        for(TypeChecksum cksum : typeChecksums) {
+            totalChecksum.applyType(cksum);
+        }
+
+        return totalChecksum;
+    }
+
+    private static final class TypeShardChecksums {
+        private final String typeName;
+        private final int[] shardChecksums;
+
+        private TypeShardChecksums(String typeName, int[] shardChecksums) {
+            this.typeName = typeName;
+            this.shardChecksums = shardChecksums;
+        }
     }
 
 

--- a/hollow/src/test/java/com/netflix/hollow/tools/checksum/HollowChecksumShardedTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/checksum/HollowChecksumShardedTest.java
@@ -1,0 +1,499 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.tools.checksum;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.api.producer.HollowProducer;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.read.HollowBlobInput;
+import com.netflix.hollow.core.read.engine.HollowBlobReader;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.read.engine.HollowTypeReadState;
+import com.netflix.hollow.core.schema.HollowListSchema;
+import com.netflix.hollow.core.schema.HollowMapSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema;
+import com.netflix.hollow.core.schema.HollowObjectSchema.FieldType;
+import com.netflix.hollow.core.schema.HollowSetSchema;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowBlobWriter;
+import com.netflix.hollow.core.write.HollowListTypeWriteState;
+import com.netflix.hollow.core.write.HollowListWriteRecord;
+import com.netflix.hollow.core.write.HollowMapTypeWriteState;
+import com.netflix.hollow.core.write.HollowMapWriteRecord;
+import com.netflix.hollow.core.write.HollowObjectTypeWriteState;
+import com.netflix.hollow.core.write.HollowObjectWriteRecord;
+import com.netflix.hollow.core.write.HollowSetTypeWriteState;
+import com.netflix.hollow.core.write.HollowSetWriteRecord;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.test.InMemoryBlobStore;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.BitSet;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Verifies the per-(type, shard) parallel checksum (design B1). The checksum for a multi-shard type
+ * is the deterministic combination of independent per-shard partial checksums, combined in ascending
+ * shard order, then combined across types in sorted type-name order.
+ */
+public class HollowChecksumShardedTest {
+
+    /**
+     * The per-shard parallel checksum is opt-in (via {@code HollowProducer.Builder.withParallelPerShardChecksum}).
+     * The no-arg / default path must be computed exactly as before: one partial per type (the serial per-type fold),
+     * combined in sorted type-name order. This preserves the historical checksum value for callers that don't opt in.
+     */
+    @Test
+    public void defaultChecksumUsesPerTypeComputation() throws IOException {
+        HollowReadStateEngine readEngine = buildMultiShardObjectEngine("TypeA", 1000);
+        HollowTypeReadState typeState = readEngine.getTypeState("TypeA");
+        Assert.assertTrue("test requires a multi-shard type", typeState.numShards() > 1);
+
+        HollowChecksum expected = new HollowChecksum();
+        expected.applyType(new HollowChecksum.TypeChecksum("TypeA", typeState.getChecksum(typeState.getSchema())));
+
+        HollowChecksum actual = HollowChecksum.forStateEngineWithCommonSchemas(readEngine, readEngine);
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void forStateEngineCombinesPerShardPartialsInShardOrder() throws IOException {
+        HollowReadStateEngine readEngine = buildMultiShardObjectEngine("TypeA", 1000);
+        HollowTypeReadState typeState = readEngine.getTypeState("TypeA");
+        Assert.assertTrue("test requires a multi-shard type", typeState.numShards() > 1);
+
+        // Expected: combine each shard's independent partial checksum in ascending shard order into the
+        // type checksum, then fold the (single) type checksum into the total in the usual way.
+        HollowChecksum expectedTypeChecksum = new HollowChecksum();
+        for (int shard = 0; shard < typeState.numShards(); shard++) {
+            expectedTypeChecksum.applyInt(typeState.getShardChecksum(typeState.getSchema(), shard).intValue());
+        }
+        HollowChecksum expected = new HollowChecksum();
+        expected.applyType(new HollowChecksum.TypeChecksum("TypeA", expectedTypeChecksum));
+
+        HollowChecksum actual = HollowChecksum.forStateEngineWithCommonSchemas(readEngine, readEngine, true);
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Detection strength (design §4.3): the per-shard combine must remain sensitive to every record, so mutating a
+     * single field of a single record changes the overall checksum. Guards against a combine that could cancel.
+     */
+    @Test
+    public void detectsSingleRecordMutationInMultiShardObject() throws IOException {
+        HollowChecksum baseline = HollowChecksum.forStateEngine(buildMultiShardObjectEngine("TypeA", 1000, -1), true);
+        HollowChecksum mutated = HollowChecksum.forStateEngine(buildMultiShardObjectEngine("TypeA", 1000, 500), true);
+
+        Assert.assertNotEquals(baseline, mutated);
+    }
+
+    /**
+     * The per-shard fan-out must work for every type kind, not just OBJECT. Builds multi-shard LIST, SET and MAP
+     * types and asserts the parallel checksum is equality-valid (identical data agrees) and detection-sensitive
+     * (a change to any one type kind is detected). Exercises the per-shard checksum of each collection read state.
+     */
+    @Test
+    public void parallelChecksumIsValidForListSetAndMapShards() throws IOException {
+        HollowReadStateEngine baseline = buildMultiShardCollectionsEngine(null);
+        Assert.assertTrue("LIST must be multi-shard", baseline.getTypeState("TestList").numShards() > 1);
+        Assert.assertTrue("SET must be multi-shard", baseline.getTypeState("TestSet").numShards() > 1);
+        Assert.assertTrue("MAP must be multi-shard", baseline.getTypeState("TestMap").numShards() > 1);
+
+        HollowChecksum baselineChecksum = HollowChecksum.forStateEngine(baseline, true);
+
+        // equality-validity: rebuilding the identical dataset yields the identical checksum
+        Assert.assertEquals(baselineChecksum, HollowChecksum.forStateEngine(buildMultiShardCollectionsEngine(null), true));
+
+        // detection: a change confined to any single type kind changes the overall checksum
+        Assert.assertNotEquals(baselineChecksum, HollowChecksum.forStateEngine(buildMultiShardCollectionsEngine("TestList"), true));
+        Assert.assertNotEquals(baselineChecksum, HollowChecksum.forStateEngine(buildMultiShardCollectionsEngine("TestSet"), true));
+        Assert.assertNotEquals(baselineChecksum, HollowChecksum.forStateEngine(buildMultiShardCollectionsEngine("TestMap"), true));
+    }
+
+    /**
+     * Validates the reshard open item (design §4.4/§9 #2). Reproduces {@code checkIntegrity}'s forward comparison
+     * across a re-sharding cycle: a {@code current} engine advanced through a delta that changes numShards, and a
+     * freshly-read {@code pending} snapshot of the same version. Because Hollow reshards the delta target to the
+     * delta's numShards before applying it, the two engines end up structurally aligned (same numShards, aligned
+     * ordinals) and their parallel checksums must agree — even though numShards changed.
+     */
+    @Test
+    public void parallelChecksumsAgreeAcrossReshardingDelta() throws IOException {
+        HollowObjectSchema schema = new HollowObjectSchema("TypeA", 2);
+        schema.addField("id", FieldType.INT);
+        schema.addField("data", FieldType.STRING);
+
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        writeEngine.setTargetMaxTypeShardSize(4096);
+        writeEngine.allowTypeResharding(true);
+        writeEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+
+        // Cycle 1: small dataset -> a baseline shard count. Snapshot it into `current`.
+        addObjectRecords(writeEngine, schema, 0, 300);
+        HollowReadStateEngine current = new HollowReadStateEngine();
+        readSnapshotInto(current, writeSnapshot(writeEngine));
+        writeEngine.prepareForNextCycle();
+        int shardsBefore = current.getTypeState("TypeA").numShards();
+
+        // Cycle 2: much larger dataset (superset) -> crosses a shard-doubling boundary, forcing a reshard.
+        addObjectRecords(writeEngine, schema, 0, 6000);
+        // Produce BOTH the fresh snapshot (pending) and the delta (advances current) from the SAME cycle,
+        // exactly as the producer does when it runs its integrity check.
+        byte[] snapshotBlob = writeSnapshot(writeEngine);
+        byte[] deltaBlob = writeDelta(writeEngine);
+        writeEngine.prepareForNextCycle();
+
+        HollowReadStateEngine pending = new HollowReadStateEngine();
+        readSnapshotInto(pending, snapshotBlob);
+        applyDeltaTo(current, deltaBlob); // reshards `current` up to the delta's (== pending's) numShards
+
+        int shardsAfter = current.getTypeState("TypeA").numShards();
+        Assert.assertNotEquals("expected the delta to reshard the type", shardsBefore, shardsAfter);
+        Assert.assertEquals("current must be resharded to match pending",
+                pending.getTypeState("TypeA").numShards(), shardsAfter);
+
+        // This is checkIntegrity's forward/reverse comparison: same logical state, compared both directions.
+        HollowChecksum currentChecksum = HollowChecksum.forStateEngineWithCommonSchemas(current, pending, true);
+        HollowChecksum pendingChecksum = HollowChecksum.forStateEngineWithCommonSchemas(pending, current, true);
+        Assert.assertEquals(pendingChecksum, currentChecksum);
+    }
+
+    /**
+     * The {@code parallelPerShard} argument selects the algorithm explicitly, and the no-arg method defaults to the
+     * legacy per-type computation. {@code checkIntegrity} passes the same producer-configured value to all four of
+     * its checksums, so they stay mutually consistent.
+     */
+    @Test
+    public void overloadSelectsPerShardOrPerType() throws IOException {
+        HollowReadStateEngine engine = buildMultiShardObjectEngine("TypeA", 1000);
+        Assert.assertTrue(engine.getTypeState("TypeA").numShards() > 1);
+
+        HollowChecksum perShard = HollowChecksum.forStateEngineWithCommonSchemas(engine, engine, true);
+        HollowChecksum perType = HollowChecksum.forStateEngineWithCommonSchemas(engine, engine, false);
+        Assert.assertNotEquals("per-shard and per-type differ for a multi-shard type", perShard, perType);
+
+        // the no-arg method defaults to the legacy per-type computation
+        Assert.assertEquals(perType, HollowChecksum.forStateEngineWithCommonSchemas(engine, engine));
+    }
+
+    @Test
+    public void getShardChecksumRejectsOutOfRangeShard() throws IOException {
+        HollowTypeReadState typeState = buildMultiShardObjectEngine("TypeA", 1000).getTypeState("TypeA");
+        int numShards = typeState.numShards();
+        Assert.assertTrue(numShards > 1);
+        assertThrowsIllegalArgument(() -> typeState.getShardChecksum(typeState.getSchema(), numShards));
+        assertThrowsIllegalArgument(() -> typeState.getShardChecksum(typeState.getSchema(), -1));
+    }
+
+    /**
+     * C1: ordinal holes (records deleted across a delta leave unpopulated ordinals within {@code [0, maxOrdinal]}).
+     * The per-shard checksum must remain equality-valid and detection-sensitive when shards contain holes.
+     */
+    @Test
+    public void parallelChecksumHandlesOrdinalHolesFromDeletions() throws IOException {
+        HollowReadStateEngine a = buildHolyMultiShardObjectEngine(-1);
+        HollowReadStateEngine b = buildHolyMultiShardObjectEngine(-1);
+        BitSet populated = a.getTypeState("TypeA").getPopulatedOrdinals();
+        Assert.assertTrue("type must be multi-shard", a.getTypeState("TypeA").numShards() > 1);
+        Assert.assertTrue("state must contain ordinal holes", populated.cardinality() < populated.length());
+
+        // equality-validity across identical hole-y states
+        Assert.assertEquals(HollowChecksum.forStateEngine(a, true), HollowChecksum.forStateEngine(b, true));
+        // detection still fires when a surviving record changes
+        HollowReadStateEngine mutated = buildHolyMultiShardObjectEngine(500);
+        Assert.assertNotEquals(HollowChecksum.forStateEngine(a, true), HollowChecksum.forStateEngine(mutated, true));
+    }
+
+    /**
+     * C2: full producer/consumer pipeline with the parallel checksum on, across a reshard. The producer runs its
+     * integrity check on every delta cycle (resharding requires it), and that check computes the parallel checksum
+     * over both the forward delta (which reshards {@code current} UP to N_new) and the reverse delta (which reshards
+     * {@code pending} back DOWN to N_old) — so a single reshard cycle exercises the parallel checksum in both shard
+     * directions. A broken parallel checksum would throw {@code ChecksumValidationException} and stall version
+     * progression. The consumer must then read identical data following the delta chain across the reshard.
+     */
+    @Test
+    public void producerConsumerEndToEndWithParallelChecksumAcrossReshard() {
+        InMemoryBlobStore blobStore = new InMemoryBlobStore();
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withTypeResharding(true)
+                .withParallelPerShardChecksum(true)
+                .withTargetMaxTypeShardSize(2048)
+                .build();
+        producer.initializeDataModel(E2EPojo.class);
+
+        long v1 = producer.runCycle(ws -> addE2ERecords(ws, 100));
+        int shards1 = producer.getWriteEngine().getTypeState("E2EPojo").getNumShards();
+        long v2 = producer.runCycle(ws -> addE2ERecords(ws, 8000)); // grow -> reshard; integrity check runs here
+        int shards2 = producer.getWriteEngine().getTypeState("E2EPojo").getNumShards();
+        long v3 = producer.runCycle(ws -> addE2ERecords(ws, 8000)); // steady multi-shard delta; integrity runs again
+
+        Assert.assertTrue("versions must advance (integrity passed each cycle)", v1 < v2 && v2 < v3);
+        Assert.assertTrue("expected a reshard (" + shards1 + "->" + shards2 + ")", shards2 > shards1);
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefreshTo(v1);
+        assertConsumerHasIds(consumer, 100);
+        consumer.triggerRefreshTo(v2); // consumer applies a reshard delta
+        assertConsumerHasIds(consumer, 8000);
+        consumer.triggerRefreshTo(v3);
+        assertConsumerHasIds(consumer, 8000);
+    }
+
+    /**
+     * C3: the reverse leg of {@code checkIntegrity} across a reshard-DOWN. Mirrors the producer applying the reverse
+     * delta to {@code pending}, which reshards it from N_new back to N_old; the reverse checksum must equal the
+     * checksum captured on {@code current} at N_old before any delta.
+     */
+    @Test
+    public void parallelChecksumsAgreeAcrossReverseReshardingDelta() throws IOException {
+        HollowObjectSchema schema = objectSchemaTypeA();
+
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        writeEngine.setTargetMaxTypeShardSize(4096);
+        writeEngine.allowTypeResharding(true);
+        writeEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+
+        // Cycle 1: small -> N_old. `current` = snapshot.
+        addObjectRecords(writeEngine, schema, 0, 300);
+        HollowReadStateEngine current = new HollowReadStateEngine();
+        readSnapshotInto(current, writeSnapshot(writeEngine));
+        writeEngine.prepareForNextCycle();
+        int nOld = current.getTypeState("TypeA").numShards();
+
+        // Cycle 2: grow -> N_new. Produce the snapshot (pending) and the reverse delta from the SAME cycle.
+        addObjectRecords(writeEngine, schema, 0, 6000);
+        byte[] snapshotBlob = writeSnapshot(writeEngine);
+        byte[] reverseDeltaBlob = writeReverseDelta(writeEngine);
+        writeEngine.prepareForNextCycle();
+
+        HollowReadStateEngine pending = new HollowReadStateEngine();
+        readSnapshotInto(pending, snapshotBlob);
+        int nNew = pending.getTypeState("TypeA").numShards();
+        Assert.assertNotEquals("expected the forward delta to reshard up", nOld, nNew);
+
+        HollowChecksum currentChecksum = HollowChecksum.forStateEngineWithCommonSchemas(current, pending, true);
+        applyDeltaTo(pending, reverseDeltaBlob); // reshards pending N_new -> N_old, back to `current`'s state
+        Assert.assertEquals("reverse delta must reshard pending back down to N_old",
+                nOld, pending.getTypeState("TypeA").numShards());
+        HollowChecksum reverseChecksum = HollowChecksum.forStateEngineWithCommonSchemas(pending, current, true);
+
+        Assert.assertEquals(currentChecksum, reverseChecksum);
+    }
+
+    private HollowReadStateEngine buildMultiShardObjectEngine(String typeName, int numRecords) throws IOException {
+        return buildMultiShardObjectEngine(typeName, numRecords, -1);
+    }
+
+    private HollowReadStateEngine buildMultiShardObjectEngine(String typeName, int numRecords, int recordToMutate) throws IOException {
+        HollowObjectSchema schema = new HollowObjectSchema(typeName, 2);
+        schema.addField("id", FieldType.INT);
+        schema.addField("data", FieldType.STRING);
+
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        writeEngine.setTargetMaxTypeShardSize(4096);
+        writeEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
+        for (int i = 0; i < numRecords; i++) {
+            rec.reset();
+            rec.setInt("id", i);
+            rec.setString("data", i == recordToMutate ? "value-" + i + "-mutated" : "value-" + i);
+            writeEngine.add(typeName, rec);
+        }
+
+        return StateEngineRoundTripper.roundTripSnapshot(writeEngine);
+    }
+
+    /**
+     * @param extraRecordInto if non-null, one extra distinct record is added to the named type so its data (and
+     *                        hence its checksum) differs from the un-mutated build.
+     */
+    private HollowReadStateEngine buildMultiShardCollectionsEngine(String extraRecordInto) throws IOException {
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        writeEngine.setTargetMaxTypeShardSize(4096);
+        writeEngine.addTypeState(new HollowListTypeWriteState(new HollowListSchema("TestList", "E")));
+        writeEngine.addTypeState(new HollowSetTypeWriteState(new HollowSetSchema("TestSet", "E")));
+        writeEngine.addTypeState(new HollowMapTypeWriteState(new HollowMapSchema("TestMap", "K", "V")));
+
+        HollowListWriteRecord list = new HollowListWriteRecord();
+        HollowSetWriteRecord set = new HollowSetWriteRecord();
+        HollowMapWriteRecord map = new HollowMapWriteRecord();
+        for (int i = 0; i < 2000; i++) {
+            list.reset();
+            list.addElement(i);
+            list.addElement(i + 1);
+            list.addElement(i + 2);
+            writeEngine.add("TestList", list);
+
+            set.reset();
+            set.addElement(i);
+            set.addElement(i + 1);
+            set.addElement(i + 2);
+            writeEngine.add("TestSet", set);
+
+            map.reset();
+            map.addEntry(i, i + 1);
+            map.addEntry(i + 2, i + 3);
+            map.addEntry(i + 4, i + 5);
+            writeEngine.add("TestMap", map);
+        }
+
+        if ("TestList".equals(extraRecordInto)) {
+            list.reset();
+            list.addElement(999999);
+            writeEngine.add("TestList", list);
+        } else if ("TestSet".equals(extraRecordInto)) {
+            set.reset();
+            set.addElement(999999);
+            writeEngine.add("TestSet", set);
+        } else if ("TestMap".equals(extraRecordInto)) {
+            map.reset();
+            map.addEntry(999999, 999998);
+            writeEngine.add("TestMap", map);
+        }
+
+        return StateEngineRoundTripper.roundTripSnapshot(writeEngine);
+    }
+
+    private void addObjectRecords(HollowWriteStateEngine writeEngine, HollowObjectSchema schema, int from, int to) {
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
+        for (int i = from; i < to; i++) {
+            rec.reset();
+            rec.setInt("id", i);
+            rec.setString("data", "value-" + i);
+            writeEngine.add(schema.getName(), rec);
+        }
+    }
+
+    private byte[] writeSnapshot(HollowWriteStateEngine writeEngine) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new HollowBlobWriter(writeEngine).writeSnapshot(baos);
+        return baos.toByteArray();
+    }
+
+    private byte[] writeDelta(HollowWriteStateEngine writeEngine) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new HollowBlobWriter(writeEngine).writeDelta(baos);
+        return baos.toByteArray();
+    }
+
+    private void readSnapshotInto(HollowReadStateEngine readEngine, byte[] blob) throws IOException {
+        HollowBlobReader reader = new HollowBlobReader(readEngine);
+        try (HollowBlobInput in = HollowBlobInput.serial(blob)) {
+            reader.readSnapshot(in);
+        }
+    }
+
+    private void applyDeltaTo(HollowReadStateEngine readEngine, byte[] blob) throws IOException {
+        HollowBlobReader reader = new HollowBlobReader(readEngine);
+        try (HollowBlobInput in = HollowBlobInput.serial(blob)) {
+            reader.applyDelta(in);
+        }
+    }
+
+    private byte[] writeReverseDelta(HollowWriteStateEngine writeEngine) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new HollowBlobWriter(writeEngine).writeReverseDelta(baos);
+        return baos.toByteArray();
+    }
+
+    private HollowObjectSchema objectSchemaTypeA() {
+        HollowObjectSchema schema = new HollowObjectSchema("TypeA", 2);
+        schema.addField("id", FieldType.INT);
+        schema.addField("data", FieldType.STRING);
+        return schema;
+    }
+
+    /**
+     * Builds a multi-shard OBJECT read engine that contains ordinal holes: cycle 1 populates ids 0..999, cycle 2
+     * (a delta) keeps only the even ids, so the odd ids' ordinals become unpopulated holes within the ordinal space.
+     *
+     * @param recordToMutate an even id whose {@code data} field is changed (or -1 for none), for detection tests
+     */
+    private HollowReadStateEngine buildHolyMultiShardObjectEngine(int recordToMutate) throws IOException {
+        HollowObjectSchema schema = objectSchemaTypeA();
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        writeEngine.setTargetMaxTypeShardSize(4096);
+        writeEngine.addTypeState(new HollowObjectTypeWriteState(schema));
+
+        addObjectRecords(writeEngine, schema, 0, 1000);
+        HollowReadStateEngine engine = new HollowReadStateEngine();
+        readSnapshotInto(engine, writeSnapshot(writeEngine));
+        writeEngine.prepareForNextCycle();
+
+        HollowObjectWriteRecord rec = new HollowObjectWriteRecord(schema);
+        for (int i = 0; i < 1000; i += 2) {
+            rec.reset();
+            rec.setInt("id", i);
+            rec.setString("data", i == recordToMutate ? "value-" + i + "-mutated" : "value-" + i);
+            writeEngine.add("TypeA", rec);
+        }
+        applyDeltaTo(engine, writeDelta(writeEngine));
+        return engine;
+    }
+
+    private void addE2ERecords(HollowProducer.WriteState ws, int count) {
+        for (int i = 0; i < count; i++) {
+            ws.add(new E2EPojo(i, "value-" + i));
+        }
+    }
+
+    private void assertConsumerHasIds(HollowConsumer consumer, int expectedCount) {
+        HollowTypeReadState typeState = consumer.getStateEngine().getTypeState("E2EPojo");
+        BitSet populated = typeState.getPopulatedOrdinals();
+        Set<Integer> ids = new HashSet<>();
+        int ordinal = populated.nextSetBit(0);
+        while (ordinal != -1) {
+            ids.add(new GenericHollowObject(consumer.getStateEngine(), "E2EPojo", ordinal).getInt("id"));
+            ordinal = populated.nextSetBit(ordinal + 1);
+        }
+        Set<Integer> expected = new TreeSet<>();
+        for (int i = 0; i < expectedCount; i++) {
+            expected.add(i);
+        }
+        Assert.assertEquals(new TreeSet<>(expected), new TreeSet<>(ids));
+    }
+
+    private void assertThrowsIllegalArgument(Runnable runnable) {
+        try {
+            runnable.run();
+            Assert.fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class E2EPojo {
+        int id;
+        String data;
+
+        E2EPojo(int id, String data) {
+            this.id = id;
+            this.data = data;
+        }
+    }
+}


### PR DESCRIPTION
Integrity checks in the producer side are currently parallelized across types. This means, if a type has many shards, the integrity check happens sequentially for each shard. This PR changes that by parallelizing it "per type and per shard". This feature is an opt-in via the builder. Opting out retains the old functionality. The benefit we get by parallelizing by shard is applicable only when type-sharding is enabled.