### PR TITLE
compaction- gradually with maxDeltaBytesPerCycle

### DIFF
--- a/docs/producer-consumer-apis.md
+++ b/docs/producer-consumer-apis.md
@@ -129,8 +129,14 @@ more optimal ordinal assignments.
 
 To run a _compaction cycle_, call `runCompactionCycle(config)` on the `HollowProducer`.  If this method returns a valid 
 version identifier, then a compaction cycle occurred and produced a new data state.  If it returns `Long.MIN_VALUE`, 
-then the compaction criteria specified in the `CompactionConfig` was not met and no action was taken.  See the 
-`HollowCompactor` javadoc for more details.
+then the compaction criteria specified in the `CompactionConfig` was not met and no action was taken.
+
+By default a compaction cycle relocates every misplaced record at once, which can produce a very large delta.  
+Supplying an `approxDeltaBytesPerCycle` to the `CompactionConfig` bounds this -- each cycle then compacts only the 
+single type with the largest hole footprint, and only as many of its records as fit within the budget, so compaction converges 
+over a series of smaller cycles. The budget also counts the records which reference a relocated record, since those 
+must be rewritten too. If it is too small to cover even one record, nothing is compacted and a warning is logged.  
+See the `HollowCompactor` javadoc for more details.
 
 ## The Incremental HollowProducer
 

--- a/hollow/src/main/java/com/netflix/hollow/tools/compact/HollowCompactor.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/compact/HollowCompactor.java
@@ -120,7 +120,7 @@ public class HollowCompactor {
      * @return {@code true} if compaction is necessary, otherwise {@code false}
      */
     public boolean needsCompaction() {
-        return !compactionPlan().isEmpty();
+        return !calculateCompactionPlan().isEmpty();
     }
     
     /**
@@ -137,7 +137,7 @@ public class HollowCompactor {
      *   
      */
     public void compact() {
-        Map<String, Integer> plan = compactionPlan();
+        Map<String, Integer> plan = calculateCompactionPlan();
 
         Map<String, BitSet> relocatedOrdinals = new HashMap<String, BitSet>();
         PartialOrdinalRemapper remapper = new PartialOrdinalRemapper();
@@ -217,7 +217,7 @@ public class HollowCompactor {
      * The types to compact in this cycle, mapped to the number of records to relocate from each.  A type is omitted
      * when the smallest batch it could produce (record + closure) > approxDeltaBytesPerCycle.
      */
-    private Map<String, Integer> compactionPlan() {
+    private Map<String, Integer> calculateCompactionPlan() {
         if(compactionPlan != null)
             return compactionPlan;
 
@@ -300,25 +300,27 @@ public class HollowCompactor {
     }
 
     /**
-     * Determine how many of the highest ordinals in the given type may be relocated within the delta size budget
+     * Determine how many of the highest ordinals in the given type may be relocated within the approx delta size budget
      */
     private int relocationsWithinDeltaBudget(String compactionTarget, BitSet populatedOrdinals, int numRelocations) {
         long deltaBytes = approximateDeltaBytes(compactionTarget, highestPopulatedOrdinals(populatedOrdinals, numRelocations));
 
-        while(deltaBytes > approxDeltaBytesPerCycle && numRelocations > 1) {
-            numRelocations = (int)Math.max(1, Math.min(numRelocations - 1, numRelocations * approxDeltaBytesPerCycle / deltaBytes));
-            deltaBytes = approximateDeltaBytes(compactionTarget, highestPopulatedOrdinals(populatedOrdinals, numRelocations));
-        }
+        if(deltaBytes <= approxDeltaBytesPerCycle)
+            return numRelocations;
 
-        if(deltaBytes > approxDeltaBytesPerCycle) {
-            log.warning("Relocating a single " + compactionTarget + " record is estimated to add " + deltaBytes
+        /// A record costs the delta its own bytes plus those of everything referencing it, so the per-record cost is
+        /// uneven and the scaled estimate below cannot be read as evidence that even one record fits
+        long singleRecordBytes = approximateDeltaBytes(compactionTarget, highestPopulatedOrdinals(populatedOrdinals, 1));
+
+        if(singleRecordBytes > approxDeltaBytesPerCycle) {
+            log.warning("Relocating a single " + compactionTarget + " record is estimated to add " + singleRecordBytes
                     + " bytes to the delta, exceeding the configured approxDeltaBytesPerCycle of " + approxDeltaBytesPerCycle
-                    + ".  " + compactionTarget + " will not be compacted; raise the budget to at least " + deltaBytes
+                    + ".  " + compactionTarget + " will not be compacted; raise the budget to at least " + singleRecordBytes
                     + " bytes to reclaim its ordinal holes.");
             return 0;
         }
 
-        return numRelocations;
+        return (int)Math.max(1, numRelocations * approxDeltaBytesPerCycle / deltaBytes);
     }
 
     private long approximateDeltaBytes(String compactionTarget, BitSet candidateRelocations) {

--- a/hollow/src/main/java/com/netflix/hollow/tools/compact/HollowCompactor.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/compact/HollowCompactor.java
@@ -31,11 +31,13 @@ import com.netflix.hollow.core.write.copy.HollowRecordCopier;
 import com.netflix.hollow.tools.patch.delta.PartialOrdinalRemapper;
 import com.netflix.hollow.tools.traverse.TransitiveSetTraverser;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * During a long delta chain, it's possible that a large number of holes in the ordinal space will exist in some types.
@@ -48,16 +50,28 @@ import java.util.Set;
  * This must sometimes be accomplished with a series of deltas, because the remapping of one state will cause some removals/additions
  * in referencing states (since they will point to new ordinals).  In a single delta transition, the HollowCompactor will
  * only attempt to compact a set of types which are not referencing each other (either directly or transitively).
- * 
+ * <p>
+ * By default, a single call to {@link #compact()} relocates every misplaced record in each targeted type, this could
+ * lead to large deltas. Specifying an approxDeltaBytesPerCycle instead bounds the size of the produced delta: each cycle
+ * will then compact only a single type (one with the biggest hole footprint), and only as many of its records as fit
+ * within the budget. The budget accounts for the referencing closure as well.
+ * <p>
+ * A budget too small to accommodate even one record together with its closure is reported and no compaction is performed.
+ * <p>
+ * A compactor must not be retained across cycles, nor reused once its read state has been refreshed; construct a new one per cycle.
  */
 public class HollowCompactor {
-    
+
+    private static final Logger log = Logger.getLogger(HollowCompactor.class.getName());
+
     private final HollowWriteStateEngine writeEngine;
     private final HollowReadStateEngine readEngine;
-    
+
     private long minCandidateHoleCostInBytes;
     private int minCandidateHolePercentage;
-    
+    private long approxDeltaBytesPerCycle;
+    private Map<String, Integer> compactionPlan;
+
     /**
      * Provide the state engines on which to operate, and the criteria to identify when a compaction is necessary 
      * 
@@ -66,7 +80,7 @@ public class HollowCompactor {
      * @param config      The criteria to identify when a compaction is necessary. 
      */
     public HollowCompactor(HollowWriteStateEngine writeEngine, HollowReadStateEngine readEngine, CompactionConfig config) {
-        this(writeEngine, readEngine, config.getMinCandidateHoleCostInBytes(), config.getMinCandidateHolePercentage());
+        this(writeEngine, readEngine, config.getMinCandidateHoleCostInBytes(), config.getMinCandidateHolePercentage(), config.getApproxDeltaBytesPerCycle());
     }
     
     /**
@@ -78,10 +92,27 @@ public class HollowCompactor {
      * @param minCandidateHolePercentage  identify a type as a candidate for compaction only when the percentage of space used by ordinal holes exceeds this value
      */
     public HollowCompactor(HollowWriteStateEngine writeEngine, HollowReadStateEngine readEngine, long minCandidateHoleCostInBytes, int minCandidateHolePercentage) {
+        this(writeEngine, readEngine, minCandidateHoleCostInBytes, minCandidateHolePercentage, Long.MAX_VALUE);
+    }
+
+    /**
+     * Provide the state engines on which to operate, and the criteria to identify when a compaction is necessary
+     *
+     * @param writeEngine                 the HollowWriteStateEngine to compact
+     * @param readEngine                  a HollowReadStateEngine at the same data state as the writeEngine
+     * @param minCandidateHoleCostInBytes identify a type as a candidate for compaction only when the bytes used by ordinal holes exceeds this value
+     * @param minCandidateHolePercentage  identify a type as a candidate for compaction only when the percentage of space used by ordinal holes exceeds this value
+     * @param approxDeltaBytesPerCycle    approx max delta size for a compaction cycle, and when specified a cycle compacts only at most one type in per compaction cycle
+     */
+    public HollowCompactor(HollowWriteStateEngine writeEngine, HollowReadStateEngine readEngine, long minCandidateHoleCostInBytes, int minCandidateHolePercentage, long approxDeltaBytesPerCycle) {
+        if(approxDeltaBytesPerCycle < 1)
+            throw new IllegalArgumentException("approxDeltaBytesPerCycle must be at least 1, was " + approxDeltaBytesPerCycle);
+
         this.writeEngine = writeEngine;
         this.readEngine = readEngine;
         this.minCandidateHoleCostInBytes = minCandidateHoleCostInBytes;
         this.minCandidateHolePercentage = minCandidateHolePercentage;
+        this.approxDeltaBytesPerCycle = approxDeltaBytesPerCycle;
     }
     
     /**
@@ -89,7 +120,7 @@ public class HollowCompactor {
      * @return {@code true} if compaction is necessary, otherwise {@code false}
      */
     public boolean needsCompaction() {
-        return !findCompactionTargets().isEmpty();
+        return !compactionPlan().isEmpty();
     }
     
     /**
@@ -98,37 +129,34 @@ public class HollowCompactor {
      * <ul>
      *   <li>the {@link HollowWriteStateEngine} supplied in the constructor is unmodified since the 
      *       last call to {@link HollowWriteStateEngine#prepareForNextCycle()}</li>
-     *   <li>the {@link HollowReadStateEngine} supplied in the constructor reflects the same state as 
+     *   <li>the {@link HollowReadStateEngine} supplied in the constructor reflects the same state as
      *       the HollowWriteStateEngine.</li>
+     *   <li>this HollowCompactor has not already been used for an earlier cycle -- an instance plans its work from
+     *       the read state once, so a stale plan would relocate the wrong ordinals.</li>
      * </ul>
      *   
      */
     public void compact() {
-        Set<String> compactionTargets = findCompactionTargets();
-        
+        Map<String, Integer> plan = compactionPlan();
+
         Map<String, BitSet> relocatedOrdinals = new HashMap<String, BitSet>();
         PartialOrdinalRemapper remapper = new PartialOrdinalRemapper();
-        
-        for(String compactionTarget : compactionTargets) {
+
+        for(Map.Entry<String, Integer> plannedCompaction : plan.entrySet()) {
+            String compactionTarget = plannedCompaction.getKey();
+            int numRelocations = plannedCompaction.getValue();
+
             HollowTypeReadState typeState = readEngine.getTypeState(compactionTarget);
             HollowTypeWriteState writeState = writeEngine.getTypeState(compactionTarget);
-            BitSet populatedOrdinals = typeState.getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
+            BitSet populatedOrdinals = populatedOrdinals(compactionTarget);
             BitSet typeRelocatedOrdinals = new BitSet(populatedOrdinals.length());
-            int populatedCardinality = populatedOrdinals.cardinality();
-            
+
             writeState.addAllObjectsFromPreviousCycle();
-            
-            int numRelocations = 0;
-            int ordinalToRelocate = populatedOrdinals.nextSetBit(populatedCardinality);
-            while(ordinalToRelocate != -1) {
-                numRelocations++;
-                ordinalToRelocate = populatedOrdinals.nextSetBit(ordinalToRelocate+1);
-            }
-            
+
             HollowRecordCopier copier = HollowRecordCopier.createCopier(typeState);
             IntMap remappedOrdinals = new IntMap(numRelocations);
-            
-            ordinalToRelocate = populatedOrdinals.length();
+
+            int ordinalToRelocate = populatedOrdinals.length();
             int relocatePosition = -1;
             
             try {
@@ -156,7 +184,7 @@ public class HollowCompactor {
         
         /// copy all forward except remapped and transitive dependents of remapped
         for(HollowSchema schema : HollowSchemaSorter.dependencyOrderedSchemaList(writeEngine.getSchemas())) {
-            if(!compactionTargets.contains(schema.getName())) {
+            if(!plan.containsKey(schema.getName())) {
                 HollowTypeWriteState writeState = writeEngine.getTypeState(schema.getName());
                 
                 writeState.addAllObjectsFromPreviousCycle();
@@ -186,8 +214,58 @@ public class HollowCompactor {
     }
     
     /**
+     * The types to compact in this cycle, mapped to the number of records to relocate from each.  A type is omitted
+     * when the smallest batch it could produce (record + closure) > approxDeltaBytesPerCycle.
+     */
+    private Map<String, Integer> compactionPlan() {
+        if(compactionPlan != null)
+            return compactionPlan;
+
+        Set<String> compactionTargets = findCompactionTargets();
+
+        if(approxDeltaBytesPerCycle != Long.MAX_VALUE)
+            compactionTargets = focusOnCostliestType(compactionTargets);
+
+        Map<String, Integer> plan = new HashMap<String, Integer>();
+
+        for(String compactionTarget : compactionTargets) {
+            BitSet populatedOrdinals = populatedOrdinals(compactionTarget);
+            int numRelocations = numMisplacedOrdinals(populatedOrdinals);
+
+            /// relocating the highest ordinals
+            if(approxDeltaBytesPerCycle != Long.MAX_VALUE)
+                numRelocations = relocationsWithinDeltaBudget(compactionTarget, populatedOrdinals, numRelocations);
+
+            if(numRelocations > 0)
+                plan.put(compactionTarget, numRelocations);
+        }
+
+        compactionPlan = plan;
+        return compactionPlan;
+    }
+
+    private BitSet populatedOrdinals(String type) {
+        return readEngine.getTypeState(type).getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
+    }
+
+    /**
+     * The populated ordinals sitting at or above the cardinality watermark
+     */
+    private int numMisplacedOrdinals(BitSet populatedOrdinals) {
+        int numMisplaced = 0;
+        int ordinal = populatedOrdinals.nextSetBit(populatedOrdinals.cardinality());
+
+        while(ordinal != -1) {
+            numMisplaced++;
+            ordinal = populatedOrdinals.nextSetBit(ordinal + 1);
+        }
+
+        return numMisplaced;
+    }
+
+    /**
      * Find candidate types for compaction.  No two types in the returned set will have a dependency relationship, either
-     * directly or transitively.  
+     * directly or transitively.
      */
     private Set<String> findCompactionTargets() {
         List<HollowSchema> schemas = HollowSchemaSorter.dependencyOrderedSchemaList(readEngine.getSchemas());
@@ -202,7 +280,78 @@ public class HollowCompactor {
         
         return typesToCompact;
     }
-    
+
+    /**
+     * Narrow the compaction targets to the single type with the biggest hole footprint
+     */
+    private Set<String> focusOnCostliestType(Set<String> compactionTargets) {
+        String costliestType = null;
+        long costliestHoleCostInBytes = -1;
+
+        for(String type : compactionTargets) {
+            long holeCostInBytes = readEngine.getTypeState(type).getApproximateHoleCostInBytes();
+            if(holeCostInBytes > costliestHoleCostInBytes) {
+                costliestHoleCostInBytes = holeCostInBytes;
+                costliestType = type;
+            }
+        }
+
+        return costliestType == null ? compactionTargets : Collections.singleton(costliestType);
+    }
+
+    /**
+     * Determine how many of the highest ordinals in the given type may be relocated within the delta size budget
+     */
+    private int relocationsWithinDeltaBudget(String compactionTarget, BitSet populatedOrdinals, int numRelocations) {
+        long deltaBytes = approximateDeltaBytes(compactionTarget, highestPopulatedOrdinals(populatedOrdinals, numRelocations));
+
+        while(deltaBytes > approxDeltaBytesPerCycle && numRelocations > 1) {
+            numRelocations = (int)Math.max(1, Math.min(numRelocations - 1, numRelocations * approxDeltaBytesPerCycle / deltaBytes));
+            deltaBytes = approximateDeltaBytes(compactionTarget, highestPopulatedOrdinals(populatedOrdinals, numRelocations));
+        }
+
+        if(deltaBytes > approxDeltaBytesPerCycle) {
+            log.warning("Relocating a single " + compactionTarget + " record is estimated to add " + deltaBytes
+                    + " bytes to the delta, exceeding the configured approxDeltaBytesPerCycle of " + approxDeltaBytesPerCycle
+                    + ".  " + compactionTarget + " will not be compacted; raise the budget to at least " + deltaBytes
+                    + " bytes to reclaim its ordinal holes.");
+            return 0;
+        }
+
+        return numRelocations;
+    }
+
+    private long approximateDeltaBytes(String compactionTarget, BitSet candidateRelocations) {
+        Map<String, BitSet> churnedOrdinals = new HashMap<String, BitSet>();
+        churnedOrdinals.put(compactionTarget, candidateRelocations);
+        TransitiveSetTraverser.addReferencingOutsideClosure(readEngine, churnedOrdinals);
+
+        long deltaBytes = 0;
+        for(Map.Entry<String, BitSet> entry : churnedOrdinals.entrySet())
+            deltaBytes += (long)entry.getValue().cardinality() * approximateRecordSizeInBytes(entry.getKey());
+
+        return deltaBytes;
+    }
+
+    private long approximateRecordSizeInBytes(String type) {
+        HollowTypeReadState typeState = readEngine.getTypeState(type);
+        int numRecords = typeState.getPopulatedOrdinals().cardinality();
+
+        return numRecords == 0 ? 0 : Math.max(1, typeState.getApproximateHeapFootprintInBytes() / numRecords);
+    }
+
+    private BitSet highestPopulatedOrdinals(BitSet populatedOrdinals, int numOrdinals) {
+        BitSet highestOrdinals = new BitSet(populatedOrdinals.length());
+        int ordinal = populatedOrdinals.length();
+
+        for(int i=0;i<numOrdinals;i++) {
+            while(!populatedOrdinals.get(--ordinal));
+            highestOrdinals.set(ordinal);
+        }
+
+        return highestOrdinals;
+    }
+
     private boolean isCompactionCandidate(String typeName) {
         HollowTypeReadState typeState = readEngine.getTypeState(typeName);
         BitSet populatedOrdinals = typeState.getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
@@ -240,17 +389,30 @@ public class HollowCompactor {
     public static class CompactionConfig {
         private final long minCandidateHoleCostInBytes;
         private final int minCandidateHolePercentage;
-        
+        private final long approxDeltaBytesPerCycle;
+
         /**
          * Create a new compaction.  Both of the criteria specified by the following parameters must be met in order for a type
          * to be considered a candidate for compaction.
-         * 
-         * @param minCandidateHoleCostInBytes identify a type as a candidate for compaction only when the bytes used by ordinal holes exceeds this value 
+         *
+         * @param minCandidateHoleCostInBytes identify a type as a candidate for compaction only when the bytes used by ordinal holes exceeds this value
          * @param minCandidateHolePercentage identify a type as a candidate for compaction only when the percentage of space used by ordinal holes exceeds this value
          */
         public CompactionConfig(long minCandidateHoleCostInBytes, int minCandidateHolePercentage) {
+            this(minCandidateHoleCostInBytes, minCandidateHolePercentage, Long.MAX_VALUE);
+        }
+
+        /**
+         * Create a new compaction which converges gradually, rather than relocating every misplaced record at once.
+         *
+         * @param minCandidateHoleCostInBytes identify a type as a candidate for compaction only when the bytes used by ordinal holes exceeds this value
+         * @param minCandidateHolePercentage identify a type as a candidate for compaction only when the percentage of space used by ordinal holes exceeds this value
+         * @param approxDeltaBytesPerCycle approx ceiling on the size of delta
+         */
+        public CompactionConfig(long minCandidateHoleCostInBytes, int minCandidateHolePercentage, long approxDeltaBytesPerCycle) {
             this.minCandidateHoleCostInBytes = minCandidateHoleCostInBytes;
             this.minCandidateHolePercentage = minCandidateHolePercentage;
+            this.approxDeltaBytesPerCycle = approxDeltaBytesPerCycle;
         }
 
         public long getMinCandidateHoleCostInBytes() {
@@ -259,6 +421,10 @@ public class HollowCompactor {
 
         public int getMinCandidateHolePercentage() {
             return minCandidateHolePercentage;
+        }
+
+        public long getApproxDeltaBytesPerCycle() {
+            return approxDeltaBytesPerCycle;
         }
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowProducerConsumerTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowProducerConsumerTests.java
@@ -30,9 +30,18 @@ import com.netflix.hollow.core.memory.MemoryMode;
 import com.netflix.hollow.core.read.engine.object.HollowObjectTypeReadState;
 import com.netflix.hollow.core.read.filter.TypeFilter;
 import com.netflix.hollow.test.InMemoryBlobStore;
+import com.netflix.hollow.tools.checksum.HollowChecksum;
 import com.netflix.hollow.tools.compact.HollowCompactor.CompactionConfig;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.BitSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Before;
@@ -454,6 +463,554 @@ public class HollowProducerConsumerTests {
         for (int i = 10000; i < 20000; i++) {
             Assert.assertTrue(foundValues.get(i));
         }
+    }
+
+    @Test
+    public void producerCompactsGraduallyWithinADeltaByteBudget() throws IOException {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        producer.runCycle(state -> {
+            for (int i = 0; i < 10000; i++) {
+                state.add(i);
+            }
+        });
+
+        long v2 = producer.runCycle(state -> {
+            for (int i = 10000; i < 20000; i++) {
+                state.add(i);
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefreshTo(v2);
+        Assert.assertEquals(20000, populatedOrdinalsLength(consumer, "Integer"));
+
+        /// small enough that a single cycle cannot possibly reclaim all 10000 holes
+        CompactionConfig config = new CompactionConfig(0, 0, 4096);
+
+        long fromVersion = v2;
+        int previousLength = 20000;
+        int cycles = 0;
+
+        while (true) {
+            long version = producer.runCompactionCycle(config);
+            if (version == HollowConsumer.AnnouncementWatcher.NO_ANNOUNCEMENT_AVAILABLE) {
+                break;
+            }
+
+            /// the budget bounds what each individual delta carries
+            Assert.assertTrue("delta from " + fromVersion + " exceeded the budget",
+                    deltaBlobSizeInBytes(fromVersion) <= 4096 * 4);
+
+            consumer.triggerRefreshTo(version);
+            int length = populatedOrdinalsLength(consumer, "Integer");
+
+            /// every cycle makes strict progress, so this terminates
+            Assert.assertTrue("cycle " + cycles + " did not shrink the ordinal space", length < previousLength);
+
+            previousLength = length;
+            fromVersion = version;
+            cycles++;
+            Assert.assertTrue("compaction is not converging", cycles < 500);
+        }
+
+        /// converged all the way down, and it genuinely took multiple cycles to get there
+        Assert.assertEquals(10000, previousLength);
+        Assert.assertTrue("expected a gradual compaction, took " + cycles + " cycle(s)", cycles > 1);
+
+        /// every record survived the gradual relocation
+        BitSet foundValues = new BitSet(20000);
+        HollowObjectTypeReadState typeState =
+                (HollowObjectTypeReadState) consumer.getStateEngine().getTypeState("Integer");
+        for (int i = 0; i < 10000; i++) {
+            foundValues.set(typeState.readInt(i, 0));
+        }
+
+        for (int i = 10000; i < 20000; i++) {
+            Assert.assertTrue(foundValues.get(i));
+        }
+    }
+
+    @Test
+    public void deltaByteBudgetAccountsForTheReferencingClosure() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        producer.runCycle(state -> {
+            for (int i = 0; i < 10000; i++) {
+                state.add(new Movie(i, "title" + i));
+            }
+        });
+
+        long v2 = producer.runCycle(state -> {
+            for (int i = 10000; i < 20000; i++) {
+                state.add(new Movie(i, "title" + i));
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefreshTo(v2);
+        Assert.assertEquals(20000, populatedOrdinalsLength(consumer, "String"));
+        Assert.assertEquals(20000, populatedOrdinalsLength(consumer, "Movie"));
+
+        /// String is the compaction target; each relocated String drags its referencing Movie into the delta too
+        long v3 = producer.runCompactionCycle(new CompactionConfig(0, 0, 8192));
+        consumer.triggerRefreshTo(v3);
+
+        int stringRelocations = 20000 - populatedOrdinalsLength(consumer, "String");
+        int movieChurn = 20000 - populatedOrdinalsLength(consumer, "Movie");
+
+        Assert.assertTrue("expected progress on the compaction target", stringRelocations > 0);
+        Assert.assertEquals("each relocated String should have churned exactly one referencing Movie",
+                stringRelocations, movieChurn);
+
+        /// the same budget spent on a type with no referencers buys strictly more relocations, because none of it
+        /// is consumed by closure churn
+        Assert.assertTrue("closure churn should have reduced the batch size",
+                stringRelocations < unreferencedTypeRelocationsForSameBudget());
+    }
+
+    @Test
+    public void aBudgetTooSmallForOneRecordSkipsCompactionEntirely() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        producer.runCycle(state -> {
+            for (int i = 0; i < 10000; i++) {
+                state.add(new Movie(i, "title" + i));
+            }
+        });
+
+        long v2 = producer.runCycle(state -> {
+            for (int i = 10000; i < 20000; i++) {
+                state.add(new Movie(i, "title" + i));
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefreshTo(v2);
+
+        /// one byte cannot cover a single record plus its closure, so no cycle should be produced at all
+        long v3 = producer.runCompactionCycle(new CompactionConfig(0, 0, 1));
+        Assert.assertEquals(HollowConsumer.AnnouncementWatcher.NO_ANNOUNCEMENT_AVAILABLE, v3);
+
+        /// no version was announced, and nothing was relocated
+        consumer.triggerRefresh();
+        Assert.assertEquals(v2, consumer.getCurrentVersionId());
+        Assert.assertEquals(20000, populatedOrdinalsLength(consumer, "String"));
+        Assert.assertEquals(20000, populatedOrdinalsLength(consumer, "Movie"));
+
+        /// and a budget that does fit still compacts, so the skip was the budget's doing and not a stuck state
+        long v4 = producer.runCompactionCycle(new CompactionConfig(0, 0, 8192));
+        Assert.assertNotEquals(HollowConsumer.AnnouncementWatcher.NO_ANNOUNCEMENT_AVAILABLE, v4);
+        consumer.triggerRefreshTo(v4);
+        Assert.assertTrue(populatedOrdinalsLength(consumer, "String") < 20000);
+    }
+
+    /// how many records a budget of 8192 buys for a type nothing references, as a baseline for the closure test
+    private int unreferencedTypeRelocationsForSameBudget() {
+        InMemoryBlobStore standaloneStore = new InMemoryBlobStore();
+        HollowProducer producer = HollowProducer.withPublisher(standaloneStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        producer.runCycle(state -> {
+            for (int i = 0; i < 10000; i++) {
+                state.add("title" + i);
+            }
+        });
+
+        long v2 = producer.runCycle(state -> {
+            for (int i = 10000; i < 20000; i++) {
+                state.add("title" + i);
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(standaloneStore).build();
+        consumer.triggerRefreshTo(v2);
+
+        long v3 = producer.runCompactionCycle(new CompactionConfig(0, 0, 8192));
+        consumer.triggerRefreshTo(v3);
+
+        return 20000 - populatedOrdinalsLength(consumer, "String");
+    }
+
+    private long deltaBlobSizeInBytes(long fromVersion) throws IOException {
+        try (InputStream is = blobStore.retrieveDeltaBlob(fromVersion).getInputStream()) {
+            long size = 0;
+            int read;
+            byte[] buf = new byte[8192];
+            while ((read = is.read(buf)) != -1) {
+                size += read;
+            }
+            return size;
+        }
+    }
+
+    /**
+     * The strongest guard available: a state reached by following compaction deltas must be ordinal-for-ordinal
+     * identical to the same version loaded fresh from a snapshot.  HollowChecksum folds the ordinal of every record
+     * of every type into the result, so this covers the remapping of the compaction target and its entire closure.
+     */
+    @Test
+    public void compactedStateIsIdenticalWhetherLoadedBySnapshotOrDelta() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        publishFragmentedMovies(producer);
+
+        HollowConsumer deltaConsumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        deltaConsumer.triggerRefresh();
+
+        int cycles = compactToConvergence(producer, deltaConsumer, new CompactionConfig(0, 0, 8192));
+        Assert.assertTrue("expected a gradual compaction, took " + cycles + " cycle(s)", cycles > 1);
+
+        HollowConsumer snapshotConsumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        snapshotConsumer.triggerRefreshTo(deltaConsumer.getCurrentVersionId());
+        Assert.assertEquals(deltaConsumer.getCurrentVersionId(), snapshotConsumer.getCurrentVersionId());
+
+        Assert.assertEquals(HollowChecksum.forStateEngine(snapshotConsumer.getStateEngine()),
+                HollowChecksum.forStateEngine(deltaConsumer.getStateEngine()));
+    }
+
+    @Test
+    public void gradualCompactionPreservesReferencesThroughTheClosure() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v2 = publishFragmentedMovies(producer);
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefreshTo(v2);
+        assertMoviesIntact(consumer);
+
+        compactToConvergence(producer, consumer, new CompactionConfig(0, 0, 8192));
+
+        /// every Movie still resolves to its own title, despite both types having been remapped piecemeal
+        assertMoviesIntact(consumer);
+    }
+
+    @Test
+    public void gradualCompactionPreservesCollectionTypes() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        producer.runCycle(state -> {
+            for (int i = 0; i < 3000; i++) {
+                state.add(new Catalog(i));
+            }
+        });
+
+        long v2 = producer.runCycle(state -> {
+            for (int i = 3000; i < 6000; i++) {
+                state.add(new Catalog(i));
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefreshTo(v2);
+
+        /// the LIST, SET and MAP copiers all run through PartialOrdinalRemapper during compaction
+        Assert.assertNotNull(consumer.getStateEngine().getTypeState("ListOfString"));
+        Assert.assertNotNull(consumer.getStateEngine().getTypeState("SetOfInteger"));
+        Assert.assertNotNull(consumer.getStateEngine().getTypeState("MapOfStringToInteger"));
+
+        int cycles = compactToConvergence(producer, consumer, new CompactionConfig(0, 0, 8192));
+        Assert.assertTrue("expected a gradual compaction, took " + cycles + " cycle(s)", cycles > 1);
+
+        HollowConsumer snapshotConsumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        snapshotConsumer.triggerRefreshTo(consumer.getCurrentVersionId());
+        Assert.assertEquals(HollowChecksum.forStateEngine(snapshotConsumer.getStateEngine()),
+                HollowChecksum.forStateEngine(consumer.getStateEngine()));
+
+        Assert.assertEquals(3000, consumer.getStateEngine().getTypeState("Catalog")
+                .getPopulatedOrdinals().cardinality());
+    }
+
+    @Test
+    public void gradualCompactionWorksOnShardedTypes() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .withTargetMaxTypeShardSize(4096) /// force the types to shard
+                .build();
+
+        publishFragmentedMovies(producer);
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefresh();
+        Assert.assertTrue("expected a sharded type",
+                consumer.getStateEngine().getTypeState("Movie").numShards() > 1);
+
+        compactToConvergence(producer, consumer, new CompactionConfig(0, 0, 8192));
+
+        assertMoviesIntact(consumer);
+
+        HollowConsumer snapshotConsumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        snapshotConsumer.triggerRefreshTo(consumer.getCurrentVersionId());
+        Assert.assertEquals(HollowChecksum.forStateEngine(snapshotConsumer.getStateEngine()),
+                HollowChecksum.forStateEngine(consumer.getStateEngine()));
+    }
+
+    @Test
+    public void compactionCyclesInterleaveWithDataCycles() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        publishFragmentedMovies(producer);
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefresh();
+
+        CompactionConfig config = new CompactionConfig(0, 0, 8192);
+        int compactions = 0;
+
+        /// alternate ordinary data cycles with budgeted compaction cycles, the way a producer actually would
+        for (int round = 0; round < 5; round++) {
+            int generation = round;
+            long dataVersion = producer.runCycle(state -> {
+                for (int i = 10000; i < 20000; i++) {
+                    state.add(new Movie(i, "title" + i));
+                }
+                state.add(new Movie(-1, "generation" + generation));
+            });
+            consumer.triggerRefreshTo(dataVersion);
+
+            long compactionVersion = producer.runCompactionCycle(config);
+            if (compactionVersion != HollowConsumer.AnnouncementWatcher.NO_ANNOUNCEMENT_AVAILABLE) {
+                consumer.triggerRefreshTo(compactionVersion);
+                compactions++;
+            }
+
+            assertMoviesIntact(consumer, "generation" + generation);
+        }
+
+        Assert.assertTrue("no compaction ran, so the interleaving was never exercised", compactions > 0);
+    }
+
+    @Test
+    public void consumerCanFollowReverseDeltaAcrossACompaction() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        long v2 = publishFragmentedMovies(producer);
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefreshTo(v2);
+        HollowChecksum beforeCompaction = HollowChecksum.forStateEngine(consumer.getStateEngine());
+
+        long v3 = producer.runCompactionCycle(new CompactionConfig(0, 0, 8192));
+        Assert.assertNotEquals(HollowConsumer.AnnouncementWatcher.NO_ANNOUNCEMENT_AVAILABLE, v3);
+        consumer.triggerRefreshTo(v3);
+
+        /// walking the reverse delta back across the compaction must restore the pre-compaction ordinals exactly
+        blobStore.removeSnapshot(v2);
+        consumer.triggerRefreshTo(v2);
+        Assert.assertEquals(v2, consumer.getCurrentVersionId());
+        Assert.assertEquals(beforeCompaction, HollowChecksum.forStateEngine(consumer.getStateEngine()));
+        assertMoviesIntact(consumer);
+    }
+
+    @Test
+    public void budgetedCompactionTerminatesAtTheHolePercentageThreshold() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        publishFragmentedMovies(producer);
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefresh();
+
+        /// a non-zero threshold must stop the loop short of a fully compacted state rather than spin forever
+        compactToConvergence(producer, consumer, new CompactionConfig(0, 25, 8192));
+
+        int length = populatedOrdinalsLength(consumer, "String");
+        Assert.assertTrue("should have compacted below the starting 50% holes, was " + length, length < 20000);
+        Assert.assertTrue("should have stopped at the threshold rather than fully compacting, was " + length,
+                length > 10000);
+    }
+
+    @Test
+    public void anUnbudgetedConfigCompactsInASingleCycle() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        publishFragmentedMovies(producer);
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefresh();
+
+        /// the two-arg config must remain equivalent to an unbounded budget
+        Assert.assertEquals(Long.MAX_VALUE, new CompactionConfig(0, 0).getApproxDeltaBytesPerCycle());
+
+        long v3 = producer.runCompactionCycle(new CompactionConfig(0, 0));
+        consumer.triggerRefreshTo(v3);
+        Assert.assertEquals(10000, populatedOrdinalsLength(consumer, "String"));
+        assertMoviesIntact(consumer);
+    }
+
+    @Test
+    public void aNonPositiveBudgetIsRejected() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        publishFragmentedMovies(producer);
+
+        try {
+            producer.runCompactionCycle(new CompactionConfig(0, 0, 0));
+            Assert.fail("expected a non-positive budget to be rejected");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertTrue(expected.getMessage().contains("approxDeltaBytesPerCycle"));
+        }
+    }
+
+    private long publishFragmentedMovies(HollowProducer producer) {
+        producer.runCycle(state -> {
+            for (int i = 0; i < 10000; i++) {
+                state.add(new Movie(i, "title" + i));
+            }
+        });
+
+        /// drops the first 10000, leaving both Movie and String half holes
+        return producer.runCycle(state -> {
+            for (int i = 10000; i < 20000; i++) {
+                state.add(new Movie(i, "title" + i));
+            }
+        });
+    }
+
+    private int compactToConvergence(HollowProducer producer, HollowConsumer consumer, CompactionConfig config) {
+        int cycles = 0;
+
+        while (true) {
+            long version = producer.runCompactionCycle(config);
+            if (version == HollowConsumer.AnnouncementWatcher.NO_ANNOUNCEMENT_AVAILABLE) {
+                return cycles;
+            }
+
+            consumer.triggerRefreshTo(version);
+            cycles++;
+            Assert.assertTrue("compaction is not converging", cycles < 500);
+        }
+    }
+
+    private static void assertMoviesIntact(HollowConsumer consumer, String... extraTitles) {
+        HollowObjectTypeReadState movies =
+                (HollowObjectTypeReadState) consumer.getStateEngine().getTypeState("Movie");
+        HollowObjectTypeReadState strings =
+                (HollowObjectTypeReadState) consumer.getStateEngine().getTypeState("String");
+        int idField = movies.getSchema().getPosition("id");
+        int titleField = movies.getSchema().getPosition("title");
+
+        BitSet seenIds = new BitSet(20000);
+        int extrasSeen = 0;
+        BitSet populated = movies.getPopulatedOrdinals();
+        int ordinal = populated.nextSetBit(0);
+
+        while (ordinal != -1) {
+            int id = movies.readInt(ordinal, idField);
+            String title = strings.readString(movies.readOrdinal(ordinal, titleField), 0);
+
+            if (id == -1) {
+                Assert.assertEquals(extraTitles[0], title);
+                extrasSeen++;
+            } else {
+                Assert.assertEquals("Movie " + id + " lost its title", "title" + id, title);
+                seenIds.set(id);
+            }
+
+            ordinal = populated.nextSetBit(ordinal + 1);
+        }
+
+        Assert.assertEquals(10000, seenIds.cardinality());
+        Assert.assertEquals(10000, seenIds.nextSetBit(0));
+        Assert.assertEquals(extraTitles.length, extrasSeen);
+    }
+
+    @SuppressWarnings("unused")
+    private static class Movie {
+        private final int id;
+        private final String title;
+
+        Movie(int id, String title) {
+            this.id = id;
+            this.title = title;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class Catalog {
+        private final int id;
+        private final List<String> tags;
+        private final Set<Integer> codes;
+        private final Map<String, Integer> ratings;
+
+        Catalog(int id) {
+            this.id = id;
+            this.tags = Arrays.asList("tag" + id, "tag" + (id % 97));
+            this.codes = new HashSet<>(Arrays.asList(id, id % 89));
+            this.ratings = new HashMap<>();
+            this.ratings.put("rating" + id, id % 5);
+        }
+    }
+
+    @Test
+    public void budgetedCompactionFocusesOnASingleType() {
+        HollowProducer producer = HollowProducer.withPublisher(blobStore)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+
+        producer.runCycle(state -> {
+            for (int i = 0; i < 10000; i++) {
+                state.add(i);
+                state.add("v" + i);
+            }
+        });
+
+        long v2 = producer.runCycle(state -> {
+            for (int i = 10000; i < 20000; i++) {
+                state.add(i);
+                state.add("v" + i);
+            }
+        });
+
+        HollowConsumer consumer = HollowConsumer.withBlobRetriever(blobStore).build();
+        consumer.triggerRefreshTo(v2);
+        Assert.assertEquals(20000, populatedOrdinalsLength(consumer, "Integer"));
+        Assert.assertEquals(20000, populatedOrdinalsLength(consumer, "String"));
+
+        /// both types are candidates, but the budget is spent entirely on the one wasting the most space
+        long v3 = producer.runCompactionCycle(new CompactionConfig(0, 0, 8192));
+        consumer.triggerRefreshTo(v3);
+
+        int integerLength = populatedOrdinalsLength(consumer, "Integer");
+        int stringLength = populatedOrdinalsLength(consumer, "String");
+
+        Assert.assertTrue("one type should have been left untouched",
+                integerLength == 20000 || stringLength == 20000);
+        Assert.assertTrue("the other should have made progress",
+                integerLength < 20000 || stringLength < 20000);
+
+        /// both types were eligible all along -- an unbudgeted cycle reclaims the rest of the holes in each at once
+        long v4 = producer.runCompactionCycle(new CompactionConfig(0, 0));
+        consumer.triggerRefreshTo(v4);
+        Assert.assertEquals(10000, populatedOrdinalsLength(consumer, "Integer"));
+        Assert.assertEquals(10000, populatedOrdinalsLength(consumer, "String"));
+    }
+
+    private static int populatedOrdinalsLength(HollowConsumer consumer, String type) {
+        return consumer.getStateEngine().getTypeState(type).getPopulatedOrdinals().length();
     }
 
     @Test


### PR DESCRIPTION
By default a compaction cycle relocates every misplaced record at once, which can produce a very large delta.  
Supplying an `approxDeltaBytesPerCycle` to the `CompactionConfig` bounds this -- each cycle then compacts only the 
single type with the largest hole footprint, and only as many of its records as fit within the budget, so compaction converges 
over a series of smaller cycles. The budget also counts the records which reference a relocated record, since those 
must be rewritten too. If it is too small to cover even one record, nothing is compacted and a warning is logged.  
See the `HollowCompactor` javadoc for more details.
