### PR TITLE
fix: Latent index size limits

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/core/HollowConstants.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/HollowConstants.java
@@ -38,6 +38,14 @@ public interface HollowConstants {
     /**
      * The maximum number of buckets allowed in a Hollow hash table. Empty space is reserved (based on 70% load factor),
      * otherwise performance approaches O(n).
+     * <p>
+     * This value is part of the blob layout contract for SET and MAP types: producers and consumers both derive a
+     * collection's bucket count from its size, so it must not change.
      */
     int HASH_TABLE_MAX_SIZE = (int)((1L << 30) * 7 / 10);
+
+    /**
+     * The maximum number of elements allowed in an in-memory index hash table, i.e. 70% of 2^31 buckets.
+     */
+    long INDEX_HASH_TABLE_MAX_SIZE = (1L << 31) * 7 / 10;
 }

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexBuilder.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowHashIndexBuilder.java
@@ -52,11 +52,11 @@ public class HollowHashIndexBuilder {
 
     private GrowingSegmentedLongArray matchIndexHashAndSizeArray;
     private FixedLengthElementArray intermediateMatchHashTable;
-    private int intermediateMatchHashTableSize;
+    private long intermediateMatchHashTableSize;
     private int bitsPerIntermediateListIdentifier;
     private int bitsPerIntermediateMatchHashEntry;
-    private int intermediateMatchHashMask;
-    private int intermediateMatchHashTableSizeBeforeGrow;
+    private long intermediateMatchHashMask;
+    private long intermediateMatchHashTableSizeBeforeGrow;
     private int matchCount;
 
 
@@ -110,16 +110,16 @@ public class HollowHashIndexBuilder {
 
         /// an initial guess at how big this table might be -- one match per top-level element.
         int guessNumberOfMatches = populatedOrdinals.cardinality();
-        intermediateMatchHashTableSize = HashCodes.hashTableSize(guessNumberOfMatches);
+        intermediateMatchHashTableSize = HashCodes.indexHashTableSize(guessNumberOfMatches);
         bitsPerIntermediateListIdentifier =  bitsRequiredToRepresentValue(intermediateMatchHashTableSize - 1);
         bitsPerIntermediateMatchHashEntry = bitsPerMatchHashKey + bitsPerIntermediateListIdentifier;
 
         intermediateMatchHashMask = intermediateMatchHashTableSize - 1;
-        intermediateMatchHashTableSizeBeforeGrow = intermediateMatchHashTableSize * 7 / 10;
+        intermediateMatchHashTableSizeBeforeGrow = sizeBeforeGrow(intermediateMatchHashTableSize);
         matchCount = 0;
 
         /// a data structure which keeps canonical matches for comparison (the matchHashTable)
-        intermediateMatchHashTable = new FixedLengthElementArray(memoryRecycler, (long)intermediateMatchHashTableSize * bitsPerIntermediateMatchHashEntry);
+        intermediateMatchHashTable = new FixedLengthElementArray(memoryRecycler, intermediateMatchHashTableSize * bitsPerIntermediateMatchHashEntry);
 
         /// a data structure which tracks lists of matches under canonical matches.
         MultiLinkedElementArray intermediateSelectLists = new MultiLinkedElementArray(memoryRecycler);
@@ -182,7 +182,7 @@ public class HollowHashIndexBuilder {
         /// turn those data structures into a compact one optimized for hash lookup
         long totalNumberOfSelectBucketsAndBitsRequiredForSelectTableSize = calculateDedupedSizesAndTotalNumberOfSelectBuckets(intermediateSelectLists, matchIndexHashAndSizeArray);
         long totalNumberOfSelectBuckets = totalNumberOfSelectBucketsAndBitsRequiredForSelectTableSize & 0xFFFFFFFFFFFFFFL;
-        long totalNumberOfMatchBuckets = HashCodes.hashTableSize(matchCount);
+        long totalNumberOfMatchBuckets = HashCodes.indexHashTableSize(matchCount);
 
         int bitsPerFinalSelectBucketPointer = bitsRequiredToRepresentValue(totalNumberOfSelectBuckets);
         int bitsPerSelectTableSize = (int)(totalNumberOfSelectBucketsAndBitsRequiredForSelectTableSize >>> 56);
@@ -255,12 +255,24 @@ public class HollowHashIndexBuilder {
         this.finalMatchHashMask = finalMatchHashMask;
     }
 
+    static long sizeBeforeGrow(long hashTableSize) {
+        return hashTableSize * 7 / 10;
+    }
+
+    static long grownTableSize(long hashTableSize) {
+        if(hashTableSize > HollowConstants.INDEX_HASH_TABLE_MAX_SIZE) {
+            throw new IllegalStateException("cannot grow the intermediate match hash table beyond " + hashTableSize
+                    + " buckets; a hash index supports at most " + HollowConstants.INDEX_HASH_TABLE_MAX_SIZE + " matches");
+        }
+        return hashTableSize * 2;
+    }
+
     private void growIntermediateHashTable() {
-        int newMatchHashTableSize = intermediateMatchHashTableSize * 2;
-        int newMatchHashMask = newMatchHashTableSize - 1;
+        long newMatchHashTableSize = grownTableSize(intermediateMatchHashTableSize);
+        long newMatchHashMask = newMatchHashTableSize - 1;
         int newBitsForListIdentifier = bitsRequiredToRepresentValue(newMatchHashTableSize - 1);
         int newBitsPerMatchHashEntry = bitsPerMatchHashKey + newBitsForListIdentifier;
-        FixedLengthElementArray newMatchHashTable = new FixedLengthElementArray(memoryRecycler, (long)newMatchHashTableSize * newBitsPerMatchHashEntry);
+        FixedLengthElementArray newMatchHashTable = new FixedLengthElementArray(memoryRecycler, newMatchHashTableSize * newBitsPerMatchHashEntry);
 
         for(int j=0;j<matchCount;j++) {
             int rehashCode = (int)matchIndexHashAndSizeArray.get(j);
@@ -297,7 +309,7 @@ public class HollowHashIndexBuilder {
 
         intermediateMatchHashTable = newMatchHashTable;
         intermediateMatchHashTableSize = newMatchHashTableSize;
-        intermediateMatchHashTableSizeBeforeGrow = intermediateMatchHashTableSize * 7 / 10;
+        intermediateMatchHashTableSizeBeforeGrow = sizeBeforeGrow(intermediateMatchHashTableSize);
         bitsPerIntermediateListIdentifier = newBitsForListIdentifier;
         bitsPerIntermediateMatchHashEntry = newBitsPerMatchHashEntry;
         intermediateMatchHashMask = newMatchHashMask;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowPrimaryKeyIndex.java
@@ -217,7 +217,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
         do {
             hashTable = this.hashTableVolatile;
-            int bucket = hashCode & hashTable.hashMask;
+            long bucket = hashCode & hashTable.hashMask;
             ordinal = readOrdinal(hashTable, bucket);
             while(ordinal != -1) {
                 if(keyDeriver.keyMatches(key, ordinal, 0))
@@ -257,7 +257,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
         do {
             hashTable = this.hashTableVolatile;
-            int bucket = hashCode & hashTable.hashMask;
+            long bucket = hashCode & hashTable.hashMask;
             ordinal = readOrdinal(hashTable, bucket);
             while(ordinal != -1) {
                 if(keyDeriver.keyMatches(key1, ordinal, 0) && keyDeriver.keyMatches(key2, ordinal, 1))
@@ -299,7 +299,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
         do {
             hashTable = this.hashTableVolatile;
-            int bucket = hashCode & hashTable.hashMask;
+            long bucket = hashCode & hashTable.hashMask;
             ordinal = readOrdinal(hashTable, bucket);
             while(ordinal != -1) {
                 if(keyDeriver.keyMatches(key1, ordinal, 0) && keyDeriver.keyMatches(key2, ordinal, 1) && keyDeriver.keyMatches(key3, ordinal, 2))
@@ -339,7 +339,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
         do {
             hashTable = this.hashTableVolatile;
-            int bucket = hashCode & hashTable.hashMask;
+            long bucket = hashCode & hashTable.hashMask;
             ordinal = readOrdinal(hashTable, bucket);
             while(ordinal != -1) {
                 if(keyDeriver.keyMatches(ordinal, keys))
@@ -354,8 +354,8 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         return ordinal;
     }
 
-    private int readOrdinal(PrimaryKeyIndexHashTable hashTable, int bucket) {
-        return (int)hashTable.hashTable.getElementValue((long)hashTable.bitsPerElement * (long)bucket, hashTable.bitsPerElement) - 1;
+    private int readOrdinal(PrimaryKeyIndexHashTable hashTable, long bucket) {
+        return (int)hashTable.hashTable.getElementValue((long)hashTable.bitsPerElement * bucket, hashTable.bitsPerElement) - 1;
     }
 
     private int keyHashCode(Object key, int fieldIdx) {
@@ -402,18 +402,18 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
         List<Object[]> duplicateKeys = new ArrayList<Object[]>();
 
-        for(int i=0;i<hashTable.hashTableSize;i++) {
-            int ordinal = (int)hashTable.hashTable.getElementValue((long)i * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+        for(long i=0;i<hashTable.hashTableSize;i++) {
+            int ordinal = (int)hashTable.hashTable.getElementValue(i * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
 
             if(ordinal != -1) {
-                int compareBucket = (i+1) & hashTable.hashMask;
-                int compareOrdinal = (int)hashTable.hashTable.getElementValue((long)compareBucket * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+                long compareBucket = (i+1) & hashTable.hashMask;
+                int compareOrdinal = (int)hashTable.hashTable.getElementValue(compareBucket * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
                 while(compareOrdinal != -1) {
                     if(recordsHaveEqualKeys(ordinal, compareOrdinal))
                         duplicateKeys.add(keyDeriver.getRecordKey(ordinal));
 
                     compareBucket = (compareBucket + 1) & hashTable.hashMask;
-                    compareOrdinal = (int)hashTable.hashTable.getElementValue((long)compareBucket * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+                    compareOrdinal = (int)hashTable.hashTable.getElementValue(compareBucket * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
                 }
             }
         }
@@ -433,15 +433,15 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         BitSet counted = new BitSet();
         List<DuplicateKeyInfo> duplicateKeys = new ArrayList<>();
 
-        for(int i=0;i<hashTable.hashTableSize && duplicateKeys.size() < maxDuplicateKeys;i++) {
-            int ordinal = (int)hashTable.hashTable.getElementValue((long)i * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+        for(long i=0;i<hashTable.hashTableSize && duplicateKeys.size() < maxDuplicateKeys;i++) {
+            int ordinal = (int)hashTable.hashTable.getElementValue(i * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
 
             if(ordinal != -1 && !counted.get(ordinal)) {
                 long count = 1;
                 counted.set(ordinal);
 
-                int compareBucket = (i+1) & hashTable.hashMask;
-                int compareOrdinal = (int)hashTable.hashTable.getElementValue((long)compareBucket * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+                long compareBucket = (i+1) & hashTable.hashMask;
+                int compareOrdinal = (int)hashTable.hashTable.getElementValue(compareBucket * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
                 while(compareOrdinal != -1) {
                     if(recordsHaveEqualKeys(ordinal, compareOrdinal)) {
                         count++;
@@ -449,7 +449,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
                     }
 
                     compareBucket = (compareBucket + 1) & hashTable.hashMask;
-                    compareOrdinal = (int)hashTable.hashTable.getElementValue((long)compareBucket * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+                    compareOrdinal = (int)hashTable.hashTable.getElementValue(compareBucket * (long)hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
                 }
 
                 if (count > 1) {
@@ -482,7 +482,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
         BitSet ordinals = typeState.getListener(PopulatedOrdinalListener.class).getPopulatedOrdinals();
 
-        int hashTableSize = HashCodes.hashTableSize(ordinals.cardinality());
+        long hashTableSize = HashCodes.indexHashTableSize(ordinals.cardinality());
         int bitsPerElement = (32 - Integer.numberOfLeadingZeros(typeState.maxOrdinal() + 1));
 
         PrimaryKeyIndexHashTable hashTable = hashTableVolatile;
@@ -542,22 +542,22 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
             ordinals = listener.getPopulatedOrdinals();
         }
 
-        int hashTableSize = HashCodes.hashTableSize(ordinals.cardinality());
+        long hashTableSize = HashCodes.indexHashTableSize(ordinals.cardinality());
         int bitsPerElement = (32 - Integer.numberOfLeadingZeros(typeState.maxOrdinal() + 1));
 
-        FixedLengthElementArray hashedArray = new FixedLengthElementArray(memoryRecycler, (long)hashTableSize * (long)bitsPerElement);
+        FixedLengthElementArray hashedArray = new FixedLengthElementArray(memoryRecycler, hashTableSize * (long)bitsPerElement);
 
-        int hashMask = hashTableSize - 1;
+        long hashMask = hashTableSize - 1;
 
         int ordinal = ordinals.nextSetBit(0);
         while(ordinal != ORDINAL_NONE) {
             int hashCode = recordHash(ordinal);
-            int bucket = hashCode & hashMask;
+            long bucket = hashCode & hashMask;
 
-            while(hashedArray.getElementValue((long)bucket * (long)bitsPerElement, bitsPerElement) != 0)
+            while(hashedArray.getElementValue(bucket * (long)bitsPerElement, bitsPerElement) != 0)
                 bucket = (bucket + 1) & hashMask;
 
-            hashedArray.setElementValue((long)bucket * (long)bitsPerElement, bitsPerElement, ordinal + 1);
+            hashedArray.setElementValue(bucket * (long)bitsPerElement, bitsPerElement, ordinal + 1);
 
             ordinal = ordinals.nextSetBit(ordinal + 1);
         }
@@ -567,7 +567,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         memoryRecycler.swap();
     }
 
-    private void deltaUpdate(int hashTableSize, int bitsPerElement) {
+    private void deltaUpdate(long hashTableSize, int bitsPerElement) {
         // For a delta update hashTableVolatile cannot be null
         PrimaryKeyIndexHashTable hashTable = hashTableVolatile;
         hashTable.hashTable.destroy(memoryRecycler);
@@ -576,37 +576,37 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         BitSet prevOrdinals = listener.getPreviousOrdinals();
         BitSet ordinals = listener.getPopulatedOrdinals();
 
-        long totalBitsInHashTable = (long)hashTableSize * (long)bitsPerElement;
+        long totalBitsInHashTable = hashTableSize * (long)bitsPerElement;
         FixedLengthElementArray hashedArray = new FixedLengthElementArray(memoryRecycler, totalBitsInHashTable);
         hashedArray.copyBits(hashTable.hashTable, 0, 0, totalBitsInHashTable);
 
-        int hashMask = hashTableSize - 1;
+        long hashMask = hashTableSize - 1;
 
         int prevOrdinal = prevOrdinals.nextSetBit(0);
         while(prevOrdinal != ORDINAL_NONE) {
             if(!ordinals.get(prevOrdinal)) {
                 /// find and remove this ordinal
                 int hashCode = recordHash(prevOrdinal);
-                int bucket = findOrdinalBucket(bitsPerElement, hashedArray, hashCode, hashMask, prevOrdinal);
+                long bucket = findOrdinalBucket(bitsPerElement, hashedArray, hashCode, hashMask, prevOrdinal);
 
-                hashedArray.clearElementValue((long)bucket * (long)bitsPerElement, bitsPerElement);
-                int emptyBucket = bucket;
+                hashedArray.clearElementValue(bucket * (long)bitsPerElement, bitsPerElement);
+                long emptyBucket = bucket;
                 bucket = (bucket + 1) & hashMask;
-                int moveOrdinal = (int)hashedArray.getElementValue((long)bucket * (long)bitsPerElement, bitsPerElement) - 1;
+                int moveOrdinal = (int)hashedArray.getElementValue(bucket * (long)bitsPerElement, bitsPerElement) - 1;
 
                 while(moveOrdinal != ORDINAL_NONE) {
                     int naturalHash = recordHash(moveOrdinal);
-                    int naturalBucket = naturalHash & hashMask;
+                    long naturalBucket = naturalHash & hashMask;
 
                     if(!bucketInRange(emptyBucket, bucket, naturalBucket)) {
-                        hashedArray.setElementValue((long)emptyBucket * (long)bitsPerElement, bitsPerElement, moveOrdinal + 1);
-                        hashedArray.clearElementValue((long)bucket * (long)bitsPerElement, bitsPerElement);
+                        hashedArray.setElementValue(emptyBucket * (long)bitsPerElement, bitsPerElement, moveOrdinal + 1);
+                        hashedArray.clearElementValue(bucket * (long)bitsPerElement, bitsPerElement);
                         emptyBucket = bucket;
                     }
 
 
                     bucket = (bucket + 1) & hashMask;
-                    moveOrdinal = (int)hashedArray.getElementValue((long)bucket * (long)bitsPerElement, bitsPerElement) - 1;
+                    moveOrdinal = (int)hashedArray.getElementValue(bucket * (long)bitsPerElement, bitsPerElement) - 1;
                 }
 
             }
@@ -619,13 +619,13 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         while(ordinal != ORDINAL_NONE) {
             if(!prevOrdinals.get(ordinal)) {
                 int hashCode = recordHash(ordinal);
-                int bucket = hashCode & hashMask;
+                long bucket = hashCode & hashMask;
 
-                while(hashedArray.getElementValue((long)bucket * (long)bitsPerElement, bitsPerElement) != 0) {
+                while(hashedArray.getElementValue(bucket * (long)bitsPerElement, bitsPerElement) != 0) {
                     bucket = (bucket + 1) & hashMask;
                 }
 
-                hashedArray.setElementValue((long)bucket * (long)bitsPerElement, bitsPerElement, ordinal + 1);
+                hashedArray.setElementValue(bucket * (long)bitsPerElement, bitsPerElement, ordinal + 1);
             }
 
             ordinal = ordinals.nextSetBit(ordinal + 1);
@@ -636,12 +636,12 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         memoryRecycler.swap();
     }
 
-    private int findOrdinalBucket(int bitsPerElement, FixedLengthElementArray hashedArray, int hashCode, int hashMask, int prevOrdinal) {
-        int startBucket = hashCode & hashMask;
-        int bucket = startBucket;
+    private long findOrdinalBucket(int bitsPerElement, FixedLengthElementArray hashedArray, int hashCode, long hashMask, int prevOrdinal) {
+        long startBucket = hashCode & hashMask;
+        long bucket = startBucket;
         long value;
         do {
-            value = hashedArray.getElementValue((long)bucket * (long)bitsPerElement, bitsPerElement);
+            value = hashedArray.getElementValue(bucket * (long)bitsPerElement, bitsPerElement);
             if (prevOrdinal + 1 == value) {
                 return bucket;
             }
@@ -657,7 +657,7 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
         }
     }
 
-    private boolean bucketInRange(int fromBucket, int toBucket, int testBucket) {
+    private boolean bucketInRange(long fromBucket, long toBucket, long testBucket) {
         if(toBucket > fromBucket) {
             return testBucket > fromBucket && testBucket <= toBucket;
         } else {
@@ -795,11 +795,11 @@ public class HollowPrimaryKeyIndex implements HollowTypeStateListener, TestableU
 
     static class PrimaryKeyIndexHashTable {
         final FixedLengthElementArray hashTable;
-        final int hashTableSize;
-        final int hashMask;
+        final long hashTableSize;
+        final long hashMask;
         final int bitsPerElement;
 
-        public PrimaryKeyIndexHashTable(FixedLengthElementArray hashTable, int hashTableSize, int hashMask, int bitsPerElement) {
+        public PrimaryKeyIndexHashTable(FixedLengthElementArray hashTable, long hashTableSize, long hashMask, int bitsPerElement) {
             this.hashTable = hashTable;
             this.hashTableSize = hashTableSize;
             this.hashMask = hashMask;

--- a/hollow/src/main/java/com/netflix/hollow/core/index/HollowUniqueKeyIndex.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/index/HollowUniqueKeyIndex.java
@@ -325,7 +325,7 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
         int ordinal;
         do {
             hashTable = this.hashTableVolatile;
-            int bucket = hashCode & hashTable.hashMask;
+            long bucket = hashCode & hashTable.hashMask;
             ordinal = readOrdinal(hashTable, bucket);
             while (ordinal != ORDINAL_NONE) {
                 if (keyMatches(key0, ordinal, 0)
@@ -365,7 +365,7 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
 
         do {
             hashTable = this.hashTableVolatile;
-            int bucket = hashCode & hashTable.hashMask;
+            long bucket = hashCode & hashTable.hashMask;
             ordinal = readOrdinal(hashTable, bucket);
             while (ordinal != -1) {
                 if (keysAllMatch(ordinal, keys))
@@ -385,8 +385,8 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
         return this.fields.length != keyCount || this.hashTableVolatile.bitsPerElement == 0;
     }
 
-    private int readOrdinal(PrimaryKeyIndexHashTable hashTable, int bucket) {
-        return (int) hashTable.hashTable.getElementValue((long) hashTable.bitsPerElement * (long) bucket, hashTable.bitsPerElement) - 1;
+    private int readOrdinal(PrimaryKeyIndexHashTable hashTable, long bucket) {
+        return (int) hashTable.hashTable.getElementValue((long) hashTable.bitsPerElement * bucket, hashTable.bitsPerElement) - 1;
     }
 
     @SuppressWarnings("UnnecessaryUnboxing")
@@ -431,18 +431,18 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
 
         List<Object[]> duplicateKeys = new ArrayList<>();
 
-        for (int i = 0; i < hashTable.hashTableSize; i++) {
-            int ordinal = (int) hashTable.hashTable.getElementValue((long) i * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+        for (long i = 0; i < hashTable.hashTableSize; i++) {
+            int ordinal = (int) hashTable.hashTable.getElementValue(i * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
 
             if (ordinal != -1) {
-                int compareBucket = (i + 1) & hashTable.hashMask;
-                int compareOrdinal = (int) hashTable.hashTable.getElementValue((long) compareBucket * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+                long compareBucket = (i + 1) & hashTable.hashMask;
+                int compareOrdinal = (int) hashTable.hashTable.getElementValue(compareBucket * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
                 while (compareOrdinal != -1) {
                     if (recordsHaveEqualKeys(ordinal, compareOrdinal))
                         duplicateKeys.add(getRecordKey(ordinal));
 
                     compareBucket = (compareBucket + 1) & hashTable.hashMask;
-                    compareOrdinal = (int) hashTable.hashTable.getElementValue((long) compareBucket * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+                    compareOrdinal = (int) hashTable.hashTable.getElementValue(compareBucket * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
                 }
             }
         }
@@ -462,15 +462,15 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
         BitSet counted = new BitSet();
         List<DuplicateKeyInfo> duplicateKeys = new ArrayList<>();
 
-        for (int i = 0; i < hashTable.hashTableSize && duplicateKeys.size() < maxDuplicateKeys; i++) {
-            int ordinal = (int) hashTable.hashTable.getElementValue((long) i * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+        for (long i = 0; i < hashTable.hashTableSize && duplicateKeys.size() < maxDuplicateKeys; i++) {
+            int ordinal = (int) hashTable.hashTable.getElementValue(i * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
 
             if (ordinal != -1 && !counted.get(ordinal)) {
                 long count = 1;
                 counted.set(ordinal);
 
-                int compareBucket = (i + 1) & hashTable.hashMask;
-                int compareOrdinal = (int) hashTable.hashTable.getElementValue((long) compareBucket * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+                long compareBucket = (i + 1) & hashTable.hashMask;
+                int compareOrdinal = (int) hashTable.hashTable.getElementValue(compareBucket * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
                 while (compareOrdinal != -1) {
                     if (recordsHaveEqualKeys(ordinal, compareOrdinal)) {
                         count++;
@@ -478,7 +478,7 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
                     }
 
                     compareBucket = (compareBucket + 1) & hashTable.hashMask;
-                    compareOrdinal = (int) hashTable.hashTable.getElementValue((long) compareBucket * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
+                    compareOrdinal = (int) hashTable.hashTable.getElementValue(compareBucket * (long) hashTable.bitsPerElement, hashTable.bitsPerElement) - 1;
                 }
 
                 if (count > 1) {
@@ -512,7 +512,7 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
         //when the index is being updated.
         BitSet ordinals = typeState.getPopulatedOrdinals();
 
-        int hashTableSize = HashCodes.hashTableSize(ordinals.cardinality());
+        long hashTableSize = HashCodes.indexHashTableSize(ordinals.cardinality());
         int bitsPerElement = (32 - Integer.numberOfLeadingZeros(typeState.maxOrdinal() + 1));
 
         PrimaryKeyIndexHashTable hashTable = hashTableVolatile;
@@ -570,22 +570,22 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
             ordinals = typeState.getPopulatedOrdinals();
         }
 
-        int hashTableSize = HashCodes.hashTableSize(ordinals.cardinality());
+        long hashTableSize = HashCodes.indexHashTableSize(ordinals.cardinality());
         int bitsPerElement = (32 - Integer.numberOfLeadingZeros(typeState.maxOrdinal() + 1));
 
-        FixedLengthElementArray hashedArray = new FixedLengthElementArray(memoryRecycler, (long) hashTableSize * (long) bitsPerElement);
+        FixedLengthElementArray hashedArray = new FixedLengthElementArray(memoryRecycler, hashTableSize * (long) bitsPerElement);
 
-        int hashMask = hashTableSize - 1;
+        long hashMask = hashTableSize - 1;
 
         int ordinal = ordinals.nextSetBit(0);
         while (ordinal != ORDINAL_NONE) {
             int hashCode = generateRecordHash(ordinal);
-            int bucket = hashCode & hashMask;
+            long bucket = hashCode & hashMask;
 
-            while (hashedArray.getElementValue((long) bucket * (long) bitsPerElement, bitsPerElement) != 0)
+            while (hashedArray.getElementValue(bucket * (long) bitsPerElement, bitsPerElement) != 0)
                 bucket = (bucket + 1) & hashMask;
 
-            hashedArray.setElementValue((long) bucket * (long) bitsPerElement, bitsPerElement, ordinal + 1);
+            hashedArray.setElementValue(bucket * (long) bitsPerElement, bitsPerElement, ordinal + 1);
 
             ordinal = ordinals.nextSetBit(ordinal + 1);
         }
@@ -595,7 +595,7 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
         memoryRecycler.swap();
     }
 
-    private void deltaUpdate(int hashTableSize, int bitsPerElement) {
+    private void deltaUpdate(long hashTableSize, int bitsPerElement) {
         // For a delta update hashTableVolatile cannot be null
         PrimaryKeyIndexHashTable hashTable = hashTableVolatile;
         hashTable.hashTable.destroy(memoryRecycler);
@@ -606,36 +606,36 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
         BitSet prevOrdinals = typeState.getPreviousOrdinals();
         BitSet ordinals = typeState.getPopulatedOrdinals();
 
-        long totalBitsInHashTable = (long) hashTableSize * (long) bitsPerElement;
+        long totalBitsInHashTable = hashTableSize * (long) bitsPerElement;
         FixedLengthElementArray hashedArray = new FixedLengthElementArray(memoryRecycler, totalBitsInHashTable);
         hashedArray.copyBits(hashTable.hashTable, 0, 0, totalBitsInHashTable);
 
-        int hashMask = hashTableSize - 1;
+        long hashMask = hashTableSize - 1;
 
         int prevOrdinal = prevOrdinals.nextSetBit(0);
         while (prevOrdinal != ORDINAL_NONE) {
             if (!ordinals.get(prevOrdinal)) {
                 /// find and remove this ordinal
                 int hashCode = generateRecordHash(prevOrdinal);
-                int bucket = findOrdinalBucket(bitsPerElement, hashedArray, hashCode, hashMask, prevOrdinal);
+                long bucket = findOrdinalBucket(bitsPerElement, hashedArray, hashCode, hashMask, prevOrdinal);
 
-                hashedArray.clearElementValue((long) bucket * (long) bitsPerElement, bitsPerElement);
-                int emptyBucket = bucket;
+                hashedArray.clearElementValue(bucket * (long) bitsPerElement, bitsPerElement);
+                long emptyBucket = bucket;
                 bucket = (bucket + 1) & hashMask;
-                int moveOrdinal = (int) hashedArray.getElementValue((long) bucket * (long) bitsPerElement, bitsPerElement) - 1;
+                int moveOrdinal = (int) hashedArray.getElementValue(bucket * (long) bitsPerElement, bitsPerElement) - 1;
 
                 while (moveOrdinal != ORDINAL_NONE) {
                     int naturalHash = generateRecordHash(moveOrdinal);
-                    int naturalBucket = naturalHash & hashMask;
+                    long naturalBucket = naturalHash & hashMask;
 
                     if (!bucketInRange(emptyBucket, bucket, naturalBucket)) {
-                        hashedArray.setElementValue((long) emptyBucket * (long) bitsPerElement, bitsPerElement, moveOrdinal + 1);
-                        hashedArray.clearElementValue((long) bucket * (long) bitsPerElement, bitsPerElement);
+                        hashedArray.setElementValue(emptyBucket * (long) bitsPerElement, bitsPerElement, moveOrdinal + 1);
+                        hashedArray.clearElementValue(bucket * (long) bitsPerElement, bitsPerElement);
                         emptyBucket = bucket;
                     }
 
                     bucket = (bucket + 1) & hashMask;
-                    moveOrdinal = (int) hashedArray.getElementValue((long) bucket * (long) bitsPerElement, bitsPerElement) - 1;
+                    moveOrdinal = (int) hashedArray.getElementValue(bucket * (long) bitsPerElement, bitsPerElement) - 1;
                 }
 
             }
@@ -648,13 +648,13 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
         while (ordinal != ORDINAL_NONE) {
             if (!prevOrdinals.get(ordinal)) {
                 int hashCode = generateRecordHash(ordinal);
-                int bucket = hashCode & hashMask;
+                long bucket = hashCode & hashMask;
 
-                while (hashedArray.getElementValue((long) bucket * (long) bitsPerElement, bitsPerElement) != 0) {
+                while (hashedArray.getElementValue(bucket * (long) bitsPerElement, bitsPerElement) != 0) {
                     bucket = (bucket + 1) & hashMask;
                 }
 
-                hashedArray.setElementValue((long) bucket * (long) bitsPerElement, bitsPerElement, ordinal + 1);
+                hashedArray.setElementValue(bucket * (long) bitsPerElement, bitsPerElement, ordinal + 1);
             }
 
             ordinal = ordinals.nextSetBit(ordinal + 1);
@@ -665,12 +665,12 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
         memoryRecycler.swap();
     }
 
-    private int findOrdinalBucket(int bitsPerElement, FixedLengthElementArray hashedArray, int hashCode, int hashMask, int prevOrdinal) {
-        int startBucket = hashCode & hashMask;
-        int bucket = startBucket;
+    private long findOrdinalBucket(int bitsPerElement, FixedLengthElementArray hashedArray, int hashCode, long hashMask, int prevOrdinal) {
+        long startBucket = hashCode & hashMask;
+        long bucket = startBucket;
         long value;
         do {
-            value = hashedArray.getElementValue((long) bucket * (long) bitsPerElement, bitsPerElement);
+            value = hashedArray.getElementValue(bucket * (long) bitsPerElement, bitsPerElement);
             if (prevOrdinal + 1 == value) {
                 return bucket;
             }
@@ -686,7 +686,7 @@ public class HollowUniqueKeyIndex implements HollowTypeStateListener, TestableUn
         }
     }
 
-    private boolean bucketInRange(int fromBucket, int toBucket, int testBucket) {
+    private boolean bucketInRange(long fromBucket, long toBucket, long testBucket) {
         if (toBucket > fromBucket) {
             return testBucket > fromBucket && testBucket <= toBucket;
         } else {

--- a/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/HashCodes.java
+++ b/hollow/src/main/java/com/netflix/hollow/core/memory/encoding/HashCodes.java
@@ -17,6 +17,7 @@
 package com.netflix.hollow.core.memory.encoding;
 
 import static com.netflix.hollow.core.HollowConstants.HASH_TABLE_MAX_SIZE;
+import static com.netflix.hollow.core.HollowConstants.INDEX_HASH_TABLE_MAX_SIZE;
 
 import com.netflix.hollow.core.memory.ArrayByteData;
 import com.netflix.hollow.core.memory.ByteData;
@@ -197,5 +198,33 @@ public class HashCodes {
         int sizeAfterLoadFactor = (int)((long)numElements * 10 / 7);
         int bits = 32 - Integer.numberOfLeadingZeros(sizeAfterLoadFactor - 1);
         return 1 << bits;
+    }
+
+    /**
+     * Determine the size of an in-memory index hash table capable of storing the specified number of elements with a
+     * load factor applied.Allows upto 2^31 buckets vs. {@link #hashTableSize(int)}'s 2^30. {@link #hashTableSize(int)} is
+     * retained for backwards compatibility of bucket layout for serialized SET and MAP records with existing consumers.
+     *
+     * @param numElements number of elements to be stored in the table
+     * @return size of hash table, always a power of 2
+     * @throws IllegalArgumentException when numElements is negative or exceeds
+     *                                  {@link com.netflix.hollow.core.HollowConstants#INDEX_HASH_TABLE_MAX_SIZE}
+     */
+    public static long indexHashTableSize(long numElements) throws IllegalArgumentException {
+        if (numElements < 0) {
+            throw new IllegalArgumentException("cannot be negative; numElements="+numElements);
+        } else if (numElements > INDEX_HASH_TABLE_MAX_SIZE) {
+            throw new IllegalArgumentException("exceeds maximum number of buckets; numElements="+numElements);
+        }
+
+        if (numElements == 0)
+            return 1;
+        if (numElements < 3)
+            return numElements * 2;
+
+        // Apply load factor to number of elements and determine next largest power of 2
+        long sizeAfterLoadFactor = numElements * 10 / 7;
+        int bits = 64 - Long.numberOfLeadingZeros(sizeAfterLoadFactor - 1);
+        return 1L << bits;
     }
 }

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexBuilderTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexBuilderTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.index;
+
+import static com.netflix.hollow.core.HollowConstants.INDEX_HASH_TABLE_MAX_SIZE;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class HollowHashIndexBuilderTest {
+
+    @Test
+    public void sizeBeforeGrowAppliesTheLoadFactor() {
+        assertEquals(179, HollowHashIndexBuilder.sizeBeforeGrow(256));
+        assertEquals(11744051, HollowHashIndexBuilder.sizeBeforeGrow(1 << 24));
+    }
+
+    /// an int multiply overflowed here, turning the threshold negative and forcing a grow on every insert until the
+    /// table size itself overflowed into a negative allocation.
+    @Test
+    public void sizeBeforeGrowStaysPositiveWhereAnIntMultiplyWouldOverflow() {
+        assertEquals(375809638, HollowHashIndexBuilder.sizeBeforeGrow(1L << 29));
+        assertEquals(751619276, HollowHashIndexBuilder.sizeBeforeGrow(1L << 30));
+        assertEquals(INDEX_HASH_TABLE_MAX_SIZE, HollowHashIndexBuilder.sizeBeforeGrow(1L << 31));
+    }
+
+    @Test
+    public void grownTableSizeDoublesUpToTwoToThe31Buckets() {
+        assertEquals(512, HollowHashIndexBuilder.grownTableSize(256));
+        assertEquals(1L << 30, HollowHashIndexBuilder.grownTableSize(1L << 29));
+        assertEquals(1L << 31, HollowHashIndexBuilder.grownTableSize(1L << 30));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void grownTableSizeRejectsATableThatCannotDouble() {
+        HollowHashIndexBuilder.grownTableSize(1L << 31);
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/index/HollowHashIndexTest.java
@@ -242,6 +242,29 @@ public class HollowHashIndexTest extends AbstractStateEngineTest {
     }
 
     @Test
+    public void testIndexingWhenTheIntermediateMatchTableGrows() throws Exception {
+        /// the intermediate match hash table is initially sized for one match per top-level record, so indexing many
+        /// more distinct match keys than there are records forces it to grow repeatedly.
+        int numRecords = 64;
+        int valuesPerRecord = 64;
+        for(int i=0;i<numRecords;i++) {
+            String[] data = new String[valuesPerRecord];
+            for(int j=0;j<valuesPerRecord;j++)
+                data[j] = "value-" + i + "-" + j;
+            mapper.add(new TypeList(data));
+        }
+        roundTripSnapshot();
+
+        HollowHashIndex index = new HollowHashIndex(readStateEngine, "TypeList", "", "data.element.value");
+
+        for(int i=0;i<numRecords;i++)
+            for(int j=0;j<valuesPerRecord;j++)
+                assertIteratorContainsAll(index.findMatches("value-" + i + "-" + j).iterator(), i);
+
+        Assert.assertNull(index.findMatches("value-not-present"));
+    }
+
+    @Test
     public void testIndexingSetTypeField() throws Exception {
         mapper.add(new TypeSet("A", "B", "C", "D"));
         mapper.add(new TypeSet("B", "C", "D", "E"));

--- a/hollow/src/test/java/com/netflix/hollow/core/memory/encoding/HashCodesTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/core/memory/encoding/HashCodesTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.core.memory.encoding;
+
+import static com.netflix.hollow.core.HollowConstants.HASH_TABLE_MAX_SIZE;
+import static com.netflix.hollow.core.HollowConstants.INDEX_HASH_TABLE_MAX_SIZE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Random;
+import org.junit.Test;
+
+public class HashCodesTest {
+
+    /// indexHashTableSize() is only safe to use in place of hashTableSize() if the two agree everywhere
+    /// hashTableSize() is defined -- an index built with one bucket count and read with the other is corrupt.
+    @Test
+    public void indexHashTableSizeMatchesHashTableSizeWhereverBothApply() {
+        for(int numElements : new int[] {0, 1, 2, 3, 4, 5, 7, 8, 9, 1023, 1024, 1 << 24, HASH_TABLE_MAX_SIZE})
+            assertEquals("numElements=" + numElements, HashCodes.hashTableSize(numElements), HashCodes.indexHashTableSize(numElements));
+
+        Random rand = new Random(20260902);
+        for(int i=0;i<100000;i++) {
+            int numElements = rand.nextInt(HASH_TABLE_MAX_SIZE);
+            assertEquals("numElements=" + numElements, HashCodes.hashTableSize(numElements), HashCodes.indexHashTableSize(numElements));
+        }
+    }
+
+    /// Note the load factor is approximate: rounding in "next power of two at or above numElements * 10 / 7" leaves a
+    /// few inputs (numElements=3 among them) slightly above 70%.  That is inherited from hashTableSize and is harmless
+    /// -- what open addressing actually requires is a power-of-two table strictly larger than the element count.
+    @Test
+    public void indexHashTableSizeReturnsAMinimalPowerOfTwoLargerThanTheElementCount() {
+        for(long numElements : new long[] {3, 100, 1 << 24, HASH_TABLE_MAX_SIZE, HASH_TABLE_MAX_SIZE + 1L, INDEX_HASH_TABLE_MAX_SIZE}) {
+            long size = HashCodes.indexHashTableSize(numElements);
+            assertEquals("numElements=" + numElements + " size=" + size + " is not a power of two", 0, size & (size - 1));
+            assertTrue("numElements=" + numElements + " does not fit in size=" + size, size > numElements);
+            assertTrue("numElements=" + numElements + " leaves size=" + size + " oversized", (size / 2) * 7 / 10 < numElements);
+        }
+    }
+
+    /// 2^31 buckets is the deliberate stopping point: the mask stays within 31 bits, so sign-extending an int hash
+    /// code into a long mask is harmless.
+    @Test
+    public void indexHashTableSizeStopsAtTwoToThe31Buckets() {
+        assertEquals(1L << 30, HashCodes.indexHashTableSize(HASH_TABLE_MAX_SIZE));
+        assertEquals(1L << 31, HashCodes.indexHashTableSize(INDEX_HASH_TABLE_MAX_SIZE));
+        assertEquals(INDEX_HASH_TABLE_MAX_SIZE, (1L << 31) * 7 / 10);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void indexHashTableSizeRejectsMoreElementsThanItCanHold() {
+        HashCodes.indexHashTableSize(INDEX_HASH_TABLE_MAX_SIZE + 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void indexHashTableSizeRejectsNegativeSizes() {
+        HashCodes.indexHashTableSize(-1);
+    }
+}


### PR DESCRIPTION
Indexes now support upto 1.5B records.  

fix: HollowHashIndex crashes at ~188M records with NegativeArraySizeException.
fix: HollowPrimaryKeyIndex threw IllegalArgumentException at ~751M records.

The fix computes the threshold in long and widens bucket counts one bit, to 2^31 buckets = ~1.5B records for both index types.
